### PR TITLE
Add working day support in DateFormula

### DIFF
--- a/Utils/Dates/DateFormula.cs
+++ b/Utils/Dates/DateFormula.cs
@@ -22,10 +22,10 @@ public static class DateFormula
 	});
 
 	/// <summary>Cache for compiled formulas.</summary>
-	private static readonly Dictionary<FormulaCacheKey, Func<DateTime, DateTime>> _cache = [];
+        private static readonly Dictionary<FormulaCacheKey, Func<DateTime, DateTime>> _cache = [];
 
 	/// <summary>Represents a unique key for the formula cache.</summary>
-	private sealed record FormulaCacheKey(IDateFormulaLanguageProvider Provider, string CultureName, string Formula);
+        private sealed record FormulaCacheKey(IDateFormulaLanguageProvider Provider, string CultureName, string Formula, ICalendarProvider? CalendarProvider);
 
 	/// <summary>
 	/// Retrieves a compiled formula from the cache or compiles it if missing.
@@ -34,14 +34,14 @@ public static class DateFormula
 	/// <param name="provider">Language provider.</param>
 	/// <param name="culture">Culture used for token interpretation.</param>
 	/// <returns>A delegate computing the date from a base value.</returns>
-	private static Func<DateTime, DateTime> GetCompiledFormula(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture)
-	{
-		var key = new FormulaCacheKey(provider, culture.Name, formula);
-		lock (_cache)
-		{
-			return _cache.GetOrAdd(key, () => Compile(formula, provider, culture));
-		}
-	}
+        private static Func<DateTime, DateTime> GetCompiledFormula(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture, ICalendarProvider? calendarProvider)
+        {
+                var key = new FormulaCacheKey(provider, culture.Name, formula, calendarProvider);
+                lock (_cache)
+                {
+                        return _cache.GetOrAdd(key, () => Compile(formula, provider, culture, calendarProvider));
+                }
+        }
 
 	/// <summary>
 	/// Calculates the date described by <paramref name="formula"/>.
@@ -50,8 +50,8 @@ public static class DateFormula
 	/// <param name="formula">Formula to evaluate.</param>
 	/// <param name="culture">Culture used to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
 	/// <returns>The computed date.</returns>
