### PR TITLE
Implement Mime reader/writer and equality

### DIFF
--- a/Utils/Net/MimeDocument.cs
+++ b/Utils/Net/MimeDocument.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Numerics;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Represents a MIME document composed of multiple parts.
+/// </summary>
+public class MimeDocument
+{
+        /// <summary>
+        /// Initializes a new empty <see cref="MimeDocument"/>.
+        /// </summary>
+        public MimeDocument()
+        {
+                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                Parts = new List<MimePart>();
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="MimeDocument"/> by copying another instance.
+        /// </summary>
+        /// <param name="other">The document to copy.</param>
+        public MimeDocument(MimeDocument other)
+        {
+                if (other == null) throw new ArgumentNullException(nameof(other));
+                Headers = new Dictionary<string, string>(other.Headers, StringComparer.OrdinalIgnoreCase);
+                Parts = other.Parts.Select(p => new MimePart(p)).ToList();
+        }
+
+        /// <summary>
+        /// Gets the document level headers.
+        /// </summary>
+        public IDictionary<string, string> Headers { get; }
+
+        /// <summary>
+        /// Gets the list of MIME parts contained in this document.
+        /// </summary>
+        public IList<MimePart> Parts { get; }
+
+        /// <summary>
+        /// Reads a MIME document from a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The stream containing the MIME document.</param>
+        /// <param name="encoding">Optional text encoding. Defaults to UTF-8.</param>
+        /// <returns>A <see cref="MimeDocument"/> instance.</returns>
+        public static MimeDocument Read(Stream stream, Encoding? encoding = null)
+        {
+                return MimeReader.Read(stream, encoding);
+        }
+
+        /// <summary>
+        /// Reads a MIME document from a <see cref="TextReader"/>.
+        /// </summary>
+        /// <param name="reader">The text reader containing the MIME document.</param>
+        /// <returns>A <see cref="MimeDocument"/> instance.</returns>
+        public static MimeDocument Read(TextReader reader)
+        {
+                return MimeReader.Read(reader);
+        }
+
+        /// <summary>
+        /// Reads a MIME document from a string.
+        /// </summary>
+        /// <param name="text">The MIME text.</param>
+        /// <returns>A <see cref="MimeDocument"/> instance.</returns>
+        public static MimeDocument Read(string text)
+        {
+                return MimeReader.Read(text);
+        }
+
+        /// <summary>
+        /// Creates a deep copy of the specified document.
+        /// </summary>
+        /// <param name="other">The source document.</param>
+        /// <returns>A new <see cref="MimeDocument"/> instance.</returns>
+        public static MimeDocument Read(MimeDocument other) => MimeReader.Read(other);
+
+        /// <summary>
+        /// Writes this document to a <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The target stream.</param>
+        /// <param name="encoding">Optional encoding. Defaults to UTF-8.</param>
+        public void Write(Stream stream, Encoding? encoding = null)
+        {
+                MimeWriter.Write(this, stream, encoding);
+        }
+
+        /// <summary>
+        /// Writes this document to a <see cref="TextWriter"/>.
+        /// </summary>
+        /// <param name="writer">The text writer.</param>
+        public void Write(TextWriter writer)
+        {
+                MimeWriter.Write(this, writer);
+        }
+
+        /// <summary>
+        /// Converts this document to its textual representation.
+        /// </summary>
+        /// <returns>The document serialized as a string.</returns>
+        public override string ToString()
+        {
+                return MimeWriter.Write(this);
+        }
+}
+
+/// <summary>
+/// Represents a single MIME part.
+/// </summary>
+public class MimePart : IEquatable<MimePart>, IEqualityOperators<MimePart, MimePart, bool>
+{
+        /// <summary>
+        /// Initializes a new empty <see cref="MimePart"/>.
+        /// </summary>
+        public MimePart()
+        {
+                Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                Body = string.Empty;
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="MimePart"/> by copying another instance.
+        /// </summary>
+        /// <param name="other">The part to copy.</param>
+        public MimePart(MimePart other)
+        {
+                Headers = new Dictionary<string, string>(other.Headers, StringComparer.OrdinalIgnoreCase);
+                Body = other.Body;
+        }
+
+        /// <summary>
+        /// Gets the headers associated with this part.
+        /// </summary>
+        public IDictionary<string, string> Headers { get; }
+
+        /// <summary>
+        /// Gets or sets the textual body of this part.
+        /// </summary>
+        public string Body { get; set; }
+
+        /// <inheritdoc />
+        public bool Equals(MimePart? other)
+        {
+                if (other is null) return false;
+                return Headers.OrderBy(k => k.Key).SequenceEqual(other.Headers.OrderBy(k => k.Key), StringComparer.OrdinalIgnoreCase)
+                        && Body == other.Body;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => Equals(obj as MimePart);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+                int hash = 0;
+                foreach (var kv in Headers.OrderBy(k => k.Key))
+                {
+                        hash = HashCode.Combine(hash, StringComparer.OrdinalIgnoreCase.GetHashCode(kv.Key));
+                        hash = HashCode.Combine(hash, StringComparer.OrdinalIgnoreCase.GetHashCode(kv.Value));
+                }
+                hash = HashCode.Combine(hash, Body.GetHashCode());
+                return hash;
+        }
+
+        /// <summary>
+        /// Equality operator comparing two parts.
+        /// </summary>
+        public static bool operator ==(MimePart? left, MimePart? right) => left?.Equals(right) ?? right is null;
+
+        /// <summary>
+        /// Inequality operator comparing two parts.
+        /// </summary>
+        public static bool operator !=(MimePart? left, MimePart? right) => !(left == right);
+}
+
+/// <summary>
+/// Defines a serializer for <see cref="MimeDocument"/> instances.
+/// </summary>
+public interface IMimeFormatter
+{
+        /// <summary>
+        /// Reads a <see cref="MimeDocument"/> from the specified reader.
+        /// </summary>
+        /// <param name="reader">The text reader containing the MIME document.</param>
+        /// <returns>The parsed document.</returns>
+        MimeDocument Read(TextReader reader);
+
+        /// <summary>
+        /// Writes the provided <see cref="MimeDocument"/> to a writer.
+        /// </summary>
+        /// <param name="document">The document to write.</param>
+        /// <param name="writer">The writer that receives the output.</param>
+        void Write(MimeDocument document, TextWriter writer);
+}
+
+/// <summary>
+/// Basic implementation of <see cref="IMimeFormatter"/> supporting simple multipart documents.
+/// </summary>
+internal class SimpleMimeFormatter : IMimeFormatter
+{
+        /// <inheritdoc />
+        public MimeDocument Read(TextReader reader)
+        {
+                var document = new MimeDocument();
+                ReadHeaders(reader, document.Headers);
+
+                if (!document.Headers.TryGetValue("Content-Type", out var ctValue))
+                {
+                        // If no content type, treat entire body as a single part of text/plain
+                        var body = reader.ReadToEnd();
+                        var part = new MimePart();
+                        part.Headers["Content-Type"] = "text/plain";
+                        part.Body = body;
+                        document.Parts.Add(part);
+                        return document;
+                }
+
+                var mime = MimeType.Parse(ctValue);
+                if (mime.Type.Equals("multipart", StringComparison.OrdinalIgnoreCase)
+                        && mime.TryGetParameter("boundary", out var boundary))
+                {
+                        ReadMultipart(reader, boundary!, document);
+                }
+                else
+                {
+                        var part = new MimePart();
+                        part.Headers["Content-Type"] = mime.ToString();
+                        part.Body = reader.ReadToEnd();
+                        document.Parts.Add(part);
+                }
+                return document;
+        }
+
+        private static void ReadHeaders(TextReader reader, IDictionary<string, string> headers)
+        {
+                string? line;
+                while (!string.IsNullOrEmpty(line = reader.ReadLine()))
+                {
+                        var index = line.IndexOf(':');
+                        if (index > 0)
+                        {
+                                var name = line[..index].Trim();
+                                var value = line[(index + 1)..].Trim();
+                                headers[name] = value;
+                        }
+                }
+        }
+
+        private static void ReadMultipart(TextReader reader, string boundary, MimeDocument document)
+        {
+                string? line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                        if (line == "--" + boundary)
+                        {
+                                var part = new MimePart();
+                                ReadHeaders(reader, part.Headers);
+                                var sb = new StringBuilder();
+                                while ((line = reader.ReadLine()) != null && line != "--" + boundary && line != "--" + boundary + "--")
+                                {
+                                        sb.AppendLine(line);
+                                }
+                                part.Body = sb.ToString();
+                                document.Parts.Add(part);
+                                if (line == "--" + boundary + "--")
+                                        break;
+                        }
+                }
+        }
+
+        /// <inheritdoc />
+        public void Write(MimeDocument document, TextWriter writer)
+        {
+                foreach (var h in document.Headers)
+                {
+                        writer.WriteLine($"{h.Key}: {h.Value}");
+                }
+                writer.WriteLine();
+
+                if (!document.Headers.TryGetValue("Content-Type", out var ctValue))
+                {
+                        // Write first part only
+                        if (document.Parts.Count > 0)
+                        {
+                                var part = document.Parts[0];
+                                foreach (var h in part.Headers)
+                                        writer.WriteLine($"{h.Key}: {h.Value}");
+                                writer.WriteLine();
+                                writer.Write(part.Body);
+                        }
+                        return;
+                }
+
+                var mime = MimeType.Parse(ctValue);
+                if (!mime.TryGetParameter("boundary", out var boundary))
+                {
+                        boundary = Guid.NewGuid().ToString("N");
+                        mime.SetParameter("boundary", boundary);
+                        document.Headers["Content-Type"] = mime.ToString();
+                }
+
+                foreach (var part in document.Parts)
+                {
+                        writer.WriteLine("--" + boundary);
+                        foreach (var h in part.Headers)
+                                writer.WriteLine($"{h.Key}: {h.Value}");
+                        writer.WriteLine();
+                        writer.Write(part.Body);
+                        if (!part.Body.EndsWith("\n"))
+                                writer.WriteLine();
+                }
+                writer.WriteLine("--" + boundary + "--");
+        }
+}
+

--- a/Utils/Net/MimeDocument.cs
+++ b/Utils/Net/MimeDocument.cs
@@ -143,16 +143,6 @@ public class MimePart : IEquatable<MimePart>, IEqualityOperators<MimePart, MimeP
         /// </summary>
         public string Body { get; set; }
 
-        /// <summary>
-        /// Attempts to return the body content as the requested type.
-        /// </summary>
-        /// <typeparam name="T">Desired content type.</typeparam>
-        /// <param name="content">When this method returns, contains the content if compatible.</param>
-        /// <returns><c>true</c> if conversion succeeded; otherwise, <c>false</c>.</returns>
-        public bool TryGetContentAs<T>(out T? content)
-        {
-                return MimePartConverter.Default.TryConvertTo(this, out content);
-        }
 
         private static bool DictionaryEquals(IDictionary<string, string> left, IDictionary<string, string> right)
         {

--- a/Utils/Net/MimePartConverter.cs
+++ b/Utils/Net/MimePartConverter.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Defines a converter capable of converting a MIME part body to a target type.
+/// </summary>
+public interface IMimePartConverter
+{
+    /// <summary>
+    /// Gets the MIME type mask handled by this converter. Wildcards are allowed.
+    /// </summary>
+    string MimeType { get; }
+
+    /// <summary>
+    /// Attempts to convert the raw textual content to the specified type.
+    /// </summary>
+    /// <typeparam name="T">Target type.</typeparam>
+    /// <param name="rawContent">The raw body content.</param>
+    /// <param name="content">When this method returns, contains the converted content.</param>
+    /// <returns><c>true</c> if conversion succeeded; otherwise, <c>false</c>.</returns>
+    bool TryConvert<T>(string rawContent, out T? content);
+}
+
+/// <summary>
+/// Provides conversion of <see cref="MimePart"/> contents based on registered converters.
+/// </summary>
+public class MimePartConverter
+{
+    private readonly List<IMimePartConverter> _converters = new();
+
+    /// <summary>
+    /// Gets a default <see cref="MimePartConverter"/> instance with common converters registered.
+    /// </summary>
+    public static MimePartConverter Default { get; } = CreateDefault();
+
+    /// <summary>
+    /// Adds a new converter to the list of available converters.
+    /// </summary>
+    /// <param name="converter">The converter to register.</param>
+    public void Add(IMimePartConverter converter)
+    {
+        ArgumentNullException.ThrowIfNull(converter);
+        _converters.Add(converter);
+    }
+
+    /// <summary>
+    /// Determines whether content of the specified MIME type can be converted to <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">Desired target type.</typeparam>
+    /// <param name="mimeType">The MIME type to test.</param>
+    /// <returns><c>true</c> if a converter exists; otherwise, <c>false</c>.</returns>
+    public bool CanConvertTo<T>(MimeType mimeType)
+    {
+        ArgumentNullException.ThrowIfNull(mimeType);
+        return GetConverters(mimeType).Any(c => c.TryConvert(string.Empty, out T? _));
+    }
+
+    /// <summary>
+    /// Determines whether content of the specified MIME type can be converted to the provided type.
+    /// </summary>
+    /// <param name="type">Desired target type.</param>
+    /// <param name="mimeType">The MIME type to test.</param>
+    /// <returns><c>true</c> if a converter exists; otherwise, <c>false</c>.</returns>
+    public bool CanConvertTo(Type type, MimeType mimeType)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(mimeType);
+        foreach (var conv in GetConverters(mimeType))
+        {
+            var method = conv.GetType().GetMethod("TryConvert")!.MakeGenericMethod(type);
+            var args = new object?[] { string.Empty, null };
+            if ((bool)method.Invoke(conv, args)!)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to convert the specified MIME part to <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">Target type.</typeparam>
+    /// <param name="part">The MIME part.</param>
+    /// <param name="content">When this method returns, contains the converted content if successful.</param>
+    /// <returns><c>true</c> if conversion succeeded; otherwise, <c>false</c>.</returns>
+    public bool TryConvertTo<T>(MimePart part, out T? content)
+    {
+        ArgumentNullException.ThrowIfNull(part);
+        content = default;
+        if (!part.Headers.TryGetValue("Content-Type", out var ct))
+            return false;
+        var mime = MimeType.Parse(ct);
+        foreach (var conv in GetConverters(mime))
+        {
+            if (conv.TryConvert(part.Body, out content))
+                return true;
+        }
+        return false;
+    }
+
+    private static MimePartConverter CreateDefault()
+    {
+        var conv = new MimePartConverter();
+        conv.Add(new TextPartConverter());
+        conv.Add(new XmlPartConverter());
+        conv.Add(new MultipartPartConverter());
+        conv.Add(new BinaryPartConverter());
+        return conv;
+    }
+
+    private IEnumerable<IMimePartConverter> GetConverters(MimeType mime)
+    {
+        return _converters
+            .Where(c => Matches(c.MimeType, mime))
+            .OrderByDescending(c => Specificity(c.MimeType));
+    }
+
+    private static bool Matches(string pattern, MimeType mime)
+    {
+        var parts = pattern.Split('/', 2);
+        var pt = parts[0];
+        var ps = parts.Length > 1 ? parts[1] : "*";
+        bool typeMatch = pt == "*" || mime.Type.Equals(pt, StringComparison.OrdinalIgnoreCase);
+        bool subMatch = ps == "*" || mime.SubType.Equals(ps, StringComparison.OrdinalIgnoreCase);
+        return typeMatch && subMatch;
+    }
+
+    private static int Specificity(string pattern)
+    {
+        var parts = pattern.Split('/', 2);
+        int score = 0;
+        if (parts[0] != "*") score++;
+        if (parts.Length > 1 && parts[1] != "*") score++;
+        return score;
+    }
+}
+
+internal sealed class TextPartConverter : IMimePartConverter
+{
+    public string MimeType => "text/*";
+
+    public bool TryConvert<T>(string rawContent, out T? content)
+    {
+        content = default;
+        var target = typeof(T);
+        if (target == typeof(string))
+        {
+            content = (T)(object)rawContent;
+            return true;
+        }
+        if (typeof(TextReader).IsAssignableFrom(target))
+        {
+            content = (T)(object)new StringReader(rawContent);
+            return true;
+        }
+        return false;
+    }
+}
+
+internal sealed class XmlPartConverter : IMimePartConverter
+{
+    public string MimeType => "text/xml";
+
+    public bool TryConvert<T>(string rawContent, out T? content)
+    {
+        content = default;
+        var target = typeof(T);
+        if (target == typeof(XDocument))
+        {
+            content = (T)(object)XDocument.Parse(rawContent);
+            return true;
+        }
+        if (target == typeof(XmlDocument))
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml(rawContent);
+            content = (T)(object)doc;
+            return true;
+        }
+        return false;
+    }
+}
+
+internal sealed class MultipartPartConverter : IMimePartConverter
+{
+    public string MimeType => "multipart/*";
+
+    public bool TryConvert<T>(string rawContent, out T? content)
+    {
+        content = default;
+        var target = typeof(T);
+        if (target == typeof(MimeDocument) || target.IsAssignableFrom(typeof(MimeDocument)))
+        {
+            content = (T)(object)MimeReader.Read(rawContent);
+            return true;
+        }
+        return false;
+    }
+}
+
+internal sealed class BinaryPartConverter : IMimePartConverter
+{
+    public string MimeType => "application/*";
+
+    public bool TryConvert<T>(string rawContent, out T? content)
+    {
+        content = default;
+        var target = typeof(T);
+        if (target == typeof(byte[]))
+        {
+            if (string.IsNullOrEmpty(rawContent))
+                return true;
+            try
+            {
+                content = (T)(object)Convert.FromBase64String(rawContent);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        if (typeof(Stream).IsAssignableFrom(target))
+        {
+            if (string.IsNullOrEmpty(rawContent))
+                return true;
+            try
+            {
+                var bytes = Convert.FromBase64String(rawContent);
+                content = (T)(object)new MemoryStream(bytes);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        return false;
+    }
+}

--- a/Utils/Net/MimePartFactory.cs
+++ b/Utils/Net/MimePartFactory.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using System.Text.Json;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Defines a converter that creates <see cref="MimePart"/> instances from objects.
+/// </summary>
+public interface IMimePartSerializer
+{
+    /// <summary>
+    /// Gets the MIME type produced by this serializer.
+    /// </summary>
+    string MimeType { get; }
+
+    /// <summary>
+    /// Gets the list of types this serializer can handle.
+    /// </summary>
+    Type[] SupportedTypes { get; }
+
+    /// <summary>
+    /// Attempts to create a <see cref="MimePart"/> from the specified value.
+    /// </summary>
+    /// <typeparam name="T">Type of the value.</typeparam>
+    /// <param name="value">The value to convert.</param>
+    /// <param name="part">When this method returns, contains the resulting part.</param>
+    /// <returns><c>true</c> if the value was converted; otherwise, <c>false</c>.</returns>
+    bool TrySerialize<T>(T value, out MimePart? part)
+    {
+        if (this is IMimePartSerializer<T> typed)
+            return typed.TrySerialize(value, out part);
+        part = null;
+        return false;
+    }
+}
+
+/// <summary>
+/// Typed serializer for values of type <typeparamref name="T"/>.
+/// </summary>
+/// <typeparam name="T">Type handled by the serializer.</typeparam>
+public interface IMimePartSerializer<T> : IMimePartSerializer
+{
+    /// <summary>
+    /// Attempts to create a MIME part from the specified value.
+    /// </summary>
+    /// <param name="value">The value to convert.</param>
+    /// <param name="part">The resulting part if successful.</param>
+    /// <returns><c>true</c> if serialization succeeded; otherwise, <c>false</c>.</returns>
+    bool TrySerialize(T value, out MimePart? part);
+}
+
+/// <summary>
+/// Factory used to convert objects to <see cref="MimePart"/> instances.
+/// </summary>
+public class MimePartFactory
+{
+    private readonly List<IMimePartSerializer> _serializers = new();
+
+    /// <summary>
+    /// Gets a default factory with common serializers registered.
+    /// </summary>
+    public static MimePartFactory Default { get; } = CreateDefault();
+
+    /// <summary>
+    /// Adds a serializer to this factory.
+    /// </summary>
+    /// <param name="serializer">Serializer to register.</param>
+    public void Add(IMimePartSerializer serializer)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        _serializers.Add(serializer);
+    }
+
+    /// <summary>
+    /// Attempts to create a <see cref="MimePart"/> from <paramref name="value"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of the value.</typeparam>
+    /// <param name="value">The value to convert.</param>
+    /// <param name="part">When this method returns, contains the converted part if successful.</param>
+    /// <returns><c>true</c> if conversion succeeded; otherwise, <c>false</c>.</returns>
+    public bool TryCreatePart<T>(T value, out MimePart? part)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        var type = value.GetType();
+        foreach (var s in _serializers.Where(s => s.SupportedTypes.Any(t => t.IsAssignableFrom(type))))
+        {
+            if (s.TrySerialize(value, out part))
+            {
+                if (!part!.Headers.ContainsKey("Content-Type"))
+                    part.Headers["Content-Type"] = s.MimeType;
+                return true;
+            }
+        }
+        part = null;
+        return false;
+    }
+
+    private static MimePartFactory CreateDefault()
+    {
+        var factory = new MimePartFactory();
+        factory.Add(new TextPartSerializer());
+        factory.Add(new XmlPartSerializer());
+        factory.Add(new JsonPartSerializer());
+        factory.Add(new MultipartPartSerializer());
+        factory.Add(new BinaryPartSerializer());
+        return factory;
+    }
+}
+
+internal sealed class TextPartSerializer :
+    IMimePartSerializer<string>,
+    IMimePartSerializer<TextReader>
+{
+    public string MimeType => "text/plain";
+
+    public Type[] SupportedTypes { get; } = [typeof(string), typeof(TextReader)];
+
+    bool IMimePartSerializer<string>.TrySerialize(string value, out MimePart? part)
+    {
+        part = new MimePart { Body = value };
+        return true;
+    }
+
+    bool IMimePartSerializer<TextReader>.TrySerialize(TextReader value, out MimePart? part)
+    {
+        part = new MimePart { Body = value.ReadToEnd() };
+        return true;
+    }
+}
+
+internal sealed class XmlPartSerializer :
+    IMimePartSerializer<XDocument>,
+    IMimePartSerializer<XmlDocument>
+{
+    public string MimeType => "text/xml";
+
+    public Type[] SupportedTypes { get; } = [typeof(XDocument), typeof(XmlDocument)];
+
+    bool IMimePartSerializer<XDocument>.TrySerialize(XDocument value, out MimePart? part)
+    {
+        part = new MimePart { Body = value.ToString() };
+        return true;
+    }
+
+    bool IMimePartSerializer<XmlDocument>.TrySerialize(XmlDocument value, out MimePart? part)
+    {
+        part = new MimePart { Body = value.OuterXml };
+        return true;
+    }
+}
+
+internal sealed class JsonPartSerializer : IMimePartSerializer<JsonDocument>
+{
+    public string MimeType => "application/json";
+
+    public Type[] SupportedTypes { get; } = [typeof(JsonDocument)];
+
+    bool IMimePartSerializer<JsonDocument>.TrySerialize(JsonDocument value, out MimePart? part)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+        value.WriteTo(writer);
+        writer.Flush();
+        part = new MimePart { Body = System.Text.Encoding.UTF8.GetString(stream.ToArray()) };
+        return true;
+    }
+}
+
+internal sealed class MultipartPartSerializer : IMimePartSerializer<MimeDocument>
+{
+    public string MimeType => "multipart/mixed";
+
+    public Type[] SupportedTypes { get; } = [typeof(MimeDocument)];
+
+    bool IMimePartSerializer<MimeDocument>.TrySerialize(MimeDocument value, out MimePart? part)
+    {
+        var text = MimeWriter.Write(value);
+        part = new MimePart { Body = text };
+        if (value.Headers.TryGetValue("Content-Type", out var ct))
+            part.Headers["Content-Type"] = ct;
+        return true;
+    }
+}
+
+internal sealed class BinaryPartSerializer :
+    IMimePartSerializer<byte[]>,
+    IMimePartSerializer<Stream>
+{
+    public string MimeType => "application/octet-stream";
+
+    public Type[] SupportedTypes { get; } = [typeof(byte[]), typeof(Stream)];
+
+    bool IMimePartSerializer<byte[]>.TrySerialize(byte[] value, out MimePart? part)
+    {
+        part = new MimePart { Body = Convert.ToBase64String(value) };
+        return true;
+    }
+
+    bool IMimePartSerializer<Stream>.TrySerialize(Stream value, out MimePart? part)
+    {
+        using var ms = new MemoryStream();
+        value.CopyTo(ms);
+        part = new MimePart { Body = Convert.ToBase64String(ms.ToArray()) };
+        return true;
+    }
+}

--- a/Utils/Net/MimeReader.cs
+++ b/Utils/Net/MimeReader.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Provides methods for reading <see cref="MimeDocument"/> instances from various sources.
+/// </summary>
+public static class MimeReader
+{
+    /// <summary>
+    /// Reads a MIME document from a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="stream">Stream containing the MIME data.</param>
+    /// <param name="encoding">Optional text encoding. Defaults to UTF-8.</param>
+    /// <returns>The parsed <see cref="MimeDocument"/>.</returns>
+    public static MimeDocument Read(Stream stream, Encoding? encoding = null)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        encoding ??= Encoding.UTF8;
+        using var reader = new StreamReader(stream, encoding, leaveOpen: true);
+        return Read(reader);
+    }
+
+    /// <summary>
+    /// Reads a MIME document from a <see cref="TextReader"/>.
+    /// </summary>
+    /// <param name="reader">Reader containing MIME text.</param>
+    /// <returns>The parsed <see cref="MimeDocument"/>.</returns>
+    public static MimeDocument Read(TextReader reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        var formatter = new SimpleMimeFormatter();
+        return formatter.Read(reader);
+    }
+
+    /// <summary>
+    /// Reads a MIME document from a string.
+    /// </summary>
+    /// <param name="text">The MIME formatted string.</param>
+    /// <returns>The parsed <see cref="MimeDocument"/>.</returns>
+    public static MimeDocument Read(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        using var reader = new StringReader(text);
+        return Read(reader);
+    }
+
+    /// <summary>
+    /// Returns a deep copy of the provided document.
+    /// </summary>
+    /// <param name="document">The document to clone.</param>
+    /// <returns>A new <see cref="MimeDocument"/> instance.</returns>
+    public static MimeDocument Read(MimeDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return new MimeDocument(document);
+    }
+}

--- a/Utils/Net/MimeType.cs
+++ b/Utils/Net/MimeType.cs
@@ -133,16 +133,7 @@ public class MimeType : IEquatable<MimeType>, IEqualityOperators<MimeType, MimeT
         /// <returns><c>true</c> if the MIME content can be mapped to the specified type; otherwise, <c>false</c>.</returns>
         public bool IsCompatibleWith(Type type)
         {
-                if (type == typeof(MimeDocument))
-                        return Type.Equals("multipart", StringComparison.OrdinalIgnoreCase);
-
-                if (type == typeof(string) || typeof(TextReader).IsAssignableFrom(type))
-                        return Type.Equals("text", StringComparison.OrdinalIgnoreCase);
-
-                if (type == typeof(byte[]) || typeof(Stream).IsAssignableFrom(type))
-                        return !Type.Equals("multipart", StringComparison.OrdinalIgnoreCase);
-
-                return false;
+                return MimePartConverter.Default.CanConvertTo(type, this);
         }
 
         /// <summary>
@@ -150,7 +141,7 @@ public class MimeType : IEquatable<MimeType>, IEqualityOperators<MimeType, MimeT
         /// </summary>
         /// <typeparam name="T">The target type.</typeparam>
         /// <returns><c>true</c> if compatible; otherwise, <c>false</c>.</returns>
-        public bool IsCompatibleWith<T>() => IsCompatibleWith(typeof(T));
+        public bool IsCompatibleWith<T>() => MimePartConverter.Default.CanConvertTo<T>(this);
 
         private static bool DictionaryEquals(IDictionary<string, string> left, IDictionary<string, string> right)
         {

--- a/Utils/Net/MimeType.cs
+++ b/Utils/Net/MimeType.cs
@@ -124,4 +124,47 @@ public class MimeType : IEquatable<MimeType>, IEqualityOperators<MimeType, MimeT
         /// Inequality operator comparing two <see cref="MimeType"/> instances.
         /// </summary>
         public static bool operator !=(MimeType? left, MimeType? right) => !(left == right);
+
+        /// <summary>
+        /// Creates a <see cref="MimeType"/> instance for plain text.
+        /// </summary>
+        /// <param name="charset">Optional text encoding. Defaults to UTF-8.</param>
+        /// <returns>A new <see cref="MimeType"/> representing <c>text/plain</c>.</returns>
+        public static MimeType CreateTextPlain(string charset = "utf-8")
+        {
+                var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                        ["charset"] = charset
+                };
+                return new MimeType("text", "plain", parameters);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="MimeType"/> instance for JSON content.
+        /// </summary>
+        /// <param name="charset">Optional text encoding. Defaults to UTF-8.</param>
+        /// <returns>A new <see cref="MimeType"/> representing <c>application/json</c>.</returns>
+        public static MimeType CreateApplicationJson(string charset = "utf-8")
+        {
+                var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                        ["charset"] = charset
+                };
+                return new MimeType("application", "json", parameters);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="MimeType"/> instance for a multipart entity.
+        /// </summary>
+        /// <param name="subType">Multipart subtype (e.g. "mixed" or "form-data").</param>
+        /// <param name="boundary">Boundary used to separate MIME parts.</param>
+        /// <returns>A new <see cref="MimeType"/> representing <c>multipart/&lt;subType&gt;</c>.</returns>
+        public static MimeType CreateMultipart(string subType, string boundary)
+        {
+                var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                        ["boundary"] = boundary
+                };
+                return new MimeType("multipart", subType, parameters);
+        }
 }

--- a/Utils/Net/MimeWriter.cs
+++ b/Utils/Net/MimeWriter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Provides methods for writing <see cref="MimeDocument"/> instances to various targets.
+/// </summary>
+public static class MimeWriter
+{
+    /// <summary>
+    /// Writes the document to a <see cref="Stream"/>.
+    /// </summary>
+    /// <param name="document">The document to write.</param>
+    /// <param name="stream">The output stream.</param>
+    /// <param name="encoding">Optional text encoding. Defaults to UTF-8.</param>
+    public static void Write(MimeDocument document, Stream stream, Encoding? encoding = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(stream);
+        encoding ??= Encoding.UTF8;
+        using var writer = new StreamWriter(stream, encoding, leaveOpen: true);
+        Write(document, writer);
+        writer.Flush();
+    }
+
+    /// <summary>
+    /// Writes the document to a <see cref="TextWriter"/>.
+    /// </summary>
+    /// <param name="document">Document to write.</param>
+    /// <param name="writer">Destination writer.</param>
+    public static void Write(MimeDocument document, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(writer);
+        var formatter = new SimpleMimeFormatter();
+        formatter.Write(document, writer);
+    }
+
+    /// <summary>
+    /// Serializes the document to a string.
+    /// </summary>
+    /// <param name="document">Document to serialize.</param>
+    /// <returns>The textual representation.</returns>
+    public static string Write(MimeDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        using var sw = new StringWriter();
+        Write(document, sw);
+        return sw.ToString();
+    }
+}

--- a/UtilsTest/Net/MimeDocumentTests.cs
+++ b/UtilsTest/Net/MimeDocumentTests.cs
@@ -63,4 +63,26 @@ public class MimeDocumentTests
                 p2.Body = "World";
                 Assert.IsTrue(p1 != p2);
         }
