### PR TITLE
Add text writer and enhance DNS record support

### DIFF
--- a/System.Net/Net/DNS/Attributes.cs
+++ b/System.Net/Net/DNS/Attributes.cs
@@ -99,12 +99,12 @@ namespace Utils.Net.DNS
 	/// <summary>
 	/// Enumerates the supported prefixed-size mechanisms for array or field lengths.
 	/// </summary>
-	public enum FieldsSizeOptions
-	{
-		/// <summary>
-		/// The field's size is prefixed by a one-byte (8-bit) length indicator.
-		/// </summary>
-		PrefixedSize1B,
+        public enum FieldsSizeOptions
+        {
+                /// <summary>
+                /// The field's size is prefixed by a one-byte (8-bit) length indicator.
+                /// </summary>
+                PrefixedSize1B,
 
 		/// <summary>
 		/// The field's size is prefixed by a two-byte (16-bit) length indicator.
@@ -114,7 +114,22 @@ namespace Utils.Net.DNS
 		/// <summary>
 		/// The field's size is prefixed in bits (1B indicating length in bits),
 		/// rather than bytes.
-		/// </summary>
-		PrefixedSizeBits1B
-	}
+                /// </summary>
+                PrefixedSizeBits1B
+        }
+
+        /// <summary>
+        /// Specifies the textual format for a DNS record. The format string may contain
+        /// property or field names enclosed in curly braces (e.g. <c>{Preference}</c>)
+        /// that will be replaced when converting to or from text.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Class)]
+        public sealed class DNSTextRecordAttribute(string format) : Attribute
+        {
+                /// <summary>
+                /// Gets the format string describing how the record should be represented
+                /// in zone file text.
+                /// </summary>
+                public string Format { get; } = format;
+        }
 }

