### PR TITLE
Fix trigonometry radian helper docs

### DIFF
--- a/Utils.VirtualMachine/INumberReader.cs
+++ b/Utils.VirtualMachine/INumberReader.cs
@@ -1,195 +1,262 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System;
 
 namespace Utils.VirtualMachine
 {
+    /// <summary>
+    /// Provides methods to read numbers from a virtual machine <see cref="Context"/>.
+    /// </summary>
+    public interface INumberReader
+    {
         /// <summary>
-        /// Provides methods to read numbers from a virtual machine context.
+        /// Reads a single byte from the supplied <paramref name="context"/>.
         /// </summary>
-        public interface INumberReader
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <returns>The next byte available in the context.</returns>
+        byte ReadByte(Context context);
+
+        /// <summary>
+        /// Reads a 16-bit signed integer from the supplied <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <returns>The next <see cref="short"/> value available in the context.</returns>
+        short ReadInt16(Context context);
+
+        /// <summary>
+        /// Reads a 32-bit signed integer from the supplied <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <returns>The next <see cref="int"/> value available in the context.</returns>
+        int ReadInt32(Context context);
+
+        /// <summary>
+        /// Reads a 64-bit signed integer from the supplied <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <returns>The next <see cref="long"/> value available in the context.</returns>
+        long ReadInt64(Context context);
+
+        /// <summary>
+        /// Reads a 16-bit unsigned integer from the supplied <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <returns>The next <see cref="ushort"/> value available in the context.</returns>
+        ushort ReadUInt16(Context context);
+
+        /// <summary>
+        /// Reads a 32-bit unsigned integer from the supplied <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <returns>The next <see cref="uint"/> value available in the context.</returns>
+        uint ReadUInt32(Context context);
+
+        /// <summary>
+        /// Reads a 64-bit unsigned integer from the supplied <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <returns>The next <see cref="ulong"/> value available in the context.</returns>
+        ulong ReadUInt64(Context context);
+
+        /// <summary>
+        /// Reads a single-precision floating-point value from the supplied <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <returns>The next <see cref="float"/> value available in the context.</returns>
+        float ReadSingle(Context context);
+
+        /// <summary>
+        /// Reads a double-precision floating-point value from the supplied <paramref name="context"/>.
+        /// </summary>
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <returns>The next <see cref="double"/> value available in the context.</returns>
+        double ReadDouble(Context context);
+    }
+
+    /// <summary>
+    /// Factory methods for obtaining <see cref="INumberReader"/> instances.
+    /// </summary>
+    public static class NumberReader
+    {
+        private static INumberReader NormalReader { get; } = new NormalReader();
+        private static INumberReader InvertedReader { get; } = new InvertedReader();
+
+        /// <summary>
+        /// Returns a reader configured for the specified endianness.
+        /// </summary>
+        /// <param name="littleEndian">True for little-endian reading; otherwise, false.</param>
+        /// <returns>An <see cref="INumberReader"/> that reads values using the desired byte order.</returns>
+        public static INumberReader GetReader(bool littleEndian)
         {
-                byte ReadByte(Context context);
-                Int16 ReadInt16(Context context);
-                Int32 ReadInt32(Context context);
-                Int64 ReadInt64(Context context);
-                UInt16 ReadUInt16(Context context);
-                UInt32 ReadUInt32(Context context);
-                UInt64 ReadUInt64(Context context);
-                float ReadSingle(Context context);
-                double ReadDouble(Context context);
+            if (!littleEndian ^ BitConverter.IsLittleEndian)
+            {
+                return NormalReader;
+            }
+
+            return InvertedReader;
+        }
+    }
+
+    /// <summary>
+    /// Reader implementation matching the system endianness.
+    /// </summary>
+    internal class NormalReader : INumberReader
+    {
+        /// <inheritdoc />
+        public byte ReadByte(Context context)
+        {
+            return context.Data[context.InstructionPointer++];
         }
 
+        /// <inheritdoc />
+        public short ReadInt16(Context context)
+        {
+            var result = BitConverter.ToInt16(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(short);
+            return result;
+        }
+
+        /// <inheritdoc />
+        public int ReadInt32(Context context)
+        {
+            var result = BitConverter.ToInt32(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(int);
+            return result;
+        }
+
+        /// <inheritdoc />
+        public long ReadInt64(Context context)
+        {
+            var result = BitConverter.ToInt64(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(long);
+            return result;
+        }
+
+        /// <inheritdoc />
+        public ushort ReadUInt16(Context context)
+        {
+            var result = BitConverter.ToUInt16(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(ushort);
+            return result;
+        }
+
+        /// <inheritdoc />
+        public uint ReadUInt32(Context context)
+        {
+            var result = BitConverter.ToUInt32(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(uint);
+            return result;
+        }
+
+        /// <inheritdoc />
+        public ulong ReadUInt64(Context context)
+        {
+            var result = BitConverter.ToUInt64(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(ulong);
+            return result;
+        }
+
+        /// <inheritdoc />
+        public float ReadSingle(Context context)
+        {
+            var result = BitConverter.ToSingle(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(float);
+            return result;
+        }
+
+        /// <inheritdoc />
+        public double ReadDouble(Context context)
+        {
+            var result = BitConverter.ToDouble(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(double);
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Reader implementation that swaps endianness when reading values.
+    /// </summary>
+    internal class InvertedReader : INumberReader
+    {
         /// <summary>
-        /// Factory methods for obtaining <see cref="INumberReader"/> instances.
+        /// Copies bytes from the context into <paramref name="target"/> in reversed order.
         /// </summary>
-        public static class NumberReader
-	{
-		private static INumberReader NormalReader { get; } = new NormalReader();
-		private static INumberReader InvertedReader { get; } = new InvertedReader();
+        /// <param name="context">The execution context containing the instruction stream.</param>
+        /// <param name="target">The buffer receiving the bytes in reversed order.</param>
+        private static void ReadDatas(Context context, byte[] target)
+        {
+            for (int i = target.Length - 1; i >= 0; i--)
+            {
+                target[i] = context.Data[context.InstructionPointer++];
+            }
+        }
 
-                /// <summary>
-                /// Returns a reader configured for the specified endianness.
-                /// </summary>
-                /// <param name="littleIndian">True for little-endian reading.</param>
-                public static INumberReader GetReader(bool littleIndian)
-                {
-                        if (!littleIndian ^ BitConverter.IsLittleEndian)
-                        {
-                                return NormalReader;
-                        }
-                        else
-                        {
-                                return InvertedReader;
-                        }
+        /// <inheritdoc />
+        public byte ReadByte(Context context)
+        {
+            return context.Data[context.InstructionPointer++];
+        }
 
-                }
-	}
+        /// <inheritdoc />
+        public short ReadInt16(Context context)
+        {
+            var temp = new byte[sizeof(short)];
+            ReadDatas(context, temp);
+            return BitConverter.ToInt16(temp, 0);
+        }
 
-        /// <summary>
-        /// Reader implementation matching the system endianness.
-        /// </summary>
-        internal class NormalReader : INumberReader
-	{
-		public byte ReadByte(Context context)
-		{
-			return context.Data[context.InstructionPointer++];
-		}
+        /// <inheritdoc />
+        public int ReadInt32(Context context)
+        {
+            var temp = new byte[sizeof(int)];
+            ReadDatas(context, temp);
+            return BitConverter.ToInt32(temp, 0);
+        }
 
-		public short ReadInt16(Context context)
-		{
-			var result = BitConverter.ToInt16(context.Data, context.InstructionPointer);
-			context.InstructionPointer += sizeof(Int16);
-			return result;
-		}
+        /// <inheritdoc />
+        public long ReadInt64(Context context)
+        {
+            var temp = new byte[sizeof(long)];
+            ReadDatas(context, temp);
+            return BitConverter.ToInt64(temp, 0);
+        }
 
-		public int ReadInt32(Context context)
-		{
-			var result = BitConverter.ToInt32(context.Data, context.InstructionPointer);
-			context.InstructionPointer += sizeof(Int32);
-			return result;
-		}
+        /// <inheritdoc />
+        public ushort ReadUInt16(Context context)
+        {
+            var temp = new byte[sizeof(ushort)];
+            ReadDatas(context, temp);
+            return BitConverter.ToUInt16(temp, 0);
+        }
 
-		public long ReadInt64(Context context)
-		{
-			var result = BitConverter.ToInt64(context.Data, context.InstructionPointer);
-			context.InstructionPointer += sizeof(Int64);
-			return result;
-		}
+        /// <inheritdoc />
+        public uint ReadUInt32(Context context)
+        {
+            var temp = new byte[sizeof(uint)];
+            ReadDatas(context, temp);
+            return BitConverter.ToUInt32(temp, 0);
+        }
 
-		public ushort ReadUInt16(Context context)
-		{
-			var result = BitConverter.ToUInt16(context.Data, context.InstructionPointer);
-			context.InstructionPointer += sizeof(UInt16);
-			return result;
-		}
+        /// <inheritdoc />
+        public ulong ReadUInt64(Context context)
+        {
+            var temp = new byte[sizeof(ulong)];
+            ReadDatas(context, temp);
+            return BitConverter.ToUInt64(temp, 0);
+        }
 
-		public uint ReadUInt32(Context context)
-		{
-			var result = BitConverter.ToUInt32(context.Data, context.InstructionPointer);
-			context.InstructionPointer += sizeof(UInt32);
-			return result;
-		}
+        /// <inheritdoc />
+        public float ReadSingle(Context context)
+        {
+            var temp = new byte[sizeof(float)];
+            ReadDatas(context, temp);
+            return BitConverter.ToSingle(temp, 0);
+        }
 
-		public ulong ReadUInt64(Context context)
-		{
-			var result = BitConverter.ToUInt64(context.Data, context.InstructionPointer);
-			context.InstructionPointer += sizeof(UInt64);
-			return result;
-		}
-
-		public float ReadSingle(Context context)
-		{
-			var result = BitConverter.ToSingle(context.Data, context.InstructionPointer);
-			context.InstructionPointer += sizeof(Single);
-			return result;
-		}
-
-		public double ReadDouble(Context context)
-		{
-			var result = BitConverter.ToDouble(context.Data, context.InstructionPointer);
-			context.InstructionPointer += sizeof(Double);
-			return result;
-		}
-
-
-	}
-
-        /// <summary>
-        /// Reader implementation that swaps endianness when reading values.
-        /// </summary>
-        internal class InvertedReader : INumberReader
-	{
-                /// <summary>
-                /// Reads bytes from the context in reverse order to handle endian swapping.
-                /// </summary>
-                private static void ReadDatas(Context context, byte[] target)
-                {
-                        for (int i = target.Length - 1; i >= 0; i--)
-                        {
-                                target[i] = context.Data[context.InstructionPointer++];
-                        }
-                }
-
-		public byte ReadByte(Context context)
-		{
-			return context.Data[context.InstructionPointer++];
-		}
-
-		public short ReadInt16(Context context)
-		{
-			var temp = new byte[sizeof(Int16)];
-			ReadDatas(context, temp);
-			return BitConverter.ToInt16(temp, 0);
-		}
-
-		public int ReadInt32(Context context)
-		{
-			var temp = new byte[sizeof(Int32)];
-			ReadDatas(context, temp);
-			return BitConverter.ToInt32(temp, 0);
-		}
-
-		public long ReadInt64(Context context)
-		{
-			var temp = new byte[sizeof(Int64)];
-			ReadDatas(context, temp);
-			return BitConverter.ToInt64(temp, 0);
-		}
-
-		public ushort ReadUInt16(Context context)
-		{
-			var temp = new byte[sizeof(UInt16)];
-			ReadDatas(context, temp);
-			return BitConverter.ToUInt16(temp, 0);
-		}
-
-		public uint ReadUInt32(Context context)
-		{
-			var temp = new byte[sizeof(UInt32)];
-			ReadDatas(context, temp);
-			return BitConverter.ToUInt32(temp, 0);
-		}
-
-		public ulong ReadUInt64(Context context)
-		{
-			var temp = new byte[sizeof(UInt64)];
-			ReadDatas(context, temp);
-			return BitConverter.ToUInt64(temp, 0);
-		}
-
-		public float ReadSingle(Context context)
-		{
-			var temp = new byte[sizeof(float)];
-			ReadDatas(context, temp);
-			return BitConverter.ToSingle(temp, 0);
-		}
-
-		public double ReadDouble(Context context)
-		{
-			var temp = new byte[sizeof(double)];
-			ReadDatas(context, temp);
-			return BitConverter.ToDouble(temp, 0);
-		}
-	}
+        /// <inheritdoc />
+        public double ReadDouble(Context context)
+        {
+            var temp = new byte[sizeof(double)];
+            ReadDatas(context, temp);
+            return BitConverter.ToDouble(temp, 0);
+        }
+    }
 }

--- a/Utils.VirtualMachine/InstructionAttribute.cs
+++ b/Utils.VirtualMachine/InstructionAttribute.cs
@@ -1,19 +1,32 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System;
 
 namespace Utils.VirtualMachine
 {
-	[AttributeUsage(AttributeTargets.Method)]
-	public class InstructionAttribute : Attribute
-	{
-		public string Name { get; }
-		public byte[] Instruction { get; }
+    /// <summary>
+    /// Identifies a method as a virtual machine instruction and stores its metadata.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class InstructionAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the human-readable name associated with the instruction.
+        /// </summary>
+        public string Name { get; }
 
-		public InstructionAttribute(string name, params byte[] instruction)
-		{
-			Name = name;
-			Instruction = instruction;
-		}
-	}
+        /// <summary>
+        /// Gets the byte sequence representing the instruction opcode.
+        /// </summary>
+        public byte[] Instruction { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstructionAttribute"/> class.
+        /// </summary>
+        /// <param name="name">The descriptive name of the instruction.</param>
+        /// <param name="instruction">The byte sequence that identifies the instruction.</param>
+        public InstructionAttribute(string name, params byte[] instruction)
+        {
+            Name = name;
+            Instruction = instruction;
+        }
+    }
 }

--- a/Utils.VirtualMachine/VirtualProcessorException.cs
+++ b/Utils.VirtualMachine/VirtualProcessorException.cs
@@ -1,15 +1,48 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
-namespace Utils.VirtualMachine;
-
-[Serializable]
-public class VirtualProcessorException : Exception
+namespace Utils.VirtualMachine
 {
-	public VirtualProcessorException() { }
+    /// <summary>
+    /// Represents errors that occur while executing a <see cref="VirtualProcessor{T}"/>.
+    /// </summary>
+    [Serializable]
+    public class VirtualProcessorException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VirtualProcessorException"/> class.
+        /// </summary>
+        public VirtualProcessorException()
+        {
+        }
 
-	public VirtualProcessorException(string message) : base(message) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VirtualProcessorException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public VirtualProcessorException(string message)
+            : base(message)
+        {
+        }
 
-	public VirtualProcessorException(string message, Exception innerException) : base(message, innerException) { }
-	protected VirtualProcessorException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VirtualProcessorException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public VirtualProcessorException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VirtualProcessorException"/> class with serialized data.
+        /// </summary>
+        /// <param name="info">The object that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        protected VirtualProcessorException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
 }

--- a/Utils/Mathematics/IAngleCalculator.cs
+++ b/Utils/Mathematics/IAngleCalculator.cs
@@ -319,7 +319,7 @@ namespace Utils.Mathematics
 		/// <summary>
 		/// A built-in calculator for Radians (Perigon = 2π).
 		/// </summary>
-		public static IAngleCalculator<T> Radian => new Radian<T>();
+                public static IAngleCalculator<T> Radian => new RadianCalculator();
 
 		/// <summary>
 		/// A built-in calculator for Degrees (Perigon = 360).
@@ -337,8 +337,13 @@ namespace Utils.Mathematics
 			{  Grade.Perigon, Grade } 
 		};
 
-		public static IAngleCalculator<T> Get(T perigon)
-			=> _angleCalculators.GetOrAdd(perigon, () => new Trigonometry<T>(perigon));
+                /// <summary>
+                /// Retrieves a cached calculator matching the specified perigon value or creates one on demand.
+                /// </summary>
+                /// <param name="perigon">The angle span representing a full rotation in the desired system.</param>
+                /// <returns>An <see cref="IAngleCalculator{T}"/> configured for the requested perigon.</returns>
+                public static IAngleCalculator<T> Get(T perigon)
+                        => _angleCalculators.GetOrAdd(perigon, () => new Trigonometry<T>(perigon));
 
 	#endregion
 
@@ -346,64 +351,113 @@ namespace Utils.Mathematics
 	/// Represents an angle calculator operating natively in radians.
 	/// </summary>
 	/// <typeparam name="T">A floating-point numeric type (e.g., float, double) implementing <see cref="IFloatingPointIeee754{T}"/>.</typeparam>
-	private sealed class Radian<T> : Trigonometry<T>
-		where T : struct, IFloatingPointIeee754<T>
-	{
-		internal Radian()
-			: base((T.Pi * (T.One + T.One))) // 2π
-		{
-			// For a fully 'native' radian approach, Perigon = 2π
-			// so that StraightAngle = π and RightAngle = π/2, etc.
-		}
+        private sealed class RadianCalculator : Trigonometry<T>
+        {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="RadianCalculator"/> class with a 2π perigon.
+                /// </summary>
+                internal RadianCalculator()
+                        : base((T.Pi * (T.One + T.One))) // 2π
+                {
+                        // For a fully 'native' radian approach, Perigon = 2π
+                        // so that StraightAngle = π and RightAngle = π/2, etc.
+                }
 
-		#region Override Basic Trig (No Rounding Needed)
+                #region Override Basic Trig (No Rounding Needed)
 
-		public override T Sin(T angle) => T.Sin(angle);
-		public override T Cos(T angle) => T.Cos(angle);
-		public override T Tan(T angle) => T.Tan(angle);
-		public override T Cot(T angle) => T.One / T.Tan(angle);
-		public override T Sec(T angle) => T.One / T.Cos(angle);
-		public override T Csc(T angle) => T.One / T.Sin(angle);
+                /// <inheritdoc />
+                public override T Sin(T angle) => T.Sin(angle);
+
+                /// <inheritdoc />
+                public override T Cos(T angle) => T.Cos(angle);
+
+                /// <inheritdoc />
+                public override T Tan(T angle) => T.Tan(angle);
+
+                /// <inheritdoc />
+                public override T Cot(T angle) => T.One / T.Tan(angle);
+
+                /// <inheritdoc />
+                public override T Sec(T angle) => T.One / T.Cos(angle);
+
+                /// <inheritdoc />
+                public override T Csc(T angle) => T.One / T.Sin(angle);
 
 		#endregion
 
 		#region Override Inverse Trig
 
-		public override T Asin(T value) => T.Asin(value);
-		public override T Acos(T value) => T.Acos(value);
-		public override T Atan(T value) => T.Atan(value);
-		public override T Acot(T value) => T.Atan2(T.One, value);
-		public override T Asec(T value) => T.Acos(T.One / value);
-		public override T Acsc(T value) => T.Asin(T.One / value);
+                /// <inheritdoc />
+                public override T Asin(T value) => T.Asin(value);
+
+                /// <inheritdoc />
+                public override T Acos(T value) => T.Acos(value);
+
+                /// <inheritdoc />
+                public override T Atan(T value) => T.Atan(value);
+
+                /// <inheritdoc />
+                public override T Acot(T value) => T.Atan2(T.One, value);
+
+                /// <inheritdoc />
+                public override T Asec(T value) => T.Acos(T.One / value);
+
+                /// <inheritdoc />
+                public override T Acsc(T value) => T.Asin(T.One / value);
 
 		#endregion
 
 		#region Override Hyperbolic
 
-		public override T Sinh(T angle) => T.Sinh(angle);
-		public override T Cosh(T angle) => T.Cosh(angle);
-		public override T Tanh(T angle) => T.Tanh(angle);
-		public override T Csch(T angle) => T.One / T.Sinh(angle);
-		public override T Sech(T angle) => T.One / T.Cosh(angle);
-		public override T Coth(T angle) => T.One / T.Tanh(angle);
+                /// <inheritdoc />
+                public override T Sinh(T angle) => T.Sinh(angle);
+
+                /// <inheritdoc />
+                public override T Cosh(T angle) => T.Cosh(angle);
+
+                /// <inheritdoc />
+                public override T Tanh(T angle) => T.Tanh(angle);
+
+                /// <inheritdoc />
+                public override T Csch(T angle) => T.One / T.Sinh(angle);
+
+                /// <inheritdoc />
+                public override T Sech(T angle) => T.One / T.Cosh(angle);
+
+                /// <inheritdoc />
+                public override T Coth(T angle) => T.One / T.Tanh(angle);
 
 		#endregion
 
 		#region Override Inverse Hyperbolic
 
-		public override T Asinh(T value) => T.Asinh(value);
-		public override T Acosh(T value) => T.Acosh(value);
-		public override T Atanh(T value) => T.Atanh(value);
-		public override T Acoth(T value) => T.Atanh(T.One / value);
-		public override T Asech(T value) => T.Acosh(T.One / value);
-		public override T Acsch(T value) => T.Asinh(T.One / value);
+                /// <inheritdoc />
+                public override T Asinh(T value) => T.Asinh(value);
+
+                /// <inheritdoc />
+                public override T Acosh(T value) => T.Acosh(value);
+
+                /// <inheritdoc />
+                public override T Atanh(T value) => T.Atanh(value);
+
+                /// <inheritdoc />
+                public override T Acoth(T value) => T.Atanh(T.One / value);
+
+                /// <inheritdoc />
+                public override T Asech(T value) => T.Acosh(T.One / value);
+
+                /// <inheritdoc />
+                public override T Acsch(T value) => T.Asinh(T.One / value);
 
 		#endregion
 
 		#region Override Angle Arithmetic
 
-		public override T Atan2(T x, T y) => T.Atan2(x, y);
-		public override T Acot2(T x, T y) => T.Atan2(y, x);
+                /// <inheritdoc />
+                public override T Atan2(T x, T y) => T.Atan2(x, y);
+
+                /// <inheritdoc />
+                public override T Acot2(T x, T y) => T.Atan2(y, x);
 
 		/// <summary>
 		/// Normalizes an angle into the range [-π, +π).
@@ -426,8 +480,11 @@ namespace Utils.Mathematics
 
 		#region Override Radian Conversions (No conversion needed natively)
 
-		public override T FromRadian(T angle) => angle;
-		public override T ToRadian(T angle) => angle;
+                /// <inheritdoc />
+                public override T FromRadian(T angle) => angle;
+
+                /// <inheritdoc />
+                public override T ToRadian(T angle) => angle;
 
 		#endregion
 	}


### PR DESCRIPTION
## Summary
- rename the radian calculator helper class to avoid naming conflicts with the exposed factory property
- document the cached-calculator accessor and inherited overrides so XML documentation is complete

## Testing
- `dotnet build Utils.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ca571dc46483268b86faa86519fee8