### PR TITLE
Add working day support in DateFormula

### DIFF
--- a/Utils/Dates/DateFormula.cs
+++ b/Utils/Dates/DateFormula.cs
@@ -22,10 +22,10 @@ public static class DateFormula
 	});
 
 	/// <summary>Cache for compiled formulas.</summary>
-	private static readonly Dictionary<FormulaCacheKey, Func<DateTime, DateTime>> _cache = [];
+        private static readonly Dictionary<FormulaCacheKey, Func<DateTime, DateTime>> _cache = [];
 
 	/// <summary>Represents a unique key for the formula cache.</summary>
-	private sealed record FormulaCacheKey(IDateFormulaLanguageProvider Provider, string CultureName, string Formula);
+        private sealed record FormulaCacheKey(IDateFormulaLanguageProvider Provider, string CultureName, string Formula, ICalendarProvider? CalendarProvider);
 
 	/// <summary>
 	/// Retrieves a compiled formula from the cache or compiles it if missing.
@@ -34,14 +34,14 @@ public static class DateFormula
 	/// <param name="provider">Language provider.</param>
 	/// <param name="culture">Culture used for token interpretation.</param>
 	/// <returns>A delegate computing the date from a base value.</returns>
-	private static Func<DateTime, DateTime> GetCompiledFormula(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture)
-	{
-		var key = new FormulaCacheKey(provider, culture.Name, formula);
-		lock (_cache)
-		{
-			return _cache.GetOrAdd(key, () => Compile(formula, provider, culture));
-		}
-	}
+        private static Func<DateTime, DateTime> GetCompiledFormula(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture, ICalendarProvider? calendarProvider)
+        {
+                var key = new FormulaCacheKey(provider, culture.Name, formula, calendarProvider);
+                lock (_cache)
+                {
+                        return _cache.GetOrAdd(key, () => Compile(formula, provider, culture, calendarProvider));
+                }
+        }
 
 	/// <summary>
 	/// Calculates the date described by <paramref name="formula"/>.
@@ -50,8 +50,8 @@ public static class DateFormula
 	/// <param name="formula">Formula to evaluate.</param>
 	/// <param name="culture">Culture used to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
 	/// <returns>The computed date.</returns>
