### PR TITLE
Implement ExtendedInvoker for multi-parameter delegates

### DIFF
--- a/Utils/Reflection/ExtendedInvoker.cs
+++ b/Utils/Reflection/ExtendedInvoker.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Utils.Expressions;
+
+namespace Utils.Reflection;
+
+/// <summary>
+/// An invoker that can store multiple delegates sharing the same return type
+/// but with different parameter lists. On invocation, the best matching
+/// delegate is selected using the compiler's distance-based method search.
+/// </summary>
+/// <typeparam name="TResult">The common return type of all registered delegates.</typeparam>
+public class ExtendedInvoker<TResult> : IEnumerable<Delegate>
+{
+        private readonly List<Delegate> _delegates = new();
+
+        /// <summary>
+        /// Adds a delegate to the invoker. The delegate must return
+        /// <typeparamref name="TResult"/>.
+        /// </summary>
+        /// <param name="function">The delegate to add.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="function"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if the delegate return type does not match <typeparamref name="TResult"/>.</exception>
+        public void Add(Delegate function)
+        {
+                ArgumentNullException.ThrowIfNull(function);
+                if (function.Method.ReturnType != typeof(TResult))
+                        throw new ArgumentException($"Delegate must return {typeof(TResult)}", nameof(function));
+                _delegates.Add(function);
+        }
+
+        /// <summary>
+        /// Attempts to invoke the best matching delegate with the provided arguments.
+        /// </summary>
+        /// <param name="arguments">An array of arguments for the delegate call.</param>
+        /// <param name="result">Receives the invocation result if successful.</param>
+        /// <returns><see langword="true"/> if a matching delegate was invoked; otherwise <see langword="false"/>.</returns>
+        public bool TryInvoke(object[] arguments, out TResult result)
+        {
+                arguments ??= [];
+                var argumentTypes = arguments.Select(a => a?.GetType() ?? typeof(object));
+
+                var candidate = _delegates
+                        .Select(d => new { Delegate = d, Distance = d.Method.CompareParametersAndTypes(null, argumentTypes) })
+                        .Where(c => c.Distance >= 0)
+                        .OrderBy(c => c.Distance)
+                        .FirstOrDefault();
+
+                if (candidate != null)
+                {
+                        result = (TResult)candidate.Delegate.DynamicInvoke(arguments);
+                        return true;
+                }
+
+                result = default!;
+                return false;
+        }
+
+        /// <summary>
+        /// Invokes the best matching delegate for the provided arguments or throws if none is found.
+        /// </summary>
+        /// <param name="arguments">Arguments for the delegate call.</param>
+        /// <returns>The result of the invoked delegate.</returns>
+        /// <exception cref="MissingMethodException">Thrown when no suitable delegate is registered.</exception>
+        public TResult Invoke(params object[] arguments)
+        {
+                if (TryInvoke(arguments, out var result))
+                        return result;
+
+                throw new MissingMethodException("No delegate matches the provided arguments.");
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<Delegate> GetEnumerator() => _delegates.GetEnumerator();
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/UtilsTest/Reflection/ExtendedInvokerTests.cs
+++ b/UtilsTest/Reflection/ExtendedInvokerTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Utils.Reflection;
+
+namespace UtilsTest.Reflection
+{
+        [TestClass]
+        public class ExtendedInvokerTests
+        {
+                private static string FromInt(int i) => "int";
+                private static string FromDouble(double d) => "double";
+                private static string FromStringInt(string s, int i) => "string-int";
+                private static string FromObject(object o) => "object";
+
+                [TestMethod]
+                public void Invoke_Selects_Best_Delegate()
+                {
+                        var invoker = new ExtendedInvoker<string>();
+                        invoker.Add((Func<int, string>)FromInt);
+                        invoker.Add((Func<double, string>)FromDouble);
+                        invoker.Add((Func<string, int, string>)FromStringInt);
+                        invoker.Add((Func<object, string>)FromObject);
+
+                        Assert.AreEqual("int", invoker.Invoke(10));
+                        Assert.AreEqual("double", invoker.Invoke(2.5));
+                        Assert.AreEqual("string-int", invoker.Invoke("foo", 3));
+                        Assert.AreEqual("object", invoker.Invoke(new object()));
+                }
+
+                [TestMethod]
+                public void TryInvoke_Returns_False_When_No_Match()
+                {
+                        var invoker = new ExtendedInvoker<string>();
+                        invoker.Add((Func<int, string>)FromInt);
+                        var ok = invoker.TryInvoke(["foo"], out var result);
+
+                        Assert.IsFalse(ok);
+                        Assert.IsNull(result);
+                }
+        }
+}


### PR DESCRIPTION
## Summary
- introduce `ExtendedInvoker<TResult>` capable of storing multiple delegates
- choose the best delegate via existing distance algorithm
- add unit tests covering selection logic

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684197971e0c83268f8ef78bb32b72ae