### PR TITLE
Enable nullable annotations across the solution

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,6 +1,7 @@
 <Project>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
+        <Nullable>annotations</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <IncludeDocumentationFile>true</IncludeDocumentationFile>
         <RepositoryUrl>https://github.com/warny/All-purpose-Utilities</RepositoryUrl>

--- a/Utils.Net/Net/Icmp/IcmpException.cs
+++ b/Utils.Net/Net/Icmp/IcmpException.cs
@@ -1,15 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
+using System;
 
 namespace Utils.Net.Icmp;
 
+/// <summary>
+/// Represents an error that occurs while sending or receiving ICMP packets.
+/// </summary>
 public class IcmpException : Exception
 {
-	public IcmpException(string message) : base(message) { }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IcmpException"/> class with the specified message.
+    /// </summary>
+    /// <param name="message">A description of the failure.</param>
+    public IcmpException(string message)
+        : base(message)
+    {
+    }
 
-	public IcmpException(string message, Exception innerException) : base(message, innerException) { }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IcmpException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">A description of the failure.</param>
+    /// <param name="innerException">The exception that triggered the ICMP failure.</param>
+    public IcmpException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
 }

--- a/Utils.Net/Net/Icmp/IcmpPacketType.cs
+++ b/Utils.Net/Net/Icmp/IcmpPacketType.cs
@@ -1,11 +1,37 @@
-﻿namespace Utils.Net.Icmp;
+namespace Utils.Net.Icmp;
 
+/// <summary>
+/// Defines well-known ICMP packet types used by the utilities.
+/// </summary>
 public enum IcmpPacketType : byte
 {
-	IcmpV4EchoReply = 0,
-	IcmpV4EchoRequest = 8,
-	IcmpV6EchoRequest = 128,
-	IcmpV6EchoReply = 129,
-	IcmpV4TimeExceeded = 11,
-	IcmpV6TimeExceeded = 3
+    /// <summary>
+    /// IPv4 echo reply (type 0).
+    /// </summary>
+    IcmpV4EchoReply = 0,
+
+    /// <summary>
+    /// IPv4 echo request (type 8).
+    /// </summary>
+    IcmpV4EchoRequest = 8,
+
+    /// <summary>
+    /// IPv6 echo request (type 128).
+    /// </summary>
+    IcmpV6EchoRequest = 128,
+
+    /// <summary>
+    /// IPv6 echo reply (type 129).
+    /// </summary>
+    IcmpV6EchoReply = 129,
+
+    /// <summary>
+    /// IPv4 time exceeded (type 11).
+    /// </summary>
+    IcmpV4TimeExceeded = 11,
+
+    /// <summary>
+    /// IPv6 time exceeded (type 3).
+    /// </summary>
+    IcmpV6TimeExceeded = 3
 }

--- a/Utils.Net/Net/Icmp/TracerouteHop.cs
+++ b/Utils.Net/Net/Icmp/TracerouteHop.cs
@@ -1,27 +1,62 @@
-﻿using System.Net;
+using System.Net;
 
 namespace Utils.Net.Icmp;
 
 /// <summary>
-/// Represents a single hop in a Traceroute operation.
+/// Represents a single hop returned by a traceroute operation.
 /// </summary>
 public class TracerouteHop
 {
-	public TracerouteHop(int hopNumber, IPAddress? address, int roundTripTime, bool isFinalDestination, bool isTimeExceed)
-	{
-		HopNumber = hopNumber;
-		Address = address;
-		RoundTripTime = roundTripTime;
-		IsFinalDestination = isFinalDestination;
-		IsTimeExceed = isTimeExceed;
-	}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TracerouteHop"/> class.
+    /// </summary>
+    /// <param name="hopNumber">The sequential hop number starting at 1.</param>
+    /// <param name="address">The IP address reached for the hop, or <c>null</c> when unreachable.</param>
+    /// <param name="roundTripTime">The measured round-trip time in milliseconds.</param>
+    /// <param name="isFinalDestination">Indicates whether the hop corresponds to the requested destination.</param>
+    /// <param name="isTimeExceed">Indicates whether the hop resulted from a TTL exceeded response.</param>
+    public TracerouteHop(int hopNumber, IPAddress? address, int roundTripTime, bool isFinalDestination, bool isTimeExceed)
+    {
+        HopNumber = hopNumber;
+        Address = address;
+        RoundTripTime = roundTripTime;
+        IsFinalDestination = isFinalDestination;
+        IsTimeExceed = isTimeExceed;
+    }
 
-	public int HopNumber { get; }
-	public IPAddress? Address { get; }
-	public int RoundTripTime { get; } // In milliseconds
-	public bool IsFinalDestination { get; }
-	public bool IsTimeExceed { get; }
+    /// <summary>
+    /// Gets the sequential hop number reported by the traceroute.
+    /// </summary>
+    public int HopNumber { get; }
 
-	public override string ToString() =>
-		$"{HopNumber}: {(Address != null ? Address.ToString() : "*")} - {RoundTripTime}ms {(IsFinalDestination ? "[Destination Reached]" : "")}";
+    /// <summary>
+    /// Gets the IP address reached for the hop, or <c>null</c> when the hop timed out.
+    /// </summary>
+    public IPAddress? Address { get; }
+
+    /// <summary>
+    /// Gets the measured round-trip time in milliseconds.
+    /// </summary>
+    public int RoundTripTime { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the hop corresponds to the destination host.
+    /// </summary>
+    public bool IsFinalDestination { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the hop was reported through a TTL exceeded response.
+    /// </summary>
+    public bool IsTimeExceed { get; }
+
+    /// <summary>
+    /// Returns a string that represents the current hop.
+    /// </summary>
+    /// <returns>A string containing the hop number, address, latency, and destination status.</returns>
+    public override string ToString()
+    {
+        string addressText = Address?.ToString() ?? "*";
+        string destinationSuffix = IsFinalDestination ? " [Destination Reached]" : string.Empty;
+        return $"{HopNumber}: {addressText} - {RoundTripTime}ms{destinationSuffix}";
+    }
 }


### PR DESCRIPTION
## Summary
- enable nullable annotations globally so nullable reference syntax no longer triggers CS8632 warnings during builds

## Testing
- dotnet build
- dotnet test --logger "console;verbosity=minimal"


------
https://chatgpt.com/codex/tasks/task_e_68ca2ccbccbc83268d06ba8b12ddadd1