### PR TITLE
Enhance expression integration

### DIFF
--- a/Utils.Mathematics/Expressions/ExpressionIntegration.cs
+++ b/Utils.Mathematics/Expressions/ExpressionIntegration.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 using Utils.Expressions;
+using Utils.Objects;
 
 namespace Utils.Mathematics.Expressions;
 
@@ -30,7 +31,16 @@ public class ExpressionIntegration : ExpressionTransformer
         object value
     )
     {
-        return parameter;
+        return Expression.Multiply(e, parameter);
+    }
+
+    [ExpressionSignature(ExpressionType.Negate)]
+    public Expression Negate(
+        UnaryExpression e,
+        Expression operand
+    )
+    {
+        return Expression.Negate(Transform(operand));
     }
 
     [ExpressionSignature(ExpressionType.Parameter)]
@@ -80,6 +90,101 @@ public class ExpressionIntegration : ExpressionTransformer
         );
     }
 
+    [ExpressionSignature(ExpressionType.Multiply)]
+    public Expression Multiply(
+        BinaryExpression e,
+        [ConstantNumeric] ConstantExpression left,
+        Expression right
+    )
+    {
+        return Expression.Multiply(left, Transform(right));
+    }
+
+    [ExpressionSignature(ExpressionType.Multiply)]
+    public Expression Multiply(
+        BinaryExpression e,
+        Expression left,
+        [ConstantNumeric] ConstantExpression right
+    )
+    {
+        return Expression.Multiply(right, Transform(left));
+    }
+
+    [ExpressionSignature(ExpressionType.Divide)]
+    public Expression Divide(
+        BinaryExpression e,
+        Expression left,
+        [ConstantNumeric] ConstantExpression right
+    )
+    {
+        return Expression.Divide(Transform(left), right);
+    }
+
+    [ExpressionSignature(ExpressionType.Divide)]
+    public Expression Divide(
+        BinaryExpression e,
+        [ConstantNumeric] ConstantExpression left,
+        ParameterExpression right
+    )
+    {
+        if (right.Name == ParameterName)
+        {
+            return Expression.Multiply(
+                left,
+                Expression.Call(typeof(Math).GetMethod("Log"), right)
+            );
+        }
+        return null;
+    }
+
+    [ExpressionSignature(ExpressionType.Divide)]
+    public Expression Divide(
+        BinaryExpression e,
+        [ConstantNumeric] ConstantExpression left,
+        [ExpressionSignature(ExpressionType.Power)] BinaryExpression right
+    )
+    {
+        if (right.Left is ParameterExpression p && p.Name == ParameterName &&
+            right.Right is ConstantExpression expo && NumberUtils.IsNumeric(expo.Value))
+        {
+            double n = Convert.ToDouble(expo.Value);
+            if (Math.Abs(n - 1.0) < double.Epsilon)
+            {
+                return Expression.Multiply(
+                    left,
+                    Expression.Call(typeof(Math).GetMethod("Log"), p)
+                );
+            }
+
+            double newExpo = 1.0 - n;
+            return Expression.Divide(
+                Expression.Multiply(left, Expression.Power(p, Expression.Constant(newExpo))),
+                Expression.Constant(newExpo)
+            );
+        }
+        return null;
+    }
+
+    [ExpressionSignature(ExpressionType.Divide)]
+    public Expression Divide(
+        BinaryExpression e,
+        [ConstantNumeric] ConstantExpression left,
+        MethodCallExpression right
+    )
+    {
+        if (right.Method.Name == nameof(Math.Sqrt) &&
+            right.Arguments.Count == 1 &&
+            right.Arguments[0] is ParameterExpression p && p.Name == ParameterName)
+        {
+            double factor = 2.0 * Convert.ToDouble(left.Value);
+            return Expression.Multiply(
+                Expression.Constant(factor),
+                Expression.Call(typeof(Math).GetMethod(nameof(Math.Sqrt)), p)
+            );
+        }
+        return null;
+    }
+
     [ExpressionCallSignature(typeof(Math), "Log")]
     public Expression Log(
         MethodCallExpression e,
@@ -98,5 +203,212 @@ public class ExpressionIntegration : ExpressionTransformer
         }
         return null;
     }
