### PR TITLE
Add stream-based command/response client and server

### DIFF
--- a/Utils.Net/Net/CommandResponseClient.cs
+++ b/Utils.Net/Net/CommandResponseClient.cs
@@ -243,12 +243,13 @@ public class CommandResponseClient : IDisposable
     /// <returns>Parsed response.</returns>
     private static ServerResponse DefaultParser(string line)
     {
-        if (line.Length >= 3 && int.TryParse(line[..3], out int code))
+        if (line.Length >= 3 && char.IsDigit(line[0]))
         {
+            string code = line[..3];
             string? text = line.Length > 4 ? line[4..] : string.Empty;
             return new ServerResponse(code, text);
         }
-        return new ServerResponse(0, ResponseSeverity.Unknown, line);
+        return new ServerResponse(string.Empty, ResponseSeverity.Unknown, line);
     }
 
     /// <summary>

--- a/Utils.Net/Net/CommandResponseClient.cs
+++ b/Utils.Net/Net/CommandResponseClient.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Provides a base client for text based command/response protocols.
+/// </summary>
+public class CommandResponseClient : IDisposable
+{
+    private TcpClient? _client;
+    private Stream? _stream;
+    private StreamReader? _reader;
+    private StreamWriter? _writer;
+    private readonly ConcurrentQueue<ServerResponse> _responseQueue = new();
+    private readonly SemaphoreSlim _responseSignal = new(0);
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private CancellationTokenSource? _listenTokenSource;
+    private Timer? _keepAliveTimer;
+    private TimeSpan _noOpInterval = Timeout.InfiniteTimeSpan;
+    private string _noOpCommand = "NOOP";
+    private bool _leaveOpen;
+
+    /// <summary>
+    /// Occurs when a response is received from the server.
+    /// </summary>
+    public event Action<ServerResponse>? UnsolicitedResponseReceived;
+
+    /// <summary>
+    /// Gets or sets the command sent during inactivity to keep the connection alive.
+    /// </summary>
+    public string NoOpCommand
+    {
+        get => _noOpCommand;
+        set => _noOpCommand = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the time to wait before sending a no-op command. Set to <see cref="Timeout.InfiniteTimeSpan"/> to disable.
+    /// </summary>
+    public TimeSpan NoOpInterval
+    {
+        get => _noOpInterval;
+        set
+        {
+            _noOpInterval = value;
+            _keepAliveTimer?.Change(value, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    /// <summary>
+    /// Connects to the specified host and port using a TCP connection.
+    /// </summary>
+    /// <param name="host">Server host name or IP address.</param>
+    /// <param name="port">Server port.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task ConnectAsync(string host, int port, CancellationToken cancellationToken = default)
+    {
+        _client = new TcpClient();
+        await _client.ConnectAsync(host, port, cancellationToken);
+        await ConnectAsync(_client.GetStream(), false, cancellationToken);
+    }
+
+    /// <summary>
+    /// Uses the provided bidirectional <see cref="Stream"/> for communication.
+    /// </summary>
+    /// <param name="stream">Connected stream used to send commands and receive responses.</param>
+    /// <param name="leaveOpen">True to leave the stream open when disposing the client.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task ConnectAsync(Stream stream, bool leaveOpen = false, CancellationToken cancellationToken = default)
+    {
+        _stream = stream;
+        _leaveOpen = leaveOpen;
+        _reader = new StreamReader(stream, Encoding.ASCII, false, 1024, true);
+        _writer = new StreamWriter(stream, Encoding.ASCII, 1024, true)
+        {
+            NewLine = "\r\n",
+            AutoFlush = true
+        };
+        _listenTokenSource = new CancellationTokenSource();
+        _ = Task.Run(() => ListenAsync(_listenTokenSource.Token), cancellationToken);
+        if (_noOpInterval != Timeout.InfiniteTimeSpan)
+        {
+            _keepAliveTimer = new Timer(async _ => await SendNoOpAsync(), null, _noOpInterval, Timeout.InfiniteTimeSpan);
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Sends a command and collects responses until a non 1xx status code is received.
+    /// </summary>
+    /// <param name="command">Command to send.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of responses returned by the server.</returns>
+    public async Task<IReadOnlyList<ServerResponse>> SendCommandAsync(string command, CancellationToken cancellationToken = default)
+    {
+        if (_writer is null)
+        {
+            throw new InvalidOperationException("Client is not connected.");
+        }
+
+        await _sendLock.WaitAsync(cancellationToken);
+        try
+        {
+            await _writer.WriteLineAsync(command);
+            List<ServerResponse> responses = new();
+            while (true)
+            {
+                await _responseSignal.WaitAsync(cancellationToken);
+                if (!_responseQueue.TryDequeue(out ServerResponse response))
+                {
+                    continue;
+                }
+                responses.Add(response);
+                if (response.Code < 100 || response.Code >= 200)
+                {
+                    break;
+                }
+            }
+            ResetKeepAlive();
+            return responses;
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Listens for responses from the server and enqueues them for processing.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    private async Task ListenAsync(CancellationToken cancellationToken)
+    {
+        if (_reader is null)
+        {
+            return;
+        }
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            string? line = await _reader.ReadLineAsync(cancellationToken);
+            if (line is null)
+            {
+                break;
+            }
+            ServerResponse response = ParseResponse(line);
+            _responseQueue.Enqueue(response);
+            _responseSignal.Release();
+            UnsolicitedResponseReceived?.Invoke(response);
+        }
+    }
+
+    /// <summary>
+    /// Parses a response line into a <see cref="ServerResponse"/> structure.
+    /// </summary>
+    /// <param name="line">Response line from the server.</param>
+    /// <returns>Parsed response.</returns>
+    private static ServerResponse ParseResponse(string line)
+    {
+        int code = 0;
+        string? text = null;
+        if (line.Length >= 3 && int.TryParse(line[..3], out int parsed))
+        {
+            code = parsed;
+            text = line.Length > 4 ? line[4..] : string.Empty;
+        }
+        return new ServerResponse(code, text);
+    }
+
+    /// <summary>
+    /// Sends the no-op command.
+    /// </summary>
+    private async Task SendNoOpAsync()
+    {
+        try
+        {
+            await SendCommandAsync(_noOpCommand);
+        }
+        catch
+        {
+            // Ignore keep-alive exceptions.
+        }
+    }
+
+    /// <summary>
+    /// Resets the keep alive timer.
+    /// </summary>
+    private void ResetKeepAlive()
+    {
+        _keepAliveTimer?.Change(_noOpInterval, Timeout.InfiniteTimeSpan);
+    }
+
+    /// <summary>
+    /// Releases the client resources.
+    /// </summary>
+    public void Dispose()
+    {
+        _listenTokenSource?.Cancel();
+        _keepAliveTimer?.Dispose();
+        _reader?.Dispose();
+        _writer?.Dispose();
+        if (!_leaveOpen)
+        {
+            _stream?.Dispose();
+        }
+        _client?.Dispose();
+        _responseSignal.Dispose();
+        _sendLock.Dispose();
+    }
+}
+

--- a/Utils.Net/Net/CommandResponseClient.cs
+++ b/Utils.Net/Net/CommandResponseClient.cs
@@ -337,14 +337,14 @@ public class CommandResponseClient : IDisposable
     public void Dispose()
     {
         _listenTokenSource?.Cancel();
-        _listenThread?.Join();
-        _keepAliveTimer?.Dispose();
         _reader?.Dispose();
         _writer?.Dispose();
         if (!_leaveOpen)
         {
             _stream?.Dispose();
         }
+        _listenThread?.Join(TimeSpan.FromSeconds(1));
+        _keepAliveTimer?.Dispose();
         _client?.Dispose();
         _responseSignal.Dispose();
         _sendLock.Dispose();

--- a/Utils.Net/Net/CommandResponseServer.cs
+++ b/Utils.Net/Net/CommandResponseServer.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Provides a base server for text based command/response protocols.
+/// </summary>
+public class CommandResponseServer : IDisposable
+{
+    private Stream? _stream;
+    private StreamReader? _reader;
+    private StreamWriter? _writer;
+    private CancellationTokenSource? _listenTokenSource;
+    private Task? _listenTask;
+    private bool _leaveOpen;
+
+    /// <summary>
+    /// Occurs when a command is received from the client. The handler must return the responses to send.
+    /// </summary>
+    public event Func<string, Task<IEnumerable<ServerResponse>>>? CommandReceived;
+
+    /// <summary>
+    /// Starts processing commands using the specified stream.
+    /// </summary>
+    /// <param name="stream">Bi-directional stream connected to the client.</param>
+    /// <param name="leaveOpen">True to leave the stream open when disposing the server.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task StartAsync(Stream stream, bool leaveOpen = false, CancellationToken cancellationToken = default)
+    {
+        _stream = stream;
+        _leaveOpen = leaveOpen;
+        _reader = new StreamReader(stream, Encoding.ASCII, false, 1024, true);
+        _writer = new StreamWriter(stream, Encoding.ASCII, 1024, true)
+        {
+            NewLine = "\r\n",
+            AutoFlush = true
+        };
+        _listenTokenSource = new CancellationTokenSource();
+        _listenTask = ListenAsync(_listenTokenSource.Token);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Gets a task that completes when the server stops listening.
+    /// </summary>
+    public Task Completion => _listenTask ?? Task.CompletedTask;
+
+    /// <summary>
+    /// Sends an unsolicited response to the client.
+    /// </summary>
+    /// <param name="response">Response to send.</param>
+    public Task SendResponseAsync(ServerResponse response)
+    {
+        if (_writer is null)
+        {
+            throw new InvalidOperationException("Server is not started.");
+        }
+        string line = response.Message is null ? $"{response.Code:D3}" : $"{response.Code:D3} {response.Message}";
+        return _writer.WriteLineAsync(line);
+    }
+
+    /// <summary>
+    /// Listens for commands from the client and dispatches responses.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    private async Task ListenAsync(CancellationToken cancellationToken)
+    {
+        if (_reader is null || _writer is null)
+        {
+            return;
+        }
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            string? command = await _reader.ReadLineAsync(cancellationToken);
+            if (command is null)
+            {
+                break;
+            }
+            IEnumerable<ServerResponse>? responses = null;
+            if (CommandReceived is not null)
+            {
+                responses = await CommandReceived.Invoke(command);
+            }
+            if (responses is null)
+            {
+                responses = new[] { new ServerResponse(500, "Command handler not set") };
+            }
+            foreach (ServerResponse response in responses)
+            {
+                string line = response.Message is null ? $"{response.Code:D3}" : $"{response.Code:D3} {response.Message}";
+                await _writer.WriteLineAsync(line);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Releases server resources.
+    /// </summary>
+    public void Dispose()
+    {
+        _listenTokenSource?.Cancel();
+        _reader?.Dispose();
+        _writer?.Dispose();
+        if (!_leaveOpen)
+        {
+            _stream?.Dispose();
+        }
+        _listenTokenSource?.Dispose();
+    }
+}
+

--- a/Utils.Net/Net/CommandResponseServer.cs
+++ b/Utils.Net/Net/CommandResponseServer.cs
@@ -222,14 +222,14 @@ public class CommandResponseServer : IDisposable
                     }
                     else
                     {
-                        responses = new[] { new ServerResponse("503", "Bad sequence of commands") };
+                        responses = new[] { new ServerResponse("503", ResponseSeverity.PermanentNegative, "Bad sequence of commands") };
                     }
                 }
                 else if (CommandReceived is not null)
                 {
                     responses = await CommandReceived.Invoke(command);
                 }
-                responses ??= new[] { new ServerResponse("502", "Command not implemented") };
+                responses ??= new[] { new ServerResponse("502", ResponseSeverity.PermanentNegative, "Command not implemented") };
                 List<ServerResponse> responseList = responses.ToList();
                 foreach (ServerResponse response in responseList)
                 {

--- a/Utils.Net/Net/CommandResponseServer.cs
+++ b/Utils.Net/Net/CommandResponseServer.cs
@@ -240,8 +240,8 @@ public class CommandResponseServer : IDisposable
 
                 if (MaxConsecutiveErrors > 0)
                 {
-                    int finalCode = responseList[^1].Code;
-                    if (finalCode >= 500)
+                    ResponseSeverity finalSeverity = responseList[^1].Severity;
+                    if (finalSeverity >= ResponseSeverity.TransientNegative)
                     {
                         _errorCount++;
                         if (_errorCount >= MaxConsecutiveErrors)

--- a/Utils.Net/Net/CommandResponseServer.cs
+++ b/Utils.Net/Net/CommandResponseServer.cs
@@ -270,7 +270,13 @@ public class CommandResponseServer : IDisposable
     public void Dispose()
     {
         _listenTokenSource?.Cancel();
-        _listenThread?.Join();
+        _reader?.Dispose();
+        _writer?.Dispose();
+        if (!_leaveOpen)
+        {
+            _stream?.Dispose();
+        }
+        _listenThread?.Join(TimeSpan.FromSeconds(1));
         try
         {
             _processTask?.Wait();
@@ -278,12 +284,6 @@ public class CommandResponseServer : IDisposable
         catch
         {
             // Ignore exceptions during shutdown.
-        }
-        _reader?.Dispose();
-        _writer?.Dispose();
-        if (!_leaveOpen)
-        {
-            _stream?.Dispose();
         }
         _listenTokenSource?.Dispose();
         _commandSignal.Dispose();

--- a/Utils.Net/Net/CommandResponseServer.cs
+++ b/Utils.Net/Net/CommandResponseServer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -16,7 +17,10 @@ public class CommandResponseServer : IDisposable
     private StreamReader? _reader;
     private StreamWriter? _writer;
     private CancellationTokenSource? _listenTokenSource;
-    private Task? _listenTask;
+    private Thread? _listenThread;
+    private Task? _processTask;
+    private readonly ConcurrentQueue<string> _commandQueue = new();
+    private readonly SemaphoreSlim _commandSignal = new(0);
     private bool _leaveOpen;
 
     /// <summary>
@@ -41,14 +45,19 @@ public class CommandResponseServer : IDisposable
             AutoFlush = true
         };
         _listenTokenSource = new CancellationTokenSource();
-        _listenTask = ListenAsync(_listenTokenSource.Token);
+        _listenThread = new Thread(() => ListenLoop(_listenTokenSource.Token))
+        {
+            IsBackground = true
+        };
+        _listenThread.Start();
+        _processTask = ProcessQueueAsync(_listenTokenSource.Token);
         return Task.CompletedTask;
     }
 
     /// <summary>
-    /// Gets a task that completes when the server stops listening.
+    /// Gets a task that completes when the server stops processing commands.
     /// </summary>
-    public Task Completion => _listenTask ?? Task.CompletedTask;
+    public Task Completion => _processTask ?? Task.CompletedTask;
 
     /// <summary>
     /// Sends an unsolicited response to the client.
@@ -65,31 +74,65 @@ public class CommandResponseServer : IDisposable
     }
 
     /// <summary>
-    /// Listens for commands from the client and dispatches responses.
+    /// Listens for commands from the client on a dedicated thread and enqueues them for processing.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
-    private async Task ListenAsync(CancellationToken cancellationToken)
+    private void ListenLoop(CancellationToken cancellationToken)
     {
-        if (_reader is null || _writer is null)
+        if (_reader is null)
+        {
+            return;
+        }
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                string? command = _reader.ReadLineAsync(cancellationToken).GetAwaiter().GetResult();
+                if (command is null)
+                {
+                    break;
+                }
+                _commandQueue.Enqueue(command);
+                _commandSignal.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Listening canceled.
+        }
+        finally
+        {
+            _commandSignal.Release();
+        }
+    }
+
+    /// <summary>
+    /// Processes queued commands and sends responses to the client.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    private async Task ProcessQueueAsync(CancellationToken cancellationToken)
+    {
+        if (_writer is null)
         {
             return;
         }
         while (!cancellationToken.IsCancellationRequested)
         {
-            string? command = await _reader.ReadLineAsync(cancellationToken);
-            if (command is null)
+            await _commandSignal.WaitAsync(cancellationToken);
+            if (!_commandQueue.TryDequeue(out string? command))
             {
-                break;
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                continue;
             }
             IEnumerable<ServerResponse>? responses = null;
             if (CommandReceived is not null)
             {
                 responses = await CommandReceived.Invoke(command);
             }
-            if (responses is null)
-            {
-                responses = new[] { new ServerResponse(500, "Command handler not set") };
-            }
+            responses ??= new[] { new ServerResponse(500, "Command handler not set") };
             foreach (ServerResponse response in responses)
             {
                 string line = response.Message is null ? $"{response.Code:D3}" : $"{response.Code:D3} {response.Message}";
@@ -104,6 +147,15 @@ public class CommandResponseServer : IDisposable
     public void Dispose()
     {
         _listenTokenSource?.Cancel();
+        _listenThread?.Join();
+        try
+        {
+            _processTask?.Wait();
+        }
+        catch
+        {
+            // Ignore exceptions during shutdown.
+        }
         _reader?.Dispose();
         _writer?.Dispose();
         if (!_leaveOpen)
@@ -111,6 +163,7 @@ public class CommandResponseServer : IDisposable
             _stream?.Dispose();
         }
         _listenTokenSource?.Dispose();
+        _commandSignal.Dispose();
     }
 }
 

--- a/Utils.Net/Net/CommandResponseServer.cs
+++ b/Utils.Net/Net/CommandResponseServer.cs
@@ -56,7 +56,7 @@ public class CommandResponseServer : IDisposable
     /// <returns>Formatted textual line.</returns>
     private static string DefaultFormatter(ServerResponse response)
     {
-        return response.Message is null ? $"{response.Code:D3}" : $"{response.Code:D3} {response.Message}";
+        return response.Message is null ? response.Code : $"{response.Code} {response.Message}";
     }
 
     /// <summary>
@@ -222,14 +222,14 @@ public class CommandResponseServer : IDisposable
                     }
                     else
                     {
-                        responses = new[] { new ServerResponse(503, "Bad sequence of commands") };
+                        responses = new[] { new ServerResponse("503", "Bad sequence of commands") };
                     }
                 }
                 else if (CommandReceived is not null)
                 {
                     responses = await CommandReceived.Invoke(command);
                 }
-                responses ??= new[] { new ServerResponse(502, "Command not implemented") };
+                responses ??= new[] { new ServerResponse("502", "Command not implemented") };
                 List<ServerResponse> responseList = responses.ToList();
                 foreach (ServerResponse response in responseList)
                 {

--- a/Utils.Net/Net/IPop3Mailbox.cs
+++ b/Utils.Net/Net/IPop3Mailbox.cs
@@ -19,6 +19,16 @@ public interface IPop3Mailbox
     Task<bool> AuthenticateAsync(string user, string password, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Authenticates a user using the APOP challenge-response mechanism.
+    /// </summary>
+    /// <param name="user">User name.</param>
+    /// <param name="timestamp">Timestamp provided in the server greeting.</param>
+    /// <param name="digest">MD5 digest of <paramref name="timestamp"/> and the user password.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> if authentication succeeds; otherwise, <see langword="false"/>.</returns>
+    Task<bool> AuthenticateApopAsync(string user, string timestamp, string digest, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Retrieves a list of available messages with their sizes.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -32,6 +42,13 @@ public interface IPop3Mailbox
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Message text.</returns>
     Task<string> RetrieveAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a list of available messages with their unique identifiers.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Dictionary mapping message identifiers to unique identifiers.</returns>
+    Task<IReadOnlyDictionary<int, string>> ListUidsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes the specified message.

--- a/Utils.Net/Net/IPop3Mailbox.cs
+++ b/Utils.Net/Net/IPop3Mailbox.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Defines operations required by a POP3 server to access mailbox data.
+/// </summary>
+public interface IPop3Mailbox
+{
+    /// <summary>
+    /// Authenticates the specified user.
+    /// </summary>
+    /// <param name="user">User name.</param>
+    /// <param name="password">Password.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><see langword="true"/> if authentication succeeds; otherwise, <see langword="false"/>.</returns>
+    Task<bool> AuthenticateAsync(string user, string password, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a list of available messages with their sizes.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Dictionary mapping message identifiers to their size in bytes.</returns>
+    Task<IReadOnlyDictionary<int, int>> ListAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the full text of a message.
+    /// </summary>
+    /// <param name="id">Message identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Message text.</returns>
+    Task<string> RetrieveAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes the specified message.
+    /// </summary>
+    /// <param name="id">Message identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/Utils.Net/Net/Pop3Client.cs
+++ b/Utils.Net/Net/Pop3Client.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Client for the Post Office Protocol version 3 (POP3).
+/// </summary>
+public class Pop3Client : IDisposable
+{
+    private readonly CommandResponseClient _client;
+    private bool _expectMultiLine;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Pop3Client"/> class.
+    /// </summary>
+    public Pop3Client()
+    {
+        _client = new CommandResponseClient(ParseResponse);
+    }
+
+    /// <summary>
+    /// Gets or sets the interval at which a NOOP command is automatically sent.
+    /// </summary>
+    public TimeSpan NoOpInterval
+    {
+        get => _client.NoOpInterval;
+        set => _client.NoOpInterval = value;
+    }
+
+    /// <summary>
+    /// Connects to the specified POP3 server using a TCP connection.
+    /// </summary>
+    /// <param name="host">Server host name or IP address.</param>
+    /// <param name="port">Server port, default is 110.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task ConnectAsync(string host, int port = 110, CancellationToken cancellationToken = default)
+    {
+        return _client.ConnectAsync(host, port, cancellationToken);
+    }
+
+    /// <summary>
+    /// Uses the provided bidirectional <see cref="Stream"/> for communication.
+    /// </summary>
+    /// <param name="stream">Connected stream used to send commands and receive responses.</param>
+    /// <param name="leaveOpen">True to leave the stream open when disposing the client.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task ConnectAsync(Stream stream, bool leaveOpen = false, CancellationToken cancellationToken = default)
+    {
+        return _client.ConnectAsync(stream, leaveOpen, cancellationToken);
+    }
+
+    /// <summary>
+    /// Authenticates the user with the POP3 server.
+    /// </summary>
+    /// <param name="user">User name.</param>
+    /// <param name="password">Password.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task AuthenticateAsync(string user, string password, CancellationToken cancellationToken = default)
+    {
+        await EnsureOkAsync(await _client.SendCommandAsync($"USER {user}", cancellationToken));
+        await EnsureOkAsync(await _client.SendCommandAsync($"PASS {password}", cancellationToken));
+    }
+
+    /// <summary>
+    /// Retrieves mailbox statistics.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Tuple containing number of messages and total mailbox size.</returns>
+    public async Task<(int messageCount, int mailboxSize)> GetStatAsync(CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<ServerResponse> responses = await _client.SendCommandAsync("STAT", cancellationToken);
+        await EnsureOkAsync(responses);
+        string[] parts = responses[0].Message?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
+        int count = parts.Length > 0 ? int.Parse(parts[0]) : 0;
+        int size = parts.Length > 1 ? int.Parse(parts[1]) : 0;
+        return (count, size);
+    }
+
+    /// <summary>
+    /// Retrieves a list of messages with their sizes.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Dictionary mapping message number to its size.</returns>
+    public async Task<IReadOnlyDictionary<int, int>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        _expectMultiLine = true;
+        IReadOnlyList<ServerResponse> responses = await _client.SendCommandAsync("LIST", cancellationToken);
+        await EnsureOkAsync(responses);
+        Dictionary<int, int> result = new();
+        for (int i = 1; i < responses.Count - 1; i++)
+        {
+            string[] parts = responses[i].Message?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
+            if (parts.Length >= 2 && int.TryParse(parts[0], out int id) && int.TryParse(parts[1], out int size))
+            {
+                result[id] = size;
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Retrieves the full text of a message.
+    /// </summary>
+    /// <param name="id">Message identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Text of the message with dot-stuffing removed.</returns>
+    public async Task<string> RetrieveAsync(int id, CancellationToken cancellationToken = default)
+    {
+        _expectMultiLine = true;
+        IReadOnlyList<ServerResponse> responses = await _client.SendCommandAsync($"RETR {id}", cancellationToken);
+        await EnsureOkAsync(responses);
+        StringBuilder builder = new();
+        for (int i = 1; i < responses.Count - 1; i++)
+        {
+            string line = responses[i].Message ?? string.Empty;
+            if (line.StartsWith("..", StringComparison.Ordinal))
+            {
+                line = line[1..];
+            }
+            builder.AppendLine(line);
+        }
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Marks the specified message for deletion.
+    /// </summary>
+    /// <param name="id">Message identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        await EnsureOkAsync(await _client.SendCommandAsync($"DELE {id}", cancellationToken));
+    }
+
+    /// <summary>
+    /// Sends the NOOP command.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task NoOpAsync(CancellationToken cancellationToken = default)
+    {
+        return _client.SendCommandAsync("NOOP", cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends the QUIT command and closes the connection.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task QuitAsync(CancellationToken cancellationToken = default)
+    {
+        return _client.DisconnectAsync("QUIT", TimeSpan.FromSeconds(5), cancellationToken);
+    }
+
+    /// <summary>
+    /// Releases the resources used by the client.
+    /// </summary>
+    public void Dispose()
+    {
+        _client.Dispose();
+    }
+
+    /// <summary>
+    /// Ensures that the last response in the sequence indicates success.
+    /// </summary>
+    /// <param name="responses">Responses to inspect.</param>
+    private static Task EnsureOkAsync(IReadOnlyList<ServerResponse> responses)
+    {
+        if (responses.Count == 0 || responses[^1].Code < 200 || responses[^1].Code >= 300)
+        {
+            throw new IOException(responses.Count > 0 ? responses[^1].Message : "Server closed connection");
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Parses POP3 response lines.
+    /// </summary>
+    /// <param name="line">Line received from the server.</param>
+    /// <returns>Parsed response.</returns>
+    private ServerResponse ParseResponse(string line)
+    {
+        if (_expectMultiLine)
+        {
+            if (line == ".")
+            {
+                _expectMultiLine = false;
+                return new ServerResponse(200, string.Empty);
+            }
+            if (line.StartsWith("+OK", StringComparison.OrdinalIgnoreCase))
+            {
+                return new ServerResponse(100, line.Length > 3 ? line[3..].TrimStart() : string.Empty);
+            }
+            if (line.StartsWith("-ERR", StringComparison.OrdinalIgnoreCase))
+            {
+                _expectMultiLine = false;
+                return new ServerResponse(500, line.Length > 4 ? line[4..].TrimStart() : string.Empty);
+            }
+            return new ServerResponse(100, line);
+        }
+        else
+        {
+            if (line.StartsWith("+OK", StringComparison.OrdinalIgnoreCase))
+            {
+                return new ServerResponse(200, line.Length > 3 ? line[3..].TrimStart() : string.Empty);
+            }
+            if (line.StartsWith("-ERR", StringComparison.OrdinalIgnoreCase))
+            {
+                return new ServerResponse(500, line.Length > 4 ? line[4..].TrimStart() : string.Empty);
+            }
+            return new ServerResponse(0, line);
+        }
+    }
+}

--- a/Utils.Net/Net/Pop3Client.cs
+++ b/Utils.Net/Net/Pop3Client.cs
@@ -192,30 +192,30 @@ public class Pop3Client : IDisposable
             if (line == ".")
             {
                 _expectMultiLine = false;
-                return new ServerResponse(200, string.Empty);
+                return new ServerResponse(".", ResponseSeverity.Completion, string.Empty);
             }
             if (line.StartsWith("+OK", StringComparison.OrdinalIgnoreCase))
             {
-                return new ServerResponse(100, line.Length > 3 ? line[3..].TrimStart() : string.Empty);
+                return new ServerResponse("+OK", ResponseSeverity.Preliminary, line.Length > 3 ? line[3..].TrimStart() : string.Empty);
             }
             if (line.StartsWith("-ERR", StringComparison.OrdinalIgnoreCase))
             {
                 _expectMultiLine = false;
-                return new ServerResponse(500, line.Length > 4 ? line[4..].TrimStart() : string.Empty);
+                return new ServerResponse("-ERR", ResponseSeverity.PermanentNegative, line.Length > 4 ? line[4..].TrimStart() : string.Empty);
             }
-            return new ServerResponse(100, line);
+            return new ServerResponse(string.Empty, ResponseSeverity.Preliminary, line);
         }
         else
         {
             if (line.StartsWith("+OK", StringComparison.OrdinalIgnoreCase))
             {
-                return new ServerResponse(200, line.Length > 3 ? line[3..].TrimStart() : string.Empty);
+                return new ServerResponse("+OK", ResponseSeverity.Completion, line.Length > 3 ? line[3..].TrimStart() : string.Empty);
             }
             if (line.StartsWith("-ERR", StringComparison.OrdinalIgnoreCase))
             {
-                return new ServerResponse(500, line.Length > 4 ? line[4..].TrimStart() : string.Empty);
+                return new ServerResponse("-ERR", ResponseSeverity.PermanentNegative, line.Length > 4 ? line[4..].TrimStart() : string.Empty);
             }
-            return new ServerResponse(0, line);
+            return new ServerResponse(string.Empty, ResponseSeverity.Unknown, line);
         }
     }
 }

--- a/Utils.Net/Net/Pop3Client.cs
+++ b/Utils.Net/Net/Pop3Client.cs
@@ -38,9 +38,11 @@ public class Pop3Client : IDisposable
     /// <param name="host">Server host name or IP address.</param>
     /// <param name="port">Server port, default is 110.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public Task ConnectAsync(string host, int port = 110, CancellationToken cancellationToken = default)
+    public async Task ConnectAsync(string host, int port = 110, CancellationToken cancellationToken = default)
     {
-        return _client.ConnectAsync(host, port, cancellationToken);
+        await _client.ConnectAsync(host, port, cancellationToken);
+        IReadOnlyList<ServerResponse> greeting = await _client.ReadAsync(cancellationToken);
+        await EnsureOkAsync(greeting);
     }
 
     /// <summary>
@@ -49,9 +51,11 @@ public class Pop3Client : IDisposable
     /// <param name="stream">Connected stream used to send commands and receive responses.</param>
     /// <param name="leaveOpen">True to leave the stream open when disposing the client.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    public Task ConnectAsync(Stream stream, bool leaveOpen = false, CancellationToken cancellationToken = default)
+    public async Task ConnectAsync(Stream stream, bool leaveOpen = false, CancellationToken cancellationToken = default)
     {
-        return _client.ConnectAsync(stream, leaveOpen, cancellationToken);
+        await _client.ConnectAsync(stream, leaveOpen, cancellationToken);
+        IReadOnlyList<ServerResponse> greeting = await _client.ReadAsync(cancellationToken);
+        await EnsureOkAsync(greeting);
     }
 
     /// <summary>

--- a/Utils.Net/Net/Pop3Client.cs
+++ b/Utils.Net/Net/Pop3Client.cs
@@ -173,7 +173,7 @@ public class Pop3Client : IDisposable
     /// <param name="responses">Responses to inspect.</param>
     private static Task EnsureOkAsync(IReadOnlyList<ServerResponse> responses)
     {
-        if (responses.Count == 0 || responses[^1].Code < 200 || responses[^1].Code >= 300)
+        if (responses.Count == 0 || responses[^1].Severity != ResponseSeverity.Completion)
         {
             throw new IOException(responses.Count > 0 ? responses[^1].Message : "Server closed connection");
         }

--- a/Utils.Net/Net/Pop3Server.cs
+++ b/Utils.Net/Net/Pop3Server.cs
@@ -42,7 +42,7 @@ public sealed class Pop3Server : IDisposable
     public async Task StartAsync(Stream stream, bool leaveOpen = false, CancellationToken cancellationToken = default)
     {
         await _server.StartAsync(stream, leaveOpen, cancellationToken);
-        await _server.SendResponseAsync(new ServerResponse("200", "POP3 ready"));
+        await _server.SendResponseAsync(new ServerResponse("200", ResponseSeverity.Completion, "POP3 ready"));
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public sealed class Pop3Server : IDisposable
     {
         _user = args.Length > 0 ? args[0] : string.Empty;
         ctx.Add("USER");
-        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "user accepted") });
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", ResponseSeverity.Completion, "user accepted") });
     }
 
     /// <summary>
@@ -100,9 +100,9 @@ public sealed class Pop3Server : IDisposable
         {
             ctx.Remove("USER");
             ctx.Add("AUTH");
-            return new[] { new ServerResponse("200", "authentication successful") };
+            return new[] { new ServerResponse("200", ResponseSeverity.Completion, "authentication successful") };
         }
-        return new[] { new ServerResponse("500", "authentication failed") };
+        return new[] { new ServerResponse("500", ResponseSeverity.PermanentNegative, "authentication failed") };
     }
 
     /// <summary>
@@ -119,7 +119,7 @@ public sealed class Pop3Server : IDisposable
         {
             total += size;
         }
-        return new[] { new ServerResponse("200", $"{list.Count} {total}") };
+        return new[] { new ServerResponse("200", ResponseSeverity.Completion, $"{list.Count} {total}") };
     }
 
     /// <summary>
@@ -135,16 +135,16 @@ public sealed class Pop3Server : IDisposable
         {
             if (list.TryGetValue(id, out int size))
             {
-                return new[] { new ServerResponse("200", $"{id} {size}") };
+                return new[] { new ServerResponse("200", ResponseSeverity.Completion, $"{id} {size}") };
             }
-            return new[] { new ServerResponse("500", "no such message") };
+            return new[] { new ServerResponse("500", ResponseSeverity.PermanentNegative, "no such message") };
         }
-        List<ServerResponse> responses = new() { new ServerResponse("200", $"{list.Count} messages") };
+        List<ServerResponse> responses = new() { new ServerResponse("200", ResponseSeverity.Completion, $"{list.Count} messages") };
         foreach (KeyValuePair<int, int> pair in list)
         {
-            responses.Add(new ServerResponse("100", $"{pair.Key} {pair.Value}"));
+            responses.Add(new ServerResponse("100", ResponseSeverity.Preliminary, $"{pair.Key} {pair.Value}"));
         }
-        responses.Add(new ServerResponse("100", "."));
+        responses.Add(new ServerResponse("100", ResponseSeverity.Preliminary, "."));
         return responses;
     }
 
@@ -158,10 +158,10 @@ public sealed class Pop3Server : IDisposable
     {
         if (args.Length == 0 || !int.TryParse(args[0], out int id))
         {
-            return new[] { new ServerResponse("500", "invalid id") };
+            return new[] { new ServerResponse("500", ResponseSeverity.PermanentNegative, "invalid id") };
         }
         string message = await _mailbox.RetrieveAsync(id);
-        List<ServerResponse> responses = new() { new ServerResponse("200", "message follows") };
+        List<ServerResponse> responses = new() { new ServerResponse("200", ResponseSeverity.Completion, "message follows") };
         using StringReader reader = new(message);
         string? line;
         while ((line = await reader.ReadLineAsync()) is not null)
@@ -170,9 +170,9 @@ public sealed class Pop3Server : IDisposable
             {
                 line = "." + line;
             }
-            responses.Add(new ServerResponse("100", line));
+            responses.Add(new ServerResponse("100", ResponseSeverity.Preliminary, line));
         }
-        responses.Add(new ServerResponse("100", "."));
+        responses.Add(new ServerResponse("100", ResponseSeverity.Preliminary, "."));
         return responses;
     }
 
@@ -186,10 +186,10 @@ public sealed class Pop3Server : IDisposable
     {
         if (args.Length == 0 || !int.TryParse(args[0], out int id))
         {
-            return new[] { new ServerResponse("500", "invalid id") };
+            return new[] { new ServerResponse("500", ResponseSeverity.PermanentNegative, "invalid id") };
         }
         await _mailbox.DeleteAsync(id);
-        return new[] { new ServerResponse("200", "deleted") };
+        return new[] { new ServerResponse("200", ResponseSeverity.Completion, "deleted") };
     }
 
     /// <summary>
@@ -200,7 +200,7 @@ public sealed class Pop3Server : IDisposable
     /// <returns>Responses to send.</returns>
     private Task<IEnumerable<ServerResponse>> HandleNoOp(CommandContext ctx, string[] args)
     {
-        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", string.Empty) });
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", ResponseSeverity.Completion, string.Empty) });
     }
 
     /// <summary>
@@ -211,6 +211,6 @@ public sealed class Pop3Server : IDisposable
     /// <returns>Responses to send.</returns>
     private Task<IEnumerable<ServerResponse>> HandleQuit(CommandContext ctx, string[] args)
     {
-        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "bye") });
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", ResponseSeverity.Completion, "bye") });
     }
 }

--- a/Utils.Net/Net/Pop3Server.cs
+++ b/Utils.Net/Net/Pop3Server.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Server for the Post Office Protocol version 3 (POP3).
+/// </summary>
+public sealed class Pop3Server : IDisposable
+{
+    private readonly CommandResponseServer _server;
+    private readonly IPop3Mailbox _mailbox;
+    private string? _user;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Pop3Server"/> class.
+    /// </summary>
+    /// <param name="mailbox">Mailbox data provider.</param>
+    public Pop3Server(IPop3Mailbox mailbox)
+    {
+        _mailbox = mailbox;
+        _server = new CommandResponseServer(FormatResponse);
+        _server.RegisterCommand("USER", HandleUser);
+        _server.RegisterCommand("PASS", HandlePass, "USER");
+        _server.RegisterCommand("STAT", HandleStat, "AUTH");
+        _server.RegisterCommand("LIST", HandleList, "AUTH");
+        _server.RegisterCommand("RETR", HandleRetr, "AUTH");
+        _server.RegisterCommand("DELE", HandleDele, "AUTH");
+        _server.RegisterCommand("NOOP", HandleNoOp, "AUTH");
+        _server.RegisterCommand("QUIT", HandleQuit);
+    }
+
+    /// <summary>
+    /// Starts the POP3 server using the specified stream and sends the greeting line.
+    /// </summary>
+    /// <param name="stream">Stream connected to the client.</param>
+    /// <param name="leaveOpen">True to leave the stream open when disposing the server.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task StartAsync(Stream stream, bool leaveOpen = false, CancellationToken cancellationToken = default)
+    {
+        await _server.StartAsync(stream, leaveOpen, cancellationToken);
+        await _server.SendResponseAsync(new ServerResponse(200, "POP3 ready"));
+    }
+
+    /// <summary>
+    /// Gets a task that completes when the server stops processing commands.
+    /// </summary>
+    public Task Completion => _server.Completion;
+
+    /// <summary>
+    /// Releases the resources used by the server.
+    /// </summary>
+    public void Dispose()
+    {
+        _server.Dispose();
+    }
+
+    /// <summary>
+    /// Formats server responses to POP3 textual lines.
+    /// </summary>
+    /// <param name="response">Response to format.</param>
+    /// <returns>Formatted line.</returns>
+    private static string FormatResponse(ServerResponse response)
+    {
+        if (response.Code >= 200 && response.Code < 300)
+        {
+            return response.Message is null ? "+OK" : $"+OK {response.Message}";
+        }
+        if (response.Code >= 400)
+        {
+            return response.Message is null ? "-ERR" : $"-ERR {response.Message}";
+        }
+        return response.Message ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Handles the USER command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private Task<IEnumerable<ServerResponse>> HandleUser(CommandContext ctx, string[] args)
+    {
+        _user = args.Length > 0 ? args[0] : string.Empty;
+        ctx.Add("USER");
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "user accepted") });
+    }
+
+    /// <summary>
+    /// Handles the PASS command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private async Task<IEnumerable<ServerResponse>> HandlePass(CommandContext ctx, string[] args)
+    {
+        string password = args.Length > 0 ? args[0] : string.Empty;
+        bool ok = await _mailbox.AuthenticateAsync(_user ?? string.Empty, password);
+        if (ok)
+        {
+            ctx.Remove("USER");
+            ctx.Add("AUTH");
+            return new[] { new ServerResponse(200, "authentication successful") };
+        }
+        return new[] { new ServerResponse(500, "authentication failed") };
+    }
+
+    /// <summary>
+    /// Handles the STAT command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private async Task<IEnumerable<ServerResponse>> HandleStat(CommandContext ctx, string[] args)
+    {
+        IReadOnlyDictionary<int, int> list = await _mailbox.ListAsync();
+        int total = 0;
+        foreach (int size in list.Values)
+        {
+            total += size;
+        }
+        return new[] { new ServerResponse(200, $"{list.Count} {total}") };
+    }
+
+    /// <summary>
+    /// Handles the LIST command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private async Task<IEnumerable<ServerResponse>> HandleList(CommandContext ctx, string[] args)
+    {
+        IReadOnlyDictionary<int, int> list = await _mailbox.ListAsync();
+        if (args.Length > 0 && int.TryParse(args[0], out int id))
+        {
+            if (list.TryGetValue(id, out int size))
+            {
+                return new[] { new ServerResponse(200, $"{id} {size}") };
+            }
+            return new[] { new ServerResponse(500, "no such message") };
+        }
+        List<ServerResponse> responses = new() { new ServerResponse(200, $"{list.Count} messages") };
+        foreach (KeyValuePair<int, int> pair in list)
+        {
+            responses.Add(new ServerResponse(100, $"{pair.Key} {pair.Value}"));
+        }
+        responses.Add(new ServerResponse(100, "."));
+        return responses;
+    }
+
+    /// <summary>
+    /// Handles the RETR command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private async Task<IEnumerable<ServerResponse>> HandleRetr(CommandContext ctx, string[] args)
+    {
+        if (args.Length == 0 || !int.TryParse(args[0], out int id))
+        {
+            return new[] { new ServerResponse(500, "invalid id") };
+        }
+        string message = await _mailbox.RetrieveAsync(id);
+        List<ServerResponse> responses = new() { new ServerResponse(200, "message follows") };
+        using StringReader reader = new(message);
+        string? line;
+        while ((line = await reader.ReadLineAsync()) is not null)
+        {
+            if (line.StartsWith(".", StringComparison.Ordinal))
+            {
+                line = "." + line;
+            }
+            responses.Add(new ServerResponse(100, line));
+        }
+        responses.Add(new ServerResponse(100, "."));
+        return responses;
+    }
+
+    /// <summary>
+    /// Handles the DELE command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private async Task<IEnumerable<ServerResponse>> HandleDele(CommandContext ctx, string[] args)
+    {
+        if (args.Length == 0 || !int.TryParse(args[0], out int id))
+        {
+            return new[] { new ServerResponse(500, "invalid id") };
+        }
+        await _mailbox.DeleteAsync(id);
+        return new[] { new ServerResponse(200, "deleted") };
+    }
+
+    /// <summary>
+    /// Handles the NOOP command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private Task<IEnumerable<ServerResponse>> HandleNoOp(CommandContext ctx, string[] args)
+    {
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, string.Empty) });
+    }
+
+    /// <summary>
+    /// Handles the QUIT command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private Task<IEnumerable<ServerResponse>> HandleQuit(CommandContext ctx, string[] args)
+    {
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "bye") });
+    }
+}

