### PR TITLE
Add basic tests for PostScript fonts

### DIFF
--- a/Utils.Fonts/PostScript/CidKeyedFont.cs
+++ b/Utils.Fonts/PostScript/CidKeyedFont.cs
@@ -9,27 +9,38 @@ using System.Text.RegularExpressions;
 namespace Utils.Fonts.PostScript;
 
 /// <summary>
-/// Very small loader for CID-Keyed Type 1 PostScript fonts.
-/// Only a subset of the format is implemented.
+/// Very small loader for CID-Keyed Type&nbsp;1 PostScript fonts. Only a subset
+/// of the format is implemented. Refer to
+/// <see href="https://adobe-type-tools.github.io/font-tech-notes/pdfs/5014.CIDFont_Spec.pdf">Adobe Technical Note 5014</see>
+/// for the full specification.
 /// </summary>
 public class CidKeyedFont : IFont
 {
+    /// <summary>Glyph table indexed by CID.</summary>
     private readonly Dictionary<int, PostScriptGlyph> _glyphs;
 
+    /// <summary>
+    /// Initializes a new instance with the specified glyph collection.
+    /// </summary>
+    /// <param name="glyphs">Mapping from CID to glyph.</param>
     private CidKeyedFont(Dictionary<int, PostScriptGlyph> glyphs)
     {
         _glyphs = glyphs;
     }
 
     /// <inheritdoc />
+    /// <remarks>Glyphs are looked up by their character code treated as CID.</remarks>
     public IGlyph GetGlyph(char c) => _glyphs.TryGetValue(c, out var g) ? g : null;
 
     /// <inheritdoc />
+    /// <remarks>No kerning data is parsed from the font.</remarks>
     public float GetSpacingCorrection(char before, char after) => 0f;
 
     /// <summary>
-    /// Loads a CID-Keyed PostScript Type 1 PFA font stream.
+    /// Loads a CID-Keyed PostScript Type&nbsp;1 <em>PFA</em> font stream.
     /// </summary>
+    /// <param name="stream">ASCII Type&nbsp;1 font stream.</param>
+    /// <returns>A new <see cref="CidKeyedFont"/>.</returns>
     public static CidKeyedFont LoadPfa(Stream stream)
     {
         using var reader = new StreamReader(stream, Encoding.ASCII);
@@ -56,8 +67,10 @@ public class CidKeyedFont : IFont
     }
 
     /// <summary>
-    /// Loads a CID-Keyed PostScript Type 1 PFB font stream.
+    /// Loads a CID-Keyed PostScript Type&nbsp;1 <em>PFB</em> font stream.
     /// </summary>
+    /// <param name="stream">Binary PFB font data.</param>
+    /// <returns>A new <see cref="CidKeyedFont"/>.</returns>
     public static CidKeyedFont LoadPfb(Stream stream)
     {
         using var br = new BinaryReader(stream, Encoding.ASCII, leaveOpen: true);
@@ -89,6 +102,11 @@ public class CidKeyedFont : IFont
         return LoadPfa(ms);
     }
 
+    /// <summary>
+    /// Parses the decrypted portion of a CID-keyed Type&nbsp;1 font.
+    /// </summary>
+    /// <param name="text">ASCII text after eexec decryption.</param>
+    /// <returns>Constructed <see cref="CidKeyedFont"/>.</returns>
     private static CidKeyedFont ParseCidType1(string text)
     {
         var glyphs = new Dictionary<int, PostScriptGlyph>();

--- a/Utils.Fonts/PostScript/CidKeyedFont.cs
+++ b/Utils.Fonts/PostScript/CidKeyedFont.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Utils.Fonts.PostScript;
+
+/// <summary>
+/// Very small loader for CID-Keyed Type 1 PostScript fonts.
+/// Only a subset of the format is implemented.
+/// </summary>
+public class CidKeyedFont : IFont
+{
+    private readonly Dictionary<int, PostScriptGlyph> _glyphs;
+
+    private CidKeyedFont(Dictionary<int, PostScriptGlyph> glyphs)
+    {
+        _glyphs = glyphs;
+    }
+
+    /// <inheritdoc />
+    public IGlyph GetGlyph(char c) => _glyphs.TryGetValue(c, out var g) ? g : null;
+
+    /// <inheritdoc />
+    public float GetSpacingCorrection(char before, char after) => 0f;
+
+    /// <summary>
+    /// Loads a CID-Keyed PostScript Type 1 PFA font stream.
+    /// </summary>
+    public static CidKeyedFont LoadPfa(Stream stream)
+    {
+        using var reader = new StreamReader(stream, Encoding.ASCII);
+        string pfaText = reader.ReadToEnd();
+        int eexecIndex = pfaText.IndexOf("eexec", StringComparison.OrdinalIgnoreCase);
+        if (eexecIndex < 0)
+            throw new InvalidDataException("Invalid PFA file: missing eexec section");
+        eexecIndex += 5;
+        var hexBuilder = new StringBuilder();
+        for (int i = eexecIndex; i < pfaText.Length; i++)
+        {
+            char c = pfaText[i];
+            if (char.IsWhiteSpace(c))
+                continue;
+            if (pfaText.AsSpan(i).StartsWith("cleartomark"))
+                break;
+            if (Uri.IsHexDigit(c))
+                hexBuilder.Append(c);
+        }
+        byte[] encrypted = PostScriptFont.ConvertHex(hexBuilder.ToString());
+        byte[] decrypted = PostScriptFont.DecryptType1(encrypted, 55665, 4);
+        string decryptedText = Encoding.ASCII.GetString(decrypted);
+        return ParseCidType1(decryptedText);
+    }
+
+    /// <summary>
+    /// Loads a CID-Keyed PostScript Type 1 PFB font stream.
+    /// </summary>
+    public static CidKeyedFont LoadPfb(Stream stream)
+    {
+        using var br = new BinaryReader(stream, Encoding.ASCII, leaveOpen: true);
+        var sb = new StringBuilder();
+        while (true)
+        {
+            int marker = br.ReadByte();
+            if (marker != 0x80)
+                throw new InvalidDataException("Invalid PFB marker");
+            int type = br.ReadByte();
+            if (type == 3)
+                break;
+            int len = br.ReadInt32();
+            byte[] data = br.ReadBytes(len);
+            switch (type)
+            {
+                case 1:
+                    sb.Append(Encoding.ASCII.GetString(data));
+                    break;
+                case 2:
+                    foreach (byte b in data)
+                        sb.AppendFormat("{0:X2}", b);
+                    break;
+                default:
+                    throw new InvalidDataException($"Unknown PFB block type {type}");
+            }
+        }
+        using var ms = new MemoryStream(Encoding.ASCII.GetBytes(sb.ToString()));
+        return LoadPfa(ms);
+    }
+
+    private static CidKeyedFont ParseCidType1(string text)
+    {
+        var glyphs = new Dictionary<int, PostScriptGlyph>();
+        int lenIV = 4;
+        var mLenIv = Regex.Match(text, @"/lenIV\s+(\d+)");
+        if (mLenIv.Success)
+            lenIV = int.Parse(mLenIv.Groups[1].Value, CultureInfo.InvariantCulture);
+
+        var csMatch = Regex.Match(text, @"/CharStrings\s+\d+\s+dict\s+dup\s+begin(?<cs>.*)end", RegexOptions.Singleline);
+        if (!csMatch.Success)
+            return new CidKeyedFont(glyphs);
+        var csSection = csMatch.Groups["cs"].Value;
+        var glyphRegex = new Regex(@"(?<cid>\d+)\s+(?<len>\d+)\s+RD\s*(?<data>[0-9A-Fa-f]+)\s+ND", RegexOptions.Singleline);
+        foreach (Match g in glyphRegex.Matches(csSection))
+        {
+            int cid = int.Parse(g.Groups["cid"].Value, CultureInfo.InvariantCulture);
+            int len = int.Parse(g.Groups["len"].Value, CultureInfo.InvariantCulture);
+            string hex = g.Groups["data"].Value;
+            byte[] data = PostScriptFont.ConvertHex(hex);
+            byte[] plain = PostScriptFont.DecryptType1(data, 4330, lenIV).Take(len).ToArray();
+            var commands = PostScriptFont.ParseCharString(plain, out float width, out float height, out float baseLine);
+            glyphs[cid] = new PostScriptGlyph(width, height, baseLine, commands);
+        }
+        return new CidKeyedFont(glyphs);
+    }
+}

--- a/Utils.Fonts/PostScript/PostScriptFont.cs
+++ b/Utils.Fonts/PostScript/PostScriptFont.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Utils.Fonts.PostScript;
+
+/// <summary>
+/// Very small PostScript font loader based on a simple text representation.
+/// Each glyph is defined in the following form:
+///
+/// Glyph: A
+/// Width: 500
+/// Height: 600
+/// Baseline: 0
+/// Path:
+/// M 0 0
+/// L 10 0
+/// ...
+/// EndGlyph
+/// </summary>
+public class PostScriptFont : IFont
+{
+    private readonly Dictionary<char, PostScriptGlyph> _glyphs;
+
+    private PostScriptFont(Dictionary<char, PostScriptGlyph> glyphs)
+    {
+        _glyphs = glyphs;
+    }
+
+    /// <summary>Loads a PostScript font from the provided stream.</summary>
+    public static PostScriptFont Load(Stream stream)
+    {
+        using var reader = new StreamReader(stream);
+        var glyphs = new Dictionary<char, PostScriptGlyph>();
+        string? line;
+        char currentChar = '\0';
+        float width = 0, height = 0, baseline = 0;
+        List<PostScriptGlyph.PathCommand>? commands = null;
+        while ((line = reader.ReadLine()) != null)
+        {
+            line = line.Trim();
+            if (line.Length == 0 || line.StartsWith("#"))
+                continue;
+            if (line.StartsWith("Glyph:", StringComparison.OrdinalIgnoreCase))
+            {
+                currentChar = line.Split(':', 2)[1].Trim()[0];
+                commands = new();
+            }
+            else if (line.StartsWith("Width:", StringComparison.OrdinalIgnoreCase))
+            {
+                width = float.Parse(line.Split(':', 2)[1].Trim(), CultureInfo.InvariantCulture);
+            }
+            else if (line.StartsWith("Height:", StringComparison.OrdinalIgnoreCase))
+            {
+                height = float.Parse(line.Split(':', 2)[1].Trim(), CultureInfo.InvariantCulture);
+            }
+            else if (line.StartsWith("Baseline:", StringComparison.OrdinalIgnoreCase))
+            {
+                baseline = float.Parse(line.Split(':', 2)[1].Trim(), CultureInfo.InvariantCulture);
+            }
+            else if (line.Equals("EndGlyph", StringComparison.OrdinalIgnoreCase))
+            {
+                if (currentChar != '\0' && commands != null)
+                {
+                    glyphs[currentChar] = new PostScriptGlyph(width, height, baseline, commands);
+                }
+                currentChar = '\0';
+                commands = null;
+            }
+            else if (commands != null)
+            {
+                ParsePathLine(line, commands);
+            }
+        }
+        return new PostScriptFont(glyphs);
+    }
+
+    private static void ParsePathLine(string line, List<PostScriptGlyph.PathCommand> commands)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return;
+        var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return;
+        switch (parts[0].ToUpperInvariant())
+        {
+            case "M":
+                commands.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.MoveTo,
+                    float.Parse(parts[1], CultureInfo.InvariantCulture), float.Parse(parts[2], CultureInfo.InvariantCulture), 0, 0, 0, 0));
+                break;
+            case "L":
+                commands.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.LineTo,
+                    float.Parse(parts[1], CultureInfo.InvariantCulture), float.Parse(parts[2], CultureInfo.InvariantCulture), 0, 0, 0, 0));
+                break;
+            case "C":
+                commands.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.BezierTo,
+                    float.Parse(parts[1], CultureInfo.InvariantCulture), float.Parse(parts[2], CultureInfo.InvariantCulture),
+                    float.Parse(parts[3], CultureInfo.InvariantCulture), float.Parse(parts[4], CultureInfo.InvariantCulture),
+                    float.Parse(parts[5], CultureInfo.InvariantCulture), float.Parse(parts[6], CultureInfo.InvariantCulture)));
+                break;
+            case "Z":
+                commands.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.Close, 0, 0, 0, 0, 0, 0));
+                break;
+        }
+    }
+
+    /// <inheritdoc />
+    public IGlyph GetGlyph(char c) => _glyphs.TryGetValue(c, out var g) ? g : null;
+
+    /// <inheritdoc />
+    public float GetSpacingCorrection(char before, char after) => 0f;
+
+    /// <summary>
+    /// Loads a PostScript Type 1 PFA font stream.
+    /// </summary>
+    /// <param name="stream">Input PFA stream.</param>
+    /// <returns>Instance of <see cref="PostScriptFont"/>.</returns>
+    public static PostScriptFont LoadPfa(Stream stream)
+    {
+        using var reader = new StreamReader(stream, Encoding.ASCII);
+        string pfaText = reader.ReadToEnd();
+        int eexecIndex = pfaText.IndexOf("eexec", StringComparison.OrdinalIgnoreCase);
+        if (eexecIndex < 0)
+            throw new InvalidDataException("Invalid PFA file: missing eexec section");
+        eexecIndex += 5;
+        var hexBuilder = new StringBuilder();
+        for (int i = eexecIndex; i < pfaText.Length; i++)
+        {
+            char c = pfaText[i];
+            if (char.IsWhiteSpace(c)) continue;
+            if (pfaText.Substring(i).StartsWith("cleartomark", StringComparison.OrdinalIgnoreCase))
+                break;
+            if (Uri.IsHexDigit(c)) hexBuilder.Append(c);
+        }
+        byte[] encrypted = ConvertHex(hexBuilder.ToString());
+        byte[] decrypted = DecryptType1(encrypted, 55665, 4);
+        string decryptedText = Encoding.ASCII.GetString(decrypted);
+        return ParseType1(decryptedText);
+    }
+
+    /// <summary>
+    /// Loads a PostScript Type 1 PFB font stream.
+    /// </summary>
+    /// <param name="stream">Input PFB stream.</param>
+    /// <returns>Instance of <see cref="PostScriptFont"/>.</returns>
+    public static PostScriptFont LoadPfb(Stream stream)
+    {
+        using var br = new BinaryReader(stream, Encoding.ASCII, leaveOpen: true);
+        var sb = new StringBuilder();
+        while (true)
+        {
+            int marker = br.ReadByte();
+            if (marker != 0x80)
+                throw new InvalidDataException("Invalid PFB marker");
+            int type = br.ReadByte();
+            if (type == 3)
+                break;
+            int len = br.ReadInt32();
+            byte[] data = br.ReadBytes(len);
+            switch (type)
+            {
+                case 1:
+                    sb.Append(Encoding.ASCII.GetString(data));
+                    break;
+                case 2:
+                    foreach (byte b in data)
+                        sb.AppendFormat("{0:X2}", b);
+                    break;
+                default:
+                    throw new InvalidDataException($"Unknown PFB block type {type}");
+            }
+        }
+        using var ms = new MemoryStream(Encoding.ASCII.GetBytes(sb.ToString()));
+        return LoadPfa(ms);
+    }
+
+    private static PostScriptFont ParseType1(string text)
+    {
+        var glyphs = new Dictionary<char, PostScriptGlyph>();
+        int lenIV = 4;
+        var mLenIv = Regex.Match(text, @"/lenIV\s+(\d+)");
+        if (mLenIv.Success) lenIV = int.Parse(mLenIv.Groups[1].Value, CultureInfo.InvariantCulture);
+
+        var csMatch = Regex.Match(text, @"/CharStrings\s+\d+\s+dict\s+begin(?<cs>.*)end", RegexOptions.Singleline);
+        if (!csMatch.Success)
+            return new PostScriptFont(glyphs);
+        var csSection = csMatch.Groups["cs"].Value;
+        var glyphRegex = new Regex(@"/(?<name>\S+)\s+(?<len>\d+)\s+RD\s*(?<data>[0-9A-Fa-f]+)\s+ND", RegexOptions.Singleline);
+        foreach (Match g in glyphRegex.Matches(csSection))
+        {
+            string name = g.Groups["name"].Value;
+            int len = int.Parse(g.Groups["len"].Value, CultureInfo.InvariantCulture);
+            string hex = g.Groups["data"].Value;
+            byte[] data = ConvertHex(hex);
+            byte[] plain = DecryptType1(data, 4330, lenIV).Take(len).ToArray();
+            var commands = ParseCharString(plain, out float width, out float height, out float baseLine);
+            char ch = MapName(name);
+            glyphs[ch] = new PostScriptGlyph(width, height, baseLine, commands);
+        }
+        return new PostScriptFont(glyphs);
+    }
+
+    private static char MapName(string name)
+    {
+        if (name.Length == 1)
+            return name[0];
+        return name switch
+        {
+            "space" => ' ',
+            "comma" => ',',
+            "period" => '.',
+            "hyphen" => '-',
+            _ => '?'
+        };
+    }
+
+    internal static byte[] ConvertHex(string hex)
+    {
+        var bytes = new byte[hex.Length / 2];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        }
+        return bytes;
+    }
+
+    internal static byte[] DecryptType1(byte[] data, int r, int discard)
+    {
+        byte[] result = new byte[data.Length];
+        for (int i = 0; i < data.Length; i++)
+        {
+            byte cipher = data[i];
+            byte plain = (byte)(cipher ^ (r >> 8));
+            r = ((cipher + r) * 52845 + 22719) & 0xFFFF;
+            result[i] = plain;
+        }
+        if (discard > 0 && discard < result.Length)
+            return result.Skip(discard).ToArray();
+        return result;
+    }
+
+    internal static List<PostScriptGlyph.PathCommand> ParseCharString(byte[] data, out float width, out float height, out float baseLine)
+    {
+        var cmds = new List<PostScriptGlyph.PathCommand>();
+        var stack = new Stack<int>();
+        float x = 0, y = 0;
+        float minX = 0, minY = 0, maxX = 0, maxY = 0;
+        width = 0; baseLine = 0; height = 0;
+        int i = 0;
+        while (i < data.Length)
+        {
+            int b = data[i++];
+            if (b >= 32 && b <= 246)
+            {
+                stack.Push(b - 139);
+            }
+            else if (b >= 247 && b <= 250)
+            {
+                int b2 = data[i++];
+                stack.Push((b - 247) * 256 + b2 + 108);
+            }
+            else if (b >= 251 && b <= 254)
+            {
+                int b2 = data[i++];
+                stack.Push(-(b - 251) * 256 - b2 - 108);
+            }
+            else if (b == 255)
+            {
+                int num = (data[i] << 24) | (data[i + 1] << 16) | (data[i + 2] << 8) | data[i + 3];
+                i += 4;
+                stack.Push(num);
+            }
+            else
+            {
+                switch (b)
+                {
+                    case 4: // vmoveto
+                        y += stack.Pop();
+                        cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.MoveTo, x, y, 0, 0, 0, 0));
+                        UpdateBounds();
+                        break;
+                    case 5: // rlineto
+                        while (stack.Count >= 2)
+                        {
+                            int dy = stack.Pop();
+                            int dx = stack.Pop();
+                            x += dx; y += dy; cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.LineTo, x, y, 0, 0, 0, 0));
+                            UpdateBounds();
+                        }
+                        break;
+                    case 6: // hlineto
+                        while (stack.Count > 0)
+                        {
+                            int dx = stack.Pop();
+                            x += dx; cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.LineTo, x, y, 0, 0, 0, 0));
+                            UpdateBounds();
+                            if (stack.Count > 0)
+                            {
+                                int dy = stack.Pop();
+                                y += dy; cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.LineTo, x, y, 0, 0, 0, 0));
+                                UpdateBounds();
+                            }
+                        }
+                        break;
+                    case 7: // vlineto
+                        while (stack.Count > 0)
+                        {
+                            int dy = stack.Pop();
+                            y += dy; cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.LineTo, x, y, 0, 0, 0, 0));
+                            UpdateBounds();
+                            if (stack.Count > 0)
+                            {
+                                int dx = stack.Pop();
+                                x += dx; cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.LineTo, x, y, 0, 0, 0, 0));
+                                UpdateBounds();
+                            }
+                        }
+                        break;
+                    case 8: // rrcurveto
+                        while (stack.Count >= 6)
+                        {
+                            int dy3 = stack.Pop();
+                            int dx3 = stack.Pop();
+                            int dy2 = stack.Pop();
+                            int dx2 = stack.Pop();
+                            int dy1 = stack.Pop();
+                            int dx1 = stack.Pop();
+                            float x1 = x + dx1; float y1 = y + dy1;
+                            float x2 = x1 + dx2; float y2 = y1 + dy2;
+                            float x3 = x2 + dx3; float y3 = y2 + dy3;
+                            cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.BezierTo, x1, y1, x2, y2, x3, y3));
+                            x = x3; y = y3; UpdateBounds();
+                        }
+                        break;
+                    case 9: // closepath
+                        cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.Close, 0, 0, 0, 0, 0, 0));
+                        break;
+                    case 13: // hsbw
+                        width = stack.Pop();
+                        x = stack.Pop();
+                        stack.Clear();
+                        break;
+                    case 21: // rmoveto
+                        {
+                            int dy = stack.Pop();
+                            int dx = stack.Pop();
+                            x += dx; y += dy;
+                            cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.MoveTo, x, y, 0, 0, 0, 0));
+                            UpdateBounds();
+                        }
+                        break;
+                    case 22: // hmoveto
+                        x += stack.Pop();
+                        cmds.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.MoveTo, x, y, 0, 0, 0, 0));
+                        UpdateBounds();
+                        break;
+                    case 14: // endchar
+                        i = data.Length;
+                        break;
+                    default:
+                        stack.Clear();
+                        break;
+                }
+            }
+        }
+
+        height = maxY - minY;
+        baseLine = -minY;
+        return cmds;
+
+        void UpdateBounds()
+        {
+            if (x < minX) minX = x; if (x > maxX) maxX = x; if (y < minY) minY = y; if (y > maxY) maxY = y;
+        }
+    }
+}

