### PR TITLE
Add multiline parsing to DNSText

### DIFF
--- a/System.Net/Net/DNS/DNSTextFileWriter.cs
+++ b/System.Net/Net/DNS/DNSTextFileWriter.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Utils.Net.DNS;
+
+/// <summary>
+/// Provides helpers to write DNS records or headers to zone text files.
+/// </summary>
+public class DNSTextFileWriter : IDNSWriter<string>
+{
+    private readonly string path;
+    private readonly bool append;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DNSTextFileWriter"/> class.
+    /// </summary>
+    /// <param name="path">Destination file path.</param>
+    /// <param name="append">If true, records are appended to the file.</param>
+    public DNSTextFileWriter(string path, bool append = false)
+    {
+        this.path = path;
+        this.append = append;
+    }
+    /// <summary>
+    /// Writes the given records to a file in standard zone file format.
+    /// </summary>
+    /// <param name="path">Destination file path.</param>
+    /// <param name="records">The DNS records to write.</param>
+    /// <param name="append">If true, records are appended to the file.</param>
+    public static void WriteRecords(string path, IEnumerable<DNSResponseRecord> records, bool append = false)
+    {
+        using var writer = new StreamWriter(path, append, Encoding.UTF8);
+        foreach (var r in records)
+            writer.WriteLine(DNSText.ToText(r));
+    }
+
+    /// <summary>
+    /// Writes the specified records using the path provided at construction.
+    /// </summary>
+    /// <param name="records">Records to write.</param>
+    public void WriteRecords(IEnumerable<DNSResponseRecord> records)
+    {
+        WriteRecords(path, records, append);
+    }
+
+    /// <summary>
+    /// Writes all records contained in a DNS header to a file.
+    /// </summary>
+    /// <param name="path">Destination file path.</param>
+    /// <param name="header">The DNS header with the records to write.</param>
+    public static void WriteHeader(string path, DNSHeader header)
+    {
+        using var writer = new StreamWriter(path, false, Encoding.UTF8);
+        writer.Write(DNSText.Default.Write(header));
+    }
+
+    /// <inheritdoc />
+    public string Write(DNSHeader header)
+    {
+        WriteHeader(path, header);
+        return path;
+    }
+}

