### PR TITLE
Add switch statement support

### DIFF
--- a/Utils/Expressions/Builders/CStyleBuilder.cs
+++ b/Utils/Expressions/Builders/CStyleBuilder.cs
@@ -66,6 +66,7 @@ public class CStyleBuilder : IBuilder
         { "while", new WhileBuilder() },
         { "for", new ForBuilder() },
         { "foreach", new ForEachBuilder() },
+        { "switch", new SwitchBuilder() },
         { "break", new BreakBuilder() },
         { "continue", new ContinueBuilder() },
 

--- a/Utils/README.md
+++ b/Utils/README.md
@@ -86,6 +86,20 @@ var lambda = Utils.Expressions.ExpressionParser.Parse<Func<string[], string>>(ex
 Func<string[], string> concat = lambda.Compile();
 string result = concat(new[] { "Hello", "World" });
 ```
+```csharp
+var switchExpr = "(i) => switch(i) { case 1: 10; case 2: 20; default: 0; }";
+var switchLambda = Utils.Expressions.ExpressionParser.Parse<Func<int, int>>(switchExpr);
+int value = switchLambda.Compile()(2); // 20
+```
+```csharp
+var switchStmt = "(int i) => { int v = 0; switch(i) { case 1: v = 10; break; case 2: v = 20; break; default: v = 0; break; } return v; }";
+var switchFunc = Utils.Expressions.ExpressionParser.Parse<Func<int, int>>(switchStmt).Compile();
+int result = switchFunc(1); // 10
+```
+```csharp
+var formatter = Utils.String.StringFormat.Create<Func<string, string>, DefaultInterpolatedStringHandler>("Name: {name}", "name");
+string formatted = formatter("John");
+```
 
 ### XML
 ```csharp

--- a/UtilsTest/Expressions/SwitchTests.cs
+++ b/UtilsTest/Expressions/SwitchTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Expressions;
+
+namespace UtilsTest.Expressions;
+
+[TestClass]
+public class SwitchTests
+{
+    [TestMethod]
+    public void SimpleSwitch()
+    {
+        var expression = "(int i) => switch(i) { case 1: 10; case 2: 20; default: 0; }";
+        var lambda = ExpressionParser.Parse<Func<int, int>>(expression);
+        var func = lambda.Compile();
+
+        Assert.AreEqual(10, func(1));
+        Assert.AreEqual(20, func(2));
+        Assert.AreEqual(0, func(3));
+    }
+
+    [TestMethod]
+    public void SwitchStatement()
+    {
+        var expression = "(int i) => { int v = 0; switch(i) { case 1: v = 10; break; case 2: v = 20; break; default: v = 0; break; } return v; }";
+        var lambda = ExpressionParser.Parse<Func<int, int>>(expression);
+        var func = lambda.Compile();
+
+        Assert.AreEqual(10, func(1));
+        Assert.AreEqual(20, func(2));
+        Assert.AreEqual(0, func(3));
+    }
+}
+

--- a/UtilsTest/Objects/FormatExTests.cs
+++ b/UtilsTest/Objects/FormatExTests.cs
@@ -75,5 +75,24 @@ namespace UtilsTest.Objects
 
             Assert.AreEqual(expected, format(dr));
         }
+
+        private struct SimpleHandler
+        {
+            private readonly StringBuilder _sb;
+            public SimpleHandler(int literalLength, int formattedCount, StringBuilder sb)
+            {
+                _sb = sb;
+            }
+            public void AppendLiteral(string s) => _sb.Append(s);
+            public void AppendFormatted<T>(T value) => _sb.Append(value);
+            public override string ToString() => _sb.ToString();
+        }
+
+        [TestMethod]
+        public void CustomHandlerTest()
+        {
+            var format = StringFormat.Create<Func<string, string>, SimpleHandler>("Value: {text}", "text");
+            Assert.AreEqual("Value: hello", format("hello"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support switch statements that require `break;` separators
- extend README with switch-statement usage
- test parsing of new switch statement form

## Testing
- `dotnet test UtilsTest/UtilsTest.csproj` *(fails: certificate retrieval blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685cb3387edc8326b723e07418dbfc7f