--- a/Utils.Net/Net/ServerResponse.cs
+++ b/Utils.Net/Net/ServerResponse.cs
@@ -1,8 +1,81 @@
 namespace Utils.Net;
 
 /// <summary>
-/// Represents a single server response line consisting of a numeric code and optional message.
+/// Indicates the severity of a server response.
 /// </summary>
-/// <param name="Code">Numeric status code.</param>
-/// <param name="Message">Optional associated message.</param>
-public readonly record struct ServerResponse(int Code, string? Message);
+public enum ResponseSeverity
+{
+    /// <summary>
+    /// Severity could not be determined.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Positive preliminary reply. Further responses will follow.
+    /// </summary>
+    Preliminary = 1,
+
+    /// <summary>
+    /// Positive completion reply.
+    /// </summary>
+    Completion = 2,
+
+    /// <summary>
+    /// Positive intermediate reply requiring more information.
+    /// </summary>
+    Intermediate = 3,
+
+    /// <summary>
+    /// Transient negative completion reply.
+    /// </summary>
+    TransientNegative = 4,
+
+    /// <summary>
+    /// Permanent negative completion reply.
+    /// </summary>
+    PermanentNegative = 5
+}
+
+/// <summary>
+/// Represents a single server response line consisting of a numeric code, its severity and an optional message.
+/// </summary>
+public readonly record struct ServerResponse
+{
+    /// <summary>
+    /// Numeric status code.
+    /// </summary>
+    public int Code { get; }
+
+    /// <summary>
+    /// Severity of the response.
+    /// </summary>
+    public ResponseSeverity Severity { get; }
+
+    /// <summary>
+    /// Optional associated message.
+    /// </summary>
+    public string? Message { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerResponse"/> struct.
+    /// </summary>
+    /// <param name="code">Numeric status code.</param>
+    /// <param name="severity">Severity of the response.</param>
+    /// <param name="message">Optional associated message.</param>
+    public ServerResponse(int code, ResponseSeverity severity, string? message)
+    {
+        Code = code;
+        Severity = severity;
+        Message = message;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerResponse"/> struct inferring severity from the status code.
+    /// </summary>
+    /// <param name="code">Numeric status code.</param>
+    /// <param name="message">Optional associated message.</param>
+    public ServerResponse(int code, string? message)
+        : this(code, (ResponseSeverity)(code / 100), message)
+    {
+    }
+}

--- a/Utils.Net/Net/ServerResponse.cs
+++ b/Utils.Net/Net/ServerResponse.cs
@@ -1,0 +1,8 @@
+namespace Utils.Net;
+
+/// <summary>
+/// Represents a single server response line consisting of a numeric code and optional message.
+/// </summary>
+/// <param name="Code">Numeric status code.</param>
+/// <param name="Message">Optional associated message.</param>
+public readonly record struct ServerResponse(int Code, string? Message);

--- a/Utils.Net/Net/ServerResponse.cs
+++ b/Utils.Net/Net/ServerResponse.cs
@@ -1,3 +1,5 @@
+using Utils.Objects;
+
 namespace Utils.Net;
 
 /// <summary>
@@ -44,7 +46,7 @@ public readonly record struct ServerResponse
     /// <summary>
     /// Numeric status code.
     /// </summary>
-    public int Code { get; }
+    public string Code { get; }
 
     /// <summary>
     /// Severity of the response.
@@ -62,7 +64,7 @@ public readonly record struct ServerResponse
     /// <param name="code">Numeric status code.</param>
     /// <param name="severity">Severity of the response.</param>
     /// <param name="message">Optional associated message.</param>
-    public ServerResponse(int code, ResponseSeverity severity, string? message)
+    public ServerResponse(string code, ResponseSeverity severity, string? message)
     {
         Code = code;
         Severity = severity;
@@ -74,8 +76,9 @@ public readonly record struct ServerResponse
     /// </summary>
     /// <param name="code">Numeric status code.</param>
     /// <param name="message">Optional associated message.</param>
-    public ServerResponse(int code, string? message)
-        : this(code, (ResponseSeverity)(code / 100), message)
+    public ServerResponse(string code, string? message)
+        : this(code, (ResponseSeverity)(code[0] - '0'), message)
     {
+        code[0].ArgMustBeBetween('0', '5', nameof(code));
     }
 }

--- a/Utils.Net/Net/ServerResponse.cs
+++ b/Utils.Net/Net/ServerResponse.cs
@@ -1,5 +1,3 @@
-using Utils.Objects;
-
 namespace Utils.Net;
 
 /// <summary>
@@ -39,7 +37,7 @@ public enum ResponseSeverity
 }
 
 /// <summary>
-/// Represents a single server response line consisting of a numeric code, its severity and an optional message.
+/// Represents a single server response line consisting of a code, its severity and an optional message.
 /// </summary>
 public readonly record struct ServerResponse
 {
@@ -61,7 +59,7 @@ public readonly record struct ServerResponse
     /// <summary>
     /// Initializes a new instance of the <see cref="ServerResponse"/> struct.
     /// </summary>
-    /// <param name="code">Numeric status code.</param>
+    /// <param name="code">Status code returned by the server.</param>
     /// <param name="severity">Severity of the response.</param>
     /// <param name="message">Optional associated message.</param>
     public ServerResponse(string code, ResponseSeverity severity, string? message)
@@ -69,16 +67,5 @@ public readonly record struct ServerResponse
         Code = code;
         Severity = severity;
         Message = message;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ServerResponse"/> struct inferring severity from the status code.
-    /// </summary>
-    /// <param name="code">Numeric status code.</param>
-    /// <param name="message">Optional associated message.</param>
-    public ServerResponse(string code, string? message)
-        : this(code, (ResponseSeverity)(code[0] - '0'), message)
-    {
-        code[0].ArgMustBeBetween('0', '5', nameof(code));
     }
 }

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -65,11 +65,11 @@ server.RegisterCommand("LOGIN", (ctx, args) =>
 {
     ctx.Add("AUTH");
     return System.Threading.Tasks.Task.FromResult<IEnumerable<Utils.Net.ServerResponse>>(
-        new[] { new Utils.Net.ServerResponse(200, "Logged in") });
+        new[] { new Utils.Net.ServerResponse("200", "Logged in") });
 });
 server.RegisterCommand("LIST", (ctx, args) =>
     System.Threading.Tasks.Task.FromResult<IEnumerable<Utils.Net.ServerResponse>>(
-        new[] { new Utils.Net.ServerResponse(200, "Listed") }),
+        new[] { new Utils.Net.ServerResponse("200", "Listed") }),
     "AUTH");
 // Attach logging
 server.Logger = loggerFactory.CreateLogger<Utils.Net.CommandResponseServer>();

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -47,6 +47,7 @@ await tcp.ConnectAsync("localhost", 25);
 using var cmdClient = new Utils.Net.CommandResponseClient { NoOpInterval = TimeSpan.FromMinutes(1) };
 await cmdClient.ConnectAsync(tcp.GetStream());
 IReadOnlyList<Utils.Net.ServerResponse> replies = await cmdClient.SendCommandAsync("NOOP");