--- a/Utils.Fonts/PostScript/PostScriptFont.cs
+++ b/Utils.Fonts/PostScript/PostScriptFont.cs
@@ -227,7 +227,7 @@ public class PostScriptFont : IFont
         return bytes;
     }
 
-    internal static byte[] DecryptType1(byte[] data, int r, int discard)
+    public static byte[] DecryptType1(byte[] data, int r, int discard)
     {
         byte[] result = new byte[data.Length];
         for (int i = 0; i < data.Length; i++)

--- a/Utils.Fonts/PostScript/PostScriptGlyph.cs
+++ b/Utils.Fonts/PostScript/PostScriptGlyph.cs
@@ -5,7 +5,9 @@ using Utils.Fonts;
 namespace Utils.Fonts.PostScript;
 
 /// <summary>
-/// Represents a glyph defined by simple PostScript path commands.
+/// Represents a glyph defined by a sequence of basic PostScript path commands.
+/// The commands correspond loosely to the operators described in
+/// <see href="https://adobe-type-tools.github.io/font-tech-notes/pdfs/T1_SPEC.pdf">Adobe's Type&nbsp;1 specification</see>.
 /// </summary>
 public class PostScriptGlyph : IGlyph
 {
@@ -35,6 +37,11 @@ public class PostScriptGlyph : IGlyph
     public float BaseLine { get; }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The drawing callbacks correspond to <c>moveto</c>, <c>lineto</c> and
+    /// <c>curveto</c> operations in PostScript.  The <c>closepath</c> operator is
+    /// implemented by drawing a line back to the starting point.
+    /// </remarks>
     public void ToGraphic(IGraphicConverter graphicConverter)
     {
         if (graphicConverter == null) throw new ArgumentNullException(nameof(graphicConverter));
@@ -61,10 +68,16 @@ public class PostScriptGlyph : IGlyph
         }
     }
 
-    /// <summary>Represents a single path command for a glyph.</summary>
+    /// <summary>
+    /// Represents a single drawing command extracted from the font.  The
+    /// coordinates use the same units as the original charstring.
+    /// </summary>
     public record struct PathCommand(PathCommandType Type, float X1, float Y1, float X2, float Y2, float X3, float Y3);
 
-    /// <summary>Enumeration of path command types.</summary>
+    /// <summary>
+    /// Enumeration of possible path command types supported by this
+    /// simplified glyph representation.
+    /// </summary>
     public enum PathCommandType
     {
         MoveTo,

--- a/Utils.Fonts/PostScript/PostScriptGlyph.cs
+++ b/Utils.Fonts/PostScript/PostScriptGlyph.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using Utils.Fonts;
+
+namespace Utils.Fonts.PostScript;
+
+/// <summary>
+/// Represents a glyph defined by simple PostScript path commands.
+/// </summary>
+public class PostScriptGlyph : IGlyph
+{
+    /// <summary>Internal list of path commands describing the glyph outline.</summary>
+    private readonly List<PathCommand> _commands;
+
+    /// <summary>Creates a new <see cref="PostScriptGlyph"/>.</summary>
+    /// <param name="width">Advance width of the glyph.</param>
+    /// <param name="height">Height of the glyph.</param>
+    /// <param name="baseLine">Baseline of the glyph.</param>
+    /// <param name="commands">List of drawing commands forming the glyph.</param>
+    public PostScriptGlyph(float width, float height, float baseLine, List<PathCommand> commands)
+    {
+        Width = width;
+        Height = height;
+        BaseLine = baseLine;
+        _commands = commands ?? throw new ArgumentNullException(nameof(commands));
+    }
+
+    /// <inheritdoc />
+    public float Width { get; }
+
+    /// <inheritdoc />
+    public float Height { get; }
+
+    /// <inheritdoc />
+    public float BaseLine { get; }
+
+    /// <inheritdoc />
+    public void ToGraphic(IGraphicConverter graphicConverter)
+    {
+        if (graphicConverter == null) throw new ArgumentNullException(nameof(graphicConverter));
+        (float startX, float startY) = (0, 0);
+        foreach (var cmd in _commands)
+        {
+            switch (cmd.Type)
+            {
+                case PathCommandType.MoveTo:
+                    startX = cmd.X1;
+                    startY = cmd.Y1;
+                    graphicConverter.StartAt(cmd.X1, cmd.Y1);
+                    break;
+                case PathCommandType.LineTo:
+                    graphicConverter.LineTo(cmd.X1, cmd.Y1);
+                    break;
+                case PathCommandType.BezierTo:
+                    graphicConverter.BezierTo((cmd.X1, cmd.Y1), (cmd.X2, cmd.Y2), (cmd.X3, cmd.Y3));
+                    break;
+                case PathCommandType.Close:
+                    graphicConverter.LineTo(startX, startY);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>Represents a single path command for a glyph.</summary>
+    public record struct PathCommand(PathCommandType Type, float X1, float Y1, float X2, float Y2, float X3, float Y3);
+
+    /// <summary>Enumeration of path command types.</summary>
+    public enum PathCommandType
+    {
+        MoveTo,
+        LineTo,
+        BezierTo,
+        Close
+    }
+}

--- a/Utils.Fonts/PostScript/Type3Font.cs
+++ b/Utils.Fonts/PostScript/Type3Font.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Utils.Fonts.PostScript;
+
+/// <summary>
+/// Minimal loader for PostScript Type 3 fonts. Only a subset of the
+/// language is interpreted: setcachedevice for metrics and basic path
+/// commands such as moveto, lineto, curveto and closepath.
+/// </summary>
+public class Type3Font : IFont
+{
+    private readonly Dictionary<char, PostScriptGlyph> _glyphs;
+
+    private Type3Font(Dictionary<char, PostScriptGlyph> glyphs)
+    {
+        _glyphs = glyphs;
+    }
+
+    /// <summary>
+    /// Loads a Type 3 font from the provided PostScript stream.
+    /// </summary>
+    public static Type3Font Load(Stream stream)
+    {
+        using var reader = new StreamReader(stream, Encoding.ASCII, leaveOpen: true);
+        string ps = reader.ReadToEnd();
+        var glyphs = new Dictionary<char, PostScriptGlyph>();
+
+        var cpMatch = Regex.Match(ps, @"/CharProcs\s+\d+\s+dict\s+dup\s+begin(?<cp>.*)end", RegexOptions.Singleline);
+        if (!cpMatch.Success)
+            return new Type3Font(glyphs);
+
+        var procs = cpMatch.Groups["cp"].Value;
+        var glyphRegex = new Regex(@"/(?<name>\S+)\s+\{(?<proc>[^}]*)\}\s+bind\s+def", RegexOptions.Singleline);
+        foreach (Match g in glyphRegex.Matches(procs))
+        {
+            string name = g.Groups["name"].Value;
+            string proc = g.Groups["proc"].Value;
+            float width = 0, height = 0, baseLine = 0;
+            var commands = ParseCharProc(proc, ref width, ref height, ref baseLine);
+            char ch = MapName(name);
+            glyphs[ch] = new PostScriptGlyph(width, height, baseLine, commands);
+        }
+
+        return new Type3Font(glyphs);
+    }
+
+    /// <inheritdoc />
+    public IGlyph GetGlyph(char c) => _glyphs.TryGetValue(c, out var g) ? g : null;
+
+    /// <inheritdoc />
+    public float GetSpacingCorrection(char before, char after) => 0f;
+
+    private static List<PostScriptGlyph.PathCommand> ParseCharProc(string proc, ref float width, ref float height, ref float baseLine)
+    {
+        var commands = new List<PostScriptGlyph.PathCommand>();
+        var cache = Regex.Match(proc, @"(?<wx>-?\d+(?:\.\d+)?)\s+-?\d+(?:\.\d+)?\s+(?<llx>-?\d+(?:\.\d+)?)\s+(?<lly>-?\d+(?:\.\d+)?)\s+(?<urx>-?\d+(?:\.\d+)?)\s+(?<ury>-?\d+(?:\.\d+)?)\s+setcachedevice");
+        if (cache.Success)
+        {
+            width = float.Parse(cache.Groups["wx"].Value, CultureInfo.InvariantCulture);
+            float llx = float.Parse(cache.Groups["llx"].Value, CultureInfo.InvariantCulture);
+            float lly = float.Parse(cache.Groups["lly"].Value, CultureInfo.InvariantCulture);
+            float ury = float.Parse(cache.Groups["ury"].Value, CultureInfo.InvariantCulture);
+            height = float.Parse(cache.Groups["ury"].Value, CultureInfo.InvariantCulture) - lly;
+            baseLine = -lly;
+        }
+
+        var tokens = Regex.Matches(proc, @"-?\d+(?:\.\d+)?|[a-zA-Z]+").Select(m => m.Value).ToList();
+        var stack = new List<float>();
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            string t = tokens[i];
+            if (float.TryParse(t, NumberStyles.Float, CultureInfo.InvariantCulture, out float num))
+            {
+                stack.Add(num);
+                continue;
+            }
+            switch (t.ToLowerInvariant())
+            {
+                case "moveto":
+                    if (stack.Count >= 2)
+                    {
+                        float y = stack[^1];
+                        float x = stack[^2];
+                        stack.RemoveRange(stack.Count - 2, 2);
+                        commands.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.MoveTo, x, y, 0, 0, 0, 0));
+                    }
+                    break;
+                case "lineto":
+                    if (stack.Count >= 2)
+                    {
+                        float y = stack[^1];
+                        float x = stack[^2];
+                        stack.RemoveRange(stack.Count - 2, 2);
+                        commands.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.LineTo, x, y, 0, 0, 0, 0));
+                    }
+                    break;
+                case "curveto":
+                    if (stack.Count >= 6)
+                    {
+                        float y3 = stack[^1];
+                        float x3 = stack[^2];
+                        float y2 = stack[^3];
+                        float x2 = stack[^4];
+                        float y1 = stack[^5];
+                        float x1 = stack[^6];
+                        stack.RemoveRange(stack.Count - 6, 6);
+                        commands.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.BezierTo, x1, y1, x2, y2, x3, y3));
+                    }
+                    break;
+                case "closepath":
+                    commands.Add(new PostScriptGlyph.PathCommand(PostScriptGlyph.PathCommandType.Close, 0, 0, 0, 0, 0, 0));
+                    break;
+                default:
+                    stack.Clear();
+                    break;
+            }
+        }
+        return commands;
+    }
+
+    private static char MapName(string name)
+    {
+        if (name.Length == 1)
+            return name[0];
+        return name switch
+        {
+            "space" => ' ',
+            "comma" => ',',
+            "period" => '.',
+            "hyphen" => '-',
+            _ => '?'
+        };
+    }
+}

