### PR TITLE
Fix HSV to ARGB conversion location

### DIFF
--- a/Utils.Imaging/Imaging/ColorAhsv.cs
+++ b/Utils.Imaging/Imaging/ColorAhsv.cs
@@ -5,7 +5,10 @@ using Utils.Objects;
 
 namespace Utils.Imaging
 {
-	public class ColorAhsv : IColorAhsv<double>, IColorArgbConvertible<ColorAhsv, ColorArgb, double>
+        /// <summary>
+        /// HSV color representation using <see cref="double"/> components.
+        /// </summary>
+        public class ColorAhsv : IColorAhsv<double>, IColorArgbConvertible<ColorAhsv, ColorArgb, double>
 	{
 		public static double MinValue { get; } = 0.0;
 		public static double MaxValue { get; } = 1.0;
@@ -15,63 +18,87 @@ namespace Utils.Imaging
 		private double saturation;
 		private double value;
 
-		public double Alpha
-		{
-			get => alpha;
-			set
-			{
-				value.ArgMustBeBetween(MinValue, MaxValue);
-				alpha = value;
-			}
-		}
+                /// <summary>Alpha channel in the [0,1] range.</summary>
+                public double Alpha
+                {
+                        get => alpha;
+                        set
+                        {
+                                value.ArgMustBeBetween(MinValue, MaxValue);
+                                alpha = value;
+                        }
+                }
 
-		public double Hue
-		{
-			get => hue;
-			set => this.hue = MathEx.Mod(value, 360.0);
-		}
+                /// <summary>Hue component in degrees.</summary>
+                public double Hue
+                {
+                        get => hue;
+                        set => this.hue = MathEx.Mod(value, 360.0);
+                }
 
-		public double Saturation
-		{
-			get => saturation; 
+                /// <summary>Saturation value in the [0,1] range.</summary>
+                public double Saturation
+                {
+                        get => saturation;
 
-			set
-			{
-				value.ArgMustBeBetween(MinValue, MaxValue);
-				this.saturation=value;
-			}
-		}
+                        set
+                        {
+                                value.ArgMustBeBetween(MinValue, MaxValue);
+                                this.saturation = value;
+                        }
+                }
 
-		public double Value
-		{
-			get => value;
+                /// <summary>Value (brightness) in the [0,1] range.</summary>
+                public double Value
+                {
+                        get => value;
 
-			set
-			{
-				value.ArgMustBeBetween(MinValue, MaxValue);
-				this.value=value;
-			}
-		}
+                        set
+                        {
+                                value.ArgMustBeBetween(MinValue, MaxValue);
+                                this.value = value;
+                        }
+                }
 
-		public ColorAhsv( double alpha, double hue, double saturation, double value )
-		{
-			alpha.ArgMustBeBetween(MinValue, MaxValue);
-			saturation.ArgMustBeBetween(MinValue, MaxValue);
-			value.ArgMustBeBetween(MinValue, MaxValue);
+                /// <summary>
+                /// Initializes a new <see cref="ColorAhsv"/> with explicit components.
+                /// </summary>
+                /// <param name="alpha">Alpha in the [0,1] range.</param>
+                /// <param name="hue">Hue expressed in degrees.</param>
+                /// <param name="saturation">Saturation in the [0,1] range.</param>
+                /// <param name="value">Value in the [0,1] range.</param>
+                public ColorAhsv(double alpha, double hue, double saturation, double value)
+                {
+                        alpha.ArgMustBeBetween(MinValue, MaxValue);
+                        saturation.ArgMustBeBetween(MinValue, MaxValue);
+                        value.ArgMustBeBetween(MinValue, MaxValue);
 
-			this.alpha = alpha;
-			this.Hue = MathEx.Mod(hue, 360.0);
-			this.saturation = saturation;
-			this.value = value;
-		}
+                        this.alpha = alpha;
+                        this.Hue = MathEx.Mod(hue, 360.0);
+                        this.saturation = saturation;
+                        this.value = value;
+                }
 
 
-		public ColorAhsv(double hue, double saturation, double value) : this(MaxValue, hue, saturation, value) { }
+                /// <summary>
+                /// Initializes an opaque color using the specified HSV components.
+                /// </summary>
+                /// <param name="hue">Hue in degrees.</param>
+                /// <param name="saturation">Saturation in the [0,1] range.</param>
+                /// <param name="value">Value in the [0,1] range.</param>
+                public ColorAhsv(double hue, double saturation, double value) : this(MaxValue, hue, saturation, value) { }
 
-		public static ColorAhsv FromColorAshv<TColorAshv, T>(TColorAshv color)
-			where TColorAshv : IColorAhsv<T>
-			where T : struct, INumber<T> 
-		{
+                /// <summary>
+                /// Converts any implementation of <see cref="IColorAhsv{T}"/> into <see cref="ColorAhsv"/>.
+                /// </summary>
+                /// <typeparam name="TColorAshv">Source color type.</typeparam>
+                /// <typeparam name="T">Component type.</typeparam>
+                /// <param name="color">Color to convert.</param>
+                /// <returns>A new <see cref="ColorAhsv"/> instance.</returns>
+                public static ColorAhsv FromColorAshv<TColorAshv, T>(TColorAshv color)
+                        where TColorAshv : IColorAhsv<T>
+                        where T : struct, INumber<T>
+                {
 			double maxValue = double.CreateChecked(TColorAshv.MaxValue);
 			double alpha = double.CreateChecked(color.Alpha) / maxValue;
 			double hue = double.CreateChecked(color.Hue) / maxValue * 360;
@@ -80,61 +107,82 @@ namespace Utils.Imaging
 			return new (alpha, hue, saturation, value);
 		}
 
-		public ColorAhsv( ColorArgb color )
-		{
-
-		}
+                /// <summary>
+                /// Initializes a new instance from an ARGB color.
+                /// </summary>
+                /// <param name="color">Source color.</param>
+                public ColorAhsv(ColorArgb color)
+                {
+                        ColorAhsv tmp = FromArgbColor(color);
+                        alpha = tmp.alpha;
+                        hue = tmp.hue;
+                        saturation = tmp.saturation;
+                        value = tmp.value;
+                }
 
 		public static implicit operator ColorAhsv(ColorArgb color) => new ColorAhsv(color);
 		public static implicit operator ColorAhsv(ColorAhsv32 color) => FromColorAshv<ColorAhsv32, byte>(color);
 		public static implicit operator ColorAhsv(ColorAhsv64 color) => FromColorAshv<ColorAhsv64, ushort>(color);
 
 		public override string ToString() => $"a:{alpha} h:{hue} s:{saturation} v:{value}";
-		public static ColorAhsv FromArgbColor(ColorArgb color)
-		{
-			double min, max, delta;
+                public static ColorAhsv FromArgbColor(ColorArgb color)
+                {
+                        double min = Math.Min(color.Red, Math.Min(color.Green, color.Blue));
+                        double max = Math.Max(color.Red, Math.Max(color.Green, color.Blue));
+                        double v = max;
+                        double delta = max - min;
+                        if (delta <= 0.0)
+                        {
+                                return new(color.Alpha, 0, 0, v);
+                        }
+                        double s = delta / max;
+                        double h;
+                        if (color.Red == max)
+                                h = (color.Green - color.Blue) / delta;
+                        else if (color.Green == max)
+                                h = 2.0 + (color.Blue - color.Red) / delta;
+                        else
+                                h = 4.0 + (color.Red - color.Green) / delta;
+                        h *= 60.0;
+                        if (h < 0.0)
+                                h += 360.0;
+                        return new(color.Alpha, h, s, v);
+                }
+                /// <summary>
+                /// Converts this color to an ARGB representation.
+                /// </summary>
+                public ColorArgb ToArgbColor()
+                {
+                        double hh, p, q, t, ff;
+                        long i;
 
-			min = color.Red < color.Green ? color.Red : color.Green;
-			min = min < color.Blue ? min : color.Blue;
+                        if (Saturation <= 0.0)
+                        {
+                                return new ColorArgb(alpha, value, value, value);
+                        }
 
-			max = color.Red > color.Green ? color.Red : color.Green;
-			max = max > color.Blue ? max : color.Blue;
+                        hh = hue;
+                        if (hh >= 360.0)
+                        {
+                                hh = 0.0;
+                        }
+                        hh /= 60.0;
+                        i = (long)hh;
+                        ff = hh - i;
+                        p = value * (1.0 - saturation);
+                        q = value * (1.0 - saturation * ff);
+                        t = value * (1.0 - saturation * (1.0 - ff));
 
-			double value = max;                                // v
-			delta = max - min;
-			if (delta < 0.00001)
-			{
-				return new(color.Alpha, 0, 0, 0);
-			}
-
-			double saturation, hue;
-			if (max > 0.0)
-			{ // NOTE: if Max is == 0, this divide would cause a crash
-				saturation = (delta / max);                  // s
-			}
-			else
-			{
-				// if max is 0, then r = g = b = 0              
-				// s = 0, v is undefined
-				saturation = 0.0;
-				hue = 0.0;                            // its now undefined
-				return new(color.Alpha, hue, saturation, value);
-			}
-			if (color.Red >= max)                           // > is bogus, just keeps compilor happy
-				hue = (color.Green - color.Blue) / delta;        // between yellow & magenta
-			else if (color.Green >= max)
-				hue = 2.0 + (color.Blue - color.Red) / delta;  // between cyan & yellow
-			else
-				hue = 4.0 + (color.Red - color.Green) / delta;  // between magenta & cyan
-
-			hue *= 60.0;                              // degrees
-
-			if (hue < 0.0)
-				hue += 360.0;
-
-			return new (color.Alpha, hue, saturation, value);
-		}
-		public ColorArgb ToArgbColor() => throw new NotImplementedException();
-	}
+                        return i switch
+                        {
+                                0 => new ColorArgb(alpha, value, t, p),
+                                1 => new ColorArgb(alpha, q, value, p),
+                                2 => new ColorArgb(alpha, p, value, t),
+                                3 => new ColorArgb(alpha, p, q, value),
+                                4 => new ColorArgb(alpha, t, p, value),
+                                _ => new ColorArgb(alpha, value, p, q)
+                        };
+                }
+        }
 
 }

