### PR TITLE
Add handler dispatch system with message validation

### DIFF
--- a/Utils.DependencyInjection/HandlerCaller.cs
+++ b/Utils.DependencyInjection/HandlerCaller.cs
@@ -1,0 +1,79 @@
+using System;
+
+namespace Utils.DependencyInjection;
+
+/// <summary>
+/// Dispatches messages to their associated handlers.
+/// </summary>
+[Injectable]
+public interface IHandlerCaller : IInjectable
+{
+        /// <summary>
+        /// Validates and handles the provided message using the registered handler for its type.
+        /// </summary>
+        /// <typeparam name="E">Type of validation error.</typeparam>
+        /// <param name="message">Message instance to dispatch.</param>
+        /// <param name="error">Validation error returned when the method yields <see langword="false"/>.</param>
+        /// <returns><see langword="true"/> when the message has been handled; otherwise, <see langword="false"/>.</returns>
+        bool Handle<E>(object message, out E error);
+}
+
+/// <summary>
+/// Default implementation of <see cref="IHandlerCaller"/> using <see cref="IServiceProvider"/>.
+/// </summary>
+[Singleton]
+public class HandlerCaller : IHandlerCaller
+{
+        private readonly IServiceProvider serviceProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HandlerCaller"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">Service provider used to resolve handlers.</param>
+        public HandlerCaller(IServiceProvider serviceProvider)
+        {
+                this.serviceProvider = serviceProvider;
+        }
+
+        /// <inheritdoc />
+        public bool Handle<E>(object message, out E error)
+        {
+                if (message is null)
+                {
+                        throw new ArgumentNullException(nameof(message));
+                }
+
+                error = default!;
+                var messageType = message.GetType();
+
+                var checkType = typeof(ICheck<,>).MakeGenericType(messageType, typeof(E));
+                var check = this.serviceProvider.GetService(checkType);
+                if (check is not null)
+                {
+                        var checkMethod = checkType.GetMethod("Check");
+                        var parameters = new object?[] { message, null };
+                        var isValid = (bool)(checkMethod?.Invoke(check, parameters) ?? false);
+                        if (!isValid)
+                        {
+                                if (parameters[1] is E typedError)
+                                {
+                                        error = typedError;
+                                }
+
+                                return false;
+                        }
+                }
+
+                var handlerType = typeof(IHandler<>).MakeGenericType(messageType);
+                var handler = this.serviceProvider.GetService(handlerType);
+                if (handler is null)
+                {
+                        throw new InvalidOperationException($"No handler registered for type {messageType}");
+                }
+
+                var handleMethod = handlerType.GetMethod("Handle");
+                handleMethod?.Invoke(handler, new[] { message });
+                return true;
+        }
+}
+

--- a/Utils.DependencyInjection/ICheck.cs
+++ b/Utils.DependencyInjection/ICheck.cs
@@ -1,0 +1,18 @@
+namespace Utils.DependencyInjection;
+
+/// <summary>
+/// Validates messages before they are handled.
+/// </summary>
+/// <typeparam name="T">Type of message to validate.</typeparam>
+/// <typeparam name="E">Type of validation error returned when validation fails.</typeparam>
+[Injectable]
+public interface ICheck<in T, E> : IInjectable
+{
+        /// <summary>
+        /// Validates the specified message instance.
+        /// </summary>
+        /// <param name="message">Message instance to validate.</param>
+        /// <param name="error">Validation error returned when the method yields <see langword="false"/>.</param>
+        /// <returns><see langword="true"/> when the message is valid; otherwise, <see langword="false"/>.</returns>
+        bool Check(T message, out E error);
+}

--- a/Utils.DependencyInjection/IHandler.cs
+++ b/Utils.DependencyInjection/IHandler.cs
@@ -1,0 +1,16 @@
+namespace Utils.DependencyInjection;
+
+/// <summary>
+/// Defines a message handler for a specific message type.
+/// </summary>
+/// <typeparam name="T">Type of message processed by the handler.</typeparam>
+[Injectable]
+public interface IHandler<in T> : IInjectable
+{
+        /// <summary>
+        /// Processes the provided message instance.
+        /// </summary>
+        /// <param name="message">Message instance to handle.</param>
+        void Handle(T message);
+}
+

--- a/Utils.DependencyInjection/IInjectable.cs
+++ b/Utils.DependencyInjection/IInjectable.cs
@@ -1,0 +1,9 @@
+namespace Utils.DependencyInjection;
+
+/// <summary>
+/// Marker interface for services that can be injected.
+/// </summary>
+public interface IInjectable
+{
+}
+

