### PR TITLE
Improve NuGet packaging metadata and workflow triggers

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,24 +1,27 @@
 name: Utils
 
-on: [push]
+on:
+    push:
+        branches-ignore:
+            - release
 
 jobs:
-  build:
+    build:
 
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: ['9.0.x' ]
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                dotnet-version: ['9.0.x' ]
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup .NET ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-      #- name: Install dependencies
-      #  run: dotnet restore --ignore-failed-sources
-      - name: Build
-        run: dotnet build --configuration GitHub # --no-restore
-      - name: Test
-        run: dotnet test --no-restore --verbosity normal
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup .NET ${{ matrix.dotnet-version }}
+              uses: actions/setup-dotnet@v3
+              with:
+                  dotnet-version: ${{ matrix.dotnet-version }}
+            #- name: Install dependencies
+            #  run: dotnet restore --ignore-failed-sources
+            - name: Build
+              run: dotnet build --configuration GitHub # --no-restore
+            - name: Test
+              run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,60 +1,63 @@
 name: Publish NuGet
 
 on:
-  push:
-    branches:
-      - release
+    push:
+        branches:
+            - release
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: ['9.0.x']
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup .NET ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-      - name: Restore
-        run: dotnet restore
-      - name: Build
-        run: dotnet build --configuration Release
-      - name: Pack and publish updated libraries
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          PROJECTS="\
-            Utils/Utils.csproj \
-            Utils.Data/Utils.Data.csproj \
-            Utils.Fonts/Utils.Fonts.csproj \
-            Utils.Geography/Utils.Geography.csproj \
-            Utils.IO/Utils.IO.csproj \
-            Utils.DependencyInjection/Utils.DependencyInjection.csproj \
-            Utils.DependencyInjection.Generators/Utils.DependencyInjection.Generators.csproj \
-            Utils.Imaging/Utils.Imaging.csproj \
-            Utils.Mathematics/Utils.Mathematics.csproj \
-            Utils.Reflection/Utils.Reflection.csproj \
-            Utils.VirtualMachine/Utils.VirtualMachine.csproj \
-            Utils.Net/Utils.Net.csproj"
-          mkdir -p packages
-          for csproj in $PROJECTS; do
-            pkg_id=$(grep -oPm1 '(?<=<PackageId>)[^<]+' "$csproj")
-            version=$(grep -oPm1 '(?<=<Version>)[^<]+' "$csproj")
-            url="https://api.nuget.org/v3-flatcontainer/$(echo "$pkg_id" | tr '[:upper:]' '[:lower:]')/index.json"
-            if curl -fsSL "$url" 2>/dev/null | grep -q "\"$version\""; then
-              echo "Skipping $pkg_id version $version"
-            else
-              if ! dotnet pack "$csproj" --configuration Release --no-build --no-restore -o packages; then
-                echo "Error packing $pkg_id version $version"
-                exit 1
-              fi
-              push_output=$(dotnet nuget push "packages/$pkg_id.$version.nupkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json 2>&1)
-              if [ $? -ne 0 ]; then
-                echo "Error publishing $pkg_id version $version"
-                echo "$push_output"
-                exit 1
-              fi
-            fi
-          done
+    build:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                dotnet-version: ['9.0.x']
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup .NET ${{ matrix.dotnet-version }}
+              uses: actions/setup-dotnet@v3
+              with:
+                  dotnet-version: ${{ matrix.dotnet-version }}
+            - name: Restore
+              run: dotnet restore
+            - name: Build
+              run: dotnet build --configuration Release
+            - name: Pack and publish updated libraries
+              env:
+                  NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+              run: |
+                  PROJECTS="\
+                    Utils/Utils.csproj \
+                    Utils.Data/Utils.Data.csproj \
+                    Utils.Fonts/Utils.Fonts.csproj \
+                    Utils.Geography/Utils.Geography.csproj \
+                    Utils.IO/Utils.IO.csproj \
+                    Utils.DependencyInjection/Utils.DependencyInjection.csproj \
+                    Utils.DependencyInjection.Generators/Utils.DependencyInjection.Generators.csproj \
+                    Utils.Imaging/Utils.Imaging.csproj \
+                    Utils.Mathematics/Utils.Mathematics.csproj \
+                    Utils.Reflection/Utils.Reflection.csproj \
+                    Utils.VirtualMachine/Utils.VirtualMachine.csproj \
+                    Utils.Net/Utils.Net.csproj"
+                  mkdir -p packages
+                  for csproj in $PROJECTS; do
+                      pkg_id=$(grep -oPm1 '(?<=<PackageId>)[^<]+' "$csproj")
+                      version=$(grep -oPm1 '(?<=<Version>)[^<]+' "$csproj")
+                      url="https://api.nuget.org/v3-flatcontainer/$(echo "$pkg_id" | tr '[:upper:]' '[:lower:]')/index.json"
+                      if curl -sSL "$url" 2>/dev/null | grep -q "\"$version\""; then
+                          echo "Skipping $pkg_id version $version"
+                      else
+                          if ! dotnet pack "$csproj" --configuration Release --no-build --no-restore -o packages -p:ContinuousIntegrationBuild=true; then
+                              echo "Error packing $pkg_id version $version"
+                              exit 1
+                          fi
+                          push_output=$(dotnet nuget push "packages/$pkg_id.$version.nupkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json 2>&1)
+                          if [ $? -ne 0 ]; then
+                              echo "Error publishing $pkg_id version $version"
+                              echo "$push_output"
+                              exit 1
+                          fi
+                          if [ -f "packages/$pkg_id.$version.snupkg" ]; then
+                              dotnet nuget push "packages/$pkg_id.$version.snupkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json || true
+                          fi
+                      fi
+                  done

--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,14 +1,24 @@
 <Project>
-  <PropertyGroup>
-    <LangVersion>latest</LangVersion>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <RepositoryUrl>https://github.com/warny/All-purpose-Utilities</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/warny/All-purpose-Utilities</PackageProjectUrl>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="../LICENSE-apache-2.0.txt">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IncludeDocumentationFile>true</IncludeDocumentationFile>
+        <RepositoryUrl>https://github.com/warny/All-purpose-Utilities</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/warny/All-purpose-Utilities</PackageProjectUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+        <Deterministic>true</Deterministic>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="../LICENSE-apache-2.0.txt">
+            <Pack>True</Pack>
+            <PackagePath></PackagePath>
+        </None>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- ensure publish workflow ignores missing NuGet packages, pushes symbol packages and enables CI build settings
- include SourceLink, deterministic symbols and XML docs in build props
- avoid building release branch in main CI workflow

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4793237388326969c329bf6368e43