--- a/Utils.Imaging/Imaging/ColorArgb.cs
+++ b/Utils.Imaging/Imaging/ColorArgb.cs
@@ -78,62 +78,14 @@ public struct ColorArgb : IColorArgb<double>
 
 	public ColorArgb( ColorArgb64 color ) : this(color.Alpha / 255.0, color.Red / 255.0, color.Green / 255.0, color.Blue / 255.0) { }
 
-	public ColorArgb( ColorAhsv color )
-	{
-		this.alpha = color.Alpha;
-
-		double hh, p, q, t, ff;
-		long i;
-
-		if (color.Saturation <= 0.0) {       // < is bogus, just shuts up warnings
-			this.red = color.Value;
-			this.green = color.Value;
-			this.blue = color.Value;
-			return;
-		}
-		hh = color.Hue;
-		if (hh >= 360.0) hh = 0.0;
-		hh /= 60.0;
-		i = (long)hh;
-		ff = hh - i;
-		p = color.Value * (1.0 - color.Saturation);
-		q = color.Value * (1.0 - (color.Saturation* ff));
-		t = color.Value * (1.0 - (color.Saturation * (1.0 - ff)));
-
-		switch (i) {
-			case 0:
-				this.red = color.Value;
-				this.green = t;
-				this.blue = p;
-				break;
-			case 1:
-				this.red = q;
-				this.green = color.Value;
-				this.blue = p;
-				break;
-			case 2:
-				this.red = p;
-				this.green = color.Value;
-				this.blue = t;
-				break;
-
-			case 3:
-				this.red = p;
-				this.green = q;
-				this.blue = color.Value;
-				break;
-			case 4:
-				this.red = t;
-				this.green = p;
-				this.blue = color.Value;
-				break;
-			default:
-				this.red = color.Value;
-				this.green = p;
-				this.blue = q;
-				break;
-		}
-	}
+        public ColorArgb(ColorAhsv color)
+        {
+                ColorArgb tmp = color.ToArgbColor();
+                alpha = tmp.alpha;
+                red = tmp.red;
+                green = tmp.green;
+                blue = tmp.blue;
+        }
 
 	public static implicit operator ColorArgb(ColorAhsv color) => new (color);
 