--- a/Utils.Fonts/PostScript/Type42Font.cs
+++ b/Utils.Fonts/PostScript/Type42Font.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using Utils.Fonts.TTF;
+
+namespace Utils.Fonts.PostScript;
+
+/// <summary>
+/// Minimal loader for PostScript Type 42 fonts which encapsulate a TrueType font.
+/// This implementation extracts the TrueType data from the /sfnts array and
+/// delegates glyph retrieval to <see cref="TrueTypeFont"/>.
+/// </summary>
+public class Type42Font : IFont
+{
+    private readonly TrueTypeFont _ttf;
+
+    private Type42Font(TrueTypeFont ttf)
+    {
+        _ttf = ttf;
+    }
+
+    /// <summary>
+    /// Loads a Type 42 font from the provided PostScript stream.
+    /// </summary>
+    /// <param name="stream">Stream containing the Type 42 font.</param>
+    /// <returns>An instance of <see cref="Type42Font"/>.</returns>
+    public static Type42Font Load(Stream stream)
+    {
+        using var reader = new StreamReader(stream, Encoding.ASCII, leaveOpen: true);
+        string ps = reader.ReadToEnd();
+
+        var match = Regex.Match(ps, @"/sfnts\s*\[(?<data>[^\]]+)\]", RegexOptions.Singleline);
+        if (!match.Success)
+            throw new InvalidDataException("Invalid Type 42 font: missing sfnts array");
+
+        string dataBlock = match.Groups["data"].Value;
+        var hexRegex = new Regex("<(?<hex>[0-9A-Fa-f]+)>");
+        var sb = new StringBuilder();
+        foreach (Match m in hexRegex.Matches(dataBlock))
+        {
+            sb.Append(m.Groups["hex"].Value);
+        }
+
+        byte[] bytes = PostScriptFont.ConvertHex(sb.ToString());
+        var ttf = TrueTypeFont.ParseFont(bytes);
+        return new Type42Font(ttf);
+    }
+
+    /// <inheritdoc />
+    public IGlyph GetGlyph(char c) => _ttf.GetGlyph(c);
+
+    /// <inheritdoc />
+    public float GetSpacingCorrection(char before, char after) => _ttf.GetSpacingCorrection(before, after);
+}