+await cmdClient.DisconnectAsync("QUIT", TimeSpan.FromSeconds(1));
 
 // Build a simple command/response server
 var server = new Utils.Net.CommandResponseServer();

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -56,6 +56,7 @@ IReadOnlyList<Utils.Net.ServerResponse> replies = await cmdClient.SendCommandAsy
 // Each response line exposes a Severity value allowing callers to inspect
 // preliminary, completion or error statuses. The client waits until a line
 // with at least completion severity is received before returning all lines.
+bool stillConnected = cmdClient.IsConnected;
 await cmdClient.DisconnectAsync("QUIT", TimeSpan.FromSeconds(1));
 
 // Build a command/response server with command mapping and contexts

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -57,6 +57,7 @@ await cmdClient.DisconnectAsync("QUIT", TimeSpan.FromSeconds(1));
 
 // Build a command/response server with command mapping and contexts
 var server = new Utils.Net.CommandResponseServer();
+server.MaxConsecutiveErrors = 3; // Shutdown after three consecutive errors
 server.RegisterCommand("LOGIN", (ctx, args) =>
 {
     ctx.Add("AUTH");

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -71,4 +71,16 @@ await pop3.AuthenticateAsync("user", "pass");
 var messages = await pop3.ListAsync();
 string firstMessage = await pop3.RetrieveAsync(1);
 await pop3.QuitAsync();
+
+// Host a POP3 server with a custom mailbox
+class MemoryMailbox : Utils.Net.IPop3Mailbox
+{
+    public Task<bool> AuthenticateAsync(string user, string password, CancellationToken token = default) => Task.FromResult(true);
+    public Task<IReadOnlyDictionary<int, int>> ListAsync(CancellationToken token = default) => Task.FromResult<IReadOnlyDictionary<int, int>>(new Dictionary<int, int>());
+    public Task<string> RetrieveAsync(int id, CancellationToken token = default) => Task.FromResult(string.Empty);
+    public Task DeleteAsync(int id, CancellationToken token = default) => Task.CompletedTask;
+}
+var mailbox = new MemoryMailbox();
+var pop3Server = new Utils.Net.Pop3Server(mailbox);
+await pop3Server.StartAsync(tcp.GetStream());
 ```

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -65,11 +65,11 @@ server.RegisterCommand("LOGIN", (ctx, args) =>
 {
     ctx.Add("AUTH");
     return System.Threading.Tasks.Task.FromResult<IEnumerable<Utils.Net.ServerResponse>>(
-        new[] { new Utils.Net.ServerResponse("200", "Logged in") });
+        new[] { new Utils.Net.ServerResponse("200", Utils.Net.ResponseSeverity.Completion, "Logged in") });
 });
 server.RegisterCommand("LIST", (ctx, args) =>
     System.Threading.Tasks.Task.FromResult<IEnumerable<Utils.Net.ServerResponse>>(
-        new[] { new Utils.Net.ServerResponse("200", "Listed") }),
+        new[] { new Utils.Net.ServerResponse("200", Utils.Net.ResponseSeverity.Completion, "Listed") }),
     "AUTH");
 // Attach logging
 server.Logger = loggerFactory.CreateLogger<Utils.Net.CommandResponseServer>();

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -53,6 +53,9 @@ using var cmdClient = new Utils.Net.CommandResponseClient
 };
 await cmdClient.ConnectAsync(tcp.GetStream());
 IReadOnlyList<Utils.Net.ServerResponse> replies = await cmdClient.SendCommandAsync("NOOP");
+// Each response line exposes a Severity value allowing callers to inspect
+// preliminary, completion or error statuses. The client waits until a line
+// with at least completion severity is received before returning all lines.
 await cmdClient.DisconnectAsync("QUIT", TimeSpan.FromSeconds(1));
 
 // Build a command/response server with command mapping and contexts

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -78,17 +78,20 @@ await server.StartAsync(tcp.GetStream());
 // Retrieve messages using the POP3 client
 using var pop3 = new Utils.Net.Pop3Client();
 await pop3.ConnectAsync("mail.example.com", 110);
-await pop3.AuthenticateAsync("user", "pass");
-var messages = await pop3.ListAsync();
+await pop3.AuthenticateApopAsync("user", "pass");
+IReadOnlyDictionary<int, string> uids = await pop3.ListUniqueIdsAsync();
 string firstMessage = await pop3.RetrieveAsync(1);
+await pop3.ResetAsync();
 await pop3.QuitAsync();
 
 // Host a POP3 server with a custom mailbox
 class MemoryMailbox : Utils.Net.IPop3Mailbox
 {
     public Task<bool> AuthenticateAsync(string user, string password, CancellationToken token = default) => Task.FromResult(true);
+    public Task<bool> AuthenticateApopAsync(string user, string timestamp, string digest, CancellationToken token = default) => Task.FromResult(true);
     public Task<IReadOnlyDictionary<int, int>> ListAsync(CancellationToken token = default) => Task.FromResult<IReadOnlyDictionary<int, int>>(new Dictionary<int, int>());
     public Task<string> RetrieveAsync(int id, CancellationToken token = default) => Task.FromResult(string.Empty);
+    public Task<IReadOnlyDictionary<int, string>> ListUidsAsync(CancellationToken token = default) => Task.FromResult<IReadOnlyDictionary<int, string>>(new Dictionary<int, string>());
     public Task DeleteAsync(int id, CancellationToken token = default) => Task.CompletedTask;
 }
 var mailbox = new MemoryMailbox();

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -49,10 +49,17 @@ await cmdClient.ConnectAsync(tcp.GetStream());
 IReadOnlyList<Utils.Net.ServerResponse> replies = await cmdClient.SendCommandAsync("NOOP");
 await cmdClient.DisconnectAsync("QUIT", TimeSpan.FromSeconds(1));
 
-// Build a simple command/response server
+// Build a command/response server with command mapping and contexts
 var server = new Utils.Net.CommandResponseServer();
-server.CommandReceived += cmd =>
+server.RegisterCommand("LOGIN", (ctx, args) =>
+{
+    ctx.Add("AUTH");
+    return System.Threading.Tasks.Task.FromResult<IEnumerable<Utils.Net.ServerResponse>>(
+        new[] { new Utils.Net.ServerResponse(200, "Logged in") });
+});
+server.RegisterCommand("LIST", (ctx, args) =>
     System.Threading.Tasks.Task.FromResult<IEnumerable<Utils.Net.ServerResponse>>(
-        new[] { new Utils.Net.ServerResponse(200, "OK") });
+        new[] { new Utils.Net.ServerResponse(200, "Listed") }),
+    "AUTH");
 await server.StartAsync(tcp.GetStream());
 ```

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -13,6 +13,7 @@ It targets **.NET 9** and is designed to be portable across platforms.
 - URI and query string manipulation helpers
 - Parsing of mail addresses and IP range calculations
 - Clients for basic network services like Echo, Quote of the Day, Time protocol and NTP
+- POP3 client for retrieving e-mail using a command/response model
 
 ## Usage examples
 ```csharp
@@ -62,4 +63,12 @@ server.RegisterCommand("LIST", (ctx, args) =>
         new[] { new Utils.Net.ServerResponse(200, "Listed") }),
     "AUTH");
 await server.StartAsync(tcp.GetStream());
+
+// Retrieve messages using the POP3 client
+using var pop3 = new Utils.Net.Pop3Client();
+await pop3.ConnectAsync("mail.example.com", 110);
+await pop3.AuthenticateAsync("user", "pass");
+var messages = await pop3.ListAsync();
+string firstMessage = await pop3.RetrieveAsync(1);
+await pop3.QuitAsync();
 ```

--- a/Utils.Net/Utils.Net.csproj
+++ b/Utils.Net/Utils.Net.csproj
@@ -19,9 +19,10 @@
 		</Description>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="System.Management" Version="9.0.6" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="System.Management" Version="9.0.6" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Utils\Utils.csproj" />

--- a/UtilsTest/Net/CommandResponseClientTests.cs
+++ b/UtilsTest/Net/CommandResponseClientTests.cs
@@ -31,7 +31,7 @@ public class CommandResponseClientTests
             using CommandResponseServer server = new();
             server.CommandReceived += cmd =>
                 Task.FromResult<IEnumerable<ServerResponse>>(cmd == "MULTI"
-                    ? new[] { new ServerResponse(100, "Continue"), new ServerResponse(200, "Done") }
+                    ? new[] { new ServerResponse("100", "Continue"), new ServerResponse("200", "Done") }
                     : System.Array.Empty<ServerResponse>());
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -44,9 +44,9 @@ public class CommandResponseClientTests
             await client.ConnectAsync("127.0.0.1", port);
             responses = await client.SendCommandAsync("MULTI");
             Assert.AreEqual(2, responses.Count);
-            Assert.AreEqual(100, responses[0].Code);
+            Assert.AreEqual("100", responses[0].Code);
             Assert.AreEqual(ResponseSeverity.Preliminary, responses[0].Severity);
-            Assert.AreEqual(200, responses[1].Code);
+            Assert.AreEqual("200", responses[1].Code);
             Assert.AreEqual(ResponseSeverity.Completion, responses[1].Severity);
         }
         await serverTask;
@@ -69,7 +69,7 @@ public class CommandResponseClientTests
             server.CommandReceived += cmd =>
             {
                 received = cmd;
-                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "OK") });
+                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "OK") });
             };
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -128,7 +128,7 @@ public class CommandResponseClientTests
             using TcpClient serverClient = await listener.AcceptTcpClientAsync();
             using CommandResponseServer server = new();
             server.CommandReceived += cmd => Task.FromResult<IEnumerable<ServerResponse>>(cmd == "QUIT"
-                ? new[] { new ServerResponse(200, "Bye") }
+                ? new[] { new ServerResponse("200", "Bye") }
                 : System.Array.Empty<ServerResponse>());
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -185,7 +185,7 @@ public class CommandResponseClientTests
                 {
                     await Task.Delay(200);
                 }