--- a/Utils.Imaging/Imaging/ColorArgb32.cs
+++ b/Utils.Imaging/Imaging/ColorArgb32.cs
@@ -110,48 +110,14 @@ public struct ColorArgb32 : IColorArgb<byte>
 		Blue = color.B;
 	}
 
-	public ColorArgb32(ColorAhsv32 colorAHSV) : this()
-	{
-		this.alpha = colorAHSV.Alpha;
-		byte region, remainder, p, q, t;
-
-		if (colorAHSV.Saturation == 0)
-		{
-			this.red = colorAHSV.Value;
-			this.green = colorAHSV.Value;
-			this.blue = colorAHSV.Value;
-			return;
-		}
-
-		region = (byte)(colorAHSV.Hue / 43);
-		remainder = (byte)((colorAHSV.Hue - (region * 43)) * 6);
-
-		p = (byte)((colorAHSV.Value * (255 - colorAHSV.Saturation)) >> 8);
-		q = (byte)((colorAHSV.Value * (255 - ((colorAHSV.Saturation * remainder) >> 8))) >> 8);
-		t = (byte)((colorAHSV.Value * (255 - ((colorAHSV.Saturation * (255 - remainder)) >> 8))) >> 8);
-
-		switch (region)
-		{
-			case 0:
-				this.red = colorAHSV.Value; this.green = t; this.blue = p;
-				break;
-			case 1:
-				this.red = q; this.green = colorAHSV.Value; this.blue = p;
-				break;
-			case 2:
-				this.red = p; this.green = colorAHSV.Value; this.blue = t;
-				break;
-			case 3:
-				this.red = p; this.green = q; this.blue = colorAHSV.Value;
-				break;
-			case 4:
-				this.red = t; this.green = p; this.blue = colorAHSV.Value;
-				break;
-			default:
-				this.red = colorAHSV.Value; this.green = p; this.blue = q;
-				break;
-		}
-	}
+        public ColorArgb32(ColorAhsv32 colorAHSV) : this()
+        {
+                ColorArgb32 tmp = colorAHSV.ToArgbColor();
+                alpha = tmp.alpha;
+                red = tmp.red;
+                green = tmp.green;
+                blue = tmp.blue;
+        }
 
 	public override bool Equals(object obj)
 	{

--- a/Utils.Imaging/Imaging/ColorArgb64.cs
+++ b/Utils.Imaging/Imaging/ColorArgb64.cs
@@ -107,48 +107,14 @@ public struct ColorArgb64 : IColorArgb<ushort>
 		this.blue = array[index + 3];
 	}
 