+
+        [TestMethod]
+        public void MimeTypeStaticFactories()
+        {
+                var plain = MimeType.CreateTextPlain();
+                Assert.AreEqual("text", plain.Type);
+                Assert.AreEqual("plain", plain.SubType);
+                Assert.IsTrue(plain.TryGetParameter("charset", out var cs1));
+                Assert.AreEqual("utf-8", cs1);
+
+                var json = MimeType.CreateApplicationJson();
+                Assert.AreEqual("application", json.Type);
+                Assert.AreEqual("json", json.SubType);
+                Assert.IsTrue(json.TryGetParameter("charset", out var cs2));
+                Assert.AreEqual("utf-8", cs2);
+
+                var multi = MimeType.CreateMultipart("mixed", "b");
+                Assert.AreEqual("multipart", multi.Type);
+                Assert.AreEqual("mixed", multi.SubType);
+                Assert.IsTrue(multi.TryGetParameter("boundary", out var b));
+                Assert.AreEqual("b", b);
+        }
 }

--- a/UtilsTest/Net/MimeDocumentTests.cs
+++ b/UtilsTest/Net/MimeDocumentTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+[TestClass]
+public class MimeDocumentTests
+{
+        [TestMethod]
+        public void ParseAndWriteSimpleMultipartDocument()
+        {
+                const string input = "Content-Type: multipart/mixed; boundary=\"b\"\n\n--b\nContent-Type: text/plain\n\nHello\n--b\nContent-Type: text/plain\n\nWorld\n--b--\n";
+                var doc = MimeReader.Read(input);
+                Assert.AreEqual(2, doc.Parts.Count);
+                Assert.AreEqual("Hello\n", doc.Parts[0].Body);
+                Assert.AreEqual("World\n", doc.Parts[1].Body);
+
+                using var ms = new MemoryStream();
+                MimeWriter.Write(doc, ms);
+                ms.Position = 0;
+                using var reader = new StreamReader(ms);
+                var output = reader.ReadToEnd();
+                var doc2 = MimeReader.Read(output);
+                Assert.AreEqual(2, doc2.Parts.Count);
+                Assert.AreEqual(doc.Parts[0].Body, doc2.Parts[0].Body);
+                Assert.AreEqual(doc.Parts[1].Body, doc2.Parts[1].Body);
+        }
+
+        [TestMethod]
+        public void MimeTypeParseToString()
+        {
+                var mt = MimeType.Parse("text/plain; charset=utf-8");
+                Assert.AreEqual("text", mt.Type);
+                Assert.AreEqual("plain", mt.SubType);
+                Assert.IsTrue(mt.TryGetParameter("charset", out var cs));
+                Assert.AreEqual("utf-8", cs);
+                Assert.AreEqual("text/plain; charset=utf-8", mt.ToString());
+        }
+
+        [TestMethod]
+        public void MimeTypeEqualityOperators()
+        {
+                var a = MimeType.Parse("text/plain; charset=utf-8");
+                var b = MimeType.Parse("text/plain; charset=utf-8");
+                var c = MimeType.Parse("text/plain; charset=ascii");
+
+                Assert.IsTrue(a == b);
+                Assert.IsFalse(a != b);
+                Assert.IsFalse(a == c);
+        }
+
+        [TestMethod]
+        public void MimePartEqualityOperators()
+        {
+                var p1 = new MimePart();
+                p1.Headers["Content-Type"] = "text/plain";
+                p1.Body = "Hello";
+
+                var p2 = new MimePart(p1);
+
+                Assert.IsTrue(p1 == p2);
+                p2.Body = "World";
+                Assert.IsTrue(p1 != p2);
+        }
+}

