### PR TITLE
Ensure IDataRecord formatting honors custom providers

### DIFF
--- a/Utils.Fonts/ttf/Enums.cs
+++ b/Utils.Fonts/ttf/Enums.cs
@@ -91,14 +91,45 @@ public enum HeadFlags : short
 [Flags]
 public enum MacStyleFlags : short
 {
-	None = 0x00,
-	Bold = 0x01,
-	Italic = 0x02,
-	Underline = 0x04,
-	Outline = 0x08,
-	Shadow = 0x10,
-	Condensed = 0x20,
-	Extended = 0x40
+        /// <summary>
+        /// No additional macStyle modifiers are applied to the font.
+        /// </summary>
+        None = 0x00,
+
+        /// <summary>
+        /// Indicates that the font should be rendered using a bold weight.
+        /// </summary>
+        Bold = 0x01,
+
+        /// <summary>
+        /// Indicates that the font should be rendered with italic styling.
+        /// </summary>
+        Italic = 0x02,
+
+        /// <summary>
+        /// Marks the font as supporting underlining by default.
+        /// </summary>
+        Underline = 0x04,
+
+        /// <summary>
+        /// Specifies that the font outlines should be drawn instead of filled shapes.
+        /// </summary>
+        Outline = 0x08,
+
+        /// <summary>
+        /// Applies a drop-shadow effect to the glyphs.
+        /// </summary>
+        Shadow = 0x10,
+
+        /// <summary>
+        /// Indicates a condensed version of the font with tighter spacing.
+        /// </summary>
+        Condensed = 0x20,
+
+        /// <summary>
+        /// Indicates an extended version of the font with wider spacing.
+        /// </summary>
+        Extended = 0x40
 }
 
 /// <summary>