--- a/Utils.Fonts/PostScript/Type42Font.cs
+++ b/Utils.Fonts/PostScript/Type42Font.cs
@@ -7,23 +7,29 @@ using Utils.Fonts.TTF;
 namespace Utils.Fonts.PostScript;
 
 /// <summary>
-/// Minimal loader for PostScript Type 42 fonts which encapsulate a TrueType font.
-/// This implementation extracts the TrueType data from the /sfnts array and
-/// delegates glyph retrieval to <see cref="TrueTypeFont"/>.
+/// Minimal loader for PostScript Type&nbsp;42 fonts which encapsulate a TrueType font.
+/// This implementation extracts the embedded TrueType data from the <c>/sfnts</c> array and
+/// delegates glyph retrieval to <see cref="TrueTypeFont"/>.  For the official format see
+/// <see href="https://adobe-type-tools.github.io/font-tech-notes/pdfs/5012.Type42_Spec.pdf">Adobe Technical Note 5012</see>.
 /// </summary>
 public class Type42Font : IFont
 {
+    /// <summary>Parsed TrueType font extracted from the Type&nbsp;42 wrapper.</summary>
     private readonly TrueTypeFont _ttf;
 
+    /// <summary>
+    /// Initializes a new instance using the provided TrueType font.
+    /// </summary>
+    /// <param name="ttf">Parsed TrueType font.</param>
     private Type42Font(TrueTypeFont ttf)
     {
         _ttf = ttf;
     }
 
     /// <summary>
-    /// Loads a Type 42 font from the provided PostScript stream.
+    /// Loads a Type&nbsp;42 font from the provided PostScript stream.
     /// </summary>
-    /// <param name="stream">Stream containing the Type 42 font.</param>
+    /// <param name="stream">Stream containing the Type&nbsp;42 font.</param>
     /// <returns>An instance of <see cref="Type42Font"/>.</returns>
     public static Type42Font Load(Stream stream)
     {
@@ -48,6 +54,7 @@ public class Type42Font : IFont
     }
 
     /// <inheritdoc />
+    /// <remarks>Glyphs are served directly from the embedded TrueType font.</remarks>
     public IGlyph GetGlyph(char c) => _ttf.GetGlyph(c);
 
     /// <inheritdoc />

--- a/UtilsTest/Fonts/PostScriptFontTests.cs
+++ b/UtilsTest/Fonts/PostScriptFontTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Text;
+using Utils.Fonts.PostScript;
+using Utils.Fonts.TTF;
+using Utils.Fonts;
+using Moq;
+
+namespace UtilsTest.Fonts
+{
+    [TestClass]
+    public class PostScriptFontTests
+    {
+        [TestMethod]
+        public void LoadSimplePostScriptFont()
+        {
+            string txt = @"Glyph: A
+Width: 10
+Height: 10
+Baseline: 0
+Path:
+M 0 0
+L 10 0
+L 10 10
+L 0 10
+Z
+EndGlyph";
+            using var ms = new MemoryStream(Encoding.ASCII.GetBytes(txt));
+            var font = PostScriptFont.Load(ms);
+            var glyph = font.GetGlyph('A');
+            Assert.IsNotNull(glyph);
+            Assert.AreEqual(10f, glyph.Width);
+        }
+
+        [TestMethod]
+        public void GlyphToGraphicInvokesCommands()
+        {
+            string txt = @"Glyph: B
+Width: 5
+Height: 5
+Baseline: 0
+Path:
+M 0 0
+L 5 0
+Z
+EndGlyph";
+            using var ms = new MemoryStream(Encoding.ASCII.GetBytes(txt));
+            var font = PostScriptFont.Load(ms);
+            var glyph = font.GetGlyph('B');
+            var mock = new Mock<IGraphicConverter>(MockBehavior.Strict);
+            mock.Setup(g => g.StartAt(0f, 0f));
+            mock.Setup(g => g.LineTo(5f, 0f));
+            mock.Setup(g => g.LineTo(0f, 0f));
+            glyph.ToGraphic(mock.Object);
+            mock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void LoadType3Font()
+        {
+            string ps = @"/CharProcs 1 dict dup begin
+/A { 5 0 0 0 5 5 setcachedevice
+0 0 moveto
+5 0 lineto
+closepath
+} bind def
+end";
+            using var ms = new MemoryStream(Encoding.ASCII.GetBytes(ps));
+            var font = Type3Font.Load(ms);
+            Assert.IsNotNull(font.GetGlyph('A'));
+        }
+
+        [TestMethod]
+        public void LoadType42Font()
+        {
+            byte[] ttf = (byte[])Fonts.ResourceManager.GetObject("Arial");
+            var hex = new StringBuilder(ttf.Length * 2);
+            foreach (byte b in ttf)
+                hex.AppendFormat("{0:X2}", b);
+            string ps = $"/sfnts [ <{hex}> ]";
+            using var ms = new MemoryStream(Encoding.ASCII.GetBytes(ps));
+            var font = Type42Font.Load(ms);
+            Assert.IsNotNull(font.GetGlyph('A'));
+        }
+
+        [TestMethod]
+        public void ParseCidKeyedFont()
+        {
+            // build simple charstring: 0 500 hsbw 50 50 rmoveto endchar
+            byte[] cs = new byte[] { 139, 248, 136, 13, 189, 189, 21, 14 };
+            byte[] enc = PostScriptFont.DecryptType1(cs, 4330, 0);
+            var hex = new StringBuilder(enc.Length * 2);
+            foreach (byte b in enc)
+                hex.AppendFormat("{0:X2}", b);
+            string plain = $"/lenIV 0\n/CharStrings 1 dict dup begin\n97 {cs.Length} RD {hex} ND\nend";
+            var method = typeof(CidKeyedFont).GetMethod("ParseCidType1", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            var font = (CidKeyedFont)method.Invoke(null, new object[] { plain });
+            Assert.IsNotNull(font.GetGlyph('a'));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering PostScript font loaders in `UtilsTest`

## Testing
- `dotnet test UtilsTest/UtilsTest.csproj -nologo` *(fails: NETSDK1045 unsupported target framework)*

------
https://chatgpt.com/codex/tasks/task_e_6846a42dab0c8326b8b7e31d4765b830