-                return new[] { new ServerResponse(200, cmd) };
+                return new[] { new ServerResponse("200", cmd) };
             };
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -238,9 +238,9 @@ public class CommandResponseClientTests
         using CommandResponseClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
         await client.ConnectAsync("127.0.0.1", port);
         IReadOnlyList<ServerResponse> greeting = await client.ReadAsync();
-        Assert.AreEqual(200, greeting[0].Code);
+        Assert.AreEqual("200", greeting[0].Code);
         IReadOnlyList<ServerResponse> response = await client.SendCommandAsync("PING");
-        Assert.AreEqual(200, response[0].Code);
+        Assert.AreEqual("200", response[0].Code);
         await serverTask;
     }
 
@@ -257,7 +257,7 @@ public class CommandResponseClientTests
         {
             using TcpClient serverClient = await listener.AcceptTcpClientAsync();
             using CommandResponseServer server = new();
-            server.CommandReceived += cmd => Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "Pong") });
+            server.CommandReceived += cmd => Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "Pong") });
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
             listener.Stop();

--- a/UtilsTest/Net/CommandResponseClientTests.cs
+++ b/UtilsTest/Net/CommandResponseClientTests.cs
@@ -45,7 +45,9 @@ public class CommandResponseClientTests
             responses = await client.SendCommandAsync("MULTI");
             Assert.AreEqual(2, responses.Count);
             Assert.AreEqual(100, responses[0].Code);
