### PR TITLE
Add clients for basic TCP and NTP services

### DIFF
--- a/Utils.Net/Net/EchoClient.cs
+++ b/Utils.Net/Net/EchoClient.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Client for the TCP Echo protocol (RFC 862).
+/// </summary>
+public static class EchoClient
+{
+    /// <summary>
+    /// Sends a message to an Echo server and returns the echoed response.
+    /// </summary>
+    /// <param name="host">Hostname or IP address of the Echo server.</param>
+    /// <param name="port">TCP port of the Echo service, default is 7.</param>
+    /// <param name="message">Message to send.</param>
+    /// <returns>Echoed message returned by the server.</returns>
+    public static async Task<string> EchoAsync(string host, int port, string message)
+    {
+        using TcpClient client = new();
+        await client.ConnectAsync(host, port);
+        NetworkStream stream = client.GetStream();
+        byte[] data = Encoding.ASCII.GetBytes(message);
+        await stream.WriteAsync(data);
+        byte[] buffer = new byte[data.Length];
+        int bytesRead = 0;
+        while (bytesRead < data.Length)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(bytesRead));
+            if (read == 0)
+            {
+                break;
+            }
+            bytesRead += read;
+        }
+        return Encoding.ASCII.GetString(buffer, 0, bytesRead);
+    }
+
+    /// <summary>
+    /// Sends a message to an Echo server on the default port (7) and returns the echoed response.
+    /// </summary>
+    /// <param name="host">Hostname or IP address of the Echo server.</param>
+    /// <param name="message">Message to send.</param>
+    /// <returns>Echoed message returned by the server.</returns>
+    public static Task<string> EchoAsync(string host, string message)
+    {
+        return EchoAsync(host, 7, message);
+    }
+}