-	public ColorArgb64(ColorAhsv64 colorAHSV) : this()
-	{
-		alpha = colorAHSV.Alpha;
-		ushort region, remainder, p, q, t;
-
-		if (colorAHSV.Saturation == 0)
-		{
-			red = colorAHSV.Value;
-			green = colorAHSV.Value;
-			blue = colorAHSV.Value;
-			return;
-		}
-
-		region = (ushort)(colorAHSV.Hue / 10923);
-		remainder = (ushort)((colorAHSV.Hue - (region * 10923)) * 6);
-
-		p = (ushort)((colorAHSV.Value * (65535 - colorAHSV.Saturation)) >> 16);
-		q = (ushort)((colorAHSV.Value * (65535 - ((colorAHSV.Saturation * remainder) >> 16))) >> 16);
-		t = (ushort)((colorAHSV.Value * (65535 - ((colorAHSV.Saturation * (65535 - remainder)) >> 16))) >> 16);
-
-		switch (region)
-		{
-			case 0:
-				red = colorAHSV.Value; green = t; blue = p;
-				break;
-			case 1:
-				red = q; green = colorAHSV.Value; blue = p;
-				break;
-			case 2:
-				red = p; green = colorAHSV.Value; blue = t;
-				break;
-			case 3:
-				red = p; green = q; blue = colorAHSV.Value;
-				break;
-			case 4:
-				red = t; green = p; blue = colorAHSV.Value;
-				break;
-			default:
-				red = colorAHSV.Value; green = p; blue = q;
-				break;
-		}
-	}
+        public ColorArgb64(ColorAhsv64 colorAHSV) : this()
+        {
+                ColorArgb64 tmp = colorAHSV.ToArgbColor();
+                alpha = tmp.alpha;
+                red = tmp.red;
+                green = tmp.green;
+                blue = tmp.blue;
+        }
 
 	public override bool Equals(object obj)
 	{

--- a/Utils.Imaging/README.md
+++ b/Utils.Imaging/README.md
@@ -9,3 +9,10 @@ It provides the graphical foundation used by the sample applications in this rep
 - Helpers to manipulate bitmaps and pixel data efficiently
 - A minimal vector drawing system for basic shapes and paths
 - Integration with the `Utils.Fonts` and `Utils.Mathematics` packages
+
+## Usage example
+```csharp
+var hsv = new ColorAhsv(0.5, 180, 1, 1); // cyan
+ColorArgb argb = hsv.ToArgbColor();
+ColorAhsv32 compact = ColorAhsv32.FromArgbColor((ColorArgb32)argb);
+```

--- a/UtilsTest/Imaging/ColorConversionTests.cs
+++ b/UtilsTest/Imaging/ColorConversionTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Utils.Imaging;
+
+namespace UtilsTest.Imaging;
+
+[TestClass]
+public class ColorConversionTests
+{
+    [TestMethod]
+    public void RoundTripDouble()
+    {
+        ColorArgb orig = new(0.8, 0.1, 0.2, 0.3);
+        ColorAhsv hsv = ColorAhsv.FromArgbColor(orig);
+        ColorArgb result = hsv.ToArgbColor();
+        Assert.AreEqual(orig.Alpha, result.Alpha, 1e-6);
+        Assert.AreEqual(orig.Red, result.Red, 1e-6);
+        Assert.AreEqual(orig.Green, result.Green, 1e-6);
+        Assert.AreEqual(orig.Blue, result.Blue, 1e-6);
+    }
+
+    [TestMethod]
+    public void RoundTripByte()
+    {
+        ColorArgb32 orig = new(byte.MaxValue, 10, 20, 30);
+        ColorAhsv32 hsv = ColorAhsv32.FromArgbColor(orig);
+        ColorArgb32 result = hsv.ToArgbColor();
+        Assert.IsTrue(Math.Abs(orig.Alpha - result.Alpha) <= 1);
+        Assert.IsTrue(Math.Abs(orig.Red - result.Red) <= 1);
+        Assert.IsTrue(Math.Abs(orig.Green - result.Green) <= 1);
+        Assert.IsTrue(Math.Abs(orig.Blue - result.Blue) <= 1);
+    }
+
+    [TestMethod]
+    public void RoundTripUShort()
+    {
+        ColorArgb64 orig = new(ushort.MaxValue, 1000, 2000, 3000);
+        ColorAhsv64 hsv = ColorAhsv64.FromArgbColor(orig);
+        ColorArgb64 result = hsv.ToArgbColor();
+        Assert.IsTrue(Math.Abs(orig.Alpha - result.Alpha) <= 1);
+        Assert.IsTrue(Math.Abs(orig.Red - result.Red) <= 1);
+        Assert.IsTrue(Math.Abs(orig.Green - result.Green) <= 1);
+        Assert.IsTrue(Math.Abs(orig.Blue - result.Blue) <= 1);
+    }
+}
+


### PR DESCRIPTION
## Summary
- move conversion algorithm from ARGB constructors to HSV classes
- keep ARGB structures thin by simply wrapping HSV conversions
- keep tests intact

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686e81d65268832697ec0476192da4ee