--- a/System.Net/Net/DNS/RFC2535/NXT.cs
+++ b/System.Net/Net/DNS/RFC2535/NXT.cs
@@ -37,6 +37,7 @@
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x1E)]
+[DNSTextRecord("{NextDomainName} {TypeBitMap}")]
 public class NXT : DNSResponseDetail
 {
 	/*

--- a/System.Net/Net/DNS/RFC2535/SIG.cs
+++ b/System.Net/Net/DNS/RFC2535/SIG.cs
@@ -164,6 +164,7 @@
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x18)]
+[DNSTextRecord("{TypeCovered} {Algorithm} {Labels} {OriginalTtl} {SignatureExpiration} {SignatureInception} {KeyTag} {SignerName} {Signature}")]
 public class SIG : DNSResponseDetail
 {
 	/// <summary>

--- a/System.Net/Net/DNS/RFC2671/OPT.cs
+++ b/System.Net/Net/DNS/RFC2671/OPT.cs
@@ -49,6 +49,7 @@ namespace Utils.Net.DNS.RFC2671;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x29)]
+[DNSTextRecord("{OptionCode} {OptionsData}")]
 public class OPT : DNSResponseDetail
 {
 	/// <summary>

--- a/System.Net/Net/DNS/RFC2672/DNAME.cs
+++ b/System.Net/Net/DNS/RFC2672/DNAME.cs
@@ -25,6 +25,7 @@ namespace Utils.Net.DNS.RFC2672;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x27)]
+[DNSTextRecord("{Target}")]
 public class DNAME : DNSResponseDetail
 {
 	/// <summary>

--- a/System.Net/Net/DNS/RFC3123/APL.cs
+++ b/System.Net/Net/DNS/RFC3123/APL.cs
@@ -57,6 +57,7 @@ namespace Utils.Net.DNS.RFC3123;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x2A)]
+[DNSTextRecord("{AddressFamily} {Prefix} {flagAndAfdLength} {AfdPart}")]
 public class APL : DNSResponseDetail
 {
 	/*

--- a/System.Net/Net/DNS/RFC4025/IPSECKEY.cs
+++ b/System.Net/Net/DNS/RFC4025/IPSECKEY.cs
@@ -37,6 +37,7 @@ namespace Utils.Net.DNS.RFC4025;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x2D)]
+[DNSTextRecord("{Precedence} {gatewayType} {SecAlgorithm} {gatewayAddressIPv4} {gatewayAddressIPv6} {gatewayDomainName} {PublicKey}")]
 public class IPSECKEY : DNSResponseDetail
 {
 	/*

--- a/System.Net/Net/DNS/RFC4034/DNSKEY.cs
+++ b/System.Net/Net/DNS/RFC4034/DNSKEY.cs
@@ -37,6 +37,7 @@
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x30)]
+[DNSTextRecord("{Flags} {Protocol} {Algorithm} {Key}")]
 public class DNSKEY : DNSResponseDetail
 {
 	/// <summary>

--- a/System.Net/Net/DNS/RFC4034/DS.cs
+++ b/System.Net/Net/DNS/RFC4034/DS.cs
@@ -54,8 +54,9 @@ namespace Utils.Net.DNS.RFC4034
 	/// The DS record is a critical element in DNSSEC, providing a secure link between a parent zone and its child.
 	/// </para>
 	/// </remarks>
-	[DNSRecord(DNSClass.IN, 0x2B)]
-	public class DS : DNSResponseDetail
+        [DNSRecord(DNSClass.IN, 0x2B)]
+        [DNSTextRecord("{KeyTag} {Algorithm} {DigestType} {Digest}")]
+        public class DS : DNSResponseDetail
 	{
 		/// <summary>
 		/// Gets or sets the Key Tag, a 16-bit integer used to identify the DNSKEY record that corresponds to this DS record.

--- a/System.Net/Net/DNS/RFC4034/NSEC.cs
+++ b/System.Net/Net/DNS/RFC4034/NSEC.cs
@@ -45,6 +45,7 @@
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x2F)]
+[DNSTextRecord("{NextDomainName} {TypeBitmaps}")]
 public class NSEC : DNSResponseDetail
 {
 	/// <summary>

--- a/System.Net/Net/DNS/RFC4034/RRSIG.cs
+++ b/System.Net/Net/DNS/RFC4034/RRSIG.cs
@@ -93,6 +93,7 @@ namespace Utils.Net.DNS.RFC4034;
 /// </list>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x2E)]
+[DNSTextRecord("{TypeCovered} {Algorithm} {Labels} {OriginalTTL} {SignatureExpiration} {SignatureInception} {KeyTag} {SignerName} {Signature}")]
 public class RRSIG : DNSResponseDetail
 {
 	/// <summary>

--- a/System.Net/Net/DNS/RFC4255/SSHFP.cs
+++ b/System.Net/Net/DNS/RFC4255/SSHFP.cs
@@ -36,6 +36,7 @@
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x2C)]
+[DNSTextRecord("{Algorithm} {FingerPrintType} {FingerPrint}")]
 public class SSHFP : DNSResponseDetail
 {
 	/// <summary>

--- a/System.Net/Net/DNS/RFC4398/CERT.cs
+++ b/System.Net/Net/DNS/RFC4398/CERT.cs
@@ -39,8 +39,9 @@ namespace Utils.Net.DNS.RFC4398
 	///   the algorithm field MUST be zero and the key tag is meaningless.
 	/// </para>
 	/// </remarks>
-	[DNSRecord(DNSClass.IN, 0x25)]
-	public class CERT : DNSResponseDetail
+        [DNSRecord(DNSClass.IN, 0x25)]
+        [DNSTextRecord("{Type} {KeyTag} {Algorithm} {ObjectDatas}")]
+        public class CERT : DNSResponseDetail
 	{
 		/// <summary>
 		/// Gets or sets the certificate type, as defined in RFC 4398 Section 2.1.

--- a/System.Net/Net/DNS/RFC4701/DHCID.cs
+++ b/System.Net/Net/DNS/RFC4701/DHCID.cs
@@ -39,8 +39,9 @@ namespace Utils.Net.DNS.RFC4701
 	/// perform dynamic DNS updates to the same zone.
 	/// </para>
 	/// </remarks>
-	[DNSRecord(DNSClass.IN, 0x31)]
-	public class DHCID : DNSResponseDetail
+        [DNSRecord(DNSClass.IN, 0x31)]
+        [DNSTextRecord("{IdentifierTypes} {DigestTypeCode} {Digest}")]
+        public class DHCID : DNSResponseDetail
 	{
 		/// <summary>
 		/// Gets or sets the Identifier Type field.

--- a/System.Net/Net/DNS/RFC5205/HIP.cs
+++ b/System.Net/Net/DNS/RFC5205/HIP.cs
@@ -71,6 +71,7 @@ namespace Utils.Net.DNS.RFC5205;
 /// </para>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 0x37)]
+[DNSTextRecord("{PKAlgorithm} {HIT} {PublicKey}")]
 public class HIP : DNSResponseDetail
 {
 	/// <summary>

--- a/System.Net/Net/DNS/RFC6844/CAA.cs
+++ b/System.Net/Net/DNS/RFC6844/CAA.cs
@@ -20,6 +20,7 @@ namespace Utils.Net.DNS.RFC6844;
 /// Let's Encrypt is authorized to issue certificates for this domain.
 /// </remarks>
 [DNSRecord(DNSClass.IN, 257, "CAA")]
+[DNSTextRecord("{Flags} {Tag} {Value}")]
 public class CAA : DNSResponseDetail
 {
 	/// <summary>

--- a/System.Net/Net/DNS/RFC7553/URI.cs
+++ b/System.Net/Net/DNS/RFC7553/URI.cs
@@ -21,6 +21,7 @@ namespace Utils.Net.DNS.RFC7553;
 /// </code>
 /// </remarks>
 [DNSRecord(DNSClass.IN, 256, "URI")]
+[DNSTextRecord("{Priority} {Weight} {Target}")]
 public class URI : DNSResponseDetail
 {
 	/// <summary>


### PR DESCRIPTION
## Summary
- support parentheses when parsing DNS zone text
- handle multiline records in `ParseFile`
- add missing text descriptors for many DNS RR classes
- implement `IDNSWriter` in `DNSTextFileWriter`
- tests use the new writer
- fix tests for unquoted TXT records

## Testing
- `dotnet test UtilsTest/UtilsTest.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6846323bf8088326b80136e6ba739cda