### PR TITLE
Add ESMTP support to SMTP client and server

### DIFF
--- a/Utils.Net/Net/CommandResponseServer.cs
+++ b/Utils.Net/Net/CommandResponseServer.cs
@@ -61,6 +61,7 @@ public class CommandResponseServer : IDisposable
 
     /// <summary>
     /// Occurs when a command is received from the client. The handler must return the responses to send.
+    /// Returning an empty sequence results in no response being written to the client.
     /// </summary>
     public event Func<string, Task<IEnumerable<ServerResponse>>>? CommandReceived;
 
@@ -238,7 +239,7 @@ public class CommandResponseServer : IDisposable
                     await _writer.WriteLineAsync(line);
                 }
 
-                if (MaxConsecutiveErrors > 0)
+                if (responseList.Count > 0 && MaxConsecutiveErrors > 0)
                 {
                     ResponseSeverity finalSeverity = responseList[^1].Severity;
                     if (finalSeverity >= ResponseSeverity.TransientNegative)

--- a/Utils.Net/Net/ISmtpAuthenticator.cs
+++ b/Utils.Net/Net/ISmtpAuthenticator.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Provides authentication services for the <see cref="SmtpServer"/>.
+/// </summary>
+public interface ISmtpAuthenticator
+{
+    /// <summary>
+    /// Authenticates the specified user.
+    /// </summary>
+    /// <param name="user">User name.</param>
+    /// <param name="password">User password.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Authentication result including relay permission.</returns>
+    Task<SmtpAuthenticationResult> AuthenticateAsync(string user, string password, CancellationToken cancellationToken = default);
+}

--- a/Utils.Net/Net/ISmtpMessageStore.cs
+++ b/Utils.Net/Net/ISmtpMessageStore.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Defines the interface used by <see cref="SmtpServer"/> to exchange messages.
+/// </summary>
+public interface ISmtpMessageStore
+{
+    /// <summary>
+    /// Stores a message received by the server.
+    /// </summary>
+    /// <param name="message">Message to store.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task StoreAsync(SmtpMessage message, CancellationToken cancellationToken = default);
+}

--- a/Utils.Net/Net/SmtpAuthenticationMechanism.cs
+++ b/Utils.Net/Net/SmtpAuthenticationMechanism.cs
@@ -1,0 +1,17 @@
+namespace Utils.Net;
+
+/// <summary>
+/// Specifies the authentication mechanism used with the <see cref="SmtpClient"/> and <see cref="SmtpServer"/>.
+/// </summary>
+public enum SmtpAuthenticationMechanism
+{
+    /// <summary>
+    /// Plain text authentication using a single base64 encoded "user\0user\0password" value.
+    /// </summary>
+    Plain,
+
+    /// <summary>
+    /// Login authentication sending the user name and password as separate base64 encoded values.
+    /// </summary>
+    Login
+}

--- a/Utils.Net/Net/SmtpAuthenticationResult.cs
+++ b/Utils.Net/Net/SmtpAuthenticationResult.cs
@@ -1,0 +1,28 @@
+namespace Utils.Net;
+
+/// <summary>
+/// Represents the result of an SMTP authentication attempt.
+/// </summary>
+public sealed class SmtpAuthenticationResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpAuthenticationResult"/> class.
+    /// </summary>
+    /// <param name="isAuthenticated">Indicates whether authentication succeeded.</param>
+    /// <param name="canRelay">Indicates whether the authenticated user can relay messages to non-local domains.</param>
+    public SmtpAuthenticationResult(bool isAuthenticated, bool canRelay)
+    {
+        IsAuthenticated = isAuthenticated;
+        CanRelay = canRelay;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether authentication succeeded.
+    /// </summary>
+    public bool IsAuthenticated { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the authenticated user is allowed to relay messages to non-local domains.
+    /// </summary>
+    public bool CanRelay { get; }
+}

--- a/Utils.Net/Net/SmtpClient.cs
+++ b/Utils.Net/Net/SmtpClient.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Client for the Simple Mail Transfer Protocol (SMTP).
+/// </summary>
+public class SmtpClient : CommandResponseClient
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpClient"/> class.
+    /// </summary>
+    public SmtpClient()
+    {
+    }
+
+    /// <summary>
+    /// Authenticates using the specified mechanism.
+    /// </summary>
+    /// <param name="user">User name.</param>
+    /// <param name="password">User password.</param>
+    /// <param name="mechanism">Authentication mechanism to use.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task AuthenticateAsync(string user, string password, SmtpAuthenticationMechanism mechanism = SmtpAuthenticationMechanism.Plain, CancellationToken cancellationToken = default)
+    {
+        switch (mechanism)
+        {
+            case SmtpAuthenticationMechanism.Plain:
+                string payload = "\0" + user + "\0" + password;
+                string encoded = Convert.ToBase64String(Encoding.ASCII.GetBytes(payload));
+                IReadOnlyList<ServerResponse> plainResult = await SendCommandAsync($"AUTH PLAIN {encoded}", cancellationToken);
+                await EnsureCompletionAsync(plainResult);
+                break;
+
+            case SmtpAuthenticationMechanism.Login:
+                IReadOnlyList<ServerResponse> loginResult = await SendCommandAsync("AUTH LOGIN", cancellationToken);
+                await EnsureIntermediateAsync(loginResult);
+                string userEncoded = Convert.ToBase64String(Encoding.ASCII.GetBytes(user));
+                IReadOnlyList<ServerResponse> userResponse = await SendCommandAsync(userEncoded, cancellationToken);
+                await EnsureIntermediateAsync(userResponse);
+                string passEncoded = Convert.ToBase64String(Encoding.ASCII.GetBytes(password));
+                IReadOnlyList<ServerResponse> passResponse = await SendCommandAsync(passEncoded, cancellationToken);
+                await EnsureCompletionAsync(passResponse);
+                break;
+
+            default:
+                throw new NotSupportedException("Unsupported authentication mechanism.");
+        }
+    }
+
+    /// <summary>
+    /// Authenticates using the <c>AUTH PLAIN</c> mechanism.
+    /// </summary>
+    /// <param name="user">User name.</param>
+    /// <param name="password">User password.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task AuthenticateAsync(string user, string password, CancellationToken cancellationToken)
+    {
+        return AuthenticateAsync(user, password, SmtpAuthenticationMechanism.Plain, cancellationToken);
+    }
+
+    /// <summary>
+    /// Connects to the specified SMTP server using a TCP connection.
+    /// </summary>
+    /// <param name="host">Server host name or IP address.</param>
+    /// <param name="port">Server port, default is 25.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task ConnectAsync(string host, int port = 25, CancellationToken cancellationToken = default)
+    {
+        await base.ConnectAsync(host, port, cancellationToken);
+        IReadOnlyList<ServerResponse> greeting = await ReadAsync(cancellationToken);
+        await EnsureCompletionAsync(greeting);
+    }
+
+    /// <summary>
+    /// Uses the provided bidirectional <see cref="Stream"/> for communication.
+    /// </summary>
+    /// <param name="stream">Connected stream used to send commands and receive responses.</param>
+    /// <param name="leaveOpen">True to leave the stream open when disposing the client.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task ConnectAsync(Stream stream, bool leaveOpen = false, CancellationToken cancellationToken = default)
+    {
+        await base.ConnectAsync(stream, leaveOpen, cancellationToken);
+        IReadOnlyList<ServerResponse> greeting = await ReadAsync(cancellationToken);
+        await EnsureCompletionAsync(greeting);
+    }
+
+    /// <summary>
+    /// Sends the EHLO command and returns the advertised extensions.
+    /// </summary>
+    /// <param name="domain">Client domain name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of server extensions.</returns>
+    public async Task<IReadOnlyList<string>> EhloAsync(string domain, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"EHLO {domain}", cancellationToken);
+        List<string> extensions = new();
+        for (int i = 1; i < responses.Count - 1; i++)
+        {
+            if (!string.IsNullOrEmpty(responses[i].Message))
+            {
+                extensions.Add(responses[i].Message);
+            }
+        }
+        await EnsureCompletionAsync(responses);
+        return extensions;
+    }
+
+    /// <summary>
+    /// Sends the HELO command.
+    /// </summary>
+    /// <param name="domain">Client domain name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task HeloAsync(string domain, CancellationToken cancellationToken = default)
+    {
+        await EnsureCompletionAsync(await SendCommandAsync($"HELO {domain}", cancellationToken));
+    }
+
+    /// <summary>
+    /// Sends the VRFY command to verify an address.
+    /// </summary>
+    /// <param name="address">Address to verify.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Server response message.</returns>
+    public async Task<string?> VrfyAsync(string address, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"VRFY {address}", cancellationToken);
+        await EnsureCompletionAsync(responses);
+        return responses[^1].Message;
+    }
+
+    /// <summary>
+    /// Sends the EXPN command to expand a mailing list.
+    /// </summary>
+    /// <param name="list">List name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Expanded entries returned by the server.</returns>
+    public async Task<IReadOnlyList<string>> ExpnAsync(string list, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"EXPN {list}", cancellationToken);
+        List<string> entries = new();
+        for (int i = 0; i < responses.Count - 1; i++)
+        {
+            if (!string.IsNullOrEmpty(responses[i].Message))
+            {
+                entries.Add(responses[i].Message);
+            }
+        }
+        await EnsureCompletionAsync(responses);
+        return entries;
+    }
+
+    /// <summary>
+    /// Sends the HELP command optionally for a specific subject.
+    /// </summary>
+    /// <param name="subject">Command or subject to request help for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Help text returned by the server.</returns>
+    public async Task<IReadOnlyList<string>> HelpAsync(string? subject = null, CancellationToken cancellationToken = default)
+    {
+        string command = subject is null ? "HELP" : $"HELP {subject}";
+        IReadOnlyList<ServerResponse> responses = await SendCommandAsync(command, cancellationToken);
+        List<string> lines = new();
+        foreach (ServerResponse response in responses)
+        {
+            if (!string.IsNullOrEmpty(response.Message))
+            {
+                lines.Add(response.Message);
+            }
+        }
+        await EnsureCompletionAsync(responses);
+        return lines;
+    }
+
+    /// <summary>
+    /// Sends a mail message.
+    /// </summary>
+    /// <param name="from">Sender address.</param>
+    /// <param name="recipients">Recipient addresses.</param>
+    /// <param name="data">Raw message data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task SendMailAsync(string from, IEnumerable<string> recipients, string data, CancellationToken cancellationToken = default)
+    {
+        await EnsureCompletionAsync(await SendCommandAsync($"MAIL FROM:<{from}>", cancellationToken));
+        foreach (string rcpt in recipients)
+        {
+            await EnsureCompletionAsync(await SendCommandAsync($"RCPT TO:<{rcpt}>", cancellationToken));
+        }
+        await EnsureIntermediateAsync(await SendCommandAsync("DATA", cancellationToken));
+        List<string> lines = new();
+        using StringReader reader = new(data);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (line.StartsWith(".", StringComparison.Ordinal))
+            {
+                line = "." + line;
+            }
+            lines.Add(line);
+        }
+        lines.Add(".");
+        await SendLinesAsync(lines, cancellationToken);
+        IReadOnlyList<ServerResponse> result = await ReadAsync(cancellationToken);
+        await EnsureCompletionAsync(result);
+    }
+
+    /// <summary>
+    /// Sends the QUIT command and closes the connection.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task QuitAsync(CancellationToken cancellationToken = default)
+    {
+        return DisconnectAsync("QUIT", TimeSpan.FromSeconds(5), cancellationToken);
+    }
+
+    /// <summary>
+    /// Parses a single response line using SMTP semantics where a hyphen after the status code
+    /// indicates that more lines will follow.
+    /// </summary>
+    /// <param name="line">Response line from the server.</param>
+    /// <returns>Parsed response.</returns>
+    protected override ServerResponse ParseResponseLine(string line)
+    {
+        if (line.Length >= 4 && char.IsDigit(line[0]) && char.IsDigit(line[1]) && char.IsDigit(line[2]))
+        {
+            string code = line.Substring(0, 3);
+            char separator = line[3];
+            string message = line.Length > 4 ? line[4..] : string.Empty;
+            int digit = code[0] - '0';
+            ResponseSeverity severity = digit >= 0 && digit <= 5 ? (ResponseSeverity)digit : ResponseSeverity.Unknown;
+            if (separator == '-')
+            {
+                severity = ResponseSeverity.Preliminary;
+            }
+            return new ServerResponse(code, severity, message);
+        }
+
+        return base.ParseResponseLine(line);
+    }
+
+    /// <summary>
+    /// Ensures that the final response has completion severity.
+    /// </summary>
+    /// <param name="responses">Responses to check.</param>
+    private static Task EnsureCompletionAsync(IReadOnlyList<ServerResponse> responses)
+    {
+        if (responses.Count == 0 || responses[^1].Severity != ResponseSeverity.Completion)
+        {
+            throw new IOException(responses.Count > 0 ? responses[^1].Message : "Server closed connection");
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Ensures that the final response has intermediate severity.
+    /// </summary>
+    /// <param name="responses">Responses to check.</param>
+    private static Task EnsureIntermediateAsync(IReadOnlyList<ServerResponse> responses)
+    {
+        if (responses.Count == 0 || responses[^1].Severity != ResponseSeverity.Intermediate)
+        {
+            throw new IOException(responses.Count > 0 ? responses[^1].Message : "Server closed connection");
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/Utils.Net/Net/SmtpMessage.cs
+++ b/Utils.Net/Net/SmtpMessage.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Represents a message exchanged via SMTP.
+/// </summary>
+/// <param name="From">Mail sender address.</param>
+/// <param name="Recipients">Recipient addresses.</param>
+/// <param name="Data">Raw message data.</param>
+public sealed record SmtpMessage(string From, IReadOnlyList<string> Recipients, string Data);

--- a/Utils.Net/Net/SmtpServer.cs
+++ b/Utils.Net/Net/SmtpServer.cs
@@ -1,0 +1,417 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Simple server implementation for the Simple Mail Transfer Protocol (SMTP).
+/// </summary>
+public sealed class SmtpServer : IDisposable
+{
+    private readonly CommandResponseServer _server;
+    private readonly ISmtpMessageStore _store;
+    private readonly ISmtpAuthenticator? _authenticator;
+    private readonly Func<string, bool> _isLocalDomain;
+    private string? _from;
+    private readonly List<string> _recipients = new();
+    private readonly List<string> _dataLines = new();
+    private string? _loginUser;
+    private bool _isAuthenticated;
+    private bool _canRelay;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmtpServer"/> class.
+    /// </summary>
+    /// <param name="store">Store used to persist received messages.</param>
+    /// <param name="isLocalDomain">Function used to determine if a domain is local and does not require relaying.</param>
+    /// <param name="authenticator">Optional authenticator used to validate credentials.</param>
+    public SmtpServer(ISmtpMessageStore store, Func<string, bool>? isLocalDomain = null, ISmtpAuthenticator? authenticator = null)
+    {
+        _store = store;
+        _authenticator = authenticator;
+        _isLocalDomain = isLocalDomain ?? (_ => true);
+        _server = new CommandResponseServer(SmtpFormatter);
+        _server.RegisterCommand("EHLO", HandleEhlo);
+        _server.RegisterCommand("HELO", HandleHelo);
+        _server.RegisterCommand("AUTH", HandleAuth, "GREETED");
+        _server.RegisterCommand("VRFY", HandleVrfy, "GREETED");
+        _server.RegisterCommand("EXPN", HandleExpn, "GREETED");
+        _server.RegisterCommand("HELP", HandleHelp);
+        _server.RegisterCommand("MAIL", HandleMail, "GREETED");
+        _server.RegisterCommand("RCPT", HandleRcpt, "MAIL");
+        _server.RegisterCommand("DATA", HandleData, "RCPT");
+        _server.RegisterCommand("RSET", HandleRset);
+        _server.RegisterCommand("NOOP", HandleNoOp);
+        _server.RegisterCommand("QUIT", HandleQuit);
+        _server.CommandReceived += HandleSpecialLinesAsync;
+    }
+
+    /// <summary>
+    /// Starts the SMTP server and sends the greeting line.
+    /// </summary>
+    /// <param name="stream">Stream connected to the client.</param>
+    /// <param name="leaveOpen">True to leave the stream open when disposing the server.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task StartAsync(Stream stream, bool leaveOpen = false, CancellationToken cancellationToken = default)
+    {
+        await _server.StartAsync(stream, leaveOpen, cancellationToken);
+        await _server.SendResponseAsync(new ServerResponse("220", ResponseSeverity.Completion, "ready"));
+    }
+
+    /// <summary>
+    /// Gets a task that completes when the server stops processing commands.
+    /// </summary>
+    public Task Completion => _server.Completion;
+
+    /// <summary>
+    /// Releases the resources used by the server.
+    /// </summary>
+    public void Dispose()
+    {
+        _server.Dispose();
+    }
+
+    /// <summary>
+    /// Handles the EHLO command for Extended SMTP and advertises supported features.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private Task<IEnumerable<ServerResponse>> HandleEhlo(CommandContext ctx, string[] args)
+    {
+        ctx.Add("GREETED");
+        List<ServerResponse> responses = new()
+        {
+            new ServerResponse("250", ResponseSeverity.Preliminary, "Hello")
+        };
+        if (_authenticator is not null)
+        {
+            responses.Add(new ServerResponse("250", ResponseSeverity.Preliminary, "AUTH PLAIN LOGIN"));
+        }
+        responses.Add(new ServerResponse("250", ResponseSeverity.Completion, "OK"));
+        return Task.FromResult<IEnumerable<ServerResponse>>(responses);
+    }
+
+    /// <summary>
+    /// Handles the HELO command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private Task<IEnumerable<ServerResponse>> HandleHelo(CommandContext ctx, string[] args)
+    {
+        ctx.Add("GREETED");
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("250", ResponseSeverity.Completion, "Hello") });
+    }
+
+    /// <summary>
+    /// Handles the MAIL command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private Task<IEnumerable<ServerResponse>> HandleMail(CommandContext ctx, string[] args)
+    {
+        _from = ExtractAddress(args);
+        _recipients.Clear();
+        ctx.Add("MAIL");
+        ctx.Remove("RCPT");
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("250", ResponseSeverity.Completion, "OK") });
+    }
+
+    /// <summary>
+    /// Handles the AUTH command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private async Task<IEnumerable<ServerResponse>> HandleAuth(CommandContext ctx, string[] args)
+    {
+        if (_authenticator is null)
+        {
+            return new[] { new ServerResponse("502", ResponseSeverity.PermanentNegative, "Auth not supported") };
+        }
+        if (args.Length == 0)
+        {
+            return new[] { new ServerResponse("501", ResponseSeverity.PermanentNegative, "Invalid auth") };
+        }
+        string mechanism = args[0];
+        if (mechanism.Equals("PLAIN", StringComparison.OrdinalIgnoreCase))
+        {
+            if (args.Length < 2)
+            {
+                return new[] { new ServerResponse("501", ResponseSeverity.PermanentNegative, "Invalid auth") };
+            }
+            byte[] decoded;
+            try
+            {
+                decoded = Convert.FromBase64String(args[1]);
+            }
+            catch (FormatException)
+            {
+                return new[] { new ServerResponse("501", ResponseSeverity.PermanentNegative, "Invalid auth") };
+            }
+            string credentials = Encoding.ASCII.GetString(decoded);
+            int secondNull = credentials.IndexOf('\0', 1);
+            string user = secondNull > 0 ? credentials[1..secondNull] : string.Empty;
+            string password = secondNull > 0 && secondNull < credentials.Length - 1 ? credentials[(secondNull + 1)..] : string.Empty;
+            SmtpAuthenticationResult result = await _authenticator.AuthenticateAsync(user, password);
+            if (result.IsAuthenticated)
+            {
+                _isAuthenticated = true;
+                _canRelay = result.CanRelay;
+                ctx.Add("AUTH");
+                return new[] { new ServerResponse("235", ResponseSeverity.Completion, "Authenticated") };
+            }
+            return new[] { new ServerResponse("535", ResponseSeverity.PermanentNegative, "Authentication failed") };
+        }
+        if (mechanism.Equals("LOGIN", StringComparison.OrdinalIgnoreCase))
+        {
+            ctx.Add("AUTH-LOGIN-USER");
+            _loginUser = null;
+            string prompt = Convert.ToBase64String(Encoding.ASCII.GetBytes("Username:"));
+            return new[] { new ServerResponse("334", ResponseSeverity.Intermediate, prompt) };
+        }
+        return new[] { new ServerResponse("504", ResponseSeverity.PermanentNegative, "Unsupported auth") };
+    }
+
+    /// <summary>
+    /// Handles the VRFY command used to verify an address.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private static Task<IEnumerable<ServerResponse>> HandleVrfy(CommandContext ctx, string[] args)
+    {
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("252", ResponseSeverity.Completion, "Cannot VRFY user") });
+    }
+
+    /// <summary>
+    /// Handles the EXPN command used to expand a mailing list.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private static Task<IEnumerable<ServerResponse>> HandleExpn(CommandContext ctx, string[] args)
+    {
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("252", ResponseSeverity.Completion, "Cannot EXPN list") });
+    }
+
+    /// <summary>
+    /// Handles the HELP command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private static Task<IEnumerable<ServerResponse>> HandleHelp(CommandContext ctx, string[] args)
+    {
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("214", ResponseSeverity.Completion, "No help available") });
+    }
+
+    /// <summary>
+    /// Handles the RCPT command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private Task<IEnumerable<ServerResponse>> HandleRcpt(CommandContext ctx, string[] args)
+    {
+        string address = ExtractAddress(args);
+        string domain = string.Empty;
+        int at = address.IndexOf('@');
+        if (at >= 0 && at < address.Length - 1)
+        {
+            domain = address[(at + 1)..];
+        }
+        if (!_isLocalDomain(domain) && (!_isAuthenticated || !_canRelay))
+        {
+            return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("550", ResponseSeverity.PermanentNegative, "Relaying denied") });
+        }
+        _recipients.Add(address);
+        ctx.Add("RCPT");
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("250", ResponseSeverity.Completion, "OK") });
+    }
+
+    /// <summary>
+    /// Handles the DATA command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private Task<IEnumerable<ServerResponse>> HandleData(CommandContext ctx, string[] args)
+    {
+        _dataLines.Clear();
+        ctx.Add("DATA");
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("354", ResponseSeverity.Intermediate, "Start mail input") });
+    }
+
+    /// <summary>
+    /// Handles the RSET command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private Task<IEnumerable<ServerResponse>> HandleRset(CommandContext ctx, string[] args)
+    {
+        _from = null;
+        _recipients.Clear();
+        _dataLines.Clear();
+        ctx.Remove("MAIL");
+        ctx.Remove("RCPT");
+        ctx.Remove("DATA");
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("250", ResponseSeverity.Completion, "OK") });
+    }
+
+    /// <summary>
+    /// Handles the NOOP command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private static Task<IEnumerable<ServerResponse>> HandleNoOp(CommandContext ctx, string[] args)
+    {
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("250", ResponseSeverity.Completion, "OK") });
+    }
+
+    /// <summary>
+    /// Handles the QUIT command.
+    /// </summary>
+    /// <param name="ctx">Command context.</param>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Responses to send.</returns>
+    private static Task<IEnumerable<ServerResponse>> HandleQuit(CommandContext ctx, string[] args)
+    {
+        return Task.FromResult<IEnumerable<ServerResponse>>(new[] { new ServerResponse("221", ResponseSeverity.Completion, "Bye") });
+    }
+
+    /// <summary>
+    /// Routes lines that are part of multi-step commands such as DATA or AUTH LOGIN.
+    /// </summary>
+    /// <param name="line">Line received from the client.</param>
+    /// <returns>Responses to send, or <see langword="null"/> if the line was not handled.</returns>
+    private async Task<IEnumerable<ServerResponse>> HandleSpecialLinesAsync(string line)
+    {
+        IEnumerable<ServerResponse>? responses = await HandleAuthLoginAsync(line);
+        if (responses is not null)
+        {
+            return responses;
+        }
+        responses = await HandleDataLinesAsync(line);
+        return responses;
+    }
+
+    /// <summary>
+    /// Handles lines that belong to the AUTH LOGIN handshake.
+    /// </summary>
+    /// <param name="line">Line received from the client.</param>
+    /// <returns>Responses to send.</returns>
+    private async Task<IEnumerable<ServerResponse>> HandleAuthLoginAsync(string line)
+    {
+        if (_server.HasContext("AUTH-LOGIN-USER"))
+        {
+            string user;
+            try
+            {
+                user = Encoding.ASCII.GetString(Convert.FromBase64String(line));
+            }
+            catch (FormatException)
+            {
+                _server.RemoveContext("AUTH-LOGIN-USER");
+                return new[] { new ServerResponse("501", ResponseSeverity.PermanentNegative, "Invalid auth") };
+            }
+            _loginUser = user;
+            _server.RemoveContext("AUTH-LOGIN-USER");
+            _server.AddContext("AUTH-LOGIN-PASS");
+            string prompt = Convert.ToBase64String(Encoding.ASCII.GetBytes("Password:"));
+            return new[] { new ServerResponse("334", ResponseSeverity.Intermediate, prompt) };
+        }
+        if (_server.HasContext("AUTH-LOGIN-PASS"))
+        {
+            string password;
+            try
+            {
+                password = Encoding.ASCII.GetString(Convert.FromBase64String(line));
+            }
+            catch (FormatException)
+            {
+                _server.RemoveContext("AUTH-LOGIN-PASS");
+                return new[] { new ServerResponse("501", ResponseSeverity.PermanentNegative, "Invalid auth") };
+            }
+            _server.RemoveContext("AUTH-LOGIN-PASS");
+            if (_authenticator is not null && _loginUser is not null)
+            {
+                SmtpAuthenticationResult result = await _authenticator.AuthenticateAsync(_loginUser, password);
+                if (result.IsAuthenticated)
+                {
+                    _isAuthenticated = true;
+                    _canRelay = result.CanRelay;
+                    _server.AddContext("AUTH");
+                    return new[] { new ServerResponse("235", ResponseSeverity.Completion, "Authenticated") };
+                }
+            }
+            return new[] { new ServerResponse("535", ResponseSeverity.PermanentNegative, "Authentication failed") };
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Handles lines sent after the DATA command until a single dot line terminates the message.
+    /// </summary>
+    /// <param name="line">Line received from the client.</param>
+    /// <returns>Responses to send.</returns>
+    private async Task<IEnumerable<ServerResponse>> HandleDataLinesAsync(string line)
+    {
+        if (_server.HasContext("DATA"))
+        {
+            if (line == ".")
+            {
+                _server.RemoveContext("DATA");
+                string data = string.Join("\r\n", _dataLines);
+                SmtpMessage message = new(_from ?? string.Empty, new List<string>(_recipients), data);
+                await _store.StoreAsync(message);
+                _from = null;
+                _recipients.Clear();
+                _dataLines.Clear();
+                return new[] { new ServerResponse("250", ResponseSeverity.Completion, "OK") };
+            }
+
+            string processed = line.StartsWith("..", StringComparison.Ordinal) ? line[1..] : line;
+            _dataLines.Add(processed);
+            return Array.Empty<ServerResponse>();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts an address from command arguments.
+    /// </summary>
+    /// <param name="args">Command arguments.</param>
+    /// <returns>Extracted address.</returns>
+    private static string ExtractAddress(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            return string.Empty;
+        }
+        string value = args[0];
+        int start = value.IndexOf('<');
+        int end = value.IndexOf('>');
+        return start >= 0 && end > start ? value[(start + 1)..end] : value;
+    }
+
+    /// <summary>
+    /// Formats SMTP responses adding a hyphen for preliminary replies to build multi-line responses.
+    /// </summary>
+    /// <param name="response">Response to format.</param>
+    /// <returns>Formatted response line.</returns>
+    private static string SmtpFormatter(ServerResponse response)
+    {
+        string separator = response.Severity == ResponseSeverity.Preliminary ? "-" : " ";
+        return response.Message is null ? response.Code : $"{response.Code}{separator}{response.Message}";
+    }
+}

--- a/UtilsTest/Net/SmtpClientServerTests.cs
+++ b/UtilsTest/Net/SmtpClientServerTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Integration tests for <see cref="SmtpClient"/> and <see cref="SmtpServer"/>.
+/// </summary>
+[TestClass]
+public class SmtpClientServerTests
+{
+    /// <summary>
+    /// Verifies that a message can be transferred from client to server.
+    /// </summary>
+    [TestMethod]
+    public async Task ClientServer_TransfersMessage()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        InMemoryStore store = new();
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using SmtpServer server = new(store, d => d == "example.com");
+            await server.StartAsync(serverClient.GetStream());
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using SmtpClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
+        await client.ConnectAsync("127.0.0.1", port);
+        await client.EhloAsync("localhost");
+        await client.SendMailAsync("alice@example.com", new[] { "bob@example.com" }, "Subject: Test\r\n\r\nBody");
+        await client.QuitAsync();
+        await serverTask;
+
+        Assert.IsNotNull(store.Message);
+        Assert.AreEqual("alice@example.com", store.Message!.From);
+        Assert.AreEqual(1, store.Message!.Recipients.Count);
+        Assert.AreEqual("bob@example.com", store.Message!.Recipients[0]);
+        StringAssert.Contains(store.Message!.Data, "Subject: Test");
+    }
+
+    /// <summary>
+    /// Ensures that relaying is rejected when the client does not authenticate.
+    /// </summary>
+    [TestMethod]
+    public async Task Server_RejectsRelayWithoutAuthentication()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        InMemoryStore store = new();
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using SmtpServer server = new(store, d => d == "example.com", new InMemoryAuthenticator());
+            await server.StartAsync(serverClient.GetStream());
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using SmtpClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
+        await client.ConnectAsync("127.0.0.1", port);
+        await client.EhloAsync("localhost");
+        await Assert.ThrowsExceptionAsync<IOException>(() =>
+            client.SendMailAsync("alice@example.com", new[] { "bob@other.com" }, "Subject: Test\r\n\r\nBody"));
+        await client.QuitAsync();
+        await serverTask;
+
+        Assert.IsNull(store.Message);
+    }
+
+    /// <summary>
+    /// Verifies that relaying succeeds after authentication.
+    /// </summary>
+    [TestMethod]
+    public async Task Server_AllowsRelayAfterAuthentication()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        InMemoryStore store = new();
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using SmtpServer server = new(store, d => d == "example.com", new InMemoryAuthenticator());
+            await server.StartAsync(serverClient.GetStream());
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using SmtpClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
+        await client.ConnectAsync("127.0.0.1", port);
+        IReadOnlyList<string> extensions = await client.EhloAsync("localhost");
+        CollectionAssert.Contains((System.Collections.ICollection)extensions, "AUTH PLAIN LOGIN");
+        await client.AuthenticateAsync("user", "pass");
+        await client.SendMailAsync("alice@example.com", new[] { "bob@other.com" }, "Subject: Test\r\n\r\nBody");
+        await client.QuitAsync();
+        await serverTask;
+
+        Assert.IsNotNull(store.Message);
+        Assert.AreEqual("bob@other.com", store.Message!.Recipients[0]);
+    }
+
+    /// <summary>
+    /// Verifies that the LOGIN authentication mechanism is accepted and allows relaying.
+    /// </summary>
+    [TestMethod]
+    public async Task Server_AllowsRelayAfterLoginAuthentication()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        InMemoryStore store = new();
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using SmtpServer server = new(store, d => d == "example.com", new InMemoryAuthenticator());
+            await server.StartAsync(serverClient.GetStream());
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using SmtpClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
+        await client.ConnectAsync("127.0.0.1", port);
+        await client.EhloAsync("localhost");
+        await client.AuthenticateAsync("user", "pass", SmtpAuthenticationMechanism.Login);
+        await client.SendMailAsync("alice@example.com", new[] { "bob@other.com" }, "Subject: Test\r\n\r\nBody");
+        await client.QuitAsync();
+        await serverTask;
+
+        Assert.IsNotNull(store.Message);
+        Assert.AreEqual("bob@other.com", store.Message!.Recipients[0]);
+    }
+
+    /// <summary>
+    /// Ensures that VRFY, EXPN and HELP commands are handled by the server.
+    /// </summary>
+    [TestMethod]
+    public async Task Server_HandlesVrfyExpnHelp()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        InMemoryStore store = new();
+        Task serverTask = Task.Run(async () =>
+        {
+            using TcpClient serverClient = await listener.AcceptTcpClientAsync();
+            using SmtpServer server = new(store);
+            await server.StartAsync(serverClient.GetStream());
+            await server.Completion;
+            listener.Stop();
+        });
+
+        using SmtpClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
+        await client.ConnectAsync("127.0.0.1", port);
+        await client.EhloAsync("localhost");
+        string? vrfy = await client.VrfyAsync("alice");
+        IReadOnlyList<string> expn = await client.ExpnAsync("list");
+        IReadOnlyList<string> help = await client.HelpAsync();
+        await client.QuitAsync();
+        await serverTask;
+
+        StringAssert.Contains(vrfy, "Cannot");
+        Assert.AreEqual(0, expn.Count);
+        StringAssert.Contains(help[0], "No help available");
+    }
+
+    private sealed class InMemoryStore : ISmtpMessageStore
+    {
+        public SmtpMessage? Message { get; private set; }
+
+        public Task StoreAsync(SmtpMessage message, CancellationToken cancellationToken = default)
+        {
+            Message = message;
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Simple authenticator used by the tests.
+    /// </summary>
+    private sealed class InMemoryAuthenticator : ISmtpAuthenticator
+    {
+        /// <summary>
+        /// Authenticates the supplied credentials.
+        /// </summary>
+        /// <param name="user">User name.</param>
+        /// <param name="password">Password.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Authentication result.</returns>
+        public Task<SmtpAuthenticationResult> AuthenticateAsync(string user, string password, CancellationToken cancellationToken = default)
+        {
+            bool success = user == "user" && password == "pass";
+            return Task.FromResult(new SmtpAuthenticationResult(success, success));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SMTP AUTH support in client
- allow SMTP server to authenticate users and control relaying
- document authentication usage
- add ESMTP EHLO support with extension parsing
- advertise AUTH extension and format multi-line responses
- update tests and docs to use EHLO
- support VRFY, EXPN and HELP commands
- add LOGIN authentication mechanism

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b54a4db9f88326b33766f853143010