### PR TITLE
Add MultiDelegateInvoker for parallel or sequential delegate invocation

### DIFF
--- a/Utils/README.md
+++ b/Utils/README.md
@@ -12,7 +12,7 @@ It targets **.NET 8** and is the base dependency for the other utility packages 
 - **Mathematics** – base classes for expression transformation and math functions
 - **Net** – advanced URI builder and network helpers
 - **Objects** – data conversion routines and an advanced string formatter
-- **Reflection** – additional reflection primitives such as `PropertyOrFieldInfo`
+- **Reflection** – additional reflection primitives such as `PropertyOrFieldInfo` and delegate invocation helpers
 - **Resources** – utilities for working with embedded resources
 - **Security** – Google Authenticator helpers
 - **Streams** – base16/base32/base64 converters and binary serialization
@@ -57,6 +57,12 @@ foreach (string exe in Utils.Files.PathUtils.EnumerateFiles(@"C:\\Program Files\
 var info = new Utils.Reflection.PropertyOrFieldInfo(typeof(MyType).GetField("Id"));
 int id = (int)info.GetValue(myObj);
 info.SetValue(myObj, 42);
+```
+```csharp
+var invoker = new Utils.Reflection.MultiDelegateInvoker<int, int>(2);
+invoker.Add(i => i + 1);
+invoker.Add(i => i + 2);
+int[] values = await invoker.InvokeSmartAsync(3); // [4, 5]
 ```
 
 ### Resources

--- a/Utils/Reflection/MultiDelegateInvoker.cs
+++ b/Utils/Reflection/MultiDelegateInvoker.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Reflection;
+
+/// <summary>
+/// Invokes multiple delegates registered for a given argument type.
+/// </summary>
+/// <typeparam name="TBaseArg">The base type for the argument of the delegates.</typeparam>
+/// <typeparam name="TResult">The return type of the delegates.</typeparam>
+public class MultiDelegateInvoker<TBaseArg, TResult> : IEnumerable<Delegate>
+{
+private readonly Dictionary<Type, List<Delegate>> _delegates = new();
+private readonly int _parallelThreshold;
+
+/// <summary>
+/// Initializes a new instance of the <see cref="MultiDelegateInvoker{TBaseArg, TResult}"/> class.
+/// </summary>
+/// <param name="parallelThreshold">Minimum number of delegates required to run in parallel when using <see cref="InvokeSmartAsync"/>.</param>
+/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="parallelThreshold"/> is less than one.</exception>
+public MultiDelegateInvoker(int parallelThreshold = 4)
+{
+if (parallelThreshold < 1) throw new ArgumentOutOfRangeException(nameof(parallelThreshold));
+_parallelThreshold = parallelThreshold;
+}
+
+/// <summary>
+/// Registers a delegate function for a specific argument type derived from <typeparamref name="TBaseArg"/>.
+/// </summary>
+/// <typeparam name="T">The argument type for the delegate.</typeparam>
+/// <param name="function">The delegate to register.</param>
+public void Add<T>(Func<T, TResult> function) where T : TBaseArg
+{
+ArgumentNullException.ThrowIfNull(function);
+if (!_delegates.TryGetValue(typeof(T), out var list))
+{
+list = [];
+_delegates[typeof(T)] = list;
+}
+list.Add(function);
+}
+
+private List<Delegate> GetDelegates(TBaseArg arg)
+{
+if (arg == null) throw new ArgumentNullException(nameof(arg));
+
+List<Delegate> list = null;
+Type type = arg.GetType();
+while (type != null && !_delegates.TryGetValue(type, out list))
+{
+type = type.BaseType;
+}
+
+return list ?? [];
+}
+
+/// <summary>
+/// Invokes the registered delegates sequentially for the runtime type of <paramref name="arg"/>.
+/// </summary>
+/// <param name="arg">The argument to pass to each delegate.</param>
+/// <returns>An array containing the results of each delegate call.</returns>
+/// <exception cref="MissingMethodException">Thrown when no delegate is registered for the argument type.</exception>
+public TResult[] Invoke(TBaseArg arg)
+{
+List<Delegate> list = GetDelegates(arg);
+if (list.Count == 0)
+throw new MissingMethodException($"No delegate is registered for type {arg.GetType()} or its base types.");
+
+TResult[] results = new TResult[list.Count];
+for (int i = 0; i < list.Count; i++)
+results[i] = (TResult)list[i].DynamicInvoke(arg);
+return results;
+}
+
+/// <summary>
+/// Invokes the registered delegates sequentially on background threads.
+/// </summary>
+/// <param name="arg">The argument to pass to each delegate.</param>
+/// <param name="cancellationToken">A token used to cancel the operation.</param>
+/// <returns>A task producing an array with the results of each delegate call.</returns>
+/// <exception cref="MissingMethodException">Thrown when no delegate is registered for the argument type.</exception>
+public async Task<TResult[]> InvokeAsync(TBaseArg arg, CancellationToken cancellationToken = default)
+{
+List<Delegate> list = GetDelegates(arg);
+if (list.Count == 0)
+throw new MissingMethodException($"No delegate is registered for type {arg.GetType()} or its base types.");
+
+TResult[] results = new TResult[list.Count];
+for (int i = 0; i < list.Count; i++)
+{
+cancellationToken.ThrowIfCancellationRequested();
+Delegate del = list[i];
+results[i] = await Task.Run(() => (TResult)del.DynamicInvoke(arg), cancellationToken).ConfigureAwait(false);
+}
+
+return results;
+}
+
+/// <summary>
+/// Invokes the registered delegates in parallel.
+/// </summary>
+/// <param name="arg">The argument to pass to each delegate.</param>
+/// <param name="cancellationToken">A token used to cancel the operation.</param>
+/// <returns>A task producing an array with the results of each delegate call.</returns>
+/// <exception cref="MissingMethodException">Thrown when no delegate is registered for the argument type.</exception>
+public async Task<TResult[]> InvokeParallelAsync(TBaseArg arg, CancellationToken cancellationToken = default)
+{
+List<Delegate> list = GetDelegates(arg);
+if (list.Count == 0)
+throw new MissingMethodException($"No delegate is registered for type {arg.GetType()} or its base types.");
+
+Task<TResult>[] tasks = new Task<TResult>[list.Count];
+for (int i = 0; i < list.Count; i++)
+{
+Delegate del = list[i];
+tasks[i] = Task.Run(() =>
+{
+cancellationToken.ThrowIfCancellationRequested();
+return (TResult)del.DynamicInvoke(arg);
+}, cancellationToken);
+}
+
+return await Task.WhenAll(tasks).ConfigureAwait(false);
+}
+
+/// <summary>
+/// Invokes the registered delegates either sequentially or in parallel depending on the configured threshold.
+/// </summary>
+/// <param name="arg">The argument to pass to each delegate.</param>
+/// <param name="cancellationToken">A token used to cancel the operation.</param>
+/// <returns>A task producing an array with the results of each delegate call.</returns>
+public Task<TResult[]> InvokeSmartAsync(TBaseArg arg, CancellationToken cancellationToken = default)
+{
+List<Delegate> list = GetDelegates(arg);
+if (list.Count == 0)
+throw new MissingMethodException($"No delegate is registered for type {arg.GetType()} or its base types.");
+
+return list.Count >= _parallelThreshold
+? InvokeParallelAsync(arg, cancellationToken)
+: InvokeAsync(arg, cancellationToken);
+}
+
+/// <inheritdoc />
+public IEnumerator<Delegate> GetEnumerator() => _delegates.Values.SelectMany(d => d).GetEnumerator();
+
+/// <inheritdoc />
+IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+

--- a/UtilsTest/Reflection/MultiDelegateInvokerTests.cs
+++ b/UtilsTest/Reflection/MultiDelegateInvokerTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Utils.Reflection;
+
+namespace UtilsTest.Reflection;
+
+[TestClass]
+public class MultiDelegateInvokerTests
+{
+private static int AddOne(int i) => i + 1;
+private static int AddTwo(int i) => i + 2;
+
+[TestMethod]
+public void Invoke_Returns_All_Results()
+{
+var invoker = new MultiDelegateInvoker<int, int>();
+invoker.Add<int>(AddOne);
+invoker.Add<int>(AddTwo);
+
+int[] results = invoker.Invoke(3);
+CollectionAssert.AreEqual(new[] { 4, 5 }, results);
+}
+
+[TestMethod]
+public async Task InvokeAsync_Returns_All_Results()
+{
+var invoker = new MultiDelegateInvoker<int, int>();
+invoker.Add<int>(AddOne);
+invoker.Add<int>(AddTwo);
+
+int[] results = await invoker.InvokeAsync(3);
+CollectionAssert.AreEqual(new[] { 4, 5 }, results);
+}
+
+[TestMethod]
+public async Task InvokeParallelAsync_Executes_In_Parallel()
+{
+var invoker = new MultiDelegateInvoker<int, int>();
+invoker.Add<int>(i => { System.Threading.Thread.Sleep(100); return i + 1; });
+invoker.Add<int>(i => { System.Threading.Thread.Sleep(100); return i + 2; });
+
+Stopwatch sw = Stopwatch.StartNew();
+int[] results = await invoker.InvokeParallelAsync(3);
+sw.Stop();
+
+CollectionAssert.AreEqual(new[] { 4, 5 }, results);
+Assert.IsTrue(sw.ElapsedMilliseconds < 190);
+}
+
+[TestMethod]
+public async Task InvokeSmartAsync_Switches_Based_On_Threshold()
+{
+var sequential = new MultiDelegateInvoker<int, int>(3);
+sequential.Add<int>(i => { System.Threading.Thread.Sleep(100); return i + 1; });
+sequential.Add<int>(i => { System.Threading.Thread.Sleep(100); return i + 2; });
+Stopwatch sw1 = Stopwatch.StartNew();
+await sequential.InvokeSmartAsync(3);
+sw1.Stop();
+Assert.IsTrue(sw1.ElapsedMilliseconds >= 190);
+
+var parallel = new MultiDelegateInvoker<int, int>(1);
+parallel.Add<int>(i => { System.Threading.Thread.Sleep(100); return i + 1; });
+parallel.Add<int>(i => { System.Threading.Thread.Sleep(100); return i + 2; });
+Stopwatch sw2 = Stopwatch.StartNew();
+await parallel.InvokeSmartAsync(3);
+sw2.Stop();
+Assert.IsTrue(sw2.ElapsedMilliseconds < 190);
+}
+}
+


### PR DESCRIPTION
## Summary
- add `MultiDelegateInvoker` to register multiple delegates per type and invoke them sequentially or in parallel
- document and demonstrate usage in README
- cover new invoker with unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68970eba00a883269e12f434d738dbed