-	public static DateTime Calculate(this DateTime date, string formula, CultureInfo culture = null)
-			=> date.Calculate(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture);
+        public static DateTime Calculate(this DateTime date, string formula, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+                        => date.Calculate(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture, calendarProvider);
 
 	/// <summary>
 	/// Calculates the date described by <paramref name="formula"/> using a custom provider.
@@ -61,12 +61,12 @@ public static class DateFormula
 	/// <param name="provider">Language provider.</param>
 	/// <param name="culture">Culture to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
 	/// <returns>The computed date.</returns>
-	public static DateTime Calculate(this DateTime date, string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null)
-	{
-		culture ??= CultureInfo.CurrentCulture;
-		var compiled = GetCompiledFormula(formula, provider, culture);
-		return compiled(date);
-	}
+        public static DateTime Calculate(this DateTime date, string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+        {
+                culture ??= CultureInfo.CurrentCulture;
+                var compiled = GetCompiledFormula(formula, provider, culture, calendarProvider);
+                return compiled(date);
+        }
 
 	/// <summary>
 	/// Compiles the provided <paramref name="formula"/> into a delegate.
@@ -74,8 +74,8 @@ public static class DateFormula
 	/// <param name="formula">Formula to compile.</param>
 	/// <param name="culture">Culture used to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
 	/// <returns>A delegate computing the resulting date.</returns>
-	public static Func<DateTime, DateTime> Compile(string formula, CultureInfo culture = null)
-			=> Compile(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture);
+        public static Func<DateTime, DateTime> Compile(string formula, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+                        => Compile(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture, calendarProvider);
 
 	/// <summary>
 	/// Compiles the provided <paramref name="formula"/> using a custom provider.
@@ -84,10 +84,10 @@ public static class DateFormula
 	/// <param name="provider">Language provider.</param>
 	/// <param name="culture">Culture used to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
 	/// <returns>A delegate computing the resulting date.</returns>
-	public static Func<DateTime, DateTime> Compile(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null)
-	{
-		culture ??= CultureInfo.CurrentCulture;
-		var lang = provider.GetLanguage(culture);
+        public static Func<DateTime, DateTime> Compile(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+        {
+                culture ??= CultureInfo.CurrentCulture;
+                var lang = provider.GetLanguage(culture);
 
 		if (formula.Length < 2)
 			throw new ArgumentException("Formula is too short.", nameof(formula));
@@ -120,8 +120,8 @@ public static class DateFormula
 				if (sign == '-') value = -value;
 				if (pos >= formula.Length)
 					throw new ArgumentException("Missing unit token.", nameof(formula));
-				var unit = ParsePeriod(formula[pos], lang);
-				expr = CreateCalendarCall(culture, expr, unit, value);
+                                var unit = ParsePeriod(formula[pos], lang);
+                                expr = CreateCalendarCall(culture, expr, unit, value, calendarProvider);
 				index = pos + 1;
 			}
 			else
@@ -149,38 +149,50 @@ public static class DateFormula
 		return Expression.Lambda<Func<DateTime, DateTime>>(expr, param).Compile();
 	}
 
-	private static Expression CreateCalendarCall(CultureInfo culture, Expression expr, PeriodTypeEnum period, int value)
-	{
-		(string methodName, value) = period switch
-		{
-			PeriodTypeEnum.Day => ("AddDays", value),
-			PeriodTypeEnum.Week => ("AddDays", value * 7),
-			PeriodTypeEnum.Month => ("AddMonths", value),
-			PeriodTypeEnum.Quarter => ("AddMonths", value * 3),
-			PeriodTypeEnum.Year => ("AddYears", value),
-			_ => (null, value)
+        private static Expression CreateCalendarCall(CultureInfo culture, Expression expr, PeriodTypeEnum period, int value, ICalendarProvider? calendarProvider)
+        {
+                if (period == PeriodTypeEnum.WorkingDay)
+                {
+                        if (calendarProvider is null)
+                                throw new InvalidOperationException("Working day operations require a calendar provider.");
+                        return Expression.Call(
+                                typeof(DateUtils).GetMethod(nameof(DateUtils.AddWorkingDays), BindingFlags.Public | BindingFlags.Static)!,
+                                expr,
+                                Expression.Constant(value),
+                                Expression.Constant(calendarProvider));
+                }
 
-		};
-		if (methodName is null) return expr;
+                (string methodName, value) = period switch
+                {
+                        PeriodTypeEnum.Day => ("AddDays", value),
+                        PeriodTypeEnum.Week => ("AddDays", value * 7),
+                        PeriodTypeEnum.Month => ("AddMonths", value),
+                        PeriodTypeEnum.Quarter => ("AddMonths", value * 3),
+                        PeriodTypeEnum.Year => ("AddYears", value),
+                        _ => (null, value)
 
-		var calendarExpression = Expression.Constant(culture.Calendar);
-		return Expression.Call(
-			calendarExpression,
-			typeof(Calendar).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!,
-			expr,
-			Expression.Constant(value));
-	}
+                };
+                if (methodName is null) return expr;
+
+                var calendarExpression = Expression.Constant(culture.Calendar);
+                return Expression.Call(
+                        calendarExpression,
+                        typeof(Calendar).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!,
+                        expr,
+                        Expression.Constant(value));
+        }
 
 	private static PeriodTypeEnum ParsePeriod(char token, DateFormulaLanguage lang)
 		=> token switch
 		{
-			var t when t == lang.Day => PeriodTypeEnum.Day,
-			var t when t == lang.Week => PeriodTypeEnum.Week,
-			var t when t == lang.Month => PeriodTypeEnum.Month,
-			var t when t == lang.Quarter => PeriodTypeEnum.Quarter,
-			var t when t == lang.Year => PeriodTypeEnum.Year,
-			_ => throw new ArgumentException($"Unknown period token '{token}'.")
-		};
+                        var t when t == lang.Day => PeriodTypeEnum.Day,
+                        var t when t == lang.Week => PeriodTypeEnum.Week,
+                        var t when t == lang.Month => PeriodTypeEnum.Month,
+                        var t when t == lang.Quarter => PeriodTypeEnum.Quarter,
+                        var t when t == lang.Year => PeriodTypeEnum.Year,
+                        var t when t == lang.WorkingDay => PeriodTypeEnum.WorkingDay,
+                        _ => throw new ArgumentException($"Unknown period token '{token}'.")
+                };
 
 	private static DateTime AdjustToDayOfWeek(DateTime date, DayOfWeek day, bool after)
 	{

--- a/Utils/Dates/DateFormulaLanguage.cs
+++ b/Utils/Dates/DateFormulaLanguage.cs
@@ -19,6 +19,8 @@ public sealed class DateFormulaLanguage
         public required char Quarter { get; init; }
         /// <summary>Token representing a year unit.</summary>
         public required char Year { get; init; }
+        /// <summary>Token representing a working day unit.</summary>
+        public required char WorkingDay { get; init; }
         /// <summary>Mapping between two-letter day names and <see cref="DayOfWeek"/>.</summary>
         public required IReadOnlyDictionary<string, DayOfWeek> Days { get; init; }
 }

--- a/Utils/Dates/DateUtils.cs
+++ b/Utils/Dates/DateUtils.cs
@@ -63,8 +63,9 @@ public static class DateUtils
 		{
 			case PeriodTypeEnum.None:
 				return dateTime;
-			case PeriodTypeEnum.Day:
-				return calendar.AddDays(dateTime, 0).Date;
+                        case PeriodTypeEnum.Day:
+                        case PeriodTypeEnum.WorkingDay:
+                                return calendar.AddDays(dateTime, 0).Date;
 			case PeriodTypeEnum.Week:
 				var difference = (7 + ((int)calendar.GetDayOfWeek(dateTime) - (int)firstDayOfWeek)) % 7;
 				DateTime weekDate = calendar.AddDays(dateTime.Date, -difference);
@@ -136,8 +137,9 @@ public static class DateUtils
 		{
 			case PeriodTypeEnum.None:
 				return dateTime;
-			case PeriodTypeEnum.Day:
-				return calendar.AddDays(dateTime.Date, 1).AddTicks(-1);
+                        case PeriodTypeEnum.Day:
+                        case PeriodTypeEnum.WorkingDay:
+                                return calendar.AddDays(dateTime.Date, 1).AddTicks(-1);
 			case PeriodTypeEnum.Week:
 				var difference = (7 - ((int)calendar.GetDayOfWeek(dateTime) - (int)firstDayOfWeek)) % 7;
 				DateTime endWeek = calendar.AddDays(dateTime.Date, difference);
@@ -280,10 +282,15 @@ public enum PeriodTypeEnum
 	/// </summary>
 	None = 0,
 
-	/// <summary>
-	/// Represents a single day.
-	/// </summary>
-	Day,
+        /// <summary>
+        /// Represents a single day.
+        /// </summary>
+        Day,
+
+        /// <summary>
+        /// Represents a working day.
+        /// </summary>
+        WorkingDay,
 
 	/// <summary>
 	/// Represents a week.

--- a/Utils/Dates/DateUtils.cs
+++ b/Utils/Dates/DateUtils.cs
@@ -192,10 +192,10 @@ public static class DateUtils
 	/// <param name="workingDays">Number of working days to add.</param>
 	/// <param name="calendarProvider">Calendar providing working day information.</param>
 	/// <returns>The resulting date including additional non working days.</returns>
-	public static DateTime AddWorkingDays(this DateTime date, int workingDays, ICalendarProvider calendarProvider)
-	{
-		workingDays.ArgMustBeGreaterOrEqualsThan(0);
-		calendarProvider.Arg().MustNotBeNull();
+        public static DateTime AddWorkingDays(this DateTime date, int workingDays, ICalendarProvider calendarProvider)
+        {
+                workingDays.ArgMustBeGreaterOrEqualsThan(0);
+                calendarProvider.Arg().MustNotBeNull();
 
 		var toAdd = workingDays;
 		var current = date;
@@ -207,8 +207,44 @@ public static class DateUtils
 			current = end;
 		}
 
-		return current;
-	}
+                return current;
+        }
+
+        /// <summary>
+        /// Gets the next working day starting at the provided <paramref name="date"/>.
+        /// </summary>
+        /// <param name="date">Base date.</param>
+        /// <param name="calendarProvider">Calendar providing working day information.</param>
+        /// <returns>The first working day on or after <paramref name="date"/>.</returns>
+        public static DateTime NextWorkingDay(this DateTime date, ICalendarProvider calendarProvider)
+        {
+                calendarProvider.Arg().MustNotBeNull();
+
+                if (calendarProvider.GetNonWorkingDaysCount(date, date) == 0)
+                        return date;
+
+                return date.AddWorkingDays(1, calendarProvider);
+        }
+
+        /// <summary>
+        /// Gets the previous working day ending at the provided <paramref name="date"/>.
+        /// </summary>
+        /// <param name="date">Base date.</param>
+        /// <param name="calendarProvider">Calendar providing working day information.</param>
+        /// <returns>The first working day on or before <paramref name="date"/>.</returns>
+        public static DateTime PreviousWorkingDay(this DateTime date, ICalendarProvider calendarProvider)
+        {
+                calendarProvider.Arg().MustNotBeNull();
+
+                if (calendarProvider.GetNonWorkingDaysCount(date, date) == 0)
+                        return date;
+
+                var current = date.AddDays(-1);
+                while (calendarProvider.GetNonWorkingDaysCount(current, current) > 0)
+                        current = current.AddDays(-1);
+
+                return current;
+        }
 
 	/// <summary>
 	/// Calculates the date of Easter Sunday for the specified year using the Anonymous Gregorian algorithm.

--- a/Utils/Dates/JsonDateFormulaLanguageProvider.cs
+++ b/Utils/Dates/JsonDateFormulaLanguageProvider.cs
@@ -26,11 +26,12 @@ public sealed class JsonDateFormulaLanguageProvider : IDateFormulaLanguageProvid
                                 End = p.Value.End[0],
                                 Day = p.Value.Units.Day[0],
                                 Week = p.Value.Units.Week[0],
-                                Month = p.Value.Units.Month[0],
-                                Quarter = p.Value.Units.Quarter[0],
-                                Year = p.Value.Units.Year[0],
-                                Days = p.Value.Days.ToDictionary(d => d.Key, d => Enum.Parse<DayOfWeek>(d.Value))
-                        });
+                               Month = p.Value.Units.Month[0],
+                               Quarter = p.Value.Units.Quarter[0],
+                               Year = p.Value.Units.Year[0],
+                               WorkingDay = p.Value.Units.Workday[0],
+                               Days = p.Value.Days.ToDictionary(d => d.Key, d => Enum.Parse<DayOfWeek>(d.Value))
+                       });
         }
 
         /// <inheritdoc />