+            Assert.AreEqual(ResponseSeverity.Preliminary, responses[0].Severity);
             Assert.AreEqual(200, responses[1].Code);
+            Assert.AreEqual(ResponseSeverity.Completion, responses[1].Severity);
         }
         await serverTask;
     }

--- a/UtilsTest/Net/CommandResponseClientTests.cs
+++ b/UtilsTest/Net/CommandResponseClientTests.cs
@@ -31,7 +31,11 @@ public class CommandResponseClientTests
             using CommandResponseServer server = new();
             server.CommandReceived += cmd =>
                 Task.FromResult<IEnumerable<ServerResponse>>(cmd == "MULTI"
-                    ? new[] { new ServerResponse("100", "Continue"), new ServerResponse("200", "Done") }
+                    ? new[]
+                    {
+                        new ServerResponse("100", ResponseSeverity.Preliminary, "Continue"),
+                        new ServerResponse("200", ResponseSeverity.Completion, "Done")
+                    }
                     : System.Array.Empty<ServerResponse>());
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -69,7 +73,7 @@ public class CommandResponseClientTests
             server.CommandReceived += cmd =>
             {
                 received = cmd;
-                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "OK") });
+                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", ResponseSeverity.Completion, "OK") });
             };
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -128,7 +132,7 @@ public class CommandResponseClientTests
             using TcpClient serverClient = await listener.AcceptTcpClientAsync();
             using CommandResponseServer server = new();
             server.CommandReceived += cmd => Task.FromResult<IEnumerable<ServerResponse>>(cmd == "QUIT"
-                ? new[] { new ServerResponse("200", "Bye") }
+                ? new[] { new ServerResponse("200", ResponseSeverity.Completion, "Bye") }
                 : System.Array.Empty<ServerResponse>());
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -185,7 +189,7 @@ public class CommandResponseClientTests
                 {
                     await Task.Delay(200);
                 }