--- a/System.Net/Net/DNS/DNSText.cs
+++ b/System.Net/Net/DNS/DNSText.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Utils.Net.DNS;
+
+/// <summary>
+/// Provides helper methods to convert DNS records to and from the textual
+/// representation commonly used in zone files.
+/// </summary>
+
+public class DNSText : IDNSWriter<string>
+{
+    private static readonly Regex FormatRegex = new("{(?<name>[^}]+)}", RegexOptions.Compiled);
+    private static readonly Regex TokenRegex = new("\\\"([^\\\"]*)\\\"|\\S+", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Gets a default instance of <see cref="DNSText"/> for convenience.
+    /// </summary>
+    public static DNSText Default { get; } = new DNSText();
+
+    /// <summary>
+    /// Converts a <see cref="DNSResponseRecord"/> into a textual line as used in
+    /// standard zone files.
+    /// </summary>
+    /// <param name="record">The record to convert.</param>
+    /// <returns>A line representing the record.</returns>
+    public static string ToText(DNSResponseRecord record)
+    {
+        var rdata = record.RData;
+        var attr = rdata.GetType().GetCustomAttribute<DNSTextRecordAttribute>();
+        string rdataText;
+        if (attr == null)
+        {
+            var fields = rdata.GetType().GetMembers()
+                .Where(m => m.GetCustomAttribute<DNSFieldAttribute>() != null)
+                .ToArray();
+            rdataText = string.Join(" ", fields.Select(m =>
+            {
+                object val = m is PropertyInfo pi ? pi.GetValue(rdata) : (m is FieldInfo fi ? fi.GetValue(rdata) : null);
+                return FormatValue(val);
+            }));
+        }
+        else
+        {
+            rdataText = FormatRegex.Replace(attr.Format, m =>
+            {
+                var name = m.Groups["name"].Value;
+                var member = rdata.GetType().GetMember(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault();
+                object value = null;
+                if (member is PropertyInfo pi)
+                    value = pi.GetValue(rdata);
+                else if (member is FieldInfo fi)
+                    value = fi.GetValue(rdata);
+                return value != null ? FormatValue(value) : m.Value;
+            });
+        }
+        return $"{record.Name} {record.TTL} {record.Class} {rdata.Name} {rdataText}".TrimEnd();
+    }
+
+    /// <summary>
+    /// Parses a single line of text into a <see cref="DNSResponseRecord"/>.
+    /// </summary>
+    /// <param name="line">The textual line.</param>
+    /// <returns>The parsed record or <c>null</c> if the line is empty or a comment.</returns>
+    public static DNSResponseRecord ParseLine(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return null;
+        int commentIndex = line.IndexOfAny(new[] { ';', '#' });
+        if (commentIndex >= 0)
+            line = line[..commentIndex];
+        var tokens = TokenRegex.Matches(line).Select(m => m.Value).ToArray();
+        if (tokens.Length < 5)
+            return null;
+        var name = new DNSDomainName(tokens[0]);
+        if (!uint.TryParse(tokens[1], out uint ttl))
+            return null;
+        if (!Enum.TryParse(tokens[2], true, out DNSClass dnsClass))
+            return null;
+        string typeName = tokens[3];
+        var rdataTokens = tokens.Skip(4).ToArray();
+
+        var factory = DNSFactory.Default;
+        ushort id = factory.GetClassId(dnsClass, typeName);
+        var rdataType = factory.GetDNSType(dnsClass, id);
+        var rdata = (DNSResponseDetail)Activator.CreateInstance(rdataType);
+        var attr = rdataType.GetCustomAttribute<DNSTextRecordAttribute>();
+        string[] fieldNames = attr != null
+            ? FormatRegex.Matches(attr.Format).Select(m => m.Groups["name"].Value).ToArray()
+            : rdataType.GetMembers().Where(m => m.GetCustomAttribute<DNSFieldAttribute>() != null).Select(m => m.Name).ToArray();
+        for (int i = 0; i < fieldNames.Length && i < rdataTokens.Length; i++)
+        {
+            SetValue(rdata, fieldNames[i], rdataTokens[i]);
+        }
+        var record = new DNSResponseRecord(name.Value, ttl, rdata)
+        {
+            Class = dnsClass
+        };
+        return record;
+    }
+
+    private static void SetValue(object obj, string memberName, string value)
+    {
+        var member = obj.GetType().GetMember(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault();
+        if (member is PropertyInfo pi)
+            pi.SetValue(obj, ConvertTo(value, pi.PropertyType));
+        else if (member is FieldInfo fi)
+            fi.SetValue(obj, ConvertTo(value, fi.FieldType));
+    }
+
+    private static object ConvertTo(string value, Type targetType)
+    {
+        if (targetType == typeof(string)) return value.Trim('"');
+        if (targetType == typeof(ushort)) return ushort.Parse(value);
+        if (targetType == typeof(uint)) return uint.Parse(value);
+        if (targetType == typeof(int)) return int.Parse(value);
+        if (targetType == typeof(IPAddress)) return IPAddress.Parse(value);
+        if (targetType == typeof(DNSDomainName)) return new DNSDomainName(value);
+        if (targetType.IsEnum) return Enum.Parse(targetType, value, true);
+        return Convert.ChangeType(value, targetType);
+    }
+
+    private static string FormatValue(object value)
+    {
+        if (value is string s)
+        {
+            return s.Contains(' ') ? $"\"{s}\"" : s;
+        }
+        return Convert.ToString(value);
+    }
+
+    /// <summary>
+    /// Parses all records contained in a text file.
+    /// </summary>
+    /// <param name="path">Path to the zone file.</param>
+    /// <returns>A list of <see cref="DNSResponseRecord"/> objects.</returns>
+    public static List<DNSResponseRecord> ParseFile(string path)
+    {
+        var list = new List<DNSResponseRecord>();
+        foreach (var line in File.ReadLines(path))
+        {
+            var rec = ParseLine(line);
+            if (rec != null)
+                list.Add(rec);
+        }
+        return list;
+    }
+
+    /// <inheritdoc />
+    public string Write(DNSHeader header)
+    {
+        var sb = new StringBuilder();
+        foreach (var r in header.Responses)
+            sb.AppendLine(ToText(r));
+        foreach (var r in header.Authorities)
+            sb.AppendLine(ToText(r));
+        foreach (var r in header.Additionals)
+            sb.AppendLine(ToText(r));
+        return sb.ToString();
+    }
+}

--- a/System.Net/Net/DNS/RFC1035/Address.cs
+++ b/System.Net/Net/DNS/RFC1035/Address.cs
@@ -32,6 +32,7 @@ namespace Utils.Net.DNS.RFC1035;
 [DNSRecord(DNSClass.IN, 0x01, "A")]
 [DNSRecord(DNSClass.IN, 0x1C, "AAAA")]
 [DNSRecord(DNSClass.IN, 0x17, "NSAP")]
+[DNSTextRecord("{IPAddress}")]
 public sealed class Address : DNSResponseDetail
 {
 	/// <inheritdoc />

--- a/System.Net/Net/DNS/RFC1035/CNAME.cs
+++ b/System.Net/Net/DNS/RFC1035/CNAME.cs
@@ -20,6 +20,7 @@
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x05)]
+[DNSTextRecord("{CName}")]
 public sealed class CNAME : DNSResponseDetail
 {
 	/*

--- a/System.Net/Net/DNS/RFC1035/HINFO.cs
+++ b/System.Net/Net/DNS/RFC1035/HINFO.cs
@@ -22,6 +22,7 @@ namespace Utils.Net.DNS.RFC1035;
 /// See RFC 1010 for standard values of CPU and OS.
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x0D)]
+[DNSTextRecord("{Info}")]
 public class HINFO : DNSResponseDetail
 {
 	/*

--- a/System.Net/Net/DNS/RFC1035/MB.cs
+++ b/System.Net/Net/DNS/RFC1035/MB.cs
@@ -19,6 +19,7 @@ namespace Utils.Net.DNS.RFC1035;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x07)]
+[DNSTextRecord("{MadName}")]
 [Obsolete("MB (Mailbox) records are obsolete; use MX records instead.")]
 public class MB : DNSResponseDetail
 {

--- a/System.Net/Net/DNS/RFC1035/MD.cs
+++ b/System.Net/Net/DNS/RFC1035/MD.cs
@@ -23,9 +23,10 @@ namespace Utils.Net.DNS.RFC1035
 	/// for completeness but should not be used in modern DNS scenarios.
 	/// </para>
 	/// </remarks>
-	[DNSRecord(DNSClass.IN, 0x03)]
-	[Obsolete("MD (Mail Destination) records are obsolete; use MX records instead.")]
-	public class MD : DNSResponseDetail
+[DNSRecord(DNSClass.IN, 0x03)]
+[DNSTextRecord("{MadName}")]
+[Obsolete("MD (Mail Destination) records are obsolete; use MX records instead.")]
+public class MD : DNSResponseDetail
 	{
 		/*
             MD RDATA format (Obsolete)

--- a/System.Net/Net/DNS/RFC1035/MF.cs
+++ b/System.Net/Net/DNS/RFC1035/MF.cs
@@ -19,9 +19,10 @@ namespace Utils.Net.DNS.RFC1035
 	/// be used in modern DNS configurations.
 	/// </para>
 	/// </remarks>
-	[DNSRecord(DNSClass.IN, 0x04)]
-	[Obsolete("MF (Mail Forwarder) records are obsolete; use MX records instead.")]
-	public class MF : DNSResponseDetail
+[DNSRecord(DNSClass.IN, 0x04)]
+[DNSTextRecord("{MadName}")]
+[Obsolete("MF (Mail Forwarder) records are obsolete; use MX records instead.")]
+public class MF : DNSResponseDetail
 	{
 		/*
             MF RDATA format (Obsolete)

--- a/System.Net/Net/DNS/RFC1035/MG.cs
+++ b/System.Net/Net/DNS/RFC1035/MG.cs
@@ -19,6 +19,7 @@ namespace Utils.Net.DNS.RFC1035;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x08)]
+[DNSTextRecord("{MGName}")]
 [Obsolete("MG (Mail Group) records are obsolete; use MX records instead.")]
 public class MG : DNSResponseDetail
 {

--- a/System.Net/Net/DNS/RFC1035/MINFO.cs
+++ b/System.Net/Net/DNS/RFC1035/MINFO.cs
@@ -21,9 +21,10 @@ namespace Utils.Net.DNS.RFC1035
 	/// but can be an empty or default domain name.
 	/// </para>
 	/// </remarks>
-	[DNSRecord(DNSClass.IN, 0x0E)]
-	[Obsolete("MINFO (mail info) records are obsolete; use MX records instead.")]
-	public class MINFO : DNSResponseDetail
+[DNSRecord(DNSClass.IN, 0x0E)]
+[DNSTextRecord("{RMailBx} {EMailBx}")]
+[Obsolete("MINFO (mail info) records are obsolete; use MX records instead.")]
+public class MINFO : DNSResponseDetail
 	{
 		/*
             MINFO RDATA format (EXPERIMENTAL)

--- a/System.Net/Net/DNS/RFC1035/MR.cs
+++ b/System.Net/Net/DNS/RFC1035/MR.cs
@@ -19,6 +19,7 @@ namespace Utils.Net.DNS.RFC1035;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x09)]
+[DNSTextRecord("{NewName}")]
 [Obsolete("MR (mail redirection) records are obsolete; use MX records instead.")]
 public class MR : DNSResponseDetail
 {

--- a/System.Net/Net/DNS/RFC1035/MX.cs
+++ b/System.Net/Net/DNS/RFC1035/MX.cs
@@ -37,8 +37,9 @@ namespace Utils.Net.DNS.RFC1035
 	/// of the <see cref="Exchange"/>) when resolving MX records.
 	/// </para>
 	/// </remarks>
-	[DNSRecord(DNSClass.IN, 0x0F)]
-	public class MX : DNSResponseDetail
+[DNSRecord(DNSClass.IN, 0x0F)]
+[DNSTextRecord("{Preference} {Exchange}")]
+public class MX : DNSResponseDetail
 	{
 		/*
             MX RDATA format (RFC 1035, Section 3.3.9):

--- a/System.Net/Net/DNS/RFC1035/NS.cs
+++ b/System.Net/Net/DNS/RFC1035/NS.cs
@@ -21,8 +21,9 @@ namespace Utils.Net.DNS.RFC1035
 	/// the IP addresses of these name servers.
 	/// </para>
 	/// </remarks>
-	[DNSRecord(DNSClass.IN, 0x02)]
-	public class NS : DNSResponseDetail
+        [DNSRecord(DNSClass.IN, 0x02)]
+        [DNSTextRecord("{DNSName}")]
+        public class NS : DNSResponseDetail
 	{
 		/*
             NS RDATA format (RFC 1035 Section 3.3.11):

--- a/System.Net/Net/DNS/RFC1035/PTR.cs
+++ b/System.Net/Net/DNS/RFC1035/PTR.cs
@@ -22,6 +22,7 @@ namespace Utils.Net.DNS.RFC1035;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x0C)]
+[DNSTextRecord("{PTRName}")]
 public class PTR : DNSResponseDetail
 {
 	/*

--- a/System.Net/Net/DNS/RFC1035/SOA.cs
+++ b/System.Net/Net/DNS/RFC1035/SOA.cs
@@ -55,6 +55,7 @@ namespace Utils.Net.DNS.RFC1035;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x06)]
+[DNSTextRecord("{MName} {RName} {Serial} {Refresh} {Retry} {Expire} {Minimum}")]
 public class SOA : DNSResponseDetail
 {
 	/*

--- a/System.Net/Net/DNS/RFC1035/TXT.cs
+++ b/System.Net/Net/DNS/RFC1035/TXT.cs
@@ -29,6 +29,7 @@ namespace Utils.Net.DNS.RFC1035;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x10)]
+[DNSTextRecord("{Text}")]
 public class TXT : DNSResponseDetail
 {
 	/*

--- a/UtilsTest/Net/DNSTextParserTests.cs
+++ b/UtilsTest/Net/DNSTextParserTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using Utils.Net.DNS;
+using Utils.Net.DNS.RFC1035;
+
+namespace UtilsTest.Net;
+
+[TestClass]
+public class DNSTextParserTests
+{
+    [TestMethod]
+    public void ParseZoneFile()
+    {
+        var lines = new List<string>
+        {
+            "example.com. 3600 IN A 192.0.2.1",
+            "example.com. 3600 IN MX 10 mail.example.com.",
+            "example.com. 3600 IN TXT \"hello world\""
+        };
+        var path = Path.GetTempFileName();
+        File.WriteAllLines(path, lines);
+        var records = DNSText.ParseFile(path);
+        Assert.AreEqual(3, records.Count);
+        Assert.IsInstanceOfType(records[0].RData, typeof(Address));
+        Assert.AreEqual("192.0.2.1", ((Address)records[0].RData).IPAddress.ToString());
+        Assert.IsInstanceOfType(records[1].RData, typeof(MX));
+        Assert.AreEqual((ushort)10, ((MX)records[1].RData).Preference);
+        Assert.AreEqual("mail.example.com.", ((MX)records[1].RData).Exchange.Value);
+        Assert.IsInstanceOfType(records[2].RData, typeof(TXT));
+        Assert.AreEqual("hello world", ((TXT)records[2].RData).Text);
+    }
+
+    [TestMethod]
+    public void WriteZoneFile()
+    {
+        var header = new DNSHeader();
+        var record = new DNSResponseRecord("example.com.", 3600, new TXT { Text = "hello world" })
+        {
+            Class = DNSClass.IN
+        };
+        header.Responses.Add(record);
+        var text = DNSText.Default.Write(header).Trim();
+        Assert.AreEqual("example.com. 3600 IN TXT \"hello world\"", text);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DNSText` as an `IDNSWriter<string>` implementation
- auto format DNS records using their fields and quote values containing spaces
- parse quoted tokens correctly in zone files
- annotate many RFC1035 RR classes for text formatting
- test parsing and writing zone file text with new writer

## Testing
- `dotnet test UtilsTest/UtilsTest.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6843ab37beb8832699992a603e6d8727