### PR TITLE
Make GetOrAdd thread-safe

### DIFF
--- a/Utils/Collections/DictionaryExtensions.cs
+++ b/Utils/Collections/DictionaryExtensions.cs
@@ -1,44 +1,89 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Utils.Collections;
 
 public static class DictionaryExtensions
 {
-	public static TValue GetOrAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
-		where TKey : notnull
-	{
-		ref var val = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out bool exists);
-		if (!exists)
-		{
-			val = value;
-		}
-		return val;
-	}
+    /// <summary>
+    /// Retrieves the value associated with <paramref name="key"/> or adds the
+    /// provided <paramref name="value"/> in a thread-safe manner.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="dictionary">The dictionary to operate on.</param>
+    /// <param name="key">Key of the element to retrieve.</param>
+    /// <param name="value">Value to add if the key is not present.</param>
+    /// <returns>The existing or newly added value.</returns>
+    [MethodImpl(MethodImplOptions.Synchronized)]
+    public static TValue GetOrAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        where TKey : notnull
+    {
+        ArgumentNullException.ThrowIfNull(dictionary);
+        lock (dictionary)
+        {
+            ref var val = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out bool exists);
+            if (!exists)
+            {
+                val = value;
+            }
+            return val;
+        }
+    }
 
-	public static TValue GetOrAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, Func<TValue> func)
-	where TKey : notnull
-	{
-		ref var val = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out bool exists);
-		if (!exists)
-		{
-			val = func();
-		}
-		return val;
-	}
+    /// <summary>
+    /// Retrieves the value associated with <paramref name="key"/> or adds a
+    /// new value created by <paramref name="func"/> in a thread-safe manner.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="dictionary">The dictionary to operate on.</param>
+    /// <param name="key">Key of the element to retrieve.</param>
+    /// <param name="func">Factory used to create the value when absent.</param>
+    /// <returns>The existing or newly added value.</returns>
+    [MethodImpl(MethodImplOptions.Synchronized)]
+    public static TValue GetOrAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, Func<TValue> func)
+        where TKey : notnull
+    {
+        ArgumentNullException.ThrowIfNull(dictionary);
+        ArgumentNullException.ThrowIfNull(func);
+        lock (dictionary)
+        {
+            ref var val = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out bool exists);
+            if (!exists)
+            {
+                val = func();
+            }
+            return val;
+        }
+    }
 
-	public static bool TryUpdate<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
-		where TKey : notnull
-	{
-		ref var val = ref CollectionsMarshal.GetValueRefOrNullRef(dictionary, key);
-		if (Unsafe.IsNullRef(ref val)) return false;
-		val = value;
-		return true;	
-	}
+    /// <summary>
+    /// Attempts to update an existing entry with the specified
+    /// <paramref name="value"/> in a thread-safe manner.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="dictionary">The dictionary to update.</param>
+    /// <param name="key">Key of the element to update.</param>
+    /// <param name="value">The new value.</param>
+    /// <returns><c>true</c> if the key was present and the value updated.</returns>
+    [MethodImpl(MethodImplOptions.Synchronized)]
+    public static bool TryUpdate<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        where TKey : notnull
+    {
+        ArgumentNullException.ThrowIfNull(dictionary);
+        lock (dictionary)
+        {
+            ref var val = ref CollectionsMarshal.GetValueRefOrNullRef(dictionary, key);
+            if (Unsafe.IsNullRef(ref val))
+            {
+                return false;
+            }
+            val = value;
+            return true;
+        }
+    }
 }

--- a/Utils/README.md
+++ b/Utils/README.md
@@ -38,6 +38,9 @@ cache.Add(1, "one");
 cache.Add(2, "two");
 cache[1];
 cache.Add(3, "three"); // evicts key 2
+var dict = new Dictionary<string, int>();
+// Thread-safe dictionary insertion
+int one = dict.GetOrAdd("one", () => 1);
 ```
 
 ### Files

--- a/UtilsTest/Collections/GetOrAddThreadSafetyTests.cs
+++ b/UtilsTest/Collections/GetOrAddThreadSafetyTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Utils.Collections;
+
+namespace UtilsTest.Collections;
+
+[TestClass]
+public class GetOrAddThreadSafetyTests
+{
+    [TestMethod]
+    public async Task GetOrAdd_AllowsConcurrentAccess()
+    {
+        var dictionary = new Dictionary<int, int>();
+
+        async Task<int> AddAsync()
+        {
+            return await Task.Run(() => dictionary.GetOrAdd(0, () => 1));
+        }
+
+        var tasks = Enumerable.Range(0, 20).Select(_ => AddAsync());
+        var results = await Task.WhenAll(tasks);
+
+        CollectionAssert.AreEqual(Enumerable.Repeat(1, 20).ToArray(), results);
+        Assert.AreEqual(1, dictionary.Count);
+        Assert.AreEqual(1, dictionary[0]);
+    }
+
+    [TestMethod]
+    public void GetOrAdd_IsMarkedAsSynchronized()
+    {
+        var methods = typeof(DictionaryExtensions).GetMethods()
+            .Where(m => m.Name == "GetOrAdd");
+
+        foreach (var method in methods)
+        {
+            var attr = method.GetCustomAttribute<MethodImplAttribute>();
+            Assert.IsNotNull(attr);
+            Assert.IsTrue(attr.Value.HasFlag(MethodImplOptions.Synchronized));
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure `DictionaryExtensions.GetOrAdd` methods are marked as synchronized
- show thread-safe dictionary insertion in README
- add test verifying `GetOrAdd` has MethodImplOptions.Synchronized

## Testing
- `dotnet test UtilsTest/UtilsTest.csproj --no-build` *(fails: project assets not restored)*

------
https://chatgpt.com/codex/tasks/task_e_686be19faf248326b5caefb0abd670b7