-                return new[] { new ServerResponse("200", cmd) };
+                return new[] { new ServerResponse("200", ResponseSeverity.Completion, cmd) };
             };
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -257,7 +261,7 @@ public class CommandResponseClientTests
         {
             using TcpClient serverClient = await listener.AcceptTcpClientAsync();
             using CommandResponseServer server = new();
-            server.CommandReceived += cmd => Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "Pong") });
+            server.CommandReceived += cmd => Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", ResponseSeverity.Completion, "Pong") });
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
             listener.Stop();

--- a/UtilsTest/Net/CommandResponseClientTests.cs
+++ b/UtilsTest/Net/CommandResponseClientTests.cs
@@ -277,5 +277,33 @@ public class CommandResponseClientTests
         Assert.IsTrue(logger.Entries.Exists(e => e.Contains("Sending: PING")), "Command send not logged");
         Assert.IsTrue(logger.Entries.Exists(e => e.Contains("Received: 200 Pong")), "Response receive not logged");
     }
+
+    /// <summary>
+    /// Ensures that response lines are split into code and message segments.
+    /// </summary>
+    [TestMethod]
+    public void SplitCodeAndMessage_SplitsCorrectly()
+    {
+        TestClient client = new();
+        (string code, string? message) = client.Split("123 Example message");
+        Assert.AreEqual("123", code);
+        Assert.AreEqual("Example message", message);
+        (code, message) = client.Split("LINE");
+        Assert.AreEqual("LINE", code);
+        Assert.IsNull(message);
+    }
+
+    /// <summary>
+    /// Test client exposing the split helper.
+    /// </summary>
+    private class TestClient : CommandResponseClient
+    {
+        /// <summary>
+        /// Exposes <see cref="CommandResponseClient.SplitCodeAndMessage(string)"/> for testing.
+        /// </summary>
+        /// <param name="line">Line to split.</param>
+        /// <returns>Tuple containing code and optional message.</returns>
+        public (string code, string? message) Split(string line) => SplitCodeAndMessage(line);
+    }
 }
 