--- a/UtilsTest/Net/MimeDocumentTests.cs
+++ b/UtilsTest/Net/MimeDocumentTests.cs
@@ -89,7 +89,7 @@ public class MimeDocumentTests
         }
 
         [TestMethod]
-        public void MimePartTryGetContentAsText()
+        public void MimePartConverterText()
         {
                 var part = new MimePart
                 {
@@ -97,9 +97,10 @@ public class MimeDocumentTests
                 };
                 part.Headers["Content-Type"] = "text/plain";
 
-                Assert.IsTrue(part.TryGetContentAs<string>(out var str));
+                var conv = MimePartConverter.Default;
+                Assert.IsTrue(conv.TryConvertTo<string>(part, out var str));
                 Assert.AreEqual("Hello", str);
-                Assert.IsTrue(part.TryGetContentAs<TextReader>(out var reader));
+                Assert.IsTrue(conv.TryConvertTo<TextReader>(part, out var reader));
                 Assert.AreEqual("Hello", reader.ReadToEnd());
 
                 var mime = MimeType.Parse(part.Headers["Content-Type"]);
@@ -109,7 +110,7 @@ public class MimeDocumentTests
         }
 
         [TestMethod]
-        public void MimePartTryGetContentAsBinary()
+        public void MimePartConverterBinary()
         {
                 var bytes = System.Text.Encoding.UTF8.GetBytes("Hello");
                 var part = new MimePart
@@ -118,9 +119,10 @@ public class MimeDocumentTests
                 };
                 part.Headers["Content-Type"] = "application/octet-stream";
 