--- a/Utils.DependencyInjection/README.md
+++ b/Utils.DependencyInjection/README.md
@@ -8,6 +8,7 @@ provided attributes are automatically added to an `IServiceCollection`.
 
 ```csharp
 using System.Reflection;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Utils.DependencyInjection;
 
@@ -21,6 +22,87 @@ var services = new ServiceCollection();
 Assembly.GetExecutingAssembly().ConfigureServices(services);
 var provider = services.BuildServiceProvider();
 var service = provider.GetRequiredService<IGreetingService>();
+```
+
+The generator can also register handlers and their checks:
+
+```csharp
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Utils.DependencyInjection;
+
+public class Ping { public bool Valid { get; set; } }
+
+[Singleton]
+public class PingCheck : ICheck<Ping, string>
+{
+    public bool Check(Ping message, out string error)
+    {
+        if (message.Valid)
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        error = "invalid";
+        return false;
+    }
+}
+
+[Singleton]
+public class PingHandler : IHandler<Ping>
+{
+    public void Handle(Ping message) => Console.WriteLine("pong");
+}
+
+[Singleton]
+public class PingCaller : HandlerCaller
+{
+    public PingCaller(IServiceProvider provider) : base(provider) { }
+}
+
+[StaticAuto]
+public partial class PingConfigurator : IServiceConfigurator { }
+
+var services = new ServiceCollection();
+new PingConfigurator().ConfigureServices(services);
+var provider = services.BuildServiceProvider();
+var caller = provider.GetRequiredService<IHandlerCaller>();
+caller.Handle<string>(new Ping { Valid = true }, out _);
+```
+
+## Handler system
+
+The library also provides a simple message handler pattern with optional message validation.
+
+```csharp
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Utils.DependencyInjection;
+
+public class Ping { }
+
+[Singleton]
+public class PingCheck : ICheck<Ping, string>
+{
+    public bool Check(Ping message, out string error)
+    {
+        error = string.Empty;
+        return true;
+    }
+}
+
+[Singleton]
+public class PingHandler : IHandler<Ping>
+{
+    public void Handle(Ping message) => Console.WriteLine("pong");
+}
+
+var services = new ServiceCollection();
+new Type[] { typeof(PingCheck), typeof(PingHandler), typeof(HandlerCaller) }.ConfigureServices(services);
+var provider = services.BuildServiceProvider();
+var caller = provider.GetRequiredService<IHandlerCaller>();
+caller.Handle<string>(new Ping(), out _);
 ```
 
 

--- a/UtilsTest/DependencyInjection/HandlerCallerTests.cs
+++ b/UtilsTest/DependencyInjection/HandlerCallerTests.cs
@@ -1,0 +1,105 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.DependencyInjection;
+
+namespace UtilsTest.DependencyInjection;
+
+/// <summary>
+/// Tests for the handler dispatching system.
+/// </summary>
+[TestClass]
+public class HandlerCallerTests
+{
+        /// <summary>
+        /// Ensures that <see cref="HandlerCaller"/> invokes the message check before the handler and dispatches when valid.
+        /// </summary>
+        [TestMethod]
+        public void Handle_CallsCheckAndHandler()
+        {
+                var services = new ServiceCollection();
+                Type[] types = [typeof(SampleHandler), typeof(SampleCheck), typeof(HandlerCaller)];
+                types.ConfigureServices(services);
+                var provider = services.BuildServiceProvider();
+
+                var caller = provider.GetRequiredService<IHandlerCaller>();
+                var message = new SampleMessage { Valid = true };
+                var handled = caller.Handle<string>(message, out var error);
+
+                Assert.IsTrue(handled);
+                Assert.IsNull(error);
+                var handler = (SampleHandler)provider.GetRequiredService<IHandler<SampleMessage>>();
+                Assert.AreSame(message, handler.LastMessage);
+        }
+
+        /// <summary>
+        /// Ensures that when the check fails the handler is not invoked.
+        /// </summary>
+        [TestMethod]
+        public void Handle_CheckFailurePreventsHandling()
+        {
+                var services = new ServiceCollection();
+                Type[] types = [typeof(SampleHandler), typeof(SampleCheck), typeof(HandlerCaller)];
+                types.ConfigureServices(services);
+                var provider = services.BuildServiceProvider();
+
+                var caller = provider.GetRequiredService<IHandlerCaller>();
+                var message = new SampleMessage { Valid = false };
+                var handled = caller.Handle<string>(message, out var error);
+
+                Assert.IsFalse(handled);
+                Assert.AreEqual("invalid", error);
+                var handler = (SampleHandler)provider.GetRequiredService<IHandler<SampleMessage>>();
+                Assert.IsNull(handler.LastMessage);
+        }
+
+        /// <summary>
+        /// Represents a message used for testing.
+        /// </summary>
+        private class SampleMessage
+        {
+                /// <summary>
+                /// Gets or sets a value indicating whether the message is valid.
+                /// </summary>
+                public bool Valid { get; set; }
+        }
+
+        /// <summary>
+        /// Handler used to capture messages during tests.
+        /// </summary>
+        [Singleton]
+        private class SampleHandler : IHandler<SampleMessage>
+        {
+                /// <summary>
+                /// Gets the last message handled by this instance.
+                /// </summary>
+                public SampleMessage? LastMessage { get; private set; }
+
+                /// <summary>
+                /// Handles the provided <paramref name="message"/> by storing it.
+                /// </summary>
+                /// <param name="message">Message instance to store.</param>
+                public void Handle(SampleMessage message) => LastMessage = message;
+        }
+
+        /// <summary>
+        /// Validation component used to verify <see cref="SampleMessage"/> instances.
+        /// </summary>
+        [Singleton]
+        private class SampleCheck : ICheck<SampleMessage, string>
+        {
+                /// <inheritdoc />
+                public bool Check(SampleMessage message, out string error)
+                {
+                        if (message.Valid)
+                        {
+                                error = string.Empty;
+                                return true;
+                        }
+
+                        error = "invalid";
+                        return false;
+                }
+        }
+}
+