-	public static DateTime Calculate(this DateTime date, string formula, CultureInfo culture = null)
-			=> date.Calculate(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture);
+        public static DateTime Calculate(this DateTime date, string formula, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+                        => date.Calculate(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture, calendarProvider);
 
 	/// <summary>
 	/// Calculates the date described by <paramref name="formula"/> using a custom provider.
@@ -61,12 +61,12 @@ public static class DateFormula
 	/// <param name="provider">Language provider.</param>
 	/// <param name="culture">Culture to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
 	/// <returns>The computed date.</returns>
-	public static DateTime Calculate(this DateTime date, string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null)
-	{
-		culture ??= CultureInfo.CurrentCulture;
-		var compiled = GetCompiledFormula(formula, provider, culture);
-		return compiled(date);
-	}
+        public static DateTime Calculate(this DateTime date, string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+        {
+                culture ??= CultureInfo.CurrentCulture;
+                var compiled = GetCompiledFormula(formula, provider, culture, calendarProvider);
+                return compiled(date);
+        }
 
 	/// <summary>
 	/// Compiles the provided <paramref name="formula"/> into a delegate.
@@ -74,8 +74,8 @@ public static class DateFormula
 	/// <param name="formula">Formula to compile.</param>
 	/// <param name="culture">Culture used to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
 	/// <returns>A delegate computing the resulting date.</returns>
-	public static Func<DateTime, DateTime> Compile(string formula, CultureInfo culture = null)
-			=> Compile(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture);
+        public static Func<DateTime, DateTime> Compile(string formula, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+                        => Compile(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture, calendarProvider);
 
 	/// <summary>
 	/// Compiles the provided <paramref name="formula"/> using a custom provider.
@@ -84,10 +84,10 @@ public static class DateFormula
 	/// <param name="provider">Language provider.</param>
 	/// <param name="culture">Culture used to interpret tokens. If null, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
 	/// <returns>A delegate computing the resulting date.</returns>
-	public static Func<DateTime, DateTime> Compile(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null)
-	{
-		culture ??= CultureInfo.CurrentCulture;
-		var lang = provider.GetLanguage(culture);
+        public static Func<DateTime, DateTime> Compile(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+        {
+                culture ??= CultureInfo.CurrentCulture;
+                var lang = provider.GetLanguage(culture);
 
 		if (formula.Length < 2)
 			throw new ArgumentException("Formula is too short.", nameof(formula));
@@ -97,7 +97,13 @@ public static class DateFormula
 		if (!start && !end)
 			throw new ArgumentException("Invalid formula start token.", nameof(formula));
 
-		var period = ParsePeriod(formula[1], lang);
+                var period = ParsePeriod(formula[1], lang);
+
+                if (start && (period == PeriodTypeEnum.Day || period == PeriodTypeEnum.WorkingDay))
+                        throw new ArgumentException("Start of day and start of working day formulas are not supported.", nameof(formula));
+
+                if (end && (period == PeriodTypeEnum.Day || period == PeriodTypeEnum.WorkingDay))
+                        throw new ArgumentException("End of day and end of working day formulas are not supported.", nameof(formula));
 
 		var param = Expression.Parameter(typeof(DateTime), "d");
 
@@ -108,11 +114,11 @@ public static class DateFormula
 				Expression.Constant(culture));
 
 		var index = 2;
-		while (index < formula.Length && (formula[index].In('+', '-')))
-		{
-			var sign = formula[index];
-			var pos = index + 1;
-			if (pos < formula.Length && char.IsDigit(formula[pos]))
+                while (index < formula.Length && (formula[index].In('+', '-')))
+                {
+                        var sign = formula[index];
+                        var pos = index + 1;
+                        if (pos < formula.Length && char.IsDigit(formula[pos]))
 			{
 				var startPos = pos;
 				while (pos < formula.Length && char.IsDigit(formula[pos])) pos++;
@@ -120,67 +126,106 @@ public static class DateFormula
 				if (sign == '-') value = -value;
 				if (pos >= formula.Length)
 					throw new ArgumentException("Missing unit token.", nameof(formula));
-				var unit = ParsePeriod(formula[pos], lang);
-				expr = CreateCalendarCall(culture, expr, unit, value);
+                                var unit = ParsePeriod(formula[pos], lang);
+                                expr = CreateCalendarCall(culture, expr, unit, value, calendarProvider);
 				index = pos + 1;
 			}
-			else
-			{
-				var day = formula.Substring(pos, 2);
-				expr = Expression.Call(
-						typeof(DateFormula).GetMethod("AdjustToDayOfWeek", BindingFlags.NonPublic | BindingFlags.Static)!,
-						expr,
-						Expression.Constant(lang.Days[day]),
-						Expression.Constant(sign == '+'));
-				index = pos + 2;
-				return Expression.Lambda<Func<DateTime, DateTime>>(Expression.Property(expr, nameof(DateTime.Date)), param).Compile();
-			}
-		}
-		if (index < formula.Length)
-		{
-			var day = formula.Substring(index, 2);
-			expr = Expression.Call(
-					typeof(DateFormula).GetMethod("MoveToSameWeekDay", BindingFlags.NonPublic | BindingFlags.Static)!,
-					expr,
-					Expression.Constant(lang.Days[day]),
-					Expression.Constant(culture.DateTimeFormat.FirstDayOfWeek));
-		}
-		expr = Expression.Property(expr, nameof(DateTime.Date));
-		return Expression.Lambda<Func<DateTime, DateTime>>(expr, param).Compile();
-	}
+                        else if (pos < formula.Length && formula[pos] == lang.WorkingDay && pos + 1 == formula.Length)
+                        {
+                                if (calendarProvider is null)
+                                        throw new InvalidOperationException("Working day operations require a calendar provider.");
+                                var method = sign == '+' ? nameof(DateUtils.NextWorkingDay) : nameof(DateUtils.PreviousWorkingDay);
+                                expr = Expression.Call(
+                                                typeof(DateUtils).GetMethod(method, BindingFlags.Public | BindingFlags.Static)!,
+                                                expr,
+                                                Expression.Constant(calendarProvider));
+                                index = pos + 1;
+                                return Expression.Lambda<Func<DateTime, DateTime>>(Expression.Property(expr, nameof(DateTime.Date)), param).Compile();
+                        }
+                        else
+                        {
+                                if (pos + 2 > formula.Length)
+                                        throw new ArgumentException("Incomplete day token.", nameof(formula));
+                                var day = formula.Substring(pos, 2);
+                                expr = Expression.Call(
+                                                typeof(DateFormula).GetMethod("AdjustToDayOfWeek", BindingFlags.NonPublic | BindingFlags.Static)!,
+                                                expr,
+                                                Expression.Constant(lang.Days[day]),
+                                                Expression.Constant(sign == '+'));
+                                index = pos + 2;
+                                return Expression.Lambda<Func<DateTime, DateTime>>(Expression.Property(expr, nameof(DateTime.Date)), param).Compile();
+                        }
+                }
+                if (index < formula.Length)
+                {
+                        var token = formula.Substring(index, 2);
+                        if (token.Length == 2 && token[1] == lang.WorkingDay && token[0].In('+', '-'))
+                        {
+                                if (calendarProvider is null)
+                                        throw new InvalidOperationException("Working day operations require a calendar provider.");
+                                var method = token[0] == '+' ? nameof(DateUtils.NextWorkingDay) : nameof(DateUtils.PreviousWorkingDay);
+                                expr = Expression.Call(
+                                                typeof(DateUtils).GetMethod(method, BindingFlags.Public | BindingFlags.Static)!,
+                                                expr,
+                                                Expression.Constant(calendarProvider));
+                        }
+                        else
+                        {
+                                expr = Expression.Call(
+                                                typeof(DateFormula).GetMethod("MoveToSameWeekDay", BindingFlags.NonPublic | BindingFlags.Static)!,
+                                                expr,
+                                                Expression.Constant(lang.Days[token]),
+                                                Expression.Constant(culture.DateTimeFormat.FirstDayOfWeek));
+                        }
+                }
+                expr = Expression.Property(expr, nameof(DateTime.Date));
+                return Expression.Lambda<Func<DateTime, DateTime>>(expr, param).Compile();
+        }
 
-	private static Expression CreateCalendarCall(CultureInfo culture, Expression expr, PeriodTypeEnum period, int value)
-	{
-		(string methodName, value) = period switch
-		{
-			PeriodTypeEnum.Day => ("AddDays", value),
-			PeriodTypeEnum.Week => ("AddDays", value * 7),
-			PeriodTypeEnum.Month => ("AddMonths", value),
-			PeriodTypeEnum.Quarter => ("AddMonths", value * 3),
-			PeriodTypeEnum.Year => ("AddYears", value),
-			_ => (null, value)
+        private static Expression CreateCalendarCall(CultureInfo culture, Expression expr, PeriodTypeEnum period, int value, ICalendarProvider? calendarProvider)
+        {
+                if (period == PeriodTypeEnum.WorkingDay)
+                {
+                        if (calendarProvider is null)
+                                throw new InvalidOperationException("Working day operations require a calendar provider.");
+                        return Expression.Call(
+                                typeof(DateUtils).GetMethod(nameof(DateUtils.AddWorkingDays), BindingFlags.Public | BindingFlags.Static)!,
+                                expr,
+                                Expression.Constant(value),
+                                Expression.Constant(calendarProvider));
+                }
 
-		};
-		if (methodName is null) return expr;
+                (string methodName, value) = period switch
+                {
+                        PeriodTypeEnum.Day => ("AddDays", value),
+                        PeriodTypeEnum.Week => ("AddDays", value * 7),
+                        PeriodTypeEnum.Month => ("AddMonths", value),
+                        PeriodTypeEnum.Quarter => ("AddMonths", value * 3),
+                        PeriodTypeEnum.Year => ("AddYears", value),
+                        _ => (null, value)
 
-		var calendarExpression = Expression.Constant(culture.Calendar);
-		return Expression.Call(
-			calendarExpression,
-			typeof(Calendar).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!,
-			expr,
-			Expression.Constant(value));
-	}
+                };
+                if (methodName is null) return expr;
+
+                var calendarExpression = Expression.Constant(culture.Calendar);
+                return Expression.Call(
+                        calendarExpression,
+                        typeof(Calendar).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!,
+                        expr,
+                        Expression.Constant(value));
+        }
 
 	private static PeriodTypeEnum ParsePeriod(char token, DateFormulaLanguage lang)
 		=> token switch
 		{
-			var t when t == lang.Day => PeriodTypeEnum.Day,
-			var t when t == lang.Week => PeriodTypeEnum.Week,
-			var t when t == lang.Month => PeriodTypeEnum.Month,
-			var t when t == lang.Quarter => PeriodTypeEnum.Quarter,
-			var t when t == lang.Year => PeriodTypeEnum.Year,
-			_ => throw new ArgumentException($"Unknown period token '{token}'.")
-		};
+                        var t when t == lang.Day => PeriodTypeEnum.Day,
+                        var t when t == lang.Week => PeriodTypeEnum.Week,
+                        var t when t == lang.Month => PeriodTypeEnum.Month,
+                        var t when t == lang.Quarter => PeriodTypeEnum.Quarter,
+                        var t when t == lang.Year => PeriodTypeEnum.Year,
+                        var t when t == lang.WorkingDay => PeriodTypeEnum.WorkingDay,
+                        _ => throw new ArgumentException($"Unknown period token '{token}'.")
+                };
 
 	private static DateTime AdjustToDayOfWeek(DateTime date, DayOfWeek day, bool after)
 	{

--- a/Utils/Dates/DateFormulaLanguage.cs
+++ b/Utils/Dates/DateFormulaLanguage.cs
@@ -19,6 +19,8 @@ public sealed class DateFormulaLanguage
         public required char Quarter { get; init; }
         /// <summary>Token representing a year unit.</summary>
         public required char Year { get; init; }
+        /// <summary>Token representing a working day unit.</summary>
+        public required char WorkingDay { get; init; }
         /// <summary>Mapping between two-letter day names and <see cref="DayOfWeek"/>.</summary>
         public required IReadOnlyDictionary<string, DayOfWeek> Days { get; init; }
 }

--- a/Utils/Dates/JsonDateFormulaLanguageProvider.cs
+++ b/Utils/Dates/JsonDateFormulaLanguageProvider.cs
@@ -26,11 +26,12 @@ public sealed class JsonDateFormulaLanguageProvider : IDateFormulaLanguageProvid
                                 End = p.Value.End[0],
                                 Day = p.Value.Units.Day[0],
                                 Week = p.Value.Units.Week[0],
-                                Month = p.Value.Units.Month[0],
-                                Quarter = p.Value.Units.Quarter[0],
-                                Year = p.Value.Units.Year[0],
-                                Days = p.Value.Days.ToDictionary(d => d.Key, d => Enum.Parse<DayOfWeek>(d.Value))
-                        });
+                               Month = p.Value.Units.Month[0],
+                               Quarter = p.Value.Units.Quarter[0],
+                               Year = p.Value.Units.Year[0],
+                               WorkingDay = p.Value.Units.Workday[0],
+                               Days = p.Value.Days.ToDictionary(d => d.Key, d => Enum.Parse<DayOfWeek>(d.Value))
+                       });
         }
 
         /// <inheritdoc />