--- a/Utils.Net/Net/NtpClient.cs
+++ b/Utils.Net/Net/NtpClient.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Client for the Network Time Protocol (RFC 5905).
+/// </summary>
+public static class NtpClient
+{
+    private static readonly DateTime Epoch = new(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Retrieves the current time from an NTP server.
+    /// </summary>
+    /// <param name="host">Hostname or IP address of the NTP server.</param>
+    /// <param name="port">UDP port of the NTP service, default is 123.</param>
+    /// <returns>UTC time reported by the server.</returns>
+    public static async Task<DateTime> GetTimeAsync(string host, int port)
+    {
+        byte[] request = new byte[48];
+        request[0] = 0x1B; // LI = 0, VN = 3, Mode = 3 (client)
+        using UdpClient client = new();
+        await client.SendAsync(request, request.Length, host, port);
+        UdpReceiveResult result = await client.ReceiveAsync();
+        byte[] response = result.Buffer;
+        ulong intPart = (ulong)response[40] << 24 | (ulong)response[41] << 16 | (ulong)response[42] << 8 | response[43];
+        ulong fracPart = (ulong)response[44] << 24 | (ulong)response[45] << 16 | (ulong)response[46] << 8 | response[47];
+        double milliseconds = intPart * 1000 + fracPart * 1000.0 / 0x100000000L;
+        return Epoch.AddMilliseconds(milliseconds);
+    }
+
+    /// <summary>
+    /// Retrieves the current time from an NTP server on the default port (123).
+    /// </summary>
+    /// <param name="host">Hostname or IP address of the NTP server.</param>
+    /// <returns>UTC time reported by the server.</returns>
+    public static Task<DateTime> GetTimeAsync(string host)
+    {
+        return GetTimeAsync(host, 123);
+    }
+}

--- a/Utils.Net/Net/QuoteOfTheDayClient.cs
+++ b/Utils.Net/Net/QuoteOfTheDayClient.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Client for the Quote of the Day protocol (RFC 865).
+/// </summary>
+public static class QuoteOfTheDayClient
+{
+    /// <summary>
+    /// Retrieves a quote from a Quote of the Day server.
+    /// </summary>
+    /// <param name="host">Hostname or IP address of the Quote server.</param>
+    /// <param name="port">TCP port of the Quote service, default is 17.</param>
+    /// <returns>Quote returned by the server.</returns>
+    public static async Task<string> GetQuoteAsync(string host, int port)
+    {
+        using TcpClient client = new();
+        await client.ConnectAsync(host, port);
+        using NetworkStream stream = client.GetStream();
+        using StreamReader reader = new(stream, Encoding.ASCII);
+        string quote = await reader.ReadToEndAsync();
+        return quote.TrimEnd('\r', '\n');
+    }
+
+    /// <summary>
+    /// Retrieves a quote from a Quote of the Day server on the default port (17).
+    /// </summary>
+    /// <param name="host">Hostname or IP address of the Quote server.</param>
+    /// <returns>Quote returned by the server.</returns>
+    public static Task<string> GetQuoteAsync(string host)
+    {
+        return GetQuoteAsync(host, 17);
+    }
+}

--- a/Utils.Net/Net/TimeProtocolClient.cs
+++ b/Utils.Net/Net/TimeProtocolClient.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Client for the Time protocol (RFC 868).
+/// </summary>
+public static class TimeProtocolClient
+{
+    private static readonly DateTime Epoch = new(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Retrieves the current time from a Time protocol server.
+    /// </summary>
+    /// <param name="host">Hostname or IP address of the Time server.</param>
+    /// <param name="port">TCP port of the Time service, default is 37.</param>
+    /// <returns>UTC time reported by the server.</returns>
+    public static async Task<DateTime> GetTimeAsync(string host, int port)
+    {
+        using TcpClient client = new();
+        await client.ConnectAsync(host, port);
+        byte[] buffer = new byte[4];
+        int bytesRead = 0;
+        NetworkStream stream = client.GetStream();
+        while (bytesRead < 4)
+        {
+            int read = await stream.ReadAsync(buffer.AsMemory(bytesRead));
+            if (read == 0)
+            {
+                throw new IOException("Connection closed before 4 bytes were received.");
+            }
+            bytesRead += read;
+        }
+        uint seconds = (uint)(buffer[0] << 24 | buffer[1] << 16 | buffer[2] << 8 | buffer[3]);
+        return Epoch.AddSeconds(seconds);
+    }
+
+    /// <summary>
+    /// Retrieves the current time from a Time protocol server on the default port (37).
+    /// </summary>
+    /// <param name="host">Hostname or IP address of the Time server.</param>
+    /// <returns>UTC time reported by the server.</returns>
+    public static Task<DateTime> GetTimeAsync(string host)
+    {
+        return GetTimeAsync(host, 37);
+    }
+}

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -12,6 +12,7 @@ It targets **.NET 9** and is designed to be portable across platforms.
 - ARP packet creation utilities
 - URI and query string manipulation helpers
 - Parsing of mail addresses and IP range calculations
+- Clients for basic network services like Echo, Quote of the Day, Time protocol and NTP
 
 ## Usage examples
 ```csharp
@@ -33,4 +34,10 @@ await Utils.Net.WakeOnLan.SendMagicPacketAsync(System.Net.NetworkInformation.Phy
 
 // Build an ARP request
 var arpRequest = Utils.Net.ArpUtils.CreateRequest(System.Net.IPAddress.Parse("192.168.1.1"), System.Net.NetworkInformation.PhysicalAddress.Parse("00-11-22-33-44-55"), System.Net.IPAddress.Parse("192.168.1.2"));
+
+// Retrieve time using NTP
+DateTime utcNow = await Utils.Net.NtpClient.GetTimeAsync("pool.ntp.org");
+
+// Fetch the quote of the day
+string quote = await Utils.Net.QuoteOfTheDayClient.GetQuoteAsync("djxmmx.net");
 ```

--- a/UtilsTest/Net/EchoClientTests.cs
+++ b/UtilsTest/Net/EchoClientTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Tests for <see cref="EchoClient"/>.
+/// </summary>
+[TestClass]
+public class EchoClientTests
+{
+    /// <summary>
+    /// Verifies that the Echo client returns the same message that was sent.
+    /// </summary>
+    [TestMethod]
+    public async Task EchoAsync_ReturnsEchoedMessage()
+    {
+        const string message = "hello";
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            NetworkStream serverStream = serverClient.GetStream();
+            byte[] buffer = new byte[1024];
+            int read = await serverStream.ReadAsync(buffer);
+            await serverStream.WriteAsync(buffer.AsMemory(0, read));
+            serverClient.Close();
+            listener.Stop();
+        });
+
+        string response = await EchoClient.EchoAsync("127.0.0.1", port, message);
+        Assert.AreEqual(message, response);
+        await serverTask;
+    }
+}