-                Assert.IsTrue(part.TryGetContentAs<byte[]>(out var arr));
+                var conv = MimePartConverter.Default;
+                Assert.IsTrue(conv.TryConvertTo<byte[]>(part, out var arr));
                 CollectionAssert.AreEqual(bytes, arr);
-                Assert.IsTrue(part.TryGetContentAs<Stream>(out var stream));
+                Assert.IsTrue(conv.TryConvertTo<Stream>(part, out var stream));
                 using var ms = new MemoryStream();
                 stream.CopyTo(ms);
                 CollectionAssert.AreEqual(bytes, ms.ToArray());
@@ -132,7 +134,7 @@ public class MimeDocumentTests
         }
 
         [TestMethod]
-        public void MimePartTryGetContentAsMultipart()
+        public void MimePartConverterMultipart()
         {
                 var child = new MimeDocument();
                 var cp = new MimePart();
@@ -149,7 +151,8 @@ public class MimeDocumentTests
                 };
                 part.Headers["Content-Type"] = "multipart/mixed; boundary=bb";
 
-                Assert.IsTrue(part.TryGetContentAs<MimeDocument>(out var doc));
+                var conv = MimePartConverter.Default;
+                Assert.IsTrue(conv.TryConvertTo<MimeDocument>(part, out var doc));
                 Assert.AreEqual(1, doc.Parts.Count);
 
                 var mime = MimeType.Parse(part.Headers["Content-Type"]);