@@ -59,5 +60,6 @@ public sealed class JsonDateFormulaLanguageProvider : IDateFormulaLanguageProvid
                 public string Month { get; set; } = string.Empty;
                 public string Quarter { get; set; } = string.Empty;
                 public string Year { get; set; } = string.Empty;
+                public string Workday { get; set; } = string.Empty;
         }
 }

--- a/Utils/Objects/DateFormulaConfigurations/DateFormulaConfiguration.json
+++ b/Utils/Objects/DateFormulaConfigurations/DateFormulaConfiguration.json
@@ -2,7 +2,7 @@
   "fr": {
     "start": "D",
     "end": "F",
-    "units": {"day": "J", "week": "S", "month": "M", "quarter": "T", "year": "A"},
+    "units": {"day": "J", "week": "S", "month": "M", "quarter": "T", "year": "A", "workday": "O"},
     "days": {
       "Lu": "Monday",
       "Ma": "Tuesday",
@@ -16,7 +16,7 @@
   "en": {
     "start": "S",
     "end": "E",
-    "units": {"day": "D", "week": "W", "month": "M", "quarter": "Q", "year": "Y"},
+    "units": {"day": "D", "week": "W", "month": "M", "quarter": "Q", "year": "Y", "workday": "O"},
     "days": {
       "Mo": "Monday",
       "Tu": "Tuesday",
@@ -30,7 +30,7 @@
   "es": {
     "start": "I",
     "end": "F",
-    "units": {"day": "D", "week": "S", "month": "M", "quarter": "T", "year": "A"},
+    "units": {"day": "D", "week": "S", "month": "M", "quarter": "T", "year": "A", "workday": "O"},
     "days": {
       "Lu": "Monday",
       "Ma": "Tuesday",
@@ -44,7 +44,7 @@
   "de": {
     "start": "A",
     "end": "E",
-    "units": {"day": "T", "week": "W", "month": "M", "quarter": "Q", "year": "J"},
+    "units": {"day": "T", "week": "W", "month": "M", "quarter": "Q", "year": "J", "workday": "O"},
     "days": {
       "Mo": "Monday",
       "Di": "Tuesday",
@@ -58,7 +58,7 @@
   "ar": {
     "start": "B",
     "end": "N",
-    "units": {"day": "Y", "week": "U", "month": "S", "quarter": "R", "year": "A"},
+    "units": {"day": "Y", "week": "U", "month": "S", "quarter": "R", "year": "A", "workday": "O"},
     "days": {
       "Ah": "Sunday",
       "It": "Monday",
@@ -72,7 +72,7 @@
   "zh": {
     "start": "S",
     "end": "E",
-    "units": {"day": "D", "week": "Z", "month": "M", "quarter": "J", "year": "N"},
+    "units": {"day": "D", "week": "Z", "month": "M", "quarter": "J", "year": "N", "workday": "O"},
     "days": {
       "Mo": "Monday",
       "Tu": "Tuesday",

--- a/Utils/README.md
+++ b/Utils/README.md
@@ -98,6 +98,18 @@ ICalendarProvider calendar = new WeekEndCalendarProvider();
 DateTime value = new DateTime(2024, 4, 5)
     .Calculate("DO+3O", new CultureInfo("fr-FR"), calendar); // 2024-04-10
 ```
+```csharp
+// Finding the next or previous working day
+ICalendarProvider calendar = new WeekEndCalendarProvider();
+DateTime next = new DateTime(2024, 4, 6).NextWorkingDay(calendar);     // 2024-04-08
+DateTime prev = new DateTime(2024, 4, 6).PreviousWorkingDay(calendar); // 2024-04-05
+```
+```csharp
+// Adjusting the result of a formula to the next working day
+ICalendarProvider calendar = new WeekEndCalendarProvider();
+DateTime adjusted = new DateTime(2024, 4, 6)
+    .Calculate("DOO+", new CultureInfo("fr-FR"), calendar); // 2024-04-08
+```
 
 ### Expressions
 ```csharp

--- a/Utils/README.md
+++ b/Utils/README.md
@@ -92,6 +92,12 @@ DateTime result = new DateTime(2023, 3, 15)
 ICalendarProvider calendar = new WeekEndCalendarProvider();
 DateTime dueDate = new DateTime(2024, 4, 5).AddWorkingDays(3, calendar); // 2024-04-10
 ```
+```csharp
+// Using working days inside a formula
+ICalendarProvider calendar = new WeekEndCalendarProvider();
+DateTime value = new DateTime(2024, 4, 5)
+    .Calculate("DO+3O", new CultureInfo("fr-FR"), calendar); // 2024-04-10
+```
 
 ### Expressions
 ```csharp

--- a/UtilsTest/Objects/DateFormulaTests.cs
+++ b/UtilsTest/Objects/DateFormulaTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Utils.Dates;
 
 namespace UtilsTest.Objects;
@@ -8,6 +10,30 @@ namespace UtilsTest.Objects;
 [TestClass]
 public class DateFormulaTests
 {
+        private sealed class WeekEndCalendarProvider : ICalendarProvider
+        {
+                private static readonly DayOfWeek[] _weekEnds = [DayOfWeek.Saturday, DayOfWeek.Sunday];
+
+                public int GetNonWorkingDaysCount(DateTime start, DateTime end)
+                                => GetHollydays(start, end).Count();
+
+                public IEnumerable<DateTime> GetHollydays(DateTime start, DateTime end)
+                {
+                        for (var d = start.Date; d <= end.Date; d = d.AddDays(1))
+                                if (System.Array.IndexOf(_weekEnds, d.DayOfWeek) >= 0)
+                                        yield return d;
+                }
+
+                public IEnumerable<DateTime> GetWorkingDays(DateTime start, DateTime end)
+                {
+                        for (var d = start.Date; d <= end.Date; d = d.AddDays(1))
+                                if (System.Array.IndexOf(_weekEnds, d.DayOfWeek) < 0)
+                                        yield return d;
+                }
+
+                public int GetWorkingDaysCount(DateTime start, DateTime end)
+                                => GetWorkingDays(start, end).Count();
+        }
 	[TestMethod]
 	public void BasicFrenchFormulas()
 	{
@@ -62,14 +88,33 @@ public class DateFormulaTests
 	}
 
 	[TestMethod]
-	public void CalculateUsesCache()
-	{
-		var culture = new CultureInfo("fr-FR");
-		var expected = DateFormula.Compile("FM+1J", culture)(new DateTime(2023, 3, 15));
-		for (int i = 0; i < 3; i++)
-		{
-			var result = new DateTime(2023, 3, 15).Calculate("FM+1J", culture);
-			Assert.AreEqual(expected, result);
-		}
-	}
+        public void CalculateUsesCache()
+        {
+                var culture = new CultureInfo("fr-FR");
+                var expected = DateFormula.Compile("FM+1J", culture)(new DateTime(2023, 3, 15));
+                for (int i = 0; i < 3; i++)
+                {
+                        var result = new DateTime(2023, 3, 15).Calculate("FM+1J", culture);
+                        Assert.AreEqual(expected, result);
+                }
+        }
+
+        [TestMethod]
+        public void FormulaWorkingDaysUsesCalendar()
+        {
+                var culture = new CultureInfo("fr-FR");
+                ICalendarProvider provider = new WeekEndCalendarProvider();
+                var date = new DateTime(2024, 4, 5); // Friday
+                var result = date.Calculate("DO+3O", culture, provider);
+                Assert.AreEqual(new DateTime(2024, 4, 10), result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void FormulaWorkingDaysRequiresCalendar()
+        {
+                var culture = new CultureInfo("fr-FR");
+                var date = new DateTime(2024, 4, 5);
+                _ = date.Calculate("DO+1O", culture);
+        }
 }

--- a/UtilsTest/Objects/DateFormulaTests.cs
+++ b/UtilsTest/Objects/DateFormulaTests.cs
@@ -117,4 +117,35 @@ public class DateFormulaTests
                 var date = new DateTime(2024, 4, 5);
                 _ = date.Calculate("DO+1O", culture);
         }
+
+        [TestMethod]
+        public void NextAndPreviousWorkingDay()
+        {
+                ICalendarProvider provider = new WeekEndCalendarProvider();
+                Assert.AreEqual(new DateTime(2024, 4, 5), new DateTime(2024, 4, 5).NextWorkingDay(provider));
+                Assert.AreEqual(new DateTime(2024, 4, 5), new DateTime(2024, 4, 5).PreviousWorkingDay(provider));
+                Assert.AreEqual(new DateTime(2024, 4, 8), new DateTime(2024, 4, 6).NextWorkingDay(provider));
+                Assert.AreEqual(new DateTime(2024, 4, 5), new DateTime(2024, 4, 6).PreviousWorkingDay(provider));
+        }
+
+        [TestMethod]
+        public void FormulaWorkingDayAdjust()
+        {
+                var culture = new CultureInfo("fr-FR");
+                ICalendarProvider provider = new WeekEndCalendarProvider();
+                var date = new DateTime(2024, 4, 6); // Saturday
+                var result = date.Calculate("DOO+", culture, provider);
+                Assert.AreEqual(new DateTime(2024, 4, 8), result);
+                result = date.Calculate("DOO-", culture, provider);
+                Assert.AreEqual(new DateTime(2024, 4, 5), result);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void FormulaWorkingDayAdjustRequiresCalendar()
+        {
+                var culture = new CultureInfo("fr-FR");
+                var date = new DateTime(2024, 4, 6);
+                _ = date.Calculate("DOO+", culture);
+        }
 }


### PR DESCRIPTION
## Summary
- extend `DateFormulaLanguage` and configuration with working day token
- support `WorkingDay` in `PeriodTypeEnum`
- implement working day handling in `DateFormula`
- update README with new example
- add unit tests for working day formulas

## Testing
- `dotnet test UtilsTest/UtilsTest.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686f8bc9fec8832687941d792104c59a