--- a/UtilsTest/Net/CommandResponseClientTests.cs
+++ b/UtilsTest/Net/CommandResponseClientTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Tests for <see cref="CommandResponseClient"/>.
+/// </summary>
+[TestClass]
+public class CommandResponseClientTests
+{
+    /// <summary>
+    /// Verifies that multiple responses are read until a final status is received.
+    /// </summary>
+    [TestMethod]
+    public async Task SendCommandAsync_ReadsMultipleResponses()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using CommandResponseServer server = new();
+            server.CommandReceived += cmd =>
+                Task.FromResult<IEnumerable<ServerResponse>>(cmd == "MULTI"
+                    ? new[] { new ServerResponse(100, "Continue"), new ServerResponse(200, "Done") }
+                    : System.Array.Empty<ServerResponse>());
+            await server.StartAsync(serverClient.GetStream());
+            await server.Completion;
+            listener.Stop();
+        });
+
+        IReadOnlyList<ServerResponse> responses;
+        using (CommandResponseClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan })
+        {
+            await client.ConnectAsync("127.0.0.1", port);
+            responses = await client.SendCommandAsync("MULTI");
+            Assert.AreEqual(2, responses.Count);
+            Assert.AreEqual(100, responses[0].Code);
+            Assert.AreEqual(200, responses[1].Code);
+        }
+        await serverTask;
+    }
+
+    /// <summary>
+    /// Verifies that a no-op command is sent after inactivity.
+    /// </summary>
+    [TestMethod]
+    public async Task Client_SendsNoOp_WhenIdle()
+    {
+        string? received = null;
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using CommandResponseServer server = new();
+            server.CommandReceived += cmd =>
+            {
+                received = cmd;
+                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "OK") });
+            };
+            await server.StartAsync(serverClient.GetStream());
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using (CommandResponseClient client = new()
+        {
+            NoOpCommand = "NOOP",
+            NoOpInterval = TimeSpan.FromMilliseconds(100)
+        })
+        {
+            await client.ConnectAsync("127.0.0.1", port);
+            await Task.Delay(300);
+        }
+        await serverTask;
+        Assert.AreEqual("NOOP", received);
+    }
+}
+

--- a/UtilsTest/Net/CommandResponseServerTests.cs
+++ b/UtilsTest/Net/CommandResponseServerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -81,6 +82,35 @@ public class CommandResponseServerTests
 
         Assert.IsTrue(logger.Entries.Exists(e => e.Contains("Received: PING")), "Command not logged");
         Assert.IsTrue(logger.Entries.Exists(e => e.Contains("Sending: 200 Pong")), "Response not logged");
+    }
+
+    /// <summary>
+    /// Ensures that the server shuts down after a configurable number of consecutive errors.
+    /// </summary>
+    [TestMethod]
+    public async Task Server_ShutsDown_AfterConsecutiveErrors()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using CommandResponseServer server = new() { MaxConsecutiveErrors = 3 };
+            await server.StartAsync(serverClient.GetStream());
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using CommandResponseClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
+        await client.ConnectAsync("127.0.0.1", port);
+        for (int i = 0; i < 3; i++)
+        {
+            IReadOnlyList<ServerResponse> replies = await client.SendCommandAsync("BOGUS");
+            Assert.AreEqual(502, replies[0].Code);
+        }
+        await serverTask; // should complete after third error
+        await Assert.ThrowsExceptionAsync<IOException>(() => client.SendCommandAsync("BOGUS"));
     }
 }
 

--- a/UtilsTest/Net/CommandResponseServerTests.cs
+++ b/UtilsTest/Net/CommandResponseServerTests.cs
@@ -32,10 +32,10 @@ public class CommandResponseServerTests
             server.RegisterCommand("LOGIN", (ctx, args) =>
             {
                 ctx.Add("AUTH");
-                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "OK") });
+                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", ResponseSeverity.Completion, "OK") });
             });
             server.RegisterCommand("LIST", (ctx, args) =>
-                Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "Listed") }),
+                Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", ResponseSeverity.Completion, "Listed") }),
                 "AUTH");
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -68,7 +68,7 @@ public class CommandResponseServerTests
         {
             using TcpClient serverClient = await listener.AcceptTcpClientAsync();
             using CommandResponseServer server = new() { Logger = logger };
-            server.RegisterCommand("PING", (ctx, args) => Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "Pong") }));
+            server.RegisterCommand("PING", (ctx, args) => Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", ResponseSeverity.Completion, "Pong") }));
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
             listener.Stop();

--- a/UtilsTest/Net/CommandResponseServerTests.cs
+++ b/UtilsTest/Net/CommandResponseServerTests.cs
@@ -32,10 +32,10 @@ public class CommandResponseServerTests
             server.RegisterCommand("LOGIN", (ctx, args) =>
             {
                 ctx.Add("AUTH");
-                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "OK") });
+                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "OK") });
             });
             server.RegisterCommand("LIST", (ctx, args) =>
-                Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "Listed") }),
+                Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "Listed") }),
                 "AUTH");
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
@@ -45,11 +45,11 @@ public class CommandResponseServerTests
         using CommandResponseClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
         await client.ConnectAsync("127.0.0.1", port);
         IReadOnlyList<ServerResponse> responses = await client.SendCommandAsync("LIST");
-        Assert.AreEqual(503, responses[0].Code);
+        Assert.AreEqual("503", responses[0].Code);
         responses = await client.SendCommandAsync("LOGIN");
-        Assert.AreEqual(200, responses[0].Code);
+        Assert.AreEqual("200", responses[0].Code);
         responses = await client.SendCommandAsync("LIST");
-        Assert.AreEqual(200, responses[0].Code);
+        Assert.AreEqual("200", responses[0].Code);
         client.Dispose();
         await serverTask;
     }
@@ -68,7 +68,7 @@ public class CommandResponseServerTests
         {
             using TcpClient serverClient = await listener.AcceptTcpClientAsync();
             using CommandResponseServer server = new() { Logger = logger };
-            server.RegisterCommand("PING", (ctx, args) => Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "Pong") }));
+            server.RegisterCommand("PING", (ctx, args) => Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("200", "Pong") }));
             await server.StartAsync(serverClient.GetStream());
             await server.Completion;
             listener.Stop();
@@ -107,7 +107,7 @@ public class CommandResponseServerTests
         for (int i = 0; i < 3; i++)
         {
             IReadOnlyList<ServerResponse> replies = await client.SendCommandAsync("BOGUS");
-            Assert.AreEqual(502, replies[0].Code);
+            Assert.AreEqual("502", replies[0].Code);
         }
         await serverTask; // should complete after third error
         await Assert.ThrowsExceptionAsync<IOException>(() => client.SendCommandAsync("BOGUS"));

--- a/UtilsTest/Net/CommandResponseServerTests.cs
+++ b/UtilsTest/Net/CommandResponseServerTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Tests for <see cref="CommandResponseServer"/> command mapping and contexts.
+/// </summary>
+[TestClass]
+public class CommandResponseServerTests
+{
+    /// <summary>
+    /// Ensures that commands are gated by required contexts.
+    /// </summary>
+    [TestMethod]
+    public async Task Command_RequiresContext()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using CommandResponseServer server = new();
+            server.RegisterCommand("LOGIN", (ctx, args) =>
+            {
+                ctx.Add("AUTH");
+                return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "OK") });
+            });
+            server.RegisterCommand("LIST", (ctx, args) =>
+                Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse(200, "Listed") }),
+                "AUTH");
+            await server.StartAsync(serverClient.GetStream());
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using CommandResponseClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
+        await client.ConnectAsync("127.0.0.1", port);
+        IReadOnlyList<ServerResponse> responses = await client.SendCommandAsync("LIST");
+        Assert.AreEqual(503, responses[0].Code);
+        responses = await client.SendCommandAsync("LOGIN");
+        Assert.AreEqual(200, responses[0].Code);
+        responses = await client.SendCommandAsync("LIST");
+        Assert.AreEqual(200, responses[0].Code);
+        client.Dispose();
+        await serverTask;
+    }
+}
+