+
+    [ExpressionCallSignature(typeof(double), nameof(double.Log10))]
+    public Expression Log10(
+        MethodCallExpression e,
+        ParameterExpression p
+    )
+    {
+        if (p.Name == ParameterName)
+        {
+            var ln10 = Expression.Constant(Math.Log(10.0));
+            return Expression.Subtract(
+                Expression.Multiply(p,
+                    Expression.Call(typeof(double).GetMethod(nameof(double.Log10)), p)),
+                Expression.Divide(p, ln10)
+            );
+        }
+        return null;
+    }
+
+    [ExpressionSignature(ExpressionType.Power)]
+    public Expression Power(
+        BinaryExpression e,
+        ParameterExpression p,
+        [ConstantNumeric] ConstantExpression expo
+    )
+    {
+        if (p.Name == ParameterName)
+        {
+            double n = Convert.ToDouble(expo.Value);
+            if (Math.Abs(n + 1.0) < double.Epsilon)
+            {
+                return Expression.Call(typeof(Math).GetMethod("Log"), p);
+            }
+            return Expression.Divide(
+                Expression.Power(p, Expression.Constant(n + 1.0)),
+                Expression.Constant(n + 1.0)
+            );
+        }
+        return null;
+    }
+
+    [ExpressionCallSignature(typeof(double), nameof(double.Exp))]
+    public Expression Exp(
+        MethodCallExpression e,
+        ParameterExpression op
+    )
+    {
+        if (op.Name == ParameterName)
+        {
+            return Expression.Call(typeof(double).GetMethod(nameof(double.Exp)), op);
+        }
+        if (op is BinaryExpression be && be.NodeType == ExpressionType.Multiply &&
+            be.Left is ConstantExpression c && NumberUtils.IsNumeric(c.Value) &&
+            be.Right is ParameterExpression p2 && p2.Name == ParameterName)
+        {
+            return Expression.Divide(
+                Expression.Call(typeof(double).GetMethod(nameof(double.Exp)), op),
+                c
+            );
+        }
+        return null;
+    }
+
+    [ExpressionCallSignature(typeof(double), nameof(double.Sin))]
+    public Expression Sin(
+        MethodCallExpression e,
+        ParameterExpression op
+    )
+    {
+        if (op.Name == ParameterName)
+        {
+            return Expression.Negate(
+                Expression.Call(typeof(double).GetMethod(nameof(double.Cos)), op)
+            );
+        }
+        if (op is BinaryExpression be && be.NodeType == ExpressionType.Multiply &&
+            be.Left is ConstantExpression c && NumberUtils.IsNumeric(c.Value) &&
+            be.Right is ParameterExpression p2 && p2.Name == ParameterName)
+        {
+            return Expression.Divide(
+                Expression.Negate(Expression.Call(typeof(double).GetMethod(nameof(double.Cos)), op)),
+                c
+            );
+        }
+        return null;
+    }
+
+    [ExpressionCallSignature(typeof(double), nameof(double.Cos))]
+    public Expression Cos(
+        MethodCallExpression e,
+        ParameterExpression op
+    )
+    {
+        if (op.Name == ParameterName)
+        {
+            return Expression.Call(typeof(double).GetMethod(nameof(double.Sin)), op);
+        }
+        if (op is BinaryExpression be && be.NodeType == ExpressionType.Multiply &&
+            be.Left is ConstantExpression c && NumberUtils.IsNumeric(c.Value) &&
+            be.Right is ParameterExpression p2 && p2.Name == ParameterName)
+        {
+            return Expression.Divide(
+                Expression.Call(typeof(double).GetMethod(nameof(double.Sin)), op),
+                c
+            );
+        }
+        return null;
+    }
+
+    [ExpressionCallSignature(typeof(double), nameof(double.Tan))]
+    public Expression Tan(
+        MethodCallExpression e,
+        ParameterExpression op
+    )
+    {
+        if (op.Name == ParameterName)
+        {
+            return Expression.Negate(
+                Expression.Call(typeof(double).GetMethod(nameof(double.Log)),
+                    Expression.Call(typeof(double).GetMethod(nameof(double.Cos)), op))
+            );
+        }
+        if (op is BinaryExpression be && be.NodeType == ExpressionType.Multiply &&
+            be.Left is ConstantExpression c && NumberUtils.IsNumeric(c.Value) &&
+            be.Right is ParameterExpression p2 && p2.Name == ParameterName)
+        {
+            return Expression.Divide(
+                Expression.Negate(Expression.Call(typeof(double).GetMethod(nameof(double.Log)),
+                    Expression.Call(typeof(double).GetMethod(nameof(double.Cos)), op))),
+                c
+            );
+        }
+        return null;
+    }
+
+    [ExpressionCallSignature(typeof(double), nameof(double.Sinh))]
+    public Expression Sinh(
+        MethodCallExpression e,
+        ParameterExpression op
+    )
+    {
+        if (op.Name == ParameterName)
+        {
+            return Expression.Call(typeof(double).GetMethod(nameof(double.Cosh)), op);
+        }
+        if (op is BinaryExpression be && be.NodeType == ExpressionType.Multiply &&
+            be.Left is ConstantExpression c && NumberUtils.IsNumeric(c.Value) &&
+            be.Right is ParameterExpression p2 && p2.Name == ParameterName)
+        {
+            return Expression.Divide(
+                Expression.Call(typeof(double).GetMethod(nameof(double.Cosh)), op),
+                c
+            );
+        }
+        return null;
+    }
+
+    [ExpressionCallSignature(typeof(double), nameof(double.Cosh))]
+    public Expression Cosh(
+        MethodCallExpression e,
+        ParameterExpression op
+    )
+    {
+        if (op.Name == ParameterName)
+        {
+            return Expression.Call(typeof(double).GetMethod(nameof(double.Sinh)), op);
+        }
+        if (op is BinaryExpression be && be.NodeType == ExpressionType.Multiply &&
+            be.Left is ConstantExpression c && NumberUtils.IsNumeric(c.Value) &&
+            be.Right is ParameterExpression p2 && p2.Name == ParameterName)
+        {
+            return Expression.Divide(
+                Expression.Call(typeof(double).GetMethod(nameof(double.Sinh)), op),
+                c
+            );
+        }
+        return null;
+    }
+
+    [ExpressionCallSignature(typeof(double), nameof(double.Tanh))]
+    public Expression Tanh(
+        MethodCallExpression e,
+        ParameterExpression op
+    )
+    {
+        if (op.Name == ParameterName)
+        {
+            return Expression.Call(
+                typeof(double).GetMethod(nameof(double.Log)),
+                Expression.Call(typeof(double).GetMethod(nameof(double.Cosh)), op)
+            );
+        }
+        if (op is BinaryExpression be && be.NodeType == ExpressionType.Multiply &&
+            be.Left is ConstantExpression c && NumberUtils.IsNumeric(c.Value) &&
+            be.Right is ParameterExpression p2 && p2.Name == ParameterName)
+        {
+            return Expression.Divide(
+                Expression.Call(
+                    typeof(double).GetMethod(nameof(double.Log)),
+                    Expression.Call(typeof(double).GetMethod(nameof(double.Cosh)), op)
+                ),
+                c
+            );
+        }
+        return null;
+    }
+
 
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq.Expressions;
+using Utils.Expressions;
+using Utils.Mathematics.Expressions;
+
+namespace UtilsTest.Mathematics.Expressions
+{
+    [TestClass]
+    public class ExpressionIntegrationTests
+    {
+        ExpressionIntegration integration = new ExpressionIntegration("x");
+
+        [TestMethod]
+        public void ExpressionsIntegration()
+        {
+            var parameters = new ParameterExpression[]
+            {
+                Expression.Parameter(typeof(double), "x"),
+            };
+
+            var tests = new (string function, string integral)[]
+            {
+                ("1/x", "Log(x)"),
+                ("1/(x**2)", "-1/x"),
+                ("1/Sqrt(x)", "2*Sqrt(x)"),
+                ("Sinh(x)", "Cosh(x)"),
+                ("Cosh(x)", "Sinh(x)"),
+                ("Tanh(x)", "Log(Cosh(x))"),
+            };
+
+            foreach (var test in tests)
+            {
+                var func = ExpressionParser.Parse(test.function, parameters, typeof(double), false);
+                var expected = ExpressionParser.Parse(test.integral, parameters, typeof(double), false);
+                var result = integration.Integrate(func);
+                Assert.AreEqual(expected, result, ExpressionComparer.Default);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand `ExpressionIntegration` to integrate 1/x, powers in denominator, sqrt, and hyperbolic functions
- add new unit tests for integration logic

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684163ca5d1c8326b44bf075fc878e95