### PR TITLE
Add compiled date formula and namespace fix

### DIFF
--- a/Utils/README.md
+++ b/Utils/README.md
@@ -79,6 +79,12 @@ string code = authenticator.ComputeAuthenticator();
 bool ok = authenticator.VerifyAuthenticator(1, code);
 ```
 
+### Dates
+```csharp
+var compiled = Utils.Dates.DateFormula.Compile("FM+1J", new CultureInfo("fr-FR"));
+DateTime result = compiled(new DateTime(2023, 3, 15)); // 2023-04-01
+```
+
 ### Expressions
 ```csharp
 var expression = "(items) => items[0] + items[1]";

--- a/Utils/Security/Authenticator.cs
+++ b/Utils/Security/Authenticator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Security.Cryptography;
-using Utils.Utils.Dates;
+using Utils.Dates;
 
 namespace Utils.Security;
 

--- a/Utils/Utils.Dates/DateFormula.cs
+++ b/Utils/Utils.Dates/DateFormula.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq.Expressions;
+using System.Reflection;
 using Utils.Objects;
 
-namespace Utils.Utils.Dates;
+namespace Utils.Dates;
 
 /// <summary>
 /// Evaluates date formulas using culture specific tokens.
@@ -86,6 +88,93 @@ public static class DateFormula
                         result = MoveToSameWeekDay(result, lang.Days[day], culture.DateTimeFormat.FirstDayOfWeek);
                 }
                 return result.Date;
+        }
+
+        /// <summary>
+        /// Compiles the provided <paramref name="formula"/> into a delegate.
+        /// </summary>
+        /// <param name="formula">Formula to compile.</param>
+        /// <param name="culture">Culture used to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+        /// <returns>A delegate computing the resulting date.</returns>
+        public static Func<DateTime, DateTime> Compile(string formula, CultureInfo culture = null)
+                => Compile(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture);
+
+        /// <summary>
+        /// Compiles the provided <paramref name="formula"/> using a custom provider.
+        /// </summary>
+        /// <param name="formula">Formula to compile.</param>
+        /// <param name="provider">Language provider.</param>
+        /// <param name="culture">Culture used to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+        /// <returns>A delegate computing the resulting date.</returns>
+        public static Func<DateTime, DateTime> Compile(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null)
+        {
+                culture ??= CultureInfo.CurrentCulture;
+                var lang = provider.GetLanguage(culture);
+
+                if (formula.Length < 2)
+                        throw new ArgumentException("Formula is too short.", nameof(formula));
+
+                var start = formula[0] == lang.Start;
+                var end = formula[0] == lang.End;
+                if (!start && !end)
+                        throw new ArgumentException("Invalid formula start token.", nameof(formula));
+
+                var period = ParsePeriod(formula[1], lang);
+
+                var param = Expression.Parameter(typeof(DateTime), "d");
+                Expression expr = Expression.Call(
+                        typeof(DateUtils),
+                        start ? nameof(DateUtils.StartOf) : nameof(DateUtils.EndOf),
+                        null,
+                        param,
+                        Expression.Constant(period),
+                        Expression.Constant(culture));
+
+                var index = 2;
+                while (index < formula.Length && (formula[index] == '+' || formula[index] == '-'))
+                {
+                        var sign = formula[index];
+                        var pos = index + 1;
+                        if (pos < formula.Length && char.IsDigit(formula[pos]))
+                        {
+                                var startPos = pos;
+                                while (pos < formula.Length && char.IsDigit(formula[pos])) pos++;
+                                var value = int.Parse(formula[startPos..pos], CultureInfo.InvariantCulture);
+                                if (sign == '-') value = -value;
+                                if (pos >= formula.Length)
+                                        throw new ArgumentException("Missing unit token.", nameof(formula));
+                                var unit = ParsePeriod(formula[pos], lang);
+                                expr = Expression.Call(
+                                        typeof(DateFormula).GetMethod("AddPeriod", BindingFlags.NonPublic | BindingFlags.Static)!,
+                                        expr,
+                                        Expression.Constant(unit),
+                                        Expression.Constant(value),
+                                        Expression.Constant(culture.Calendar));
+                                index = pos + 1;
+                        }
+                        else
+                        {
+                                var day = formula.Substring(pos, 2);
+                                expr = Expression.Call(
+                                        typeof(DateFormula).GetMethod("AdjustToDayOfWeek", BindingFlags.NonPublic | BindingFlags.Static)!,
+                                        expr,
+                                        Expression.Constant(lang.Days[day]),
+                                        Expression.Constant(sign == '+'));
+                                index = pos + 2;
+                                return Expression.Lambda<Func<DateTime, DateTime>>(Expression.Property(expr, nameof(DateTime.Date)), param).Compile();
+                        }
+                }
+                if (index < formula.Length)
+                {
+                        var day = formula.Substring(index, 2);
+                        expr = Expression.Call(
+                                typeof(DateFormula).GetMethod("MoveToSameWeekDay", BindingFlags.NonPublic | BindingFlags.Static)!,
+                                expr,
+                                Expression.Constant(lang.Days[day]),
+                                Expression.Constant(culture.DateTimeFormat.FirstDayOfWeek));
+                }
+                expr = Expression.Property(expr, nameof(DateTime.Date));
+                return Expression.Lambda<Func<DateTime, DateTime>>(expr, param).Compile();
         }
 
         private static PeriodTypeEnum ParsePeriod(char token, DateFormulaLanguage lang)

