### PR TITLE
Implement DI infrastructure for SpecFlow tests

### DIFF
--- a/UtilsTest/DefaultHooks.cs
+++ b/UtilsTest/DefaultHooks.cs
@@ -9,9 +9,14 @@ using TechTalk.SpecFlow;
 namespace UtilsTest
 {
 	[Binding]
-	public sealed class DefaultHooks
-	{
-		readonly ScenarioContext context = ScenarioContext.Current;
+        public sealed class DefaultHooks
+        {
+                readonly ScenarioContext context;
+
+                public DefaultHooks(ScenarioContext context)
+                {
+                        this.context = context;
+                }
 
 		[Then("I expect an exception")]
 		public void ThenIExpectAnException()

--- a/UtilsTest/Lists/ListsHooks.cs
+++ b/UtilsTest/Lists/ListsHooks.cs
@@ -11,9 +11,14 @@ using Utils.Objects;
 namespace UtilsTest.Lists
 {
 	[Binding]
-	public sealed class ListsHooks
-	{
-		readonly ScenarioContext context = ScenarioContext.Current;
+        public sealed class ListsHooks
+        {
+                readonly ScenarioContext context;
+
+                public ListsHooks(ScenarioContext context)
+                {
+                        this.context = context;
+                }
 
 		// For additional details on SpecFlow hooks see http://go.specflow.org/doc-hooks
 		DoubleIndexedDictionary<int, string> d;

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixHooks.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixHooks.cs
@@ -8,9 +8,14 @@ using Utils.Mathematics.LinearAlgebra;
 namespace UtilsTest.Mathematics.LinearAlgebra
 {
 	[Binding]
-	public sealed class MatrixHooks
-	{
-		readonly ScenarioContext context = ScenarioContext.Current;
+        public sealed class MatrixHooks
+        {
+                readonly ScenarioContext context;
+
+                public MatrixHooks(ScenarioContext context)
+                {
+                        this.context = context;
+                }
 
 		private static Matrix<double> TransformToMatrix(Table values)
 		{

--- a/UtilsTest/ScenarioDependencies.cs
+++ b/UtilsTest/ScenarioDependencies.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+using SolidToken.SpecFlow.DependencyInjection;
+
+namespace UtilsTest;
+
+public static class ScenarioDependencies
+{
+    [ScenarioDependencies]
+    public static IServiceCollection CreateServices()
+    {
+        var services = new ServiceCollection();
+        // register additional services here if needed
+        return services;
+    }
+}

--- a/UtilsTest/UtilsTest.csproj
+++ b/UtilsTest/UtilsTest.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="SpecFlow" Version="3.9.74" />
     <PackageReference Include="SpecFlow.MsTest" Version="3.9.74" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
+    <PackageReference Include="SolidToken.SpecFlow.DependencyInjection" Version="3.9.3" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add SolidToken.SpecFlow.DependencyInjection package
- provide `ScenarioDependencies` class for configuring SpecFlow services

## Testing
- `dotnet test Utils.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6846d4587bfc8326ae40c8df7f3bbec9