@@ -59,5 +60,6 @@ public sealed class JsonDateFormulaLanguageProvider : IDateFormulaLanguageProvid
                 public string Month { get; set; } = string.Empty;
                 public string Quarter { get; set; } = string.Empty;
                 public string Year { get; set; } = string.Empty;
+                public string Workday { get; set; } = string.Empty;
         }
 }

--- a/Utils/Objects/DateFormulaConfigurations/DateFormulaConfiguration.json
+++ b/Utils/Objects/DateFormulaConfigurations/DateFormulaConfiguration.json
@@ -2,7 +2,7 @@
   "fr": {
     "start": "D",
     "end": "F",
-    "units": {"day": "J", "week": "S", "month": "M", "quarter": "T", "year": "A"},
+    "units": {"day": "J", "week": "S", "month": "M", "quarter": "T", "year": "A", "workday": "O"},
     "days": {
       "Lu": "Monday",
       "Ma": "Tuesday",
@@ -16,7 +16,7 @@
   "en": {
     "start": "S",
     "end": "E",
-    "units": {"day": "D", "week": "W", "month": "M", "quarter": "Q", "year": "Y"},
+    "units": {"day": "D", "week": "W", "month": "M", "quarter": "Q", "year": "Y", "workday": "O"},
     "days": {
       "Mo": "Monday",
       "Tu": "Tuesday",
@@ -30,7 +30,7 @@
   "es": {
     "start": "I",
     "end": "F",
-    "units": {"day": "D", "week": "S", "month": "M", "quarter": "T", "year": "A"},
+    "units": {"day": "D", "week": "S", "month": "M", "quarter": "T", "year": "A", "workday": "O"},
     "days": {
       "Lu": "Monday",
       "Ma": "Tuesday",
@@ -44,7 +44,7 @@
   "de": {
     "start": "A",
     "end": "E",
-    "units": {"day": "T", "week": "W", "month": "M", "quarter": "Q", "year": "J"},
+    "units": {"day": "T", "week": "W", "month": "M", "quarter": "Q", "year": "J", "workday": "O"},
     "days": {
       "Mo": "Monday",
       "Di": "Tuesday",
@@ -58,7 +58,7 @@
   "ar": {
     "start": "B",
     "end": "N",
-    "units": {"day": "Y", "week": "U", "month": "S", "quarter": "R", "year": "A"},
+    "units": {"day": "Y", "week": "U", "month": "S", "quarter": "R", "year": "A", "workday": "O"},
     "days": {
       "Ah": "Sunday",
       "It": "Monday",
@@ -72,7 +72,7 @@
   "zh": {
     "start": "S",
     "end": "E",
-    "units": {"day": "D", "week": "Z", "month": "M", "quarter": "J", "year": "N"},
+    "units": {"day": "D", "week": "Z", "month": "M", "quarter": "J", "year": "N", "workday": "O"},
     "days": {
       "Mo": "Monday",
       "Tu": "Tuesday",

--- a/Utils/README.md
+++ b/Utils/README.md
@@ -92,6 +92,24 @@ DateTime result = new DateTime(2023, 3, 15)
 ICalendarProvider calendar = new WeekEndCalendarProvider();
 DateTime dueDate = new DateTime(2024, 4, 5).AddWorkingDays(3, calendar); // 2024-04-10
 ```
+```csharp
+// Using working days inside a formula
+ICalendarProvider calendar = new WeekEndCalendarProvider();
+DateTime value = new DateTime(2024, 4, 5)
+    .Calculate("FS+3O", new CultureInfo("fr-FR"), calendar); // 2024-04-10
+```
+```csharp
+// Finding the next or previous working day
+ICalendarProvider calendar = new WeekEndCalendarProvider();
+DateTime next = new DateTime(2024, 4, 6).NextWorkingDay(calendar);     // 2024-04-08
+DateTime prev = new DateTime(2024, 4, 6).PreviousWorkingDay(calendar); // 2024-04-05
+```
+```csharp
+// Adjusting the result of a formula to the next working day
+ICalendarProvider calendar = new WeekEndCalendarProvider();
+DateTime adjusted = new DateTime(2024, 4, 6)
+    .Calculate("FS+O", new CultureInfo("fr-FR"), calendar); // 2024-04-08
+```
 
 ### Expressions
 ```csharp


### PR DESCRIPTION
## Summary
- extend `DateFormula` validation to reject end-of-day formulas
- adjust working day examples in README
- update tests for working day modifiers and add checks for invalid end-of-day formulas

## Testing
- `dotnet test UtilsTest/UtilsTest.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686f8bc9fec8832687941d792104c59a