--- a/Utils/Utils.Dates/DateFormulaLanguage.cs
+++ b/Utils/Utils.Dates/DateFormulaLanguage.cs
@@ -1,4 +1,4 @@
-namespace Utils.Utils.Dates;
+namespace Utils.Dates;
 
 /// <summary>
 /// Represents culture specific tokens used to interpret date formulas.

--- a/Utils/Utils.Dates/DateUtils.cs
+++ b/Utils/Utils.Dates/DateUtils.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Utils.Objects;
 
-namespace Utils.Utils.Dates;
+namespace Utils.Dates;
 
 /// <summary>
 /// Provides utility methods for date and time calculations and manipulations.

--- a/Utils/Utils.Dates/IDateFormulaLanguageProvider.cs
+++ b/Utils/Utils.Dates/IDateFormulaLanguageProvider.cs
@@ -1,6 +1,6 @@
 using System.Globalization;
 
-namespace Utils.Utils.Dates;
+namespace Utils.Dates;
 
 /// <summary>
 /// Provides culture specific <see cref="DateFormulaLanguage"/> instances.

--- a/Utils/Utils.Dates/JsonDateFormulaLanguageProvider.cs
+++ b/Utils/Utils.Dates/JsonDateFormulaLanguageProvider.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 
-namespace Utils.Utils.Dates;
+namespace Utils.Dates;
 
 /// <summary>
 /// Loads <see cref="DateFormulaLanguage"/> data from a JSON configuration.

--- a/Utils/Utils.Dates/Week.cs
+++ b/Utils/Utils.Dates/Week.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Numerics;
 using Utils.Objects;
 
-namespace Utils.Utils.Dates;
+namespace Utils.Dates;
 /// <summary>
 /// Represents a specific week in a given year.
 /// </summary>

--- a/Utils/Utils.Dates/WeekUtils.cs
+++ b/Utils/Utils.Dates/WeekUtils.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using Utils.Objects;
 
-namespace Utils.Utils.Dates;
+namespace Utils.Dates;
 
 public static class WeekUtils
 {

--- a/UtilsTest/Objects/DateFormulaTests.cs
+++ b/UtilsTest/Objects/DateFormulaTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Globalization;
-using Utils.Utils.Dates;
+using Utils.Dates;
 
 namespace UtilsTest.Objects;
 
@@ -51,5 +51,13 @@ public class DateFormulaTests
         {
                 var date = new DateTime(2023, 3, 15);
                 Assert.AreEqual(new DateTime(2023, 4, 1), date.Calculate("EM+1D", new CultureInfo("zh-CN")));
+        }
+
+        [TestMethod]
+        public void CompiledFormula()
+        {
+                var func = DateFormula.Compile("FM+1J", new CultureInfo("fr-FR"));
+                var result = func(new DateTime(2023, 3, 15));
+                Assert.AreEqual(new DateTime(2023, 4, 1), result);
         }
 }

--- a/UtilsTest/Objects/DateUtilitiesTests.cs
+++ b/UtilsTest/Objects/DateUtilitiesTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Utils.Objects;
-using Utils.Utils.Dates;
+using Utils.Dates;
 
 namespace UtilsTest.Objects;
 


### PR DESCRIPTION
## Summary
- update namespace for date utilities to `Utils.Dates`
- show date formula compilation example with new namespace in README
- adjust tests and sources accordingly

## Testing
- `dotnet build Utils.sln -c Release`
- `dotnet test UtilsTest/UtilsTest.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685d5fd389f883268c700cac88487d20