--- a/UtilsTest/Net/MimePartConverterTests.cs
+++ b/UtilsTest/Net/MimePartConverterTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+[TestClass]
+public class MimePartConverterTests
+{
+    [TestMethod]
+    public void ConvertTextPart()
+    {
+        var part = new MimePart { Body = "Hello" };
+        part.Headers["Content-Type"] = "text/plain";
+
+        var converter = MimePartConverter.Default;
+        Assert.IsTrue(converter.CanConvertTo<string>(MimeType.Parse(part.Headers["Content-Type"]!)));
+        Assert.IsTrue(converter.TryConvertTo<string>(part, out var text));
+        Assert.AreEqual("Hello", text);
+        Assert.IsTrue(converter.TryConvertTo<TextReader>(part, out var reader));
+        Assert.AreEqual("Hello", reader.ReadToEnd());
+    }
+
+    [TestMethod]
+    public void ConvertXmlPart()
+    {
+        var part = new MimePart { Body = "<root/>" };
+        part.Headers["Content-Type"] = "text/xml";
+        var converter = MimePartConverter.Default;
+        Assert.IsTrue(converter.TryConvertTo<XDocument>(part, out var doc));
+        Assert.AreEqual("root", doc.Root!.Name.LocalName);
+    }
+
+    [TestMethod]
+    public void ConvertBinaryPart()
+    {
+        var bytes = Encoding.UTF8.GetBytes("abc");
+        var part = new MimePart { Body = Convert.ToBase64String(bytes) };
+        part.Headers["Content-Type"] = "application/octet-stream";
+        var converter = MimePartConverter.Default;
+        Assert.IsTrue(converter.TryConvertTo<byte[]>(part, out var arr));
+        CollectionAssert.AreEqual(bytes, arr);
+        Assert.IsTrue(converter.TryConvertTo<Stream>(part, out var stream));
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        CollectionAssert.AreEqual(bytes, ms.ToArray());
+    }
+}