--- a/UtilsTest/Net/ListLogger.cs
+++ b/UtilsTest/Net/ListLogger.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Simple logger that stores formatted entries for inspection during tests.
+/// </summary>
+internal sealed class ListLogger : ILogger
+{
+    /// <summary>
+    /// Gets the log entries recorded by this logger.
+    /// </summary>
+    public List<string> Entries { get; } = new();
+
+    /// <inheritdoc/>
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    /// <inheritdoc/>
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    /// <inheritdoc/>
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add(formatter(state, exception));
+    }
+}

--- a/UtilsTest/Net/Pop3ClientTests.cs
+++ b/UtilsTest/Net/Pop3ClientTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Tests for <see cref="Pop3Client"/>.
+/// </summary>
+[TestClass]
+public class Pop3ClientTests
+{
+    /// <summary>
+    /// Verifies basic POP3 interactions including authentication, listing and retrieving messages.
+    /// </summary>
+    [TestMethod]
+    public async Task Pop3Client_BasicFlow()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using NetworkStream ns = serverClient.GetStream();
+            using StreamWriter writer = new(ns) { NewLine = "\r\n", AutoFlush = true };
+            using StreamReader reader = new(ns);
+            await writer.WriteLineAsync("+OK POP3 ready");
+            bool quit = false;
+            while (!quit)
+            {
+                string? line = await reader.ReadLineAsync();
+                if (line is null) break;
+                if (line.StartsWith("USER"))
+                {
+                    await writer.WriteLineAsync("+OK user accepted");
+                }
+                else if (line.StartsWith("PASS"))
+                {
+                    await writer.WriteLineAsync("+OK pass accepted");
+                }
+                else if (line == "STAT")
+                {
+                    await writer.WriteLineAsync("+OK 2 40");
+                }
+                else if (line == "LIST")
+                {
+                    await writer.WriteLineAsync("+OK");
+                    await writer.WriteLineAsync("1 20");
+                    await writer.WriteLineAsync("2 20");
+                    await writer.WriteLineAsync(".");
+                }
+                else if (line == "RETR 1")
+                {
+                    await writer.WriteLineAsync("+OK message follows");
+                    await writer.WriteLineAsync("line1");
+                    await writer.WriteLineAsync("..leading dot");
+                    await writer.WriteLineAsync("line3");
+                    await writer.WriteLineAsync(".");
+                }
+                else if (line == "DELE 1")
+                {
+                    await writer.WriteLineAsync("+OK deleted");
+                }
+                else if (line == "NOOP")
+                {
+                    await writer.WriteLineAsync("+OK");
+                }
+                else if (line == "QUIT")
+                {
+                    await writer.WriteLineAsync("+OK bye");
+                    quit = true;
+                }
+                else
+                {
+                    await writer.WriteLineAsync("-ERR");
+                }
+            }
+            listener.Stop();
+        });
+
+        using Pop3Client client = new() { NoOpInterval = TimeSpan.FromMilliseconds(100) };
+        await client.ConnectAsync("127.0.0.1", port);
+        await client.AuthenticateAsync("user", "pass");
+        (int count, int size) stat = await client.GetStatAsync();
+        Assert.AreEqual(2, stat.count);
+        IReadOnlyDictionary<int, int> list = await client.ListAsync();
+        Assert.AreEqual(2, list.Count);
+        string message = await client.RetrieveAsync(1);
+        StringAssert.Contains(message, "line1");
+        StringAssert.Contains(message, ".leading dot");
+        await client.DeleteAsync(1);
+        await client.NoOpAsync();
+        await client.QuitAsync();
+        await serverTask;
+    }
+}

--- a/UtilsTest/Net/Pop3ServerTests.cs
+++ b/UtilsTest/Net/Pop3ServerTests.cs
@@ -5,6 +5,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Net;
 
@@ -52,6 +54,45 @@ public class Pop3ServerTests
     }
 
     /// <summary>
+    /// Verifies extended POP3 commands such as APOP, RSET, CAPA and UIDL.
+    /// </summary>
+    [TestMethod]
+    public async Task Pop3Server_AdditionalCommands()
+    {
+        InMemoryMailbox mailbox = new();
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using NetworkStream ns = serverClient.GetStream();
+            using Pop3Server server = new(mailbox);
+            await server.StartAsync(ns);
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using Pop3Client client = new();
+        await client.ConnectAsync("127.0.0.1", port);
+        IReadOnlyList<string> capa = await client.GetCapabilitiesAsync();
+        CollectionAssert.Contains((System.Collections.ICollection)capa, "UIDL");
+        CollectionAssert.Contains((System.Collections.ICollection)capa, "APOP");
+        await client.AuthenticateApopAsync("user", "pass");
+        IReadOnlyDictionary<int, string> uids = await client.ListUniqueIdsAsync();
+        Assert.AreEqual(2, uids.Count);
+        Assert.AreEqual("uid1", await client.GetUniqueIdAsync(1));
+        await client.DeleteAsync(1);
+        IReadOnlyDictionary<int, int> list = await client.ListAsync();
+        Assert.AreEqual(1, list.Count);
+        await client.ResetAsync();
+        IReadOnlyDictionary<int, int> resetList = await client.ListAsync();
+        Assert.AreEqual(2, resetList.Count);
+        await client.QuitAsync();
+        await serverTask;
+    }
+
+    /// <summary>
     /// Simple in-memory mailbox used for testing.
     /// </summary>
     private sealed class InMemoryMailbox : IPop3Mailbox
@@ -62,10 +103,29 @@ public class Pop3ServerTests
             [2] = "second\r\n"
         };
 
+        private readonly Dictionary<int, string> _uids = new()
+        {
+            [1] = "uid1",
+            [2] = "uid2"
+        };
+
         /// <inheritdoc />
         public Task<bool> AuthenticateAsync(string user, string password, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(user == "user" && password == "pass");
+        }
+
+        /// <inheritdoc />
+        public Task<bool> AuthenticateApopAsync(string user, string timestamp, string digest, CancellationToken cancellationToken = default)
+        {
+            if (user != "user")
+            {
+                return Task.FromResult(false);
+            }
+            using MD5 md5 = MD5.Create();
+            byte[] hash = md5.ComputeHash(Encoding.ASCII.GetBytes(timestamp + "pass"));
+            string expected = Convert.ToHexString(hash).ToLowerInvariant();
+            return Task.FromResult(string.Equals(expected, digest, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <inheritdoc />
@@ -86,9 +146,24 @@ public class Pop3ServerTests
         }
 
         /// <inheritdoc />
+        public Task<IReadOnlyDictionary<int, string>> ListUidsAsync(CancellationToken cancellationToken = default)
+        {
+            Dictionary<int, string> list = new();
+            foreach (KeyValuePair<int, string> pair in _uids)
+            {
+                if (_messages.ContainsKey(pair.Key))
+                {
+                    list[pair.Key] = pair.Value;
+                }
+            }
+            return Task.FromResult<IReadOnlyDictionary<int, string>>(list);
+        }
+
+        /// <inheritdoc />
         public Task DeleteAsync(int id, CancellationToken cancellationToken = default)
         {
             _messages.Remove(id);
+            _uids.Remove(id);
             return Task.CompletedTask;
         }
     }

--- a/UtilsTest/Net/Pop3ServerTests.cs
+++ b/UtilsTest/Net/Pop3ServerTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Tests for <see cref="Pop3Server"/>.
+/// </summary>
+[TestClass]
+public class Pop3ServerTests
+{
+    /// <summary>
+    /// Verifies that the POP3 server interacts with the mailbox provider.
+    /// </summary>
+    [TestMethod]
+    public async Task Pop3Server_BasicFlow()
+    {
+        InMemoryMailbox mailbox = new();
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using NetworkStream ns = serverClient.GetStream();
+            using Pop3Server server = new(mailbox);
+            await server.StartAsync(ns);
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using Pop3Client client = new();
+        await client.ConnectAsync("127.0.0.1", port);
+        await client.AuthenticateAsync("user", "pass");
+        (int count, int size) stat = await client.GetStatAsync();
+        Assert.AreEqual(2, stat.count);
+        IReadOnlyDictionary<int, int> list = await client.ListAsync();
+        Assert.AreEqual(2, list.Count);
+        string message = await client.RetrieveAsync(1);
+        StringAssert.Contains(message, "line1");
+        StringAssert.Contains(message, ".leading");
+        await client.DeleteAsync(1);
+        await client.QuitAsync();
+        await serverTask;
+    }
+
+    /// <summary>
+    /// Simple in-memory mailbox used for testing.
+    /// </summary>
+    private sealed class InMemoryMailbox : IPop3Mailbox
+    {
+        private readonly Dictionary<int, string> _messages = new()
+        {
+            [1] = "line1\r\n.leading\r\n",
+            [2] = "second\r\n"
+        };
+
+        /// <inheritdoc />
+        public Task<bool> AuthenticateAsync(string user, string password, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(user == "user" && password == "pass");
+        }
+
+        /// <inheritdoc />
+        public Task<IReadOnlyDictionary<int, int>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            Dictionary<int, int> list = new();
+            foreach (KeyValuePair<int, string> pair in _messages)
+            {
+                list[pair.Key] = pair.Value.Length;
+            }
+            return Task.FromResult<IReadOnlyDictionary<int, int>>(list);
+        }
+
+        /// <inheritdoc />
+        public Task<string> RetrieveAsync(int id, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_messages[id]);
+        }
+
+        /// <inheritdoc />
+        public Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+        {
+            _messages.Remove(id);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/UtilsTest/UtilsTest.csproj
+++ b/UtilsTest/UtilsTest.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
     <PackageReference Include="SolidToken.SpecFlow.DependencyInjection" Version="3.9.3" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- generalize CommandResponseClient to operate on arbitrary streams
- add CommandResponseServer for handling incoming commands
- update docs and tests to cover stream usage

## Testing
- `dotnet test --no-build` *(hangs after running tests, build canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2bdb7e0c8326986124b514aac2b6