--- a/UtilsTest/DependencyInjection/StaticAutoHandlerCallerTests.cs
+++ b/UtilsTest/DependencyInjection/StaticAutoHandlerCallerTests.cs
@@ -1,0 +1,125 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.DependencyInjection;
+
+namespace UtilsTest.DependencyInjection;
+
+/// <summary>
+/// Tests the handler system with statically generated configuration.
+/// </summary>
+[TestClass]
+public class StaticAutoHandlerCallerTests
+{
+        /// <summary>
+        /// Ensures that the generated configurator registers handlers and checks, allowing messages to be dispatched.
+        /// </summary>
+        [TestMethod]
+        public void Handle_UsesGeneratedConfiguration()
+        {
+                var services = new ServiceCollection();
+                new HandlerAutoConfigurator().ConfigureServices(services);
+                var provider = services.BuildServiceProvider();
+
+                var caller = provider.GetRequiredService<IHandlerCaller>();
+                var message = new SampleMessage { Valid = true };
+                var handled = caller.Handle<string>(message, out var error);
+
+                Assert.IsTrue(handled);
+                Assert.IsNull(error);
+                var handler = (SampleHandler)provider.GetRequiredService<IHandler<SampleMessage>>();
+                Assert.AreSame(message, handler.LastMessage);
+        }
+
+        /// <summary>
+        /// Ensures that when the check fails, the handler is not invoked.
+        /// </summary>
+        [TestMethod]
+        public void Handle_CheckFailurePreventsHandling()
+        {
+                var services = new ServiceCollection();
+                new HandlerAutoConfigurator().ConfigureServices(services);
+                var provider = services.BuildServiceProvider();
+
+                var caller = provider.GetRequiredService<IHandlerCaller>();
+                var message = new SampleMessage { Valid = false };
+                var handled = caller.Handle<string>(message, out var error);
+
+                Assert.IsFalse(handled);
+                Assert.AreEqual("invalid", error);
+                var handler = (SampleHandler)provider.GetRequiredService<IHandler<SampleMessage>>();
+                Assert.IsNull(handler.LastMessage);
+        }
+
+        /// <summary>
+        /// Represents a message used for testing.
+        /// </summary>
+        internal class SampleMessage
+        {
+                /// <summary>
+                /// Gets or sets a value indicating whether the message is valid.
+                /// </summary>
+                public bool Valid { get; set; }
+        }
+
+        /// <summary>
+        /// Handler used to capture messages during tests.
+        /// </summary>
+        [Singleton]
+        internal class SampleHandler : IHandler<SampleMessage>
+        {
+                /// <summary>
+                /// Gets the last message handled by this instance.
+                /// </summary>
+                public SampleMessage? LastMessage { get; private set; }
+
+                /// <summary>
+                /// Handles the provided <paramref name="message"/> by storing it.
+                /// </summary>
+                /// <param name="message">Message instance to store.</param>
+                public void Handle(SampleMessage message) => LastMessage = message;
+        }
+
+        /// <summary>
+        /// Validation component used to verify <see cref="SampleMessage"/> instances.
+        /// </summary>
+        [Singleton]
+        internal class SampleCheck : ICheck<SampleMessage, string>
+        {
+                /// <inheritdoc />
+                public bool Check(SampleMessage message, out string error)
+                {
+                        if (message.Valid)
+                        {
+                                error = string.Empty;
+                                return true;
+                        }
+
+                        error = "invalid";
+                        return false;
+                }
+        }
+
+        /// <summary>
+        /// Wrapper to register <see cref="HandlerCaller"/> through the source generator.
+        /// </summary>
+        [Singleton]
+        internal class TestHandlerCaller : HandlerCaller, IHandlerCaller
+        {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="TestHandlerCaller"/> class.
+                /// </summary>
+                /// <param name="serviceProvider">Service provider used to resolve handlers.</param>
+                public TestHandlerCaller(IServiceProvider serviceProvider) : base(serviceProvider)
+                {
+                }
+        }
+
+}
+
+/// <summary>
+/// Configurator used to exercise source generation.
+/// </summary>
+[StaticAuto]
+public partial class HandlerAutoConfigurator : IServiceConfigurator { }
+


### PR DESCRIPTION
## Summary
- add generic `ICheck<T, E>` for validating messages before handling
- update `HandlerCaller` to run checks and return validation errors
- document validation usage and add tests for successful and failing checks
- refine handler unit tests with array initializers and comments
- cover static handler configuration via source generator

## Testing
- `dotnet test --logger "console;verbosity=minimal" UtilsTest/UtilsTest.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6897abb71240832680833f744552f199