--- a/UtilsTest/Net/MimePartConverterTests.cs
+++ b/UtilsTest/Net/MimePartConverterTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Xml.Linq;
+using System.Text.Json;
 using Utils.Net;
 
 namespace UtilsTest.Net;
@@ -47,5 +48,16 @@ public class MimePartConverterTests
         using var ms = new MemoryStream();
         stream.CopyTo(ms);
         CollectionAssert.AreEqual(bytes, ms.ToArray());
+    }
+
+    [TestMethod]
+    public void ConvertJsonPart()
+    {
+        var part = new MimePart { Body = "{\"name\":\"test\"}" };
+        part.Headers["Content-Type"] = "application/json";
+        var converter = MimePartConverter.Default;
+        Assert.IsTrue(converter.CanConvertTo<System.Text.Json.JsonDocument>(MimeType.Parse(part.Headers["Content-Type"]!)));
+        Assert.IsTrue(converter.TryConvertTo<System.Text.Json.JsonDocument>(part, out var doc));
+        Assert.AreEqual("test", doc.RootElement.GetProperty("name").GetString());
     }
 }

--- a/UtilsTest/Net/MimePartFactoryTests.cs
+++ b/UtilsTest/Net/MimePartFactoryTests.cs
@@ -1,0 +1,54 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using System.Text.Json;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+[TestClass]
+public class MimePartFactoryTests
+{
+    [TestMethod]
+    public void CreateTextPart()
+    {
+        var factory = MimePartFactory.Default;
+        Assert.IsTrue(factory.TryCreatePart("Hello", out var part));
+        Assert.IsNotNull(part);
+        Assert.AreEqual("text/plain", part!.Headers["Content-Type"]);
+        Assert.AreEqual("Hello", part.Body);
+    }
+
+    [TestMethod]
+    public void CreateXmlPart()
+    {
+        var doc = new XDocument(new XElement("root"));
+        var factory = MimePartFactory.Default;
+        Assert.IsTrue(factory.TryCreatePart(doc, out var part));
+        Assert.AreEqual("text/xml", part!.Headers["Content-Type"]);
+        Assert.IsTrue(part.Body.Contains("<root"));
+    }
+
+    [TestMethod]
+    public void CreateBinaryPart()
+    {
+        var bytes = Encoding.UTF8.GetBytes("abc");
+        var factory = MimePartFactory.Default;
+        Assert.IsTrue(factory.TryCreatePart(bytes, out var part));
+        Assert.AreEqual("application/octet-stream", part!.Headers["Content-Type"]);
+        CollectionAssert.AreEqual(bytes, Convert.FromBase64String(part.Body));
+    }
+
+    [TestMethod]
+    public void CreateJsonPart()
+    {
+        using var doc = JsonDocument.Parse("{\"name\":\"test\"}");
+        var factory = MimePartFactory.Default;
+        Assert.IsTrue(factory.TryCreatePart(doc, out var part));
+        Assert.AreEqual("application/json", part!.Headers["Content-Type"]);
+        using var parsed = JsonDocument.Parse(part.Body);
+        Assert.AreEqual("test", parsed.RootElement.GetProperty("name").GetString());
+    }
+}


### PR DESCRIPTION
## Summary
- add `MimeReader` and `MimeWriter` utility classes
- route `MimeDocument` I/O through the new reader/writer helpers
- implement equality operators for `MimeType` and `MimePart`
- extend tests for reader/writer usage and equality semantics

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484ea2da088326b6131809e050951e