--- a/UtilsTest/Net/NtpClientTests.cs
+++ b/UtilsTest/Net/NtpClientTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Tests for <see cref="NtpClient"/>.
+/// </summary>
+[TestClass]
+public class NtpClientTests
+{
+    /// <summary>
+    /// Verifies that the NTP client parses the time provided by the server.
+    /// </summary>
+    [TestMethod]
+    public async Task GetTimeAsync_ReturnsExpectedTime()
+    {
+        DateTime expected = new(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        ulong seconds = (ulong)(expected - new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
+        ulong fraction = 0;
+        UdpClient server = new(new IPEndPoint(IPAddress.Loopback, 0));
+        int port = ((IPEndPoint)server.Client.LocalEndPoint!).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            UdpReceiveResult request = await server.ReceiveAsync();
+            byte[] response = new byte[48];
+            response[0] = 0x1C; // LI = 0, VN = 3, Mode = 4 (server)
+            response[40] = (byte)(seconds >> 24);
+            response[41] = (byte)(seconds >> 16);
+            response[42] = (byte)(seconds >> 8);
+            response[43] = (byte)seconds;
+            response[44] = (byte)(fraction >> 24);
+            response[45] = (byte)(fraction >> 16);
+            response[46] = (byte)(fraction >> 8);
+            response[47] = (byte)fraction;
+            await server.SendAsync(response, response.Length, request.RemoteEndPoint);
+        });
+
+        DateTime result = await NtpClient.GetTimeAsync("127.0.0.1", port);
+        Assert.AreEqual(expected, result);
+        server.Close();
+        await serverTask;
+    }
+}

--- a/UtilsTest/Net/QuoteOfTheDayClientTests.cs
+++ b/UtilsTest/Net/QuoteOfTheDayClientTests.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Tests for <see cref="QuoteOfTheDayClient"/>.
+/// </summary>
+[TestClass]
+public class QuoteOfTheDayClientTests
+{
+    /// <summary>
+    /// Verifies that the Quote of the Day client retrieves the quote sent by the server.
+    /// </summary>
+    [TestMethod]
+    public async Task GetQuoteAsync_ReturnsQuote()
+    {
+        const string quote = "Be yourself";
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            NetworkStream serverStream = serverClient.GetStream();
+            byte[] bytes = Encoding.ASCII.GetBytes(quote + "\r\n");
+            await serverStream.WriteAsync(bytes);
+            serverClient.Close();
+            listener.Stop();
+        });
+
+        string result = await QuoteOfTheDayClient.GetQuoteAsync("127.0.0.1", port);
+        Assert.AreEqual(quote, result);
+        await serverTask;
+    }
+}

--- a/UtilsTest/Net/TimeProtocolClientTests.cs
+++ b/UtilsTest/Net/TimeProtocolClientTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Tests for <see cref="TimeProtocolClient"/>.
+/// </summary>
+[TestClass]
+public class TimeProtocolClientTests
+{
+    /// <summary>
+    /// Verifies that the Time protocol client parses the time sent by the server.
+    /// </summary>
+    [TestMethod]
+    public async Task GetTimeAsync_ReturnsExpectedTime()
+    {
+        DateTime expected = new(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        uint seconds = (uint)(expected - new DateTime(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            NetworkStream stream = serverClient.GetStream();
+            byte[] bytes = new byte[4];
+            bytes[0] = (byte)(seconds >> 24);
+            bytes[1] = (byte)(seconds >> 16);
+            bytes[2] = (byte)(seconds >> 8);
+            bytes[3] = (byte)seconds;
+            await stream.WriteAsync(bytes);
+            serverClient.Close();
+            listener.Stop();
+        });
+
+        DateTime result = await TimeProtocolClient.GetTimeAsync("127.0.0.1", port);
+        Assert.AreEqual(expected, result);
+        await serverTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add EchoClient for RFC 862 echo service
- add QuoteOfTheDayClient for RFC 865
- add TimeProtocolClient and NtpClient to retrieve network time
- document new clients in Utils.Net README

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ac21c7d28c8326b2d2bd9375abedcd