@@ -138,7 +169,10 @@ public enum FontDirectionHintEnum : short
 [Flags]
 public enum OutlineFlags : byte
 {
-	None = 0x00,
+        /// <summary>
+        /// No outline flags are set for the point.
+        /// </summary>
+        None = 0x00,
 
 	/// <summary>
 	/// The point is on the curve (versus a control point).

--- a/Utils.Imaging/Drawing/DrawF.cs
+++ b/Utils.Imaging/Drawing/DrawF.cs
@@ -8,115 +8,335 @@ using System.Linq;
 
 namespace Utils.Drawing
 {
-	public class DrawF<T> : BaseDrawing<T>
-	{
-		public DrawI<T> Draw { get; }
-		public float Top { get; }
-		public float Left { get; }
-		public float Right { get; }
-		public float Down { get; }
+        /// <summary>
+        /// Provides floating-point drawing helpers on top of <see cref="DrawI{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of the pixel value handled by the drawing operations.</typeparam>
+        /// <remarks>
+        /// <para>
+        /// The floating-point API mirrors the integer-based <see cref="DrawI{T}"/> helpers while transparently
+        /// converting coordinates expressed in an arbitrary viewport to pixel positions.  This allows callers to
+        /// operate in normalized or physical spaces without manually performing the conversions required by the
+        /// underlying <see cref="IImageAccessor{T}"/> implementation.
+        /// </para>
+        /// <para>
+        /// All conversions clamp to the image bounds when delegated to <see cref="Draw"/>, ensuring consistency
+        /// with the low-level routines.
+        /// </para>
+        /// </remarks>
+        public class DrawF<T> : BaseDrawing<T>
+        {
+                /// <summary>
+                /// Gets the integer-based drawing helper that ultimately performs the rasterization work.
+                /// </summary>
+                public DrawI<T> Draw { get; }
 
-		private readonly float hRatio, vRatio;
-		private readonly float hPrecision, vPrecision;
+                /// <summary>
+                /// Gets the top coordinate of the drawing viewport in the caller-provided space.
+                /// </summary>
+                public float Top { get; }
 
-		public DrawF(IImageAccessor<T> imageAccessor) : this(imageAccessor, 0, 0, imageAccessor.Width, imageAccessor.Height) { }
+                /// <summary>
+                /// Gets the left coordinate of the drawing viewport in the caller-provided space.
+                /// </summary>
+                public float Left { get; }
 
-		public DrawF(IImageAccessor<T> imageAccessor, float top, float left, float right, float down) : base (imageAccessor)
-		{
-			Draw = new DrawI<T>(imageAccessor);
-			Top = top;
-			Left = left;
-			Right = right;
-			Down = down;
-			hRatio = ImageAccessor.Width / (Right - Left);
-			vRatio = ImageAccessor.Height / (Down - Top);
-			hPrecision = Math.Abs(1 / hRatio);
-			vPrecision = Math.Abs(1 / vRatio);
-		}
+                /// <summary>
+                /// Gets the right coordinate of the drawing viewport in the caller-provided space.
+                /// </summary>
+                public float Right { get; }
 
-		public Point ComputePixelPosition(PointF p) => ComputePixelPosition(p.X, p.Y);
-		public Point ComputePixelPosition(float x, float y)
-		{
-			return new Point(
-				(int)((x - Left) * hRatio),
-				(int)((y - Top) * vRatio)
-			);
-		}
+                /// <summary>
+                /// Gets the bottom coordinate of the drawing viewport in the caller-provided space.
+                /// </summary>
+                public float Down { get; }
 
-		public PointF ComputePixelPositionF(PointF p) => ComputePixelPositionF(p.X, p.Y);
-		public PointF ComputePixelPositionF(float x, float y)
-		{
-			return new PointF(
-				(x - Left) * hRatio,
-				(y - Top) * vRatio
-			);
-		}
+                private readonly float hRatio, vRatio;
+                private readonly float hPrecision, vPrecision;
 
-		#region Point
-		public PointF ComputePoint(PointF p) => ComputePoint(p.X, p.Y);
-		public PointF ComputePoint(float x, float y)
-		{
-			return new PointF(
-				x / hRatio + Left,
-				y / vRatio + Top
-			);
-		}
+                /// <summary>
+                /// Initializes a new instance of the <see cref="DrawF{T}"/> class covering the entire image.
+                /// </summary>
+                /// <param name="imageAccessor">Accessor used to manipulate the underlying image.</param>
+                /// <remarks>
+                /// The viewport matches the full image bounds so one drawing unit equals one pixel.
+                /// </remarks>
+                public DrawF(IImageAccessor<T> imageAccessor) : this(imageAccessor, 0, 0, imageAccessor.Width, imageAccessor.Height) { }
 
-		public void DrawPoint(PointF point, T color) => DrawPoint(point.X, point.Y, color);
-		public void DrawPoint(float x, float y, T color)
-		{
-			var p = ComputePixelPosition(x, y);
-			Draw.DrawPoint(p.X, p.Y, color);
-		}
+                /// <summary>
+                /// Initializes a new instance of the <see cref="DrawF{T}"/> class using a custom viewport.
+                /// </summary>
+                /// <param name="imageAccessor">Accessor used to manipulate the underlying image.</param>
+                /// <param name="top">Top boundary of the viewport.</param>
+                /// <param name="left">Left boundary of the viewport.</param>
+                /// <param name="right">Right boundary of the viewport.</param>
+                /// <param name="down">Bottom boundary of the viewport.</param>
+                /// <remarks>
+                /// The viewport boundaries define the coordinate space exposed to callers; the constructor computes
+                /// the scaling factors that map the viewport to pixel positions.
+                /// </remarks>
+                public DrawF(IImageAccessor<T> imageAccessor, float top, float left, float right, float down) : base (imageAccessor)
+                {
+                        Draw = new DrawI<T>(imageAccessor);
+                        Top = top;
+                        Left = left;
+                        Right = right;
+                        Down = down;
+                        hRatio = ImageAccessor.Width / (Right - Left);
+                        vRatio = ImageAccessor.Height / (Down - Top);
+                        hPrecision = Math.Abs(1 / hRatio);
+                        vPrecision = Math.Abs(1 / vRatio);
+                }
+
+                /// <summary>
+                /// Computes the integer pixel corresponding to the provided floating-point coordinates.
+                /// </summary>
+                /// <param name="p">Coordinates expressed in the viewport space.</param>
+                /// <returns>The integer pixel location within the image.</returns>
+                /// <remarks>
+                /// The conversion applies the viewport scaling and truncates the result to the nearest lower integer,
+                /// matching the behavior of <see cref="Math.Floor(double)"/> for positive coordinates.
+                /// </remarks>
+                public Point ComputePixelPosition(PointF p) => ComputePixelPosition(p.X, p.Y);
+
+                /// <summary>
+                /// Computes the integer pixel corresponding to the provided floating-point coordinates.
+                /// </summary>
+                /// <param name="x">Horizontal coordinate in the viewport space.</param>
+                /// <param name="y">Vertical coordinate in the viewport space.</param>
+                /// <returns>The integer pixel location within the image.</returns>
+                /// <remarks>
+                /// Values falling outside the viewport range result in negative or oversized pixel indices; the
+                /// downstream <see cref="Draw"/> helper clamps them to the image dimensions when actually drawing.
+                /// </remarks>
+                public Point ComputePixelPosition(float x, float y)
+                {
+                        return new Point(
+                                (int)((x - Left) * hRatio),
+                                (int)((y - Top) * vRatio)
+                        );
+                }
+
+                /// <summary>
+                /// Computes the floating-point pixel location corresponding to the provided viewport coordinates.
+                /// </summary>
+                /// <param name="p">Coordinates expressed in the viewport space.</param>
+                /// <returns>The floating-point pixel position inside the image.</returns>
+                /// <remarks>
+                /// The method preserves the fractional part, which is useful for anti-aliasing or sub-pixel sampling
+                /// scenarios.
+                /// </remarks>
+                public PointF ComputePixelPositionF(PointF p) => ComputePixelPositionF(p.X, p.Y);
+
+                /// <summary>
+                /// Computes the floating-point pixel location corresponding to the provided viewport coordinates.
+                /// </summary>
+                /// <param name="x">Horizontal coordinate in the viewport space.</param>
+                /// <param name="y">Vertical coordinate in the viewport space.</param>
+                /// <returns>The floating-point pixel position inside the image.</returns>
+                /// <remarks>
+                /// Unlike <see cref="ComputePixelPosition(float, float)"/>, this overload returns sub-pixel precision
+                /// so callers can implement their own interpolation strategies.
+                /// </remarks>
+                public PointF ComputePixelPositionF(float x, float y)
+                {
+                        return new PointF(
+                                (x - Left) * hRatio,
+                                (y - Top) * vRatio
+                        );
+                }
+
+                #region Point
+                /// <summary>
+                /// Converts a pixel coordinate to the viewport space.
+                /// </summary>
+                /// <param name="p">Pixel coordinate.</param>
+                /// <returns>The corresponding viewport coordinate.</returns>
+                public PointF ComputePoint(PointF p) => ComputePoint(p.X, p.Y);
+
+                /// <summary>
+                /// Converts a pixel coordinate to the viewport space.
+                /// </summary>
+                /// <param name="x">Pixel horizontal coordinate.</param>
+                /// <param name="y">Pixel vertical coordinate.</param>
+                /// <returns>The corresponding viewport coordinate.</returns>
+                public PointF ComputePoint(float x, float y)
+                {
+                        return new PointF(
+                                x / hRatio + Left,
+                                y / vRatio + Top
+                        );
+                }
+
+                /// <summary>
+                /// Draws a single point expressed in viewport coordinates.
+                /// </summary>
+                /// <param name="point">Point in viewport coordinates.</param>
+                /// <param name="color">Color to draw.</param>
+                public void DrawPoint(PointF point, T color) => DrawPoint(point.X, point.Y, color);
+
+                /// <summary>
+                /// Draws a single point expressed in viewport coordinates.
+                /// </summary>
+                /// <param name="x">Horizontal coordinate.</param>
+                /// <param name="y">Vertical coordinate.</param>
+                /// <param name="color">Color to draw.</param>
+                public void DrawPoint(float x, float y, T color)
+                {
+                        var p = ComputePixelPosition(x, y);
+                        Draw.DrawPoint(p.X, p.Y, color);
+                }
 		#endregion
-		#region Line
-		public void DrawLine(PointF p1, PointF p2, T color) => DrawLine(p1.X, p1.Y, p2.X, p2.Y, color);
-		public void DrawLine(float x1, float y1, float x2, float y2, T color)
-		{
-			var p1 = ComputePixelPosition(x1, y1);
-			var p2 = ComputePixelPosition(x2, y2);
-			Draw.DrawLine(p1, p2, color);
-		}
+                #region Line
+                /// <summary>
+                /// Draws a line between two viewport coordinates using a solid color.
+                /// </summary>
+                /// <param name="p1">Starting point in viewport coordinates.</param>
+                /// <param name="p2">Ending point in viewport coordinates.</param>
+                /// <param name="color">Color to apply.</param>
+                public void DrawLine(PointF p1, PointF p2, T color) => DrawLine(p1.X, p1.Y, p2.X, p2.Y, color);
 
-		public void DrawLine(PointF p1, PointF p2, IBrush<T> color) => DrawLine(p1.X, p1.Y, p2.X, p2.Y, color);
-		public void DrawLine(float x1, float y1, float x2, float y2, IBrush<T> color)
-		{
-			var p1 = ComputePixelPosition(x1, y1);
-			var p2 = ComputePixelPosition(x2, y2);
-			Draw.DrawLine(p1, p2, color);
-		}
+                /// <summary>
+                /// Draws a line between two viewport coordinates using a solid color.
+                /// </summary>
+                /// <param name="x1">Starting point horizontal coordinate.</param>
+                /// <param name="y1">Starting point vertical coordinate.</param>
+                /// <param name="x2">Ending point horizontal coordinate.</param>
+                /// <param name="y2">Ending point vertical coordinate.</param>
+                /// <param name="color">Color to apply.</param>
+                public void DrawLine(float x1, float y1, float x2, float y2, T color)
+                {
+                        var p1 = ComputePixelPosition(x1, y1);
+                        var p2 = ComputePixelPosition(x2, y2);
+                        Draw.DrawLine(p1, p2, color);
+                }
 
+                /// <summary>
+                /// Draws a line between two viewport coordinates using a brush.
+                /// </summary>
+                /// <param name="p1">Starting point in viewport coordinates.</param>
+                /// <param name="p2">Ending point in viewport coordinates.</param>
+                /// <param name="color">Brush providing the color values.</param>
+                public void DrawLine(PointF p1, PointF p2, IBrush<T> color) => DrawLine(p1.X, p1.Y, p2.X, p2.Y, color);
+
+                /// <summary>
+                /// Draws a line between two viewport coordinates using a brush.
+                /// </summary>
+                /// <param name="x1">Starting point horizontal coordinate.</param>
+                /// <param name="y1">Starting point vertical coordinate.</param>
+                /// <param name="x2">Ending point horizontal coordinate.</param>
+                /// <param name="y2">Ending point vertical coordinate.</param>
+                /// <param name="color">Brush providing the color values.</param>
+                public void DrawLine(float x1, float y1, float x2, float y2, IBrush<T> color)
+                {
+                        var p1 = ComputePixelPosition(x1, y1);
+                        var p2 = ComputePixelPosition(x2, y2);
+                        Draw.DrawLine(p1, p2, color);
+                }
+
+                #endregion
+                #region Bezier
+                /// <summary>
+                /// Draws a Bézier curve using viewport coordinates.
+                /// </summary>
+                /// <param name="color">Color applied to the curve.</param>
+                /// <param name="points">Control points expressed in viewport coordinates.</param>
+                public void DrawBezier(T color, params PointF[] points) => Draw.DrawBezier(color, points.Select(p => ComputePixelPosition(p)).ToArray());
+
+                //public void DrawBezier(Func<float, T> color, params PointF[] points) => Draw.DrawBezier(color, points.Select(p => ComputePixelPosition(p)).ToArray());
+                #endregion
+                #region Polygon
+                /// <summary>
+                /// Draws a polygon filled with a solid color.
+                /// </summary>
+                /// <param name="color">Color applied to the polygon.</param>
+                /// <param name="points">Polygon vertices in viewport coordinates.</param>
+                public void DrawPolygon(T color, IEnumerable<PointF> points) => Draw.DrawPolygon(color, points.Select(p => ComputePixelPosition(p)));
+                /// <summary>
+                /// Draws a polygon filled with a solid color.
+                /// </summary>
+                /// <param name="color">Color applied to the polygon.</param>
+                /// <param name="points">Polygon vertices in viewport coordinates.</param>
+                public void DrawPolygon(T color, params PointF[] points) => Draw.DrawPolygon(color, points.Select(p => ComputePixelPosition(p)).ToArray());
+                /// <summary>
+                /// Draws a polygon filled with a brush.
+                /// </summary>
+                /// <param name="color">Brush providing the polygon colors.</param>
+                /// <param name="points">Polygon vertices in viewport coordinates.</param>
+                public void DrawPolygon(IBrush<T> color, IEnumerable<PointF> points) => Draw.DrawPolygon(color, points.Select(p => ComputePixelPosition(p)));
+                /// <summary>
+                /// Draws a polygon filled with a brush.
+                /// </summary>
+                /// <param name="color">Brush providing the polygon colors.</param>
+                /// <param name="points">Polygon vertices in viewport coordinates.</param>
+                public void DrawPolygon(IBrush<T> color, params PointF[] points) => Draw.DrawPolygon(color, points.Select(p => ComputePixelPosition(p)).ToArray());
 		#endregion
-		#region Bezier
-		public void DrawBezier(T color, params PointF[] points) => Draw.DrawBezier(color, points.Select(p => ComputePixelPosition(p)).ToArray());
+                #region Circle
+                /// <summary>
+                /// Fills a circle using viewport coordinates.
+                /// </summary>
+                /// <param name="center">Center of the circle.</param>
+                /// <param name="radius">Radius of the circle.</param>
+                /// <param name="color">Color applied to the circle.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void FillCircle(PointF center, float radius, T color, double startAngle = 0, double endAngle = Math.PI * 2)
+                        => Draw.DrawEllipse(ComputePixelPosition(center), (int)(radius * hRatio), (int) (radius * vRatio), color, 0, startAngle, endAngle);
 
-		//public void DrawBezier(Func<float, T> color, params PointF[] points) => Draw.DrawBezier(color, points.Select(p => ComputePixelPosition(p)).ToArray());
-		#endregion
-		#region Polygon
-		public void DrawPolygon(T color, IEnumerable<PointF> points) => Draw.DrawPolygon(color, points.Select(p => ComputePixelPosition(p)));
-		public void DrawPolygon(T color, params PointF[] points) => Draw.DrawPolygon(color, points.Select(p => ComputePixelPosition(p)).ToArray());
-		public void DrawPolygon(IBrush<T> color, IEnumerable<PointF> points) => Draw.DrawPolygon(color, points.Select(p => ComputePixelPosition(p)));
-		public void DrawPolygon(IBrush<T> color, params PointF[] points) => Draw.DrawPolygon(color, points.Select(p => ComputePixelPosition(p)).ToArray());
-		#endregion
-		#region Circle
-		public void FillCircle(PointF center, float radius, T color, double startAngle = 0, double endAngle = Math.PI * 2)
-			=> Draw.DrawEllipse(ComputePixelPosition(center), (int)(radius * hRatio), (int) (radius * vRatio), color, 0, startAngle, endAngle); 
-		public void DrawCircle(PointF center, float radius, IBrush<T> color, double startAngle = 0, double endAngle = Math.PI * 2)
-			=> Draw.DrawEllipse(ComputePixelPosition(center), (int)(radius * hRatio), (int)(radius * vRatio), color, 0, startAngle, endAngle);
+                /// <summary>
+                /// Draws a circle outline using a brush.
+                /// </summary>
+                /// <param name="center">Center of the circle.</param>
+                /// <param name="radius">Radius of the circle.</param>
+                /// <param name="color">Brush providing the circle colors.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void DrawCircle(PointF center, float radius, IBrush<T> color, double startAngle = 0, double endAngle = Math.PI * 2)
+                        => Draw.DrawEllipse(ComputePixelPosition(center), (int)(radius * hRatio), (int)(radius * vRatio), color, 0, startAngle, endAngle);
 
-		public void DrawEllipse(PointF center, float radius1, float radius2, T color, double rotation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
-		{
-			var points = ComputeEllipsePoints(center, radius1, radius2, rotation, startAngle, endAngle);
-			Draw.DrawPolygon(color, points);
-		}
+                /// <summary>
+                /// Draws an ellipse outline with a solid color using viewport coordinates.
+                /// </summary>
+                /// <param name="center">Center of the ellipse.</param>
+                /// <param name="radius1">Radius along the horizontal axis.</param>
+                /// <param name="radius2">Radius along the vertical axis.</param>
+                /// <param name="color">Color applied to the ellipse.</param>
+                /// <param name="rotation">Rotation in radians.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void DrawEllipse(PointF center, float radius1, float radius2, T color, double rotation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
+                {
+                        var points = ComputeEllipsePoints(center, radius1, radius2, rotation, startAngle, endAngle);
+                        Draw.DrawPolygon(color, points);
+                }
 
-		public void DrawEllipse(PointF center, float radius1, float radius2, IBrush<T> color, double rotation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
-		{
-			var points = ComputeEllipsePoints(center, radius1, radius2, rotation, startAngle, endAngle);
-			Draw.DrawPolygon(color, points);
-		}
+                /// <summary>
+                /// Draws an ellipse outline with a brush using viewport coordinates.
+                /// </summary>
+                /// <param name="center">Center of the ellipse.</param>
+                /// <param name="radius1">Radius along the horizontal axis.</param>
+                /// <param name="radius2">Radius along the vertical axis.</param>
+                /// <param name="color">Brush providing the ellipse colors.</param>
+                /// <param name="rotation">Rotation in radians.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void DrawEllipse(PointF center, float radius1, float radius2, IBrush<T> color, double rotation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
+                {
+                        var points = ComputeEllipsePoints(center, radius1, radius2, rotation, startAngle, endAngle);
+                        Draw.DrawPolygon(color, points);
+                }
 
-		private IEnumerable<Point> ComputeEllipsePoints(PointF centerF, float radius1, float radius2, double rotation, double startAngle, double endAngle)
+                /// <summary>
+                /// Computes the pixel coordinates used to approximate an ellipse arc.
+                /// </summary>
+                /// <param name="centerF">Center of the ellipse in viewport coordinates.</param>
+                /// <param name="radius1">Radius along the horizontal axis.</param>
+                /// <param name="radius2">Radius along the vertical axis.</param>
+                /// <param name="rotation">Rotation in radians.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                /// <returns>A sequence of points describing the ellipse.</returns>
+                private IEnumerable<Point> ComputeEllipsePoints(PointF centerF, float radius1, float radius2, double rotation, double startAngle, double endAngle)
 		{
 			Point center = ComputePixelPosition(centerF);
 			double angle = endAngle - startAngle;
@@ -165,18 +385,39 @@ namespace Utils.Drawing
 		}
 
 		#endregion
-		#region Rectangle
-		public void FillRectangle(RectangleF r, T color)
-			=> FillRectangle(r.Top, r.Left, r.Bottom, r.Right, color);
-		public void FillRectangle(PointF p1, PointF p2, T color)
-			=> FillRectangle(p1.X, p1.Y, p2.X, p2.Y, color);
-		public void FillRectangle(float x1, float y1, float x2, float y2, T color)
-		{
-			var p1 = ComputePixelPosition(x1, y1);
-			var p2 = ComputePixelPosition(x2, y2);
-			Draw.FillRectangle(p1.X, p1.Y, p2.X, p2.Y, color);
-		}
-		#endregion
+                #region Rectangle
+                /// <summary>
+                /// Fills a rectangle defined in viewport coordinates.
+                /// </summary>
+                /// <param name="r">Rectangle to fill.</param>
+                /// <param name="color">Color applied to the rectangle.</param>
+                public void FillRectangle(RectangleF r, T color)
+                        => FillRectangle(r.Top, r.Left, r.Bottom, r.Right, color);
+
+                /// <summary>
+                /// Fills a rectangle defined by two viewport points.
+                /// </summary>
+                /// <param name="p1">First point of the rectangle.</param>
+                /// <param name="p2">Opposite corner of the rectangle.</param>
+                /// <param name="color">Color applied to the rectangle.</param>
+                public void FillRectangle(PointF p1, PointF p2, T color)
+                        => FillRectangle(p1.X, p1.Y, p2.X, p2.Y, color);
+
+                /// <summary>
+                /// Fills a rectangle defined by its viewport coordinates.
+                /// </summary>
+                /// <param name="x1">First corner horizontal coordinate.</param>
+                /// <param name="y1">First corner vertical coordinate.</param>
+                /// <param name="x2">Opposite corner horizontal coordinate.</param>
+                /// <param name="y2">Opposite corner vertical coordinate.</param>
+                /// <param name="color">Color applied to the rectangle.</param>
+                public void FillRectangle(float x1, float y1, float x2, float y2, T color)
+                {
+                        var p1 = ComputePixelPosition(x1, y1);
+                        var p2 = ComputePixelPosition(x2, y2);
+                        Draw.FillRectangle(p1.X, p1.Y, p2.X, p2.Y, color);
+                }
+                #endregion
 
 	}
 }

--- a/Utils.Imaging/Drawing/DrawI.cs
+++ b/Utils.Imaging/Drawing/DrawI.cs
@@ -11,24 +11,59 @@ using Utils.Objects;
 
 namespace Utils.Drawing
 {
-	public class DrawI<T> : BaseDrawing<T>
-	{
-		public DrawI(IImageAccessor<T> imageAccessor) : base(imageAccessor) { }
+        /// <summary>
+        /// Provides integer-based drawing helpers for image accessors.
+        /// </summary>
+        /// <typeparam name="T">Type of the pixel value handled by the drawing operations.</typeparam>
+        /// <remarks>
+        /// The <c>DrawI</c> class exposes low-level rasterization primitives.  It is intentionally conservative about
+        /// bounds checking and delegates all color decisions to <see cref="IBrush{T}"/> implementations so that higher
+        /// level helpers, such as <see cref="DrawF{T}"/>, can reuse the same pixel pipeline.
+        /// </remarks>
+        public class DrawI<T> : BaseDrawing<T>
+        {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="DrawI{T}"/> class.
+                /// </summary>
+                /// <param name="imageAccessor">Accessor used to manipulate the underlying image.</param>
+                /// <remarks>
+                /// The accessor reference is stored for the whole lifetime of the helper so that callers can perform
+                /// several drawing operations without recreating the wrapper.
+                /// </remarks>
+                public DrawI(IImageAccessor<T> imageAccessor) : base(imageAccessor) { }
 
-		#region Point
-		public void DrawPoint(Point point, T color) => DrawPoint(point.X, point.Y, color);
-		public void DrawPoint(int x, int y, T color)
-		{
-			if (x.Between(0, ImageAccessor.Width-1) && y.Between(0, ImageAccessor.Height-1))
-			{
-				ImageAccessor[x, y] = color;
-			}
-		}
+                #region Point
+                /// <summary>
+                /// Draws a single pixel.
+                /// </summary>
+                /// <param name="point">Pixel coordinates.</param>
+                /// <param name="color">Color applied to the pixel.</param>
+                public void DrawPoint(Point point, T color) => DrawPoint(point.X, point.Y, color);
 
-		private void DrawShape(IBrush<T> draw, IDrawable drawable, float width = 1)
-		{
-			draw.Reset();
-			var length = drawable.Length;
+                /// <summary>
+                /// Draws a single pixel.
+                /// </summary>
+                /// <param name="x">Horizontal coordinate.</param>
+                /// <param name="y">Vertical coordinate.</param>
+                /// <param name="color">Color applied to the pixel.</param>
+                public void DrawPoint(int x, int y, T color)
+                {
+                        if (x.Between(0, ImageAccessor.Width-1) && y.Between(0, ImageAccessor.Height-1))
+                        {
+                                ImageAccessor[x, y] = color;
+                        }
+                }
+
+                /// <summary>
+                /// Draws the provided shape using the specified brush.
+                /// </summary>
+                /// <param name="draw">Brush generating the pixels to render.</param>
+                /// <param name="drawable">Shape definition.</param>
+                /// <param name="width">Brush width.</param>
+                private void DrawShape(IBrush<T> draw, IDrawable drawable, float width = 1)
+                {
+                        draw.Reset();
+                        var length = drawable.Length;
 
 			foreach (var point in drawable.GetPoints(false))
 			{
@@ -39,13 +74,23 @@ namespace Utils.Drawing
 			}
 		}
 
-		public void FillShape1(UVMap<T> color, params IDrawable[] drawables)
-			=> FillShape1(color, (IEnumerable<IDrawable>)drawables);
+                /// <summary>
+                /// Fills shapes using the even-odd rule with a UV color mapping.
+                /// </summary>
+                /// <param name="color">Delegate providing colors for each pixel.</param>
+                /// <param name="drawables">Shapes to fill.</param>
+                public void FillShape1(UVMap<T> color, params IDrawable[] drawables)
+                        => FillShape1(color, (IEnumerable<IDrawable>)drawables);
 
-		public void FillShape1(UVMap<T> color, IEnumerable<IDrawable> drawables)
-		{
-			var points = drawables.SelectMany(d => d.GetPoints(true));
-			foreach (var linePoints in points.GroupBy(p => p.Y))
+                /// <summary>
+                /// Fills shapes using the even-odd rule with a UV color mapping.
+                /// </summary>
+                /// <param name="color">Delegate providing colors for each pixel.</param>
+                /// <param name="drawables">Shapes to fill.</param>
+                public void FillShape1(UVMap<T> color, IEnumerable<IDrawable> drawables)
+                {
+                        var points = drawables.SelectMany(d => d.GetPoints(true));
+                        foreach (var linePoints in points.GroupBy(p => p.Y))
 			{
 				var orderedPoints = linePoints.OrderBy(p => p.X);
 				int direction = 0;
@@ -63,10 +108,20 @@ namespace Utils.Drawing
 			}
 		}
 
-		public void FillShape2(UVMap<T> color, params IDrawable[] drawables) 
-			=> FillShape2(color, (IEnumerable<IDrawable>)drawables);
+                /// <summary>
+                /// Fills shapes using the non-zero winding rule with a UV color mapping.
+                /// </summary>
+                /// <param name="color">Delegate providing colors for each pixel.</param>
+                /// <param name="drawables">Shapes to fill.</param>
+                public void FillShape2(UVMap<T> color, params IDrawable[] drawables)
+                        => FillShape2(color, (IEnumerable<IDrawable>)drawables);
 
-		public void FillShape2(UVMap<T> color, IEnumerable<IDrawable> drawables)
+                /// <summary>
+                /// Fills shapes using the non-zero winding rule with a UV color mapping.
+                /// </summary>
+                /// <param name="color">Delegate providing colors for each pixel.</param>
+                /// <param name="drawables">Shapes to fill.</param>
+                public void FillShape2(UVMap<T> color, IEnumerable<IDrawable> drawables)
 		{
 			var points = drawables.SelectMany(d => d.GetPoints(true));
 			foreach (var linePoints in points.GroupBy(p => p.Y))
@@ -90,116 +145,296 @@ namespace Utils.Drawing
 		}
 
 		#endregion
-		#region Line
-		public void DrawLine(Point p1, Point p2, T color) => DrawLine(p1.X, p1.Y, p2.X, p2.Y, new MapBrush<T>(color));
-		public void DrawLine(int x1, int y1, int x2, int y2, T color) => DrawLine(x1, y1, x2, y2, new MapBrush<T>(color));
-		public void DrawLine(Point p1, Point p2, IBrush<T> color) => DrawLine(p1.X, p1.Y, p2.X, p2.Y, color);
-		public void DrawLine(int x1, int y1, int x2, int y2, IBrush<T> color)
-		{
-			var segment = new Segment(x1, y1, x2, y2);
-			DrawShape(color, segment);
+                #region Line
+                /// <summary>
+                /// Draws a line between two pixels using a solid color.
+                /// </summary>
+                /// <param name="p1">Starting point.</param>
+                /// <param name="p2">Ending point.</param>
+                /// <param name="color">Color applied to the line.</param>
+                public void DrawLine(Point p1, Point p2, T color) => DrawLine(p1.X, p1.Y, p2.X, p2.Y, new MapBrush<T>(color));
+
+                /// <summary>
+                /// Draws a line between two pixels using a solid color.
+                /// </summary>
+                /// <param name="x1">Starting point horizontal coordinate.</param>
+                /// <param name="y1">Starting point vertical coordinate.</param>
+                /// <param name="x2">Ending point horizontal coordinate.</param>
+                /// <param name="y2">Ending point vertical coordinate.</param>
+                /// <param name="color">Color applied to the line.</param>
+                public void DrawLine(int x1, int y1, int x2, int y2, T color) => DrawLine(x1, y1, x2, y2, new MapBrush<T>(color));
+
+                /// <summary>
+                /// Draws a line between two pixels using a brush.
+                /// </summary>
+                /// <param name="p1">Starting point.</param>
+                /// <param name="p2">Ending point.</param>
+                /// <param name="color">Brush providing the colors.</param>
+                public void DrawLine(Point p1, Point p2, IBrush<T> color) => DrawLine(p1.X, p1.Y, p2.X, p2.Y, color);
+
+                /// <summary>
+                /// Draws a line between two pixels using a brush.
+                /// </summary>
+                /// <param name="x1">Starting point horizontal coordinate.</param>
+                /// <param name="y1">Starting point vertical coordinate.</param>
+                /// <param name="x2">Ending point horizontal coordinate.</param>
+                /// <param name="y2">Ending point vertical coordinate.</param>
+                /// <param name="color">Brush providing the colors.</param>
+                public void DrawLine(int x1, int y1, int x2, int y2, IBrush<T> color)
+                {
+                        var segment = new Segment(x1, y1, x2, y2);
+                        DrawShape(color, segment);
 		}
 		#endregion
-		#region Bezier
-		public void DrawBezier(T color, params Point[] points) => DrawBezier(color, points.Select(p => new PointF(p.X, p.Y)).ToArray());
-		internal void DrawBezier(T color, params PointF[] points)
-		{
-			var bezier = new Bezier(points);
-			DrawShape(new MapBrush<T>(color), bezier);
-		}
+                #region Bezier
+                /// <summary>
+                /// Draws a Bézier curve using integer coordinates.
+                /// </summary>
+                /// <param name="color">Color applied to the curve.</param>
+                /// <param name="points">Control points in pixel coordinates.</param>
+                public void DrawBezier(T color, params Point[] points) => DrawBezier(color, points.Select(p => new PointF(p.X, p.Y)).ToArray());
 
-		public void DrawBezier(MapBrush<T> color, params Point[] points) => DrawBezier(color, points.Select(p => new PointF(p.X, p.Y)).ToArray());
-		internal void DrawBezier(MapBrush<T> color, params PointF[] points)
-		{
-			var bezier = new Bezier(points);
-			DrawShape(color, bezier);
-		}
+                /// <summary>
+                /// Draws a Bézier curve using floating-point coordinates.
+                /// </summary>
+                /// <param name="color">Color applied to the curve.</param>
+                /// <param name="points">Control points.</param>
+                internal void DrawBezier(T color, params PointF[] points)
+                {
+                        var bezier = new Bezier(points);
+                        DrawShape(new MapBrush<T>(color), bezier);
+                }
 
-		public void FillBezier(T color, params Point[] points) => FillBezier(color, points.Select(p => new PointF(p.X, p.Y)).ToArray());
-		internal void FillBezier(T color, params PointF[] points)
-		{
-			var bezier = new Bezier(points);
-			FillShape1((x,y) => color, bezier);
-		}
+                /// <summary>
+                /// Draws a Bézier curve using a brush.
+                /// </summary>
+                /// <param name="color">Brush providing the colors.</param>
+                /// <param name="points">Control points.</param>
+                public void DrawBezier(MapBrush<T> color, params Point[] points) => DrawBezier(color, points.Select(p => new PointF(p.X, p.Y)).ToArray());
 
-		public void FillBezier(UVMap<T> color, params Point[] points) => FillBezier(color, points.Select(p => new PointF(p.X, p.Y)).ToArray());
-		internal void FillBezier(UVMap<T> color, params PointF[] points)
+                /// <summary>
+                /// Draws a Bézier curve using a brush.
+                /// </summary>
+                /// <param name="color">Brush providing the colors.</param>
+                /// <param name="points">Control points.</param>
+                internal void DrawBezier(MapBrush<T> color, params PointF[] points)
+                {
+                        var bezier = new Bezier(points);
+                        DrawShape(color, bezier);
+                }
+
+                /// <summary>
+                /// Fills the area enclosed by a Bézier curve with a solid color.
+                /// </summary>
+                /// <param name="color">Color applied to the curve interior.</param>
+                /// <param name="points">Control points.</param>
+                public void FillBezier(T color, params Point[] points) => FillBezier(color, points.Select(p => new PointF(p.X, p.Y)).ToArray());
+
+                /// <summary>
+                /// Fills the area enclosed by a Bézier curve with a solid color.
+                /// </summary>
+                /// <param name="color">Color applied to the curve interior.</param>
+                /// <param name="points">Control points.</param>
+                internal void FillBezier(T color, params PointF[] points)
+                {
+                        var bezier = new Bezier(points);
+                        FillShape1((x,y) => color, bezier);
+                }
+
+                /// <summary>
+                /// Fills the area enclosed by a Bézier curve using a UV mapping.
+                /// </summary>
+                /// <param name="color">Delegate providing colors for each pixel.</param>
+                /// <param name="points">Control points.</param>
+                public void FillBezier(UVMap<T> color, params Point[] points) => FillBezier(color, points.Select(p => new PointF(p.X, p.Y)).ToArray());
+
+                /// <summary>
+                /// Fills the area enclosed by a Bézier curve using a UV mapping.
+                /// </summary>
+                /// <param name="color">Delegate providing colors for each pixel.</param>
+                /// <param name="points">Control points.</param>
+                internal void FillBezier(UVMap<T> color, params PointF[] points)
 		{
 			var bezier = new Bezier(points);
 			FillShape1(color, bezier);
 		}
 
 		#endregion
-		#region Polygon
-		public void DrawPolygon(T color, IEnumerable<Point> points) => DrawPolygon(color, points.ToArray());
-		public void DrawPolygon(T color, params Point[] points)
-		{
-			Polygon polygon = new Polygon(points.Select(p=>(PointF)p));
-			DrawShape(new MapBrush<T>(color), polygon);
-		}
+                #region Polygon
+                /// <summary>
+                /// Draws a polygon filled with a solid color.
+                /// </summary>
+                /// <param name="color">Color applied to the polygon.</param>
+                /// <param name="points">Polygon vertices.</param>
+                public void DrawPolygon(T color, IEnumerable<Point> points) => DrawPolygon(color, points.ToArray());
 
-		public void DrawPolygon(IBrush<T> color, IEnumerable<Point> points) => DrawPolygon(color, points.ToArray());
-		public void DrawPolygon(IBrush<T> color, params Point[] points)
-		{
-			Polygon polygon = new Polygon(points.Select(p => (PointF)p));
-			DrawShape(color, polygon);
-		}
+                /// <summary>
+                /// Draws a polygon filled with a solid color.
+                /// </summary>
+                /// <param name="color">Color applied to the polygon.</param>
+                /// <param name="points">Polygon vertices.</param>
+                public void DrawPolygon(T color, params Point[] points)
+                {
+                        Polygon polygon = new Polygon(points.Select(p=>(PointF)p));
+                        DrawShape(new MapBrush<T>(color), polygon);
+                }
 
-		public void FillPolygon1(T color, params Point[] points)
-		{
-			Polygon polygon = new Polygon(points.Select(p => (PointF)p));
-			FillShape1((x, y) => color, polygon);
-		}
+                /// <summary>
+                /// Draws a polygon filled with a brush.
+                /// </summary>
+                /// <param name="color">Brush providing the polygon colors.</param>
+                /// <param name="points">Polygon vertices.</param>
+                public void DrawPolygon(IBrush<T> color, IEnumerable<Point> points) => DrawPolygon(color, points.ToArray());
 
-		public void FillPolygon2(T color, params Point[] points)
-		{
-			Polygon polygon = new Polygon(points.Select(p => (PointF)p));
-			FillShape2((x, y) => color, polygon);
-		}
+                /// <summary>
+                /// Draws a polygon filled with a brush.
+                /// </summary>
+                /// <param name="color">Brush providing the polygon colors.</param>
+                /// <param name="points">Polygon vertices.</param>
+                public void DrawPolygon(IBrush<T> color, params Point[] points)
+                {
+                        Polygon polygon = new Polygon(points.Select(p => (PointF)p));
+                        DrawShape(color, polygon);
+                }
+
+                /// <summary>
+                /// Fills a polygon using the even-odd rule and a solid color.
+                /// </summary>
+                /// <param name="color">Color applied to the polygon interior.</param>
+                /// <param name="points">Polygon vertices.</param>
+                public void FillPolygon1(T color, params Point[] points)
+                {
+                        Polygon polygon = new Polygon(points.Select(p => (PointF)p));
+                        FillShape1((x, y) => color, polygon);
+                }
+
+                /// <summary>
+                /// Fills a polygon using the non-zero winding rule and a solid color.
+                /// </summary>
+                /// <param name="color">Color applied to the polygon interior.</param>
+                /// <param name="points">Polygon vertices.</param>
+                public void FillPolygon2(T color, params Point[] points)
+                {
+                        Polygon polygon = new Polygon(points.Select(p => (PointF)p));
+                        FillShape2((x, y) => color, polygon);
+                }
 
 		#endregion
-		#region Circle
-		public void FillCircle(Point center, int radius, T color, double startAngle = 0, double endAngle = Math.PI * 2)
-		{
-			var ellipse = new Circle(center, radius, startAngle, endAngle);
-			FillShape1((x, y) => color, ellipse);
-		}
+                #region Circle
+                /// <summary>
+                /// Fills a circular arc with a solid color.
+                /// </summary>
+                /// <param name="center">Center of the circle.</param>
+                /// <param name="radius">Circle radius in pixels.</param>
+                /// <param name="color">Color applied to the circle interior.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void FillCircle(Point center, int radius, T color, double startAngle = 0, double endAngle = Math.PI * 2)
+                {
+                        var ellipse = new Circle(center, radius, startAngle, endAngle);
+                        FillShape1((x, y) => color, ellipse);
+                }
 
-		public void FillCircle(Point center, int radius, UVMap<T> color, double startAngle = 0, double endAngle = Math.PI * 2)
-		{
-			var ellipse = new Circle(center, radius, startAngle, endAngle);
-			FillShape1(color, ellipse);
-		}
+                /// <summary>
+                /// Fills a circular arc using a UV color mapping.
+                /// </summary>
+                /// <param name="center">Center of the circle.</param>
+                /// <param name="radius">Circle radius in pixels.</param>
+                /// <param name="color">Delegate providing colors for each pixel.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void FillCircle(Point center, int radius, UVMap<T> color, double startAngle = 0, double endAngle = Math.PI * 2)
+                {
+                        var ellipse = new Circle(center, radius, startAngle, endAngle);
+                        FillShape1(color, ellipse);
+                }
 
-		public void DrawCircle(Point center, int radius, T color, double startAngle = 0, double endAngle = Math.PI * 2) 
-			=> DrawEllipse(center, radius, radius, color, 0, startAngle, endAngle);
+                /// <summary>
+                /// Draws a circle outline with a solid color.
+                /// </summary>
+                /// <param name="center">Center of the circle.</param>
+                /// <param name="radius">Circle radius in pixels.</param>
+                /// <param name="color">Color applied to the circle outline.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void DrawCircle(Point center, int radius, T color, double startAngle = 0, double endAngle = Math.PI * 2)
+                        => DrawEllipse(center, radius, radius, color, 0, startAngle, endAngle);
 
-		public void DrawCircle(Point center, int radius, IBrush<T> color, double startAngle = 0, double endAngle = Math.PI * 2) 
-			=> DrawEllipse(center, radius, radius, color, 0, startAngle, endAngle);
+                /// <summary>
+                /// Draws a circle outline with a brush.
+                /// </summary>
+                /// <param name="center">Center of the circle.</param>
+                /// <param name="radius">Circle radius in pixels.</param>
+                /// <param name="color">Brush providing the circle colors.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void DrawCircle(Point center, int radius, IBrush<T> color, double startAngle = 0, double endAngle = Math.PI * 2)
+                        => DrawEllipse(center, radius, radius, color, 0, startAngle, endAngle);
 
-		public void DrawEllipse(Point center, int radius1, int radius2, T color, double orientation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
-		{
-			var ellipse = new Circle(center, radius1, radius2, orientation, startAngle, endAngle);
-			DrawShape(new MapBrush<T>(color), ellipse);
-		}
+                /// <summary>
+                /// Draws an ellipse outline with a solid color.
+                /// </summary>
+                /// <param name="center">Center of the ellipse.</param>
+                /// <param name="radius1">Horizontal radius in pixels.</param>
+                /// <param name="radius2">Vertical radius in pixels.</param>
+                /// <param name="color">Color applied to the ellipse outline.</param>
+                /// <param name="orientation">Ellipse rotation in radians.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void DrawEllipse(Point center, int radius1, int radius2, T color, double orientation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
+                {
+                        var ellipse = new Circle(center, radius1, radius2, orientation, startAngle, endAngle);
+                        DrawShape(new MapBrush<T>(color), ellipse);
+                }
 
-		public void DrawEllipse(Point center, int radius1, int radius2, IBrush<T> color, double orientation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
-		{
-			var ellipse = new Circle(center, radius1, radius2, orientation, startAngle, endAngle);
-			DrawShape(color, ellipse);
-		}
+                /// <summary>
+                /// Draws an ellipse outline with a brush.
+                /// </summary>
+                /// <param name="center">Center of the ellipse.</param>
+                /// <param name="radius1">Horizontal radius in pixels.</param>
+                /// <param name="radius2">Vertical radius in pixels.</param>
+                /// <param name="color">Brush providing the ellipse colors.</param>
+                /// <param name="orientation">Ellipse rotation in radians.</param>
+                /// <param name="startAngle">Start angle in radians.</param>
+                /// <param name="endAngle">End angle in radians.</param>
+                public void DrawEllipse(Point center, int radius1, int radius2, IBrush<T> color, double orientation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
+                {
+                        var ellipse = new Circle(center, radius1, radius2, orientation, startAngle, endAngle);
+                        DrawShape(color, ellipse);
+                }
 
-		#endregion
-		#region Rectangle
-		public void FillRectangle(Rectangle r, T color)
-			=> FillRectangle(r.Top, r.Left, r.Bottom, r.Right, color);
-		public void FillRectangle(Point p1, Point p2, T color)
-			=> FillRectangle(p1.X, p1.Y, p2.X, p2.Y, color);
-		public void FillRectangle(int x1, int y1, int x2, int y2, T color)
-		{
-			FillPolygon1(color, new Point(x1, y1), new Point(x2, y1), new Point(x2, y2), new Point(x1, y2));
-		}
-		#endregion
+                #endregion
+                #region Rectangle
+                /// <summary>
+                /// Fills a rectangle with a solid color.
+                /// </summary>
+                /// <param name="r">Rectangle to fill.</param>
+                /// <param name="color">Color applied to the rectangle.</param>
+                public void FillRectangle(Rectangle r, T color)
+                        => FillRectangle(r.Top, r.Left, r.Bottom, r.Right, color);
+
+                /// <summary>
+                /// Fills a rectangle with a solid color.
+                /// </summary>
+                /// <param name="p1">First corner of the rectangle.</param>
+                /// <param name="p2">Opposite corner of the rectangle.</param>
+                /// <param name="color">Color applied to the rectangle.</param>
+                public void FillRectangle(Point p1, Point p2, T color)
+                        => FillRectangle(p1.X, p1.Y, p2.X, p2.Y, color);
+
+                /// <summary>
+                /// Fills a rectangle with a solid color.
+                /// </summary>
+                /// <param name="x1">First corner horizontal coordinate.</param>
+                /// <param name="y1">First corner vertical coordinate.</param>
+                /// <param name="x2">Opposite corner horizontal coordinate.</param>
+                /// <param name="y2">Opposite corner vertical coordinate.</param>
+                /// <param name="color">Color applied to the rectangle.</param>
+                public void FillRectangle(int x1, int y1, int x2, int y2, T color)
+                {
+                        FillPolygon1(color, new Point(x1, y1), new Point(x2, y1), new Point(x2, y2), new Point(x1, y2));
+                }
+                #endregion
 
 	}
 }

--- a/Utils.Imaging/Drawing/DrawPoint.cs
+++ b/Utils.Imaging/Drawing/DrawPoint.cs
@@ -1,54 +1,107 @@
-﻿namespace Utils.Drawing
+namespace Utils.Drawing
 {
-	public class DrawPoint
-	{
-		public DrawPoint(int x, int y, int horizontalDirection, int verticalDirection, float sin, float cos, float position)
-		{
-			X = x;
-			Y = y;
-			HorizontalDirection = horizontalDirection;
-			VerticalDirection = verticalDirection;
-			Sin = sin;
-			Cos = cos;
-			Position = position;
-		}
+        /// <summary>
+        /// Represents a sampled point produced by a drawing algorithm.
+        /// </summary>
+        /// <remarks>
+        /// Instances carry both spatial information and the derivative of the drawing trajectory.  The directional
+        /// metadata is required by flood-fill and polygon filling routines to determine winding and sweep direction.
+        /// </remarks>
+        public class DrawPoint
+        {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="DrawPoint"/> class.
+                /// </summary>
+                /// <param name="x">Horizontal coordinate.</param>
+                /// <param name="y">Vertical coordinate.</param>
+                /// <param name="horizontalDirection">Horizontal direction of the drawing step.</param>
+                /// <param name="verticalDirection">Vertical direction of the drawing step.</param>
+                /// <param name="sin">Sine of the drawing direction.</param>
+                /// <param name="cos">Cosine of the drawing direction.</param>
+                /// <param name="position">Normalized position along the drawing.</param>
+                /// <remarks>
+                /// The sine and cosine values are precomputed so that consumers can derive tangents without recomputing
+                /// trigonometric functions for every pixel.
+                /// </remarks>
+                public DrawPoint(int x, int y, int horizontalDirection, int verticalDirection, float sin, float cos, float position)
+                {
+                        X = x;
+                        Y = y;
+                        HorizontalDirection = horizontalDirection;
+                        VerticalDirection = verticalDirection;
+                        Sin = sin;
+                        Cos = cos;
+                        Position = position;
+                }
 
-		public int X { get; }
-		public int Y { get; }
-		public int HorizontalDirection { get; }
-		public int VerticalDirection { get; }
-		public float Sin { get; }
-		public float Cos { get; }
-		public float Position { get; }
+                /// <summary>
+                /// Gets the horizontal coordinate.
+                /// </summary>
+                public int X { get; }
 
-		public override string ToString() {
-			string vDir, hDir;
-			switch (HorizontalDirection)
-			{
-				case -1:
-					hDir = "◄";
-					break;
-				case 1:
-					hDir = "►";
-					break;
-				default:
-					hDir = " ";
-					break;
-			}
-			switch (VerticalDirection)
-			{
-				case -1:
-					vDir = "▲";
-					break;
-				case 1:
-					vDir = "▼";
-					break;
-				default:
-					vDir = " ";
-					break;
-			}
+                /// <summary>
+                /// Gets the vertical coordinate.
+                /// </summary>
+                public int Y { get; }
 
-			return $"X={X},Y={Y} (P={Position}{hDir}{vDir})";
-		}
-	}
+                /// <summary>
+                /// Gets the horizontal direction of the drawing step.
+                /// </summary>
+                public int HorizontalDirection { get; }
+
+                /// <summary>
+                /// Gets the vertical direction of the drawing step.
+                /// </summary>
+                public int VerticalDirection { get; }
+
+                /// <summary>
+                /// Gets the sine of the drawing direction.
+                /// </summary>
+                public float Sin { get; }
+
+                /// <summary>
+                /// Gets the cosine of the drawing direction.
+                /// </summary>
+                public float Cos { get; }
+
+                /// <summary>
+                /// Gets the normalized position along the drawing.
+                /// </summary>
+                public float Position { get; }
+
+                /// <summary>
+                /// Returns a textual representation of the point.
+                /// </summary>
+                /// <returns>Text describing the position and directions.</returns>
+                public override string ToString()
+                {
+                        string vDir, hDir;
+                        switch (HorizontalDirection)
+                        {
+                                case -1:
+                                        hDir = "◄";
+                                        break;
+                                case 1:
+                                        hDir = "►";
+                                        break;
+                                default:
+                                        hDir = " ";
+                                        break;
+                        }
+                        switch (VerticalDirection)
+                        {
+                                case -1:
+                                        vDir = "▲";
+                                        break;
+                                case 1:
+                                        vDir = "▼";
+                                        break;
+                                default:
+                                        vDir = " ";
+                                        break;
+                        }
+
+                        return $"X={X},Y={Y} (P={Position}{hDir}{vDir})";
+                }
+        }
 }

--- a/Utils.Imaging/Imaging/ColorArgb64.cs
+++ b/Utils.Imaging/Imaging/ColorArgb64.cs
@@ -6,10 +6,10 @@ using Utils.Mathematics;
 namespace Utils.Imaging;
 
 
-[StructLayout(LayoutKind.Explicit)]
 /// <summary>
 /// Represents a 64-bit ARGB color using 16-bit components.
 /// </summary>
+[StructLayout(LayoutKind.Explicit)]
 public struct ColorArgb64 : IColorArgb<ushort>, IEquatable<ColorArgb64>, IEqualityOperators<ColorArgb64, ColorArgb64, bool>
 {
 	public static ushort MinValue { get; } = 0;
@@ -57,60 +57,102 @@ public struct ColorArgb64 : IColorArgb<ushort>, IEquatable<ColorArgb64>, IEquali
 		set { this.blue = value; }
 	}
 
-	public ColorArgb64(ulong color) : this()
-	{
-		this.value = color;
-	}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorArgb64"/> struct from a 64-bit packed ARGB value.
+        /// </summary>
+        /// <param name="color">The packed ARGB value containing four 16-bit components.</param>
+        public ColorArgb64(ulong color) : this()
+        {
+                this.value = color;
+        }
 
-	public ColorArgb64(uint color) : this()
-	{
-		this.alpha = (ushort)(0xFF00 & color >> 16);
-		this.red = (ushort)(0xFF00 & color >> 8);
-		this.green = (ushort)(0xFF00 & color);
-		this.blue = (ushort)(0xFF00 & color << 8);
-	}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorArgb64"/> struct from a 32-bit packed ARGB value.
+        /// </summary>
+        /// <param name="color">The packed ARGB value containing four 8-bit components.</param>
+        public ColorArgb64(uint color) : this()
+        {
+                this.alpha = (ushort)(0xFF00 & color >> 16);
+                this.red = (ushort)(0xFF00 & color >> 8);
+                this.green = (ushort)(0xFF00 & color);
+                this.blue = (ushort)(0xFF00 & color << 8);
+        }
 
-	public ColorArgb64(ColorArgb colorArgb) : this()
-	{
-		this.alpha = (ushort)(colorArgb.Alpha * 65535);
-		this.red = (ushort)(colorArgb.Red * 65535);
-		this.green = (ushort)(colorArgb.Green * 65535);
-		this.blue = (ushort)(colorArgb.Blue * 65535);
-	}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorArgb64"/> struct from a floating-point color.
+        /// </summary>
+        /// <param name="colorArgb">The floating-point color whose channels are scaled to 16 bits.</param>
+        public ColorArgb64(ColorArgb colorArgb) : this()
+        {
+                this.alpha = (ushort)(colorArgb.Alpha * 65535);
+                this.red = (ushort)(colorArgb.Red * 65535);
+                this.green = (ushort)(colorArgb.Green * 65535);
+                this.blue = (ushort)(colorArgb.Blue * 65535);
+        }
 
-	public ColorArgb64(ColorArgb32 colorArgb32) : this()
-	{
-		this.alpha = (ushort)(colorArgb32.Alpha << 8);
-		this.red = (ushort)(colorArgb32.Red << 8);
-		this.green = (ushort)(colorArgb32.Green << 8);
-		this.blue = (ushort)(colorArgb32.Blue << 8);
-	}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorArgb64"/> struct from an 8-bit color.
+        /// </summary>
+        /// <param name="colorArgb32">The 8-bit color whose channels are expanded to 16 bits.</param>
+        public ColorArgb64(ColorArgb32 colorArgb32) : this()
+        {
+                this.alpha = (ushort)(colorArgb32.Alpha << 8);
+                this.red = (ushort)(colorArgb32.Red << 8);
+                this.green = (ushort)(colorArgb32.Green << 8);
+                this.blue = (ushort)(colorArgb32.Blue << 8);
+        }
 
-	public ColorArgb64(System.Drawing.Color color) : this()
-	{
-		this.alpha = (ushort)(color.A << 8);
-		this.red = (ushort)(color.R << 8);
-		this.green = (ushort)(color.G << 8);
-		this.blue = (ushort)(color.B << 8);
-	}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorArgb64"/> struct from a <see cref="System.Drawing.Color"/> value.
+        /// </summary>
+        /// <param name="color">The color whose channels are expanded to 16 bits.</param>
+        public ColorArgb64(System.Drawing.Color color) : this()
+        {
+                this.alpha = (ushort)(color.A << 8);
+                this.red = (ushort)(color.R << 8);
+                this.green = (ushort)(color.G << 8);
+                this.blue = (ushort)(color.B << 8);
+        }
 
-	public ColorArgb64(ushort red, ushort green, ushort blue) : this(ushort.MaxValue, red, green, blue) { }
-	public ColorArgb64(ushort alpha, ushort red, ushort green, ushort blue) : this()
-	{
-		this.alpha = alpha;
-		this.red = red;
-		this.green = green;
-		this.blue = blue;
-	}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorArgb64"/> struct using explicit RGB components.
+        /// </summary>
+        /// <param name="red">The red component of the color.</param>
+        /// <param name="green">The green component of the color.</param>
+        /// <param name="blue">The blue component of the color.</param>
+        public ColorArgb64(ushort red, ushort green, ushort blue) : this(ushort.MaxValue, red, green, blue) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorArgb64"/> struct using explicit ARGB components.
+        /// </summary>
+        /// <param name="alpha">The alpha component of the color.</param>
+        /// <param name="red">The red component of the color.</param>
+        /// <param name="green">The green component of the color.</param>
+        /// <param name="blue">The blue component of the color.</param>
+        public ColorArgb64(ushort alpha, ushort red, ushort green, ushort blue) : this()
+        {
+                this.alpha = alpha;
+                this.red = red;
+                this.green = green;
+                this.blue = blue;
+        }
 
-	public ColorArgb64(ushort[] array, int index) : this()
-	{
-		this.alpha = array[index];
-		this.red = array[index + 1];
-		this.green = array[index + 2];
-		this.blue = array[index + 3];
-	}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorArgb64"/> struct from an array of channel values.
+        /// </summary>
+        /// <param name="array">The array containing ARGB components.</param>
+        /// <param name="index">The starting index of the alpha component in the array.</param>
+        public ColorArgb64(ushort[] array, int index) : this()
+        {
+                this.alpha = array[index];
+                this.red = array[index + 1];
+                this.green = array[index + 2];
+                this.blue = array[index + 3];
+        }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorArgb64"/> struct from an HSV color representation.
+        /// </summary>
+        /// <param name="colorAHSV">The HSV color converted to the ARGB representation.</param>
         public ColorArgb64(ColorAhsv64 colorAHSV) : this()
         {
                 this = colorAHSV.ToArgbColor();
@@ -135,49 +177,101 @@ public struct ColorArgb64 : IColorArgb<ushort>, IEquatable<ColorArgb64>, IEquali
         /// </summary>
         public static bool operator !=(ColorArgb64 left, ColorArgb64 right) => !left.Equals(right);
 
-	public static implicit operator ColorArgb64(ColorArgb color) => new ColorArgb64(color);
-	public static implicit operator ColorArgb64(ColorArgb32 color) => new ColorArgb64(color);
-	public static implicit operator ColorArgb64(System.Drawing.Color color) => new ColorArgb64(color);
+        /// <summary>
+        /// Creates a <see cref="ColorArgb64"/> instance from a floating-point color.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>A <see cref="ColorArgb64"/> with 16-bit components.</returns>
+        public static implicit operator ColorArgb64(ColorArgb color) => new ColorArgb64(color);
 
-	public override string ToString() => $"a:{alpha} R:{red} G:{green} B:{blue}";
+        /// <summary>
+        /// Creates a <see cref="ColorArgb64"/> instance from an 8-bit per channel color.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>A <see cref="ColorArgb64"/> with 16-bit components.</returns>
+        public static implicit operator ColorArgb64(ColorArgb32 color) => new ColorArgb64(color);
 
-	private ColorArgb64 BuildColor(
-		IColorArgb<ushort> other,
-		Func<ushort, ushort, ushort> alphaFunction,
-		Func<ushort, ushort, ushort, ushort, ushort, ushort> colorFunction)
-	{
-		ushort computedAlpha = alphaFunction(this.Alpha, other.Alpha);
-		if (computedAlpha == 0) return new ColorArgb64(0);
-		return new ColorArgb64(
-				alpha,
-				colorFunction(computedAlpha, this.Alpha, other.Alpha, this.Red, other.Alpha),
-				colorFunction(computedAlpha, this.Alpha, other.Alpha, this.Green, other.Red),
-				colorFunction(computedAlpha, this.Alpha, other.Alpha, this.Blue, other.Blue)
-			);
-	}
+        /// <summary>
+        /// Creates a <see cref="ColorArgb64"/> instance from a <see cref="System.Drawing.Color"/> value.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>A <see cref="ColorArgb64"/> with 16-bit components.</returns>
+        public static implicit operator ColorArgb64(System.Drawing.Color color) => new ColorArgb64(color);
 
-	public IColorArgb<ushort> Over(IColorArgb<ushort> other)
-	{
-		return BuildColor(
-			other,
-			(thisAlpha, otherAlpha) => (ushort)(thisAlpha + (ushort.MaxValue - thisAlpha) * otherAlpha / ushort.MaxValue),
-			(alpha, thisAlpha, otherAlpha, thisComponent, otherComponent) => (ushort)(thisComponent * thisAlpha + (ushort.MaxValue - thisAlpha) * otherComponent / ushort.MaxValue));
-	}
+        /// <summary>
+        /// Returns a textual representation of the color components.
+        /// </summary>
+        /// <returns>A string describing the ARGB components.</returns>
+        public override string ToString() => $"a:{alpha} R:{red} G:{green} B:{blue}";
 
-	public IColorArgb<ushort> Add(IColorArgb<ushort> other)
-	{
-		return BuildColor(
-			other,
-			(thisAlpha, otherAlpha) => (ushort)Math.Sqrt(thisAlpha * otherAlpha),
-			(alpha, thisAlpha, otherAlpha, thisComponent, otherComponent) => (ushort)((thisComponent * thisAlpha + otherComponent * otherAlpha) / (thisAlpha + otherAlpha))
-		);
-	}
+        /// <summary>
+        /// Creates a new color by combining this color with another one using provided blending functions.
+        /// </summary>
+        /// <param name="other">The color blended with the current instance.</param>
+        /// <param name="alphaFunction">Function computing the resulting alpha component.</param>
+        /// <param name="colorFunction">Function computing a resulting color component.</param>
+        /// <returns>The blended color produced by the supplied delegates.</returns>
+        private ColorArgb64 BuildColor(
+                IColorArgb<ushort> other,
+                Func<ushort, ushort, ushort> alphaFunction,
+                Func<ushort, ushort, ushort, ushort, ushort, ushort> colorFunction)
+        {
+                ushort computedAlpha = alphaFunction(this.Alpha, other.Alpha);
+                if (computedAlpha == 0) return new ColorArgb64(0);
+                return new ColorArgb64(
+                                computedAlpha,
+                                colorFunction(computedAlpha, this.Alpha, other.Alpha, this.Red, other.Red),
+                                colorFunction(computedAlpha, this.Alpha, other.Alpha, this.Green, other.Green),
+                                colorFunction(computedAlpha, this.Alpha, other.Alpha, this.Blue, other.Blue)
+                        );
+        }
 
-	public IColorArgb<ushort> Substract(IColorArgb<ushort> other)
-	{
-		return new ColorArgb64(
-						MathEx.Min(this.Alpha, other.Alpha),
-						MathEx.Min(this.Red, other.Red),
+        /// <summary>
+        /// Applies standard alpha compositing with another color placed underneath the current one.
+        /// </summary>
+        /// <param name="other">The background color.</param>
+        /// <returns>The result of the over compositing operation.</returns>
+        public IColorArgb<ushort> Over(IColorArgb<ushort> other)
+        {
+                return BuildColor(
+                        other,
+                        (thisAlpha, otherAlpha) => (ushort)(thisAlpha + (ushort.MaxValue - thisAlpha) * otherAlpha / ushort.MaxValue),
+                        (alpha, thisAlpha, otherAlpha, thisComponent, otherComponent) =>
+                        {
+                                double numerator = (double)thisComponent * thisAlpha + (double)(ushort.MaxValue - thisAlpha) * otherComponent;
+                                return (ushort)(numerator / ushort.MaxValue);
+                        });
+        }
+
+        /// <summary>
+        /// Combines this color with another one by averaging the components using the alphas as weights.
+        /// </summary>
+        /// <param name="other">The color blended with the current instance.</param>
+        /// <returns>The blended color.</returns>
+        public IColorArgb<ushort> Add(IColorArgb<ushort> other)
+        {
+                return BuildColor(
+                        other,
+                        (thisAlpha, otherAlpha) => (ushort)Math.Sqrt((double)thisAlpha * otherAlpha),
+                        (alpha, thisAlpha, otherAlpha, thisComponent, otherComponent) =>
+                        {
+                                double numerator = (double)thisComponent * thisAlpha + (double)otherComponent * otherAlpha;
+                                double denominator = thisAlpha + otherAlpha;
+                                return denominator == 0 ? (ushort)0 : (ushort)(numerator / denominator);
+                        }
+                );
+        }
+
+        /// <summary>
+        /// Subtracts each component of another color from the current one using a minimum operator.
+        /// </summary>
+        /// <param name="other">The color to subtract.</param>
+        /// <returns>The resulting color containing the minimum components.</returns>
+        public IColorArgb<ushort> Substract(IColorArgb<ushort> other)
+        {
+                return new ColorArgb64(
+                                                MathEx.Min(this.Alpha, other.Alpha),
+                                                MathEx.Min(this.Red, other.Red),
 						MathEx.Min(this.Green, other.Green),
 						MathEx.Min(this.Blue, other.Blue)
 				);

--- a/Utils/Collections/DictionaryExtensions.cs
+++ b/Utils/Collections/DictionaryExtensions.cs
@@ -5,6 +5,9 @@ using System.Runtime.InteropServices;
 
 namespace Utils.Collections;
 
+/// <summary>
+/// Provides thread-safe helper methods for working with <see cref="Dictionary{TKey, TValue}"/> instances.
+/// </summary>
 public static class DictionaryExtensions
 {
     /// <summary>

--- a/Utils/Format/CustomFormatter.cs
+++ b/Utils/Format/CustomFormatter.cs
@@ -8,12 +8,29 @@ using System.Threading.Tasks;
 
 namespace Utils.Format;
 
+/// <summary>
+/// Provides a customisable <see cref="ICustomFormatter"/> implementation backed by delegates registered per type.
+/// </summary>
 public class CustomFormatter : NullFormatter
 {
-    private readonly IDictionary<Type, IDictionary <string, Func<object, IFormatProvider, string>>> typeFormatters = new Dictionary<Type, IDictionary<string, Func<object, IFormatProvider, string>>>();
+    private readonly IDictionary<Type, IDictionary<string, Func<object, IFormatProvider, string>>> typeFormatters =
+        new Dictionary<Type, IDictionary<string, Func<object, IFormatProvider, string>>>();
 
-    public CustomFormatter() { }
-    public CustomFormatter (CultureInfo CultureInfo) : base (CultureInfo) { }
+    /// <summary>
+    /// Initialises a new instance of the <see cref="CustomFormatter"/> class using the current culture.
+    /// </summary>
+    public CustomFormatter()
+    {
+    }
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="CustomFormatter"/> class.
+    /// </summary>
+    /// <param name="cultureInfo">The culture to use for formatting operations.</param>
+    public CustomFormatter(CultureInfo cultureInfo)
+        : base(cultureInfo)
+    {
+    }
 
     /// <summary>
     /// Add a custom format
@@ -26,6 +43,7 @@ public class CustomFormatter : NullFormatter
         if (!typeFormatters.TryGetValue(typeof(T), out var formatters))
         {
             formatters = new Dictionary<string, Func<object, IFormatProvider, string>>();
+            typeFormatters[typeof(T)] = formatters;
         }
         formatters[format] = (object o, IFormatProvider formatProvider) => formatter((T)o);
     }
@@ -41,21 +59,27 @@ public class CustomFormatter : NullFormatter
         if (!typeFormatters.TryGetValue(typeof(T), out var formatters))
         {
             formatters = new Dictionary<string, Func<object, IFormatProvider, string>>();
+            typeFormatters[typeof(T)] = formatters;
         }
         formatters[format] = (object o, IFormatProvider formatProvider) => formatter((T)o, formatProvider);
     }
 
     /// <summary>
-    /// format a string using the format identifier
+    /// Formats a string using the registered formatter for the argument type.
     /// </summary>
     /// <param name="format">Format identifier</param>
     /// <param name="arg">Object to be formatted</param>
     /// <param name="formatProvider">format provider</param>
-    /// <returns></returns>
+    /// <returns>The formatted string, or the base formatting when no formatter matches.</returns>
     public override string Format(string format, object arg, IFormatProvider formatProvider)
     {
         formatProvider ??= CultureInfo;
         if (arg is null) return "";
+        if (format is null)
+        {
+            return base.Format(format, arg, formatProvider);
+        }
+
         if (typeFormatters.TryGetValue(arg.GetType(), out var formatters) && formatters.TryGetValue(format, out var formatter))
         {
             return formatter(arg, formatProvider);
@@ -66,31 +90,63 @@ public class CustomFormatter : NullFormatter
 }
 
 
+/// <summary>
+/// Provides a minimal <see cref="ICustomFormatter"/> that forwards formatting to the wrapped provider or <see cref="object.ToString()"/>.
+/// </summary>
 public class NullFormatter : IFormatProvider, ICustomFormatter
 {
-public static NullFormatter Default { get; } = new NullFormatter();
+    /// <summary>
+    /// Gets a reusable instance of <see cref="NullFormatter"/> that uses the current culture.
+    /// </summary>
+    public static NullFormatter Default { get; } = new NullFormatter();
 
-public CultureInfo CultureInfo { get; }
+    /// <summary>
+    /// Gets the culture used when no explicit provider is supplied.
+    /// </summary>
+    public CultureInfo CultureInfo { get; }
 
-public NullFormatter() : this (CultureInfo.CurrentCulture) { }
-public NullFormatter(CultureInfo cultureInfo)
-{
-    CultureInfo = cultureInfo;
-}
+    /// <summary>
+    /// Initialises a new instance of the <see cref="NullFormatter"/> class using the current culture.
+    /// </summary>
+    public NullFormatter()
+        : this(CultureInfo.CurrentCulture)
+    {
+    }
 
-public object GetFormat(Type formatType)
-{
-    if (formatType == typeof(ICustomFormatter))
-        return this;
-    else
+    /// <summary>
+    /// Initialises a new instance of the <see cref="NullFormatter"/> class.
+    /// </summary>
+    /// <param name="cultureInfo">The culture to use as the default when formatting.</param>
+    public NullFormatter(CultureInfo cultureInfo)
+    {
+        CultureInfo = cultureInfo;
+    }
+
+    /// <summary>
+    /// Retrieves the format object associated with the specified type.
+    /// </summary>
+    /// <param name="formatType">The requested format type.</param>
+    /// <returns>This instance when <paramref name="formatType"/> is <see cref="ICustomFormatter"/>; otherwise <see langword="null"/>.</returns>
+    public object GetFormat(Type formatType)
+    {
+        if (formatType == typeof(ICustomFormatter))
+        {
+            return this;
+        }
+
         return null;
-}
+    }
 
+    /// <summary>
+    /// Formats the specified argument using the provided format string.
+    /// </summary>
+    /// <param name="format">The format string.</param>
+    /// <param name="arg">The value to format.</param>
+    /// <param name="formatProvider">An optional format provider.</param>
+    /// <returns>The formatted representation of <paramref name="arg"/>.</returns>
     public virtual string Format(string format, object arg, IFormatProvider formatProvider) => arg switch
     {
         IFormattable formattable => formattable.ToString(format, formatProvider ?? CultureInfo),
-        _ => arg?.ToString() ?? ""
+        _ => arg?.ToString() ?? string.Empty,
     };
-
-
 }

--- a/Utils/Format/StringFormat.cs
+++ b/Utils/Format/StringFormat.cs
@@ -192,12 +192,15 @@ namespace Utils.Format
 
 			var parametersCases = new List<Expression[]>();
 
-			if (formatter != null)
-			{
-				parametersCases.Add(
-					[literalLengthConstant, formattedCountConstant, formatter]
-				);
-			}
+                        if (formatter != null)
+                        {
+                                var formatterArgument = formatter.Type == typeof(IFormatProvider)
+                                        ? (Expression)formatter
+                                        : Expression.Convert(formatter, typeof(IFormatProvider));
+                                parametersCases.Add(
+                                        [literalLengthConstant, formattedCountConstant, formatterArgument]
+                                );
+                        }
 
 			parametersCases.Add([literalLengthConstant, formattedCountConstant]);
 			parametersCases.Add([]);

--- a/Utils/Objects/ConstrainedValue.cs
+++ b/Utils/Objects/ConstrainedValue.cs
@@ -5,20 +5,41 @@ using System.Text;
 namespace Utils.Objects;
 
 /// <summary>
-/// Base class for creating a type that automatically check at runtime its value specific constraints
+/// Base class for creating types that validate their value against runtime constraints.
 /// </summary>
-/// <typeparam name="T"></typeparam>
+/// <typeparam name="T">The wrapped value type.</typeparam>
 public abstract class ConstrainedValue<T>
 {
+    /// <summary>
+    /// Gets the validated value.
+    /// </summary>
     public T Value { get; }
-    public ConstrainedValue(T value) {
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="ConstrainedValue{T}"/> class.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    protected ConstrainedValue(T value)
+    {
         CheckValue(value);
-        Value = value; 
+        Value = value;
     }
 
+    /// <summary>
+    /// Validates the provided <paramref name="value"/> according to the derived class rules.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
     protected abstract void CheckValue(T value);
 
-    public override string ToString() { return Value.ToString(); }
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return Value?.ToString() ?? string.Empty;
+    }
 
-    public static implicit operator T (ConstrainedValue<T> constrainedValue) => constrainedValue.Value;
+    /// <summary>
+    /// Converts a <see cref="ConstrainedValue{T}"/> to its underlying <typeparamref name="T"/> value.
+    /// </summary>
+    /// <param name="constrainedValue">The constrained value to unwrap.</param>
+    public static implicit operator T(ConstrainedValue<T> constrainedValue) => constrainedValue.Value;
 }

--- a/UtilsTest/Collections/DictionaryExtensionsTests.cs
+++ b/UtilsTest/Collections/DictionaryExtensionsTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Collections;
+
+namespace UtilsTest.Collections;
+
+[TestClass]
+public class DictionaryExtensionsTests
+{
+    [TestMethod]
+    public void GetOrAddValueAddsWhenMissing()
+    {
+        var dictionary = new Dictionary<int, string>();
+
+        var first = dictionary.GetOrAdd(1, "initial");
+        var second = dictionary.GetOrAdd(1, "ignored");
+
+        Assert.AreEqual("initial", first);
+        Assert.AreEqual("initial", second);
+        Assert.AreEqual("initial", dictionary[1]);
+    }
+
+    [TestMethod]
+    public void GetOrAddFactoryInvokesFactoryOnce()
+    {
+        var dictionary = new Dictionary<int, int>();
+        int calls = 0;
+
+        int first = dictionary.GetOrAdd(2, () =>
+        {
+            calls++;
+            return 5;
+        });
+        int second = dictionary.GetOrAdd(2, () =>
+        {
+            calls++;
+            return 7;
+        });
+
+        Assert.AreEqual(5, first);
+        Assert.AreEqual(5, second);
+        Assert.AreEqual(1, calls);
+    }
+
+    [TestMethod]
+    public void TryUpdateReturnsExpectedResult()
+    {
+        var dictionary = new Dictionary<int, string>
+        {
+            { 3, "old" },
+        };
+
+        bool updated = dictionary.TryUpdate(3, "new");
+        bool notUpdated = dictionary.TryUpdate(4, "ignored");
+
+        Assert.IsTrue(updated);
+        Assert.IsFalse(notUpdated);
+        Assert.AreEqual("new", dictionary[3]);
+    }
+}

--- a/UtilsTest/Expressions/CStyleBuilderTests.cs
+++ b/UtilsTest/Expressions/CStyleBuilderTests.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Expressions.Builders;
+
+namespace UtilsTest.Expressions;
+
+[TestClass]
+public class CStyleBuilderTests
+{
+    [TestMethod]
+    public void SymbolsExposeCoreSyntaxTokens()
+    {
+        var builder = new CStyleBuilder();
+        var symbols = builder.Symbols.ToArray();
+
+        CollectionAssert.Contains(symbols, ";");
+        CollectionAssert.Contains(symbols, ",");
+        CollectionAssert.Contains(symbols, " ");
+        CollectionAssert.Contains(symbols, "=>");
+        CollectionAssert.Contains(symbols, "if");
+        CollectionAssert.Contains(symbols, "+");
+    }
+
+    [TestMethod]
+    public void TokenReadersMaintainExpectedOrder()
+    {
+        var builder = new CStyleBuilder();
+        var readers = builder.TokenReaders.ToArray();
+
+        Assert.AreEqual("TryReadInterpolatedString1", readers[0].Method.Name);
+        Assert.AreEqual("TryReadInterpolatedString2", readers[1].Method.Name);
+        Assert.AreEqual("TryReadInterpolatedString3", readers[2].Method.Name);
+        Assert.AreEqual("TryReadName", readers[3].Method.Name);
+    }
+
+    [TestMethod]
+    public void IntegerPrefixesIncludeCommonBases()
+    {
+        var builder = new CStyleBuilder();
+
+        Assert.AreEqual(16, builder.IntegerPrefixes["0x"]);
+        Assert.AreEqual(2, builder.IntegerPrefixes["0b"]);
+        Assert.AreEqual(8, builder.IntegerPrefixes["0o"]);
+    }
+
+    [TestMethod]
+    public void FollowUpExpressionBuildersIncludeAssignmentOperators()
+    {
+        var builder = new CStyleBuilder();
+
+        Assert.IsTrue(builder.FollowUpExpressionBuilder.ContainsKey("+="));
+        Assert.IsTrue(builder.FollowUpExpressionBuilder.ContainsKey("-="));
+        Assert.IsNotNull(builder.FallbackBinaryOrTernaryBuilder);
+    }
+}

--- a/UtilsTest/Format/CustomFormatterTests.cs
+++ b/UtilsTest/Format/CustomFormatterTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Format;
+
+namespace UtilsTest.Format;
+
+[TestClass]
+public class CustomFormatterTests
+{
+    [TestMethod]
+    public void AddFormatterWithoutProviderFormatsValue()
+    {
+        var formatter = new CustomFormatter(CultureInfo.InvariantCulture);
+        formatter.AddFormatter<DateTime>("ymd", dt => dt.ToString("yyyyMMdd", CultureInfo.InvariantCulture));
+
+        var date = new DateTime(2024, 5, 17);
+        var result = formatter.Format("ymd", date, formatter);
+
+        Assert.AreEqual("20240517", result);
+    }
+
+    [TestMethod]
+    public void AddFormatterWithProviderUsesGivenCulture()
+    {
+        var formatter = new CustomFormatter(CultureInfo.InvariantCulture);
+        formatter.AddFormatter<double>("num", (value, provider) => value.ToString("N2", provider));
+
+        var provider = new CultureInfo("fr-FR");
+        var result = formatter.Format("num", 1234.5, provider);
+        var expected = 1234.5.ToString("N2", provider);
+
+        Assert.AreEqual(expected, result);
+    }
+
+    [TestMethod]
+    public void FormatFallsBackToBaseFormatterWhenUnregistered()
+    {
+        var formatter = new CustomFormatter(CultureInfo.InvariantCulture);
+
+        var result = formatter.Format("G", 42, null);
+
+        Assert.AreEqual("42", result);
+    }
+}

--- a/UtilsTest/Imaging/ColorArgb64Tests.cs
+++ b/UtilsTest/Imaging/ColorArgb64Tests.cs
@@ -1,0 +1,107 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Imaging;
+
+namespace UtilsTest.Imaging;
+
+[TestClass]
+public class ColorArgb64Tests
+{
+        [TestMethod]
+        public void ImplicitConversionFromColorArgb32ExpandsComponents()
+        {
+                ColorArgb32 source = new(128, 10, 20, 30);
+                ColorArgb64 converted = source;
+
+                Assert.AreEqual((ushort)(128 << 8), converted.Alpha);
+                Assert.AreEqual((ushort)(10 << 8), converted.Red);
+                Assert.AreEqual((ushort)(20 << 8), converted.Green);
+                Assert.AreEqual((ushort)(30 << 8), converted.Blue);
+        }
+
+        [TestMethod]
+        public void AddWithEqualAlphaAveragesComponents()
+        {
+                ColorArgb64 first = new(ushort.MaxValue, 1000, 4000, 6000);
+                ColorArgb64 second = new(ushort.MaxValue, 2000, 2000, 2000);
+
+                ColorArgb64 result = (ColorArgb64)first.Add(second);
+
+                Assert.AreEqual(ushort.MaxValue, result.Alpha);
+                Assert.AreEqual((ushort)1500, result.Red);
+                Assert.AreEqual((ushort)3000, result.Green);
+                Assert.AreEqual((ushort)4000, result.Blue);
+        }
+
+        [TestMethod]
+        public void OverWithOpaqueForegroundKeepsForegroundColor()
+        {
+                ColorArgb64 foreground = new(ushort.MaxValue, 3000, 4000, 5000);
+                ColorArgb64 background = new(1000, 1000, 2000, 3000);
+
+                ColorArgb64 result = (ColorArgb64)foreground.Over(background);
+
+                Assert.AreEqual(foreground.Alpha, result.Alpha);
+                Assert.AreEqual(foreground.Red, result.Red);
+                Assert.AreEqual(foreground.Green, result.Green);
+                Assert.AreEqual(foreground.Blue, result.Blue);
+        }
+
+        [TestMethod]
+        public void SubstractReturnsComponentWiseMinimum()
+        {
+                ColorArgb64 first = new(4000, 3000, 2000, 1000);
+                ColorArgb64 second = new(1000, 4000, 1500, 6000);
+
+                ColorArgb64 result = (ColorArgb64)first.Substract(second);
+
+                Assert.AreEqual((ushort)1000, result.Alpha);
+                Assert.AreEqual((ushort)3000, result.Red);
+                Assert.AreEqual((ushort)1500, result.Green);
+                Assert.AreEqual((ushort)1000, result.Blue);
+        }
+
+        [TestMethod]
+        public void ConstructorFromArrayReadsSequentialChannels()
+        {
+                ushort[] values =
+                {
+                        0, 1, 2, 3,
+                        100,
+                        500,
+                        1000,
+                        2000
+                };
+
+                ColorArgb64 color = new(values, 4);
+
+                Assert.AreEqual((ushort)100, color.Alpha);
+                Assert.AreEqual((ushort)500, color.Red);
+                Assert.AreEqual((ushort)1000, color.Green);
+                Assert.AreEqual((ushort)2000, color.Blue);
+        }
+
+        [TestMethod]
+        public void ConstructorFromSystemDrawingColorExpandsChannels()
+        {
+                System.Drawing.Color source = System.Drawing.Color.FromArgb(25, 12, 34, 56);
+
+                ColorArgb64 color = new(source);
+
+                Assert.AreEqual((ushort)(25 << 8), color.Alpha);
+                Assert.AreEqual((ushort)(12 << 8), color.Red);
+                Assert.AreEqual((ushort)(34 << 8), color.Green);
+                Assert.AreEqual((ushort)(56 << 8), color.Blue);
+        }
+
+        [TestMethod]
+        public void ToStringProducesReadableOutput()
+        {
+                ColorArgb64 color = new(ushort.MaxValue, 1, 2, 3);
+                string result = color.ToString();
+
+                StringAssert.Contains(result, "a:");
+                StringAssert.Contains(result, "R:");
+                StringAssert.Contains(result, "G:");
+                StringAssert.Contains(result, "B:");
+        }
+}

--- a/UtilsTest/Imaging/DrawMappingTests.cs
+++ b/UtilsTest/Imaging/DrawMappingTests.cs
@@ -1,0 +1,110 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
+using Utils.Drawing;
+using Utils.Imaging;
+
+namespace UtilsTest.Imaging;
+
+[TestClass]
+public class DrawMappingTests
+{
+        private sealed class ArrayImageAccessor<T> : IImageAccessor<T>
+        {
+                private readonly T[,] data;
+
+                public ArrayImageAccessor(int width, int height)
+                {
+                        data = new T[width, height];
+                        Width = width;
+                        Height = height;
+                }
+
+                public int Width { get; }
+                public int Height { get; }
+
+                public T this[int x, int y]
+                {
+                        get => data[x, y];
+                        set => data[x, y] = value;
+                }
+        }
+
+        [TestMethod]
+        public void ComputePixelPosition_MapsViewportCoordinates()
+        {
+                var accessor = new ArrayImageAccessor<ColorArgb32>(100, 50);
+                var draw = new DrawF<ColorArgb32>(accessor, -10, -5, 5, 10);
+
+                Point pixel = draw.ComputePixelPosition(0f, 0f);
+
+                Assert.AreEqual(50, pixel.X);
+                Assert.AreEqual(25, pixel.Y);
+        }
+
+        [TestMethod]
+        public void ComputePoint_InvertsPixelMapping()
+        {
+                var accessor = new ArrayImageAccessor<ColorArgb32>(80, 60);
+                var draw = new DrawF<ColorArgb32>(accessor, 0, 0, accessor.Width, accessor.Height);
+                PointF viewportPoint = new(12.5f, 30.5f);
+
+                PointF pixel = draw.ComputePixelPositionF(viewportPoint);
+                PointF mappedBack = draw.ComputePoint(pixel);
+
+                Assert.AreEqual(viewportPoint.X, mappedBack.X, 1e-3);
+                Assert.AreEqual(viewportPoint.Y, mappedBack.Y, 1e-3);
+        }
+
+        [TestMethod]
+        public void DrawPoint_WritesPixelWhenInsideBounds()
+        {
+                var accessor = new ArrayImageAccessor<ColorArgb32>(10, 10);
+                var draw = new DrawI<ColorArgb32>(accessor);
+                ColorArgb32 color = new(255, 10, 20, 30);
+
+                draw.DrawPoint(3, 4, color);
+
+                Assert.AreEqual(color.Alpha, accessor[3, 4].Alpha);
+                Assert.AreEqual(color.Red, accessor[3, 4].Red);
+                Assert.AreEqual(color.Green, accessor[3, 4].Green);
+                Assert.AreEqual(color.Blue, accessor[3, 4].Blue);
+        }
+
+        [TestMethod]
+        public void DrawPoint_IgnoresOutOfBoundsCoordinates()
+        {
+                var accessor = new ArrayImageAccessor<ColorArgb32>(5, 5);
+                var draw = new DrawI<ColorArgb32>(accessor);
+                ColorArgb32 color = new(255, 10, 20, 30);
+
+                draw.DrawPoint(-1, 0, color);
+                draw.DrawPoint(0, 5, color);
+
+                for (int y = 0; y < accessor.Height; y++)
+                {
+                        for (int x = 0; x < accessor.Width; x++)
+                        {
+                                Assert.AreEqual(0, accessor[x, y].Alpha);
+                                Assert.AreEqual(0, accessor[x, y].Red);
+                                Assert.AreEqual(0, accessor[x, y].Green);
+                                Assert.AreEqual(0, accessor[x, y].Blue);
+                        }
+                }
+        }
+
+        [TestMethod]
+        public void DrawFDrawPointUsesViewportMapping()
+        {
+                var accessor = new ArrayImageAccessor<ColorArgb32>(16, 16);
+                var draw = new DrawF<ColorArgb32>(accessor, 0, 0, 16, 16);
+                ColorArgb32 color = new(255, 100, 110, 120);
+
+                draw.DrawPoint(7.9f, 8.2f, color);
+
+                Point expectedPixel = draw.ComputePixelPosition(7.9f, 8.2f);
+                Assert.AreEqual(color.Alpha, accessor[expectedPixel.X, expectedPixel.Y].Alpha);
+                Assert.AreEqual(color.Red, accessor[expectedPixel.X, expectedPixel.Y].Red);
+                Assert.AreEqual(color.Green, accessor[expectedPixel.X, expectedPixel.Y].Green);
+                Assert.AreEqual(color.Blue, accessor[expectedPixel.X, expectedPixel.Y].Blue);
+        }
+}

--- a/UtilsTest/Objects/ConstrainedValueTests.cs
+++ b/UtilsTest/Objects/ConstrainedValueTests.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Objects;
+
+namespace UtilsTest.Objects;
+
+[TestClass]
+public class ConstrainedValueTests
+{
+    private sealed class PositiveIntValue : ConstrainedValue<int>
+    {
+        public PositiveIntValue(int value)
+            : base(value)
+        {
+        }
+
+        protected override void CheckValue(int value)
+        {
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+        }
+    }
+
+    private sealed class NullableTextValue : ConstrainedValue<string>
+    {
+        public NullableTextValue(string value)
+            : base(value)
+        {
+        }
+
+        protected override void CheckValue(string value)
+        {
+            // All values accepted for this test helper.
+        }
+    }
+
+    [TestMethod]
+    public void ConstructorThrowsWhenValueInvalid()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new PositiveIntValue(0));
+    }
+
+    [TestMethod]
+    public void ImplicitConversionReturnsUnderlyingValue()
+    {
+        PositiveIntValue positive = new(10);
+
+        int value = positive;
+
+        Assert.AreEqual(10, value);
+        Assert.AreEqual("10", positive.ToString());
+    }
+
+    [TestMethod]
+    public void ToStringReturnsEmptyWhenUnderlyingValueIsNull()
+    {
+        var value = new NullableTextValue(null);
+
+        Assert.AreEqual(string.Empty, value.ToString());
+    }
+}

--- a/UtilsTest/Objects/FormatExTests.cs
+++ b/UtilsTest/Objects/FormatExTests.cs
@@ -53,7 +53,7 @@ namespace UtilsTest.Objects
                 (typeof(string), "field1", () => result.Field1),
                 (typeof(int), "field2", () => result.Field2),
                 (typeof(DateTime), "field3", () => result.Field3),
-                (typeof(string), "field3", () => result.Field3_1),
+                (typeof(string), "field3_1", () => result.Field3_1),
                 (typeof(string), "field4", () => result.Field4),
             };
 


### PR DESCRIPTION
## Summary
- fix the IDataRecord test fixture so the field alias matches the format string name
- convert the formatter expression to an IFormatProvider when constructing the interpolated string handler so custom formatters are honored

## Testing
- `dotnet test UtilsTest/UtilsTest.csproj -nologo --logger "console;verbosity=minimal"`


------
https://chatgpt.com/codex/tasks/task_e_68cc03330db08326b7acfe1a53412352