### PR TITLE
Document imaging interfaces

### DIFF
--- a/Utils.Imaging/Drawing/BaseDrawing.cs
+++ b/Utils.Imaging/Drawing/BaseDrawing.cs
@@ -5,13 +5,26 @@ using Utils.Imaging;
 
 namespace Utils.Drawing
 {
-	public class BaseDrawing<T>
-	{
-		public IImageAccessor<T> ImageAccessor { get; }
-		public BaseDrawing(IImageAccessor<T> imageAccessor)
-		{
-			ImageAccessor = imageAccessor;
-		}
+        /// <summary>
+        /// Provides a base implementation that gives access to an image accessor
+        /// for derived drawing helpers.
+        /// </summary>
+        /// <typeparam name="T">Type of the pixel data exposed by the accessor.</typeparam>
+        public class BaseDrawing<T>
+        {
+                /// <summary>
+                /// Gets the image accessor used to read and write pixel information.
+                /// </summary>
+                public IImageAccessor<T> ImageAccessor { get; }
 
-	}
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BaseDrawing{T}"/> class.
+                /// </summary>
+                /// <param name="imageAccessor">Accessor that exposes the underlying image.</param>
+                public BaseDrawing(IImageAccessor<T> imageAccessor)
+                {
+                        ImageAccessor = imageAccessor;
+                }
+
+        }
 }

--- a/Utils.Imaging/Drawing/Bezier.cs
+++ b/Utils.Imaging/Drawing/Bezier.cs
@@ -9,25 +9,43 @@ using static System.Net.Mime.MediaTypeNames;
 
 namespace Utils.Drawing
 {
-	public class Bezier : IDrawable
-	{
-		public PointF[] Points { get; }
+        /// <summary>
+        /// Represents a Bézier curve that can be rasterized to points or line segments.
+        /// </summary>
+        public class Bezier : IDrawable
+        {
+                /// <summary>
+                /// Gets the control points defining the Bézier curve.
+                /// </summary>
+                public PointF[] Points { get; }
 
-		private Segment[] segments;
-		private float length = -1;
+                private Segment[] segments;
+                private float length = -1;
 
-		public Bezier(params Point[] points)
-			: this(points.Select(p => new PointF(p.X, p.Y)).ToArray()) { }
-		public Bezier(params PointF[] points)
-		{
-			Points = points;
-		}
+                /// <summary>
+                /// Initializes a new instance of the <see cref="Bezier"/> class using integer points.
+                /// </summary>
+                /// <param name="points">Control points defining the curve.</param>
+                public Bezier(params Point[] points)
+                        : this(points.Select(p => new PointF(p.X, p.Y)).ToArray()) { }
 
-		public float Length
-		{
-			get
-			{
-				if (length == -1)
+                /// <summary>
+                /// Initializes a new instance of the <see cref="Bezier"/> class using floating point coordinates.
+                /// </summary>
+                /// <param name="points">Control points defining the curve.</param>
+                public Bezier(params PointF[] points)
+                {
+                        Points = points;
+                }
+
+                /// <summary>
+                /// Gets the total length of the curve approximated by its generated segments.
+                /// </summary>
+                public float Length
+                {
+                        get
+                        {
+                                if (length == -1)
 				{
 					length = Segments.Sum(s => s.Length);
 				}
@@ -35,13 +53,13 @@ namespace Utils.Drawing
 			}
 		}
 
-		/// <summary>
-		/// Simplification of shape to segments
-		/// </summary>
-		private Segment[] Segments {
-			get {
-				if (segments is null)
-				{
+                /// <summary>
+                /// Gets or creates the cached segments approximating the curve.
+                /// </summary>
+                private Segment[] Segments {
+                        get {
+                                if (segments is null)
+                                {
 
 					List<Segment> result = new List<Segment>();
 					var computedPoints = ComputeBezierPoints(Points.Select(p => new PointF(p.X, p.Y)).ToArray());
@@ -59,16 +77,17 @@ namespace Utils.Drawing
 			}
 		}
 
-		/// <summary>
-		/// Rasterization to oriented points coordinates
-		/// </summary>
-		/// <param name="position"></param>
-		/// <returns></returns>
-		public IEnumerable<DrawPoint> GetPoints(bool closed, float position = 0)
-		{
-			foreach (var segment in GetSegments(closed))
-			{
-				foreach (var drawPoint in segment.GetPoints(false, position))
+                /// <summary>
+                /// Rasterizes the curve into oriented points.
+                /// </summary>
+                /// <param name="closed">Indicates whether the returned points should form a closed path.</param>
+                /// <param name="position">Starting accumulated length value for the first point.</param>
+                /// <returns>Enumeration of oriented points describing the curve.</returns>
+                public IEnumerable<DrawPoint> GetPoints(bool closed, float position = 0)
+                {
+                        foreach (var segment in GetSegments(closed))
+                        {
+                                foreach (var drawPoint in segment.GetPoints(false, position))
 				{
 					position = drawPoint.Position;
 					yield return drawPoint;
@@ -76,32 +95,43 @@ namespace Utils.Drawing
 			}
 		}
 
-		public IEnumerable<Segment> GetSegments(bool closed)
-		{
-			foreach (var segment in Segments)
-			{
-				yield return segment;
-			}
+                /// <summary>
+                /// Returns a set of segments approximating the curve.
+                /// </summary>
+                /// <param name="closed">Indicates whether a closing segment should be added.</param>
+                /// <returns>Enumeration of segments representing the curve.</returns>
+                public IEnumerable<Segment> GetSegments(bool closed)
+                {
+                        foreach (var segment in Segments)
+                        {
+                                yield return segment;
+                        }
 			if (closed)
 			{
 				yield return new Segment(Point.Truncate(Points[0]), Point.Truncate(Points.Last()));
 			}
 		}
 
-		/// <summary>
-		/// Compute the points for bezier curve
-		/// </summary>
-		/// <param name="points"></param>
-		/// <returns></returns>
-		private IEnumerable<PointF> ComputeBezierPoints(params PointF[] points)
-		{
-			var n = points.Length - 1;
+                /// <summary>
+                /// Computes a set of interpolated points describing the Bézier curve using the
+                /// De Casteljau algorithm.
+                /// </summary>
+                /// <param name="points">Control points used to build the curve.</param>
+                /// <returns>Points describing the curve.</returns>
+                private IEnumerable<PointF> ComputeBezierPoints(params PointF[] points)
+                {
+                        var n = points.Length - 1;
 
-			PointF ComputeBezierPoint(float t)
-			{
-				PointF[] newPoints = (PointF[])points.Clone();
-				var u = 1 - t;
-				for (int i = 1; i <= n; i++)
+                        /// <summary>
+                        /// Computes a single interpolated point for the provided progress value.
+                        /// </summary>
+                        /// <param name="t">Progress along the curve in the range [0, 1].</param>
+                        /// <returns>The interpolated point.</returns>
+                        PointF ComputeBezierPoint(float t)
+                        {
+                                PointF[] newPoints = (PointF[])points.Clone();
+                                var u = 1 - t;
+                                for (int i = 1; i <= n; i++)
 				{
 					for (int j = 0; j <= n - i; j++)
 					{

--- a/Utils.Imaging/Drawing/Circle.cs
+++ b/Utils.Imaging/Drawing/Circle.cs
@@ -7,36 +7,85 @@ using Utils.Collections;
 
 namespace Utils.Drawing
 {
-	public class Circle : IDrawable
-	{
-		public float Length
-		{
-			get
-			{
-				ComputeLines();
-				return polylines.Length;
-			}
-		}
+        /// <summary>
+        /// Represents an ellipse or circle drawable approximation that can be converted into
+        /// points or segments.
+        /// </summary>
+        public class Circle : IDrawable
+        {
+                /// <summary>
+                /// Gets the perimeter length of the computed polyline representation.
+                /// </summary>
+                public float Length
+                {
+                        get
+                        {
+                                ComputeLines();
+                                return polylines.Length;
+                        }
+                }
 
-		public PointF Center { get; }
-		public double Orientation { get; }
-		public float Radius1 { get; }
-		public float Radius2 { get; }
-		public double StartAngle { get; }
-		public double EndAngle { get; }
+                /// <summary>
+                /// Gets the geometric center of the circle or ellipse.
+                /// </summary>
+                public PointF Center { get; }
 
-		private Polylines polylines;
+                /// <summary>
+                /// Gets the rotation of the ellipse around its center in radians.
+                /// </summary>
+                public double Orientation { get; }
 
-		public Circle(PointF center, float radius, double startAngle = 0, double endAngle = Math.PI * 2)
-			: this(center, radius, radius, 0, startAngle, endAngle)
-		{
-		}
-		
-		public Circle(PointF center, float radius1, float radius2, double orientation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
-		{
-			Center = center;
-			Radius1 = radius1;
-			Radius2 = radius2;
+                /// <summary>
+                /// Gets the first radius of the ellipse. When equal to <see cref="Radius2"/> it
+                /// represents the radius of a circle.
+                /// </summary>
+                public float Radius1 { get; }
+
+                /// <summary>
+                /// Gets the second radius of the ellipse.
+                /// </summary>
+                public float Radius2 { get; }
+
+                /// <summary>
+                /// Gets the angle, in radians, at which the arc starts.
+                /// </summary>
+                public double StartAngle { get; }
+
+                /// <summary>
+                /// Gets the angle, in radians, at which the arc ends.
+                /// </summary>
+                public double EndAngle { get; }
+
+                private Polylines polylines;
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="Circle"/> class representing an
+                /// arc of a circle.
+                /// </summary>
+                /// <param name="center">Center of the circle.</param>
+                /// <param name="radius">Radius of the circle.</param>
+                /// <param name="startAngle">Starting angle of the arc in radians.</param>
+                /// <param name="endAngle">Ending angle of the arc in radians.</param>
+                public Circle(PointF center, float radius, double startAngle = 0, double endAngle = Math.PI * 2)
+                        : this(center, radius, radius, 0, startAngle, endAngle)
+                {
+                }
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="Circle"/> class representing an
+                /// ellipse arc.
+                /// </summary>
+                /// <param name="center">Center of the ellipse.</param>
+                /// <param name="radius1">Radius along the first axis.</param>
+                /// <param name="radius2">Radius along the second axis.</param>
+                /// <param name="orientation">Rotation of the ellipse in radians.</param>
+                /// <param name="startAngle">Starting angle of the arc in radians.</param>
+                /// <param name="endAngle">Ending angle of the arc in radians.</param>
+                public Circle(PointF center, float radius1, float radius2, double orientation = 0, double startAngle = 0, double endAngle = Math.PI * 2)
+                {
+                        Center = center;
+                        Radius1 = radius1;
+                        Radius2 = radius2;
 			Orientation = orientation;
 
 			double angle = endAngle - startAngle;
@@ -45,16 +94,23 @@ namespace Utils.Drawing
 				startAngle = 0;
 				endAngle = Math.PI * 2;
 			}
-			StartAngle = startAngle;
-			EndAngle = endAngle;
-		}
+                        StartAngle = startAngle;
+                        EndAngle = endAngle;
+                }
 
-		private void ComputeLines()
-		{
-			IEnumerable<PointF> ComputePoints()
-			{
-				double angle = EndAngle - StartAngle;
-				var angularResolution = angle / (Math.Max(Radius1, Radius2) * Math.PI * 2);
+                /// <summary>
+                /// Generates the polyline approximation of the ellipse if it has not been created yet.
+                /// </summary>
+                private void ComputeLines()
+                {
+                        /// <summary>
+                        /// Lazily computes the points that describe the ellipse.
+                        /// </summary>
+                        /// <returns>Sequence of points describing the ellipse.</returns>
+                        IEnumerable<PointF> ComputePoints()
+                        {
+                                double angle = EndAngle - StartAngle;
+                                var angularResolution = angle / (Math.Max(Radius1, Radius2) * Math.PI * 2);
 
 				var cosR = Math.Cos(Orientation);
 				var sinR = Math.Sin(Orientation);
@@ -93,18 +149,29 @@ namespace Utils.Drawing
 				}
 			}
 
-			polylines ??= new Polylines(ComputePoints().ToArray());
-		}
+                        polylines ??= new Polylines(ComputePoints().ToArray());
+                }
 
-		public IEnumerable<DrawPoint> GetPoints(bool closed, float position = 0)
-		{
-			ComputeLines();
-			return polylines.GetPoints(closed, position);
-		}
+                /// <summary>
+                /// Returns oriented points along the ellipse arc.
+                /// </summary>
+                /// <param name="closed">Indicates whether the sequence should be closed.</param>
+                /// <param name="position">Starting accumulated length value for the first point.</param>
+                /// <returns>Enumeration of oriented points.</returns>
+                public IEnumerable<DrawPoint> GetPoints(bool closed, float position = 0)
+                {
+                        ComputeLines();
+                        return polylines.GetPoints(closed, position);
+                }
 
-		public IEnumerable<Segment> GetSegments(bool closed)
-		{
-			return polylines.GetSegments(closed);
-		}
-	}
+                /// <summary>
+                /// Returns segments describing the ellipse arc.
+                /// </summary>
+                /// <param name="closed">Indicates whether the returned segments should form a closed path.</param>
+                /// <returns>Enumeration of segments representing the ellipse.</returns>
+                public IEnumerable<Segment> GetSegments(bool closed)
+                {
+                        return polylines.GetSegments(closed);
+                }
+        }
 }

--- a/Utils.Imaging/Drawing/IDrawable.cs
+++ b/Utils.Imaging/Drawing/IDrawable.cs
@@ -4,10 +4,30 @@ using System.Text;
 
 namespace Utils.Drawing
 {
-	public interface IDrawable
-	{
-		float Length { get; }
-		IEnumerable<DrawPoint> GetPoints(bool closed, float position = 0);
-		IEnumerable<Segment> GetSegments(bool closed);
-	}
+        /// <summary>
+        /// Describes an object that can be converted into drawing primitives such as
+        /// segments or oriented points.
+        /// </summary>
+        public interface IDrawable
+        {
+                /// <summary>
+                /// Gets the total length of the drawable object.
+                /// </summary>
+                float Length { get; }
+
+                /// <summary>
+                /// Returns oriented points that describe the shape.
+                /// </summary>
+                /// <param name="closed">Indicates whether the returned points should form a closed loop.</param>
+                /// <param name="position">Starting accumulated length value for the first point.</param>
+                /// <returns>Enumeration of oriented points.</returns>
+                IEnumerable<DrawPoint> GetPoints(bool closed, float position = 0);
+
+                /// <summary>
+                /// Returns line segments that describe the shape.
+                /// </summary>
+                /// <param name="closed">Indicates whether the returned segments should form a closed loop.</param>
+                /// <returns>Enumeration of line segments.</returns>
+                IEnumerable<Segment> GetSegments(bool closed);
+        }
 }

--- a/Utils.Imaging/Imaging/BitmapArgb32Accessor.cs
+++ b/Utils.Imaging/Imaging/BitmapArgb32Accessor.cs
@@ -5,52 +5,84 @@ using Utils.Mathematics;
 
 namespace Utils.Imaging
 {
-	public unsafe class BitmapArgb32Accessor : IDisposable, IImageAccessor<ColorArgb32, byte>, IImageAccessor<uint>
-	{
-		private Bitmap bitmap;
-		private BitmapData bmpdata = null;
-		private uint* uintdata;
-		private readonly int totalBytes;
+        /// <summary>
+        /// Provides direct memory access to 32-bit ARGB bitmap data, enabling fast pixel
+        /// manipulation scenarios.
+        /// </summary>
+        public unsafe class BitmapArgb32Accessor : IDisposable, IImageAccessor<ColorArgb32, byte>, IImageAccessor<uint>
+        {
+                private Bitmap bitmap;
+                private BitmapData bmpdata = null;
+                private uint* uintdata;
+                private readonly int totalBytes;
 
-		public int Width => bmpdata.Width;
-		public int Height => bmpdata.Height;
+                /// <summary>
+                /// Gets the width of the accessed bitmap region.
+                /// </summary>
+                public int Width => bmpdata.Width;
 
-		uint IImageAccessor<uint>.this[int x, int y]
-		{
-			get { return uintdata[y * bmpdata.Width + x]; }
-			set { uintdata[y * bmpdata.Width + x] = value; }
-		}
+                /// <summary>
+                /// Gets the height of the accessed bitmap region.
+                /// </summary>
+                public int Height => bmpdata.Height;
 
-		public BitmapArgb32Accessor( Bitmap bitmap, Rectangle? region = null )
-		{
-			this.bitmap = bitmap;
-			region = region ?? new Rectangle(0, 0, bitmap.Width, bitmap.Height);
+                /// <inheritdoc/>
+                uint IImageAccessor<uint>.this[int x, int y]
+                {
+                        get { return uintdata[y * bmpdata.Width + x]; }
+                        set { uintdata[y * bmpdata.Width + x] = value; }
+                }
 
-			this.bmpdata = bitmap.LockBits(region.Value, ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
-			this.totalBytes = bmpdata.Stride * bmpdata.Height;
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BitmapArgb32Accessor"/> class and
+                /// locks the specified bitmap region.
+                /// </summary>
+                /// <param name="bitmap">Bitmap providing the pixel data.</param>
+                /// <param name="region">Optional region to lock; when omitted the entire bitmap is used.</param>
+                public BitmapArgb32Accessor( Bitmap bitmap, Rectangle? region = null )
+                {
+                        this.bitmap = bitmap;
+                        region = region ?? new Rectangle(0, 0, bitmap.Width, bitmap.Height);
 
-			this.uintdata = (uint*)(void*)bmpdata.Scan0;
-		}
-		public ColorArgb32 this[int x, int y]
-		{
-			get { return new ColorArgb32(uintdata[y * bmpdata.Width + x]); }
-			set { uintdata[y * bmpdata.Width + x] = value.Value; }
-		}
+                        this.bmpdata = bitmap.LockBits(region.Value, ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
+                        this.totalBytes = bmpdata.Stride * bmpdata.Height;
 
-		public uint[] CopyToArray()
-		{
-			uint[] copy = new uint[totalBytes / sizeof(uint)];
-			for (int i = 0 ; i < copy.Length ; i++) {
-				copy[i] = uintdata[i];
-			}
-			return copy;
-		}
+                        this.uintdata = (uint*)(void*)bmpdata.Scan0;
+                }
 
-		public ColorArgb32[,] CopyToColorArray()
-		{
-			ColorArgb32[,] copy = new ColorArgb32[Width, Height];
-			for (int y = 0 ; y < Height ; y++) {
-				for (int x = 0 ; x < Width ; x++) {
+                /// <summary>
+                /// Gets or sets the color at the specified pixel coordinates.
+                /// </summary>
+                /// <param name="x">Horizontal pixel coordinate.</param>
+                /// <param name="y">Vertical pixel coordinate.</param>
+                public ColorArgb32 this[int x, int y]
+                {
+                        get { return new ColorArgb32(uintdata[y * bmpdata.Width + x]); }
+                        set { uintdata[y * bmpdata.Width + x] = value.Value; }
+                }
+
+                /// <summary>
+                /// Copies the raw pixel data to an array of unsigned integers.
+                /// </summary>
+                /// <returns>Array containing the raw pixel values.</returns>
+                public uint[] CopyToArray()
+                {
+                        uint[] copy = new uint[totalBytes / sizeof(uint)];
+                        for (int i = 0 ; i < copy.Length ; i++) {
+                                copy[i] = uintdata[i];
+                        }
+                        return copy;
+                }
+
+                /// <summary>
+                /// Copies the pixel data to a two-dimensional array of color structures.
+                /// </summary>
+                /// <returns>Matrix of <see cref="ColorArgb32"/> values.</returns>
+                public ColorArgb32[,] CopyToColorArray()
+                {
+                        ColorArgb32[,] copy = new ColorArgb32[Width, Height];
+                        for (int y = 0 ; y < Height ; y++) {
+                                for (int x = 0 ; x < Width ; x++) {
 					copy[x, y] = this[x, y];
 				}
 			}
@@ -82,21 +114,31 @@ namespace Utils.Imaging
 					this[dx, dy] = result;
 				}
 			}
-		}
+                }
 
-		public void Dispose()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
+                /// <summary>
+                /// Releases resources associated with the accessor and unlocks the bitmap.
+                /// </summary>
+                public void Dispose()
+                {
+                        Dispose(true);
+                        GC.SuppressFinalize(this);
+                }
 
-		~BitmapArgb32Accessor() => Dispose(false);
+                /// <summary>
+                /// Finalizes the accessor and ensures resources are released.
+                /// </summary>
+                ~BitmapArgb32Accessor() => Dispose(false);
 
-		protected virtual void Dispose(bool disposing)
-		{
-			if (bitmap is not null && bmpdata is not null) {
-				this.bitmap.UnlockBits(bmpdata);
-				this.bitmap = null;
+                /// <summary>
+                /// Performs the actual resource cleanup.
+                /// </summary>
+                /// <param name="disposing">Indicates whether the method is called from <see cref="Dispose()"/>.</param>
+                protected virtual void Dispose(bool disposing)
+                {
+                        if (bitmap is not null && bmpdata is not null) {
+                                this.bitmap.UnlockBits(bmpdata);
+                                this.bitmap = null;
 				this.uintdata = null;
 				this.bmpdata = null;
 			}

--- a/Utils.Imaging/Imaging/BitmapIndexed8Accessor.cs
+++ b/Utils.Imaging/Imaging/BitmapIndexed8Accessor.cs
@@ -4,47 +4,78 @@ using System.Drawing.Imaging;
 
 namespace Utils.Imaging
 {
-	public unsafe class BitmapIndexed8Accessor : IDisposable, IImageAccessor<byte>
-	{
-		private Bitmap bitmap;
-		private BitmapData bmpdata = null;
-		private byte* bytedata;
-		private readonly int totalBytes;
+        /// <summary>
+        /// Provides direct memory access to 8-bit indexed bitmap data.
+        /// </summary>
+        public unsafe class BitmapIndexed8Accessor : IDisposable, IImageAccessor<byte>
+        {
+                private Bitmap bitmap;
+                private BitmapData bmpdata = null;
+                private byte* bytedata;
+                private readonly int totalBytes;
 
-		public int Width => bmpdata.Width;
-		public int Height => bmpdata.Height;
+                /// <summary>
+                /// Gets the width of the accessed bitmap region.
+                /// </summary>
+                public int Width => bmpdata.Width;
 
-		public BitmapIndexed8Accessor( Bitmap bitmap, Rectangle? region = null )
-		{
-			this.bitmap = bitmap;
-			region = region ?? new Rectangle(0, 0, bitmap.Width, bitmap.Height);
+                /// <summary>
+                /// Gets the height of the accessed bitmap region.
+                /// </summary>
+                public int Height => bmpdata.Height;
 
-			this.bmpdata = bitmap.LockBits(region.Value, ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed);
-			this.totalBytes = bmpdata.Stride * bmpdata.Height;
+                /// <summary>
+                /// Initializes a new instance of the <see cref="BitmapIndexed8Accessor"/> class and
+                /// locks the specified bitmap region.
+                /// </summary>
+                /// <param name="bitmap">Bitmap providing the pixel data.</param>
+                /// <param name="region">Optional region to lock; when omitted the entire bitmap is used.</param>
+                public BitmapIndexed8Accessor( Bitmap bitmap, Rectangle? region = null )
+                {
+                        this.bitmap = bitmap;
+                        region = region ?? new Rectangle(0, 0, bitmap.Width, bitmap.Height);
 
-			this.bytedata = (byte*)(void*)bmpdata.Scan0;
-		}
+                        this.bmpdata = bitmap.LockBits(region.Value, ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed);
+                        this.totalBytes = bmpdata.Stride * bmpdata.Height;
 
-		public byte this[int x, int y]
-		{
-			get { return bytedata[y * bmpdata.Stride + x]; }
-			set { bytedata[y * bmpdata.Stride + x] = value; }
-		}
+                        this.bytedata = (byte*)(void*)bmpdata.Scan0;
+                }
 
-		public void Dispose()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
+                /// <summary>
+                /// Gets or sets the indexed value at the specified pixel coordinates.
+                /// </summary>
+                /// <param name="x">Horizontal pixel coordinate.</param>
+                /// <param name="y">Vertical pixel coordinate.</param>
+                public byte this[int x, int y]
+                {
+                        get { return bytedata[y * bmpdata.Stride + x]; }
+                        set { bytedata[y * bmpdata.Stride + x] = value; }
+                }
 
-		~BitmapIndexed8Accessor() => Dispose(false);
-		
-		protected virtual void Dispose(bool disposing)
-		{
-			if (bitmap is not null && bmpdata is not null) {
-				this.bitmap.UnlockBits(bmpdata);
-				this.bitmap = null;
-				this.bytedata = null;
+                /// <summary>
+                /// Releases resources associated with the accessor and unlocks the bitmap.
+                /// </summary>
+                public void Dispose()
+                {
+                        Dispose(true);
+                        GC.SuppressFinalize(this);
+                }
+
+                /// <summary>
+                /// Finalizes the accessor and ensures resources are released.
+                /// </summary>
+                ~BitmapIndexed8Accessor() => Dispose(false);
+
+                /// <summary>
+                /// Performs the actual resource cleanup.
+                /// </summary>
+                /// <param name="disposing">Indicates whether the method is called from <see cref="Dispose()"/>.</param>
+                protected virtual void Dispose(bool disposing)
+                {
+                        if (bitmap is not null && bmpdata is not null) {
+                                this.bitmap.UnlockBits(bmpdata);
+                                this.bitmap = null;
+                                this.bytedata = null;
 				this.bmpdata = null;
 			}
 		}

--- a/Utils.Imaging/Imaging/ColorAhsv.cs
+++ b/Utils.Imaging/Imaging/ColorAhsv.cs
@@ -14,8 +14,15 @@ namespace Utils.Imaging
                 IEquatable<ColorAhsv>,
                 IEqualityOperators<ColorAhsv, ColorAhsv, bool>
 	{
-		public static double MinValue { get; } = 0.0;
-		public static double MaxValue { get; } = 1.0;
+                /// <summary>
+                /// Lower bound accepted for HSV components expressed as <see cref="double"/> values.
+                /// </summary>
+                public static double MinValue { get; } = 0.0;
+
+                /// <summary>
+                /// Upper bound accepted for HSV components expressed as <see cref="double"/> values.
+                /// </summary>
+                public static double MaxValue { get; } = 1.0;
 
 		private double alpha;
 		private double hue;
@@ -112,9 +119,9 @@ namespace Utils.Imaging
 		}
 
                 /// <summary>
-                /// Initializes a new instance from an ARGB color.
+                /// Initializes a new instance from the specified ARGB color.
                 /// </summary>
-                /// <param name="color">Source color.</param>
+                /// <param name="color">Source color converted into HSV space.</param>
                 public ColorAhsv(ColorArgb color)
                 {
                         ColorAhsv tmp = FromArgbColor(color);
@@ -124,11 +131,38 @@ namespace Utils.Imaging
                         value = tmp.value;
                 }
 
-		public static implicit operator ColorAhsv(ColorArgb color) => new ColorAhsv(color);
-		public static implicit operator ColorAhsv(ColorAhsv32 color) => FromColorAshv<ColorAhsv32, byte>(color);
-		public static implicit operator ColorAhsv(ColorAhsv64 color) => FromColorAshv<ColorAhsv64, ushort>(color);
+                /// <summary>
+                /// Converts an ARGB color into an HSV representation.
+                /// </summary>
+                /// <param name="color">Source color expressed with floating-point components.</param>
+                /// <returns>The corresponding HSV color.</returns>
+                public static implicit operator ColorAhsv(ColorArgb color) => new ColorAhsv(color);
 
-		public override string ToString() => $"a:{alpha} h:{hue} s:{saturation} v:{value}";
+                /// <summary>
+                /// Converts an 8-bit HSV color to the double-precision representation.
+                /// </summary>
+                /// <param name="color">Source HSV color.</param>
+                /// <returns>The converted color.</returns>
+                public static implicit operator ColorAhsv(ColorAhsv32 color) => FromColorAshv<ColorAhsv32, byte>(color);
+
+                /// <summary>
+                /// Converts a 16-bit HSV color to the double-precision representation.
+                /// </summary>
+                /// <param name="color">Source HSV color.</param>
+                /// <returns>The converted color.</returns>
+                public static implicit operator ColorAhsv(ColorAhsv64 color) => FromColorAshv<ColorAhsv64, ushort>(color);
+
+                /// <summary>
+                /// Returns a textual representation of the HSV components.
+                /// </summary>
+                /// <returns>A string describing the alpha, hue, saturation, and value.</returns>
+                public override string ToString() => $"a:{alpha} h:{hue} s:{saturation} v:{value}";
+
+                /// <summary>
+                /// Converts an ARGB color into the HSV representation.
+                /// </summary>
+                /// <param name="color">Source color expressed with floating-point components.</param>
+                /// <returns>A new HSV color containing the converted values.</returns>
                 public static ColorAhsv FromArgbColor(ColorArgb color)
                 {
                         double min = Math.Min(color.Red, Math.Min(color.Green, color.Blue));

--- a/Utils.Imaging/Imaging/ColorAhsv32.cs
+++ b/Utils.Imaging/Imaging/ColorAhsv32.cs
@@ -12,8 +12,15 @@ public class ColorAhsv32 :
         IEquatable<ColorAhsv32>,
         IEqualityOperators<ColorAhsv32, ColorAhsv32, bool>
 {
-	public static byte MinValue { get; } = 0;
-	public static byte MaxValue { get; } = byte.MaxValue;
+        /// <summary>
+        /// Lowest component value that can be represented with this color depth.
+        /// </summary>
+        public static byte MinValue { get; } = 0;
+
+        /// <summary>
+        /// Highest component value that can be represented with this color depth.
+        /// </summary>
+        public static byte MaxValue { get; } = byte.MaxValue;
 
 /// <summary>Alpha channel.</summary>
 public byte Alpha { get; set; }
@@ -62,8 +69,10 @@ public ColorAhsv32(ColorAhsv color)
 public ColorAhsv32(System.Drawing.Color colorArgb) { FromArgbColor(colorArgb.A, colorArgb.R, colorArgb.G, colorArgb.B); }
 
 /// <summary>
-/// Converts from a 32-bit ARGB color.
+/// Creates an HSV color from an ARGB color stored with 8-bit components.
 /// </summary>
+/// <param name="colorArgb">The ARGB color to convert.</param>
+/// <returns>A new <see cref="ColorAhsv32"/> instance.</returns>
 public static ColorAhsv32 FromArgbColor(ColorArgb32 colorArgb) => FromArgbColor(colorArgb.Alpha, colorArgb.Red, colorArgb.Green, colorArgb.Blue);
 
 /// <summary>
@@ -135,11 +144,32 @@ public static ColorAhsv32 FromArgbColor(byte alpha, byte red, byte green, byte b
         }
 
 
-	public static implicit operator ColorAhsv32(ColorAhsv color) => new ColorAhsv32(color);
-	public static implicit operator ColorAhsv32(ColorAhsv64 color) => new ColorAhsv32(color);
-        public static implicit operator ColorAhsv32(System.Drawing.Color color) => new ColorAhsv32(color);
+/// <summary>
+/// Converts a double-precision HSV color to the 8-bit representation.
+/// </summary>
+/// <param name="color">The HSV color to convert.</param>
+/// <returns>The converted color.</returns>
+public static implicit operator ColorAhsv32(ColorAhsv color) => new ColorAhsv32(color);
 
-        public override string ToString() => $"a:{Alpha} h:{Hue} s:{Saturation} v:{Value}";
+/// <summary>
+/// Converts a 16-bit HSV color to the 8-bit representation.
+/// </summary>
+/// <param name="color">The HSV color to convert.</param>
+/// <returns>The converted color.</returns>
+public static implicit operator ColorAhsv32(ColorAhsv64 color) => new ColorAhsv32(color);
+
+/// <summary>
+/// Converts a <see cref="System.Drawing.Color"/> value to its HSV equivalent.
+/// </summary>
+/// <param name="color">The color to convert.</param>
+/// <returns>The converted HSV color.</returns>
+public static implicit operator ColorAhsv32(System.Drawing.Color color) => new ColorAhsv32(color);
+
+/// <summary>
+/// Returns a textual representation of the HSV components.
+/// </summary>
+/// <returns>A string describing the alpha, hue, saturation, and value.</returns>
+public override string ToString() => $"a:{Alpha} h:{Hue} s:{Saturation} v:{Value}";
 
         /// <inheritdoc/>
         public bool Equals(ColorAhsv32? other) =>

--- a/Utils.Imaging/Imaging/ColorAhsv64.cs
+++ b/Utils.Imaging/Imaging/ColorAhsv64.cs
@@ -12,8 +12,15 @@ namespace Utils.Imaging
                 IEquatable<ColorAhsv64>,
                 IEqualityOperators<ColorAhsv64, ColorAhsv64, bool>
 	{
-		public static ushort MinValue { get; } = 0;
-		public static ushort MaxValue { get; } = ushort.MaxValue;
+                /// <summary>
+                /// Lowest component value representable with 16-bit HSV colors.
+                /// </summary>
+                public static ushort MinValue { get; } = 0;
+
+                /// <summary>
+                /// Highest component value representable with 16-bit HSV colors.
+                /// </summary>
+                public static ushort MaxValue { get; } = ushort.MaxValue;
 
                 /// <summary>Alpha component.</summary>
                 public ushort Alpha { get; set; }
@@ -103,7 +110,17 @@ namespace Utils.Imaging
                         };
                 }
 
+                /// <summary>
+                /// Converts a double-precision HSV color to the 16-bit representation.
+                /// </summary>
+                /// <param name="color">The color to convert.</param>
+                /// <returns>The converted color.</returns>
                 public static implicit operator ColorAhsv64(ColorAhsv color) => new ColorAhsv64((ushort)(color.Alpha * 65535), (ushort)(color.Hue * 65535), (ushort)(color.Saturation * 65535), (ushort)(color.Value * 65535));
+
+                /// <summary>
+                /// Returns a textual representation of the HSV components.
+                /// </summary>
+                /// <returns>A string describing the alpha, hue, saturation, and value.</returns>
                 public override string ToString() => $"a:{Alpha} h:{Hue} s:{Saturation} v:{Value}";
                 /// <summary>
                 /// Converts from a <see cref="ColorArgb64"/> value.

--- a/Utils.Imaging/Imaging/ColorArgb.cs
+++ b/Utils.Imaging/Imaging/ColorArgb.cs
@@ -11,66 +11,98 @@ namespace Utils.Imaging;
 public struct ColorArgb : IColorArgb<double>, IEquatable<ColorArgb>, IEqualityOperators<ColorArgb, ColorArgb, bool>
 {
 
-	public static double MinValue { get; } = 0.0;
-	public static double MaxValue { get; } = 1.0;
+        /// <summary>
+        /// Lowest component value accepted for <see cref="ColorArgb"/> instances.
+        /// </summary>
+        public static double MinValue { get; } = 0.0;
+
+        /// <summary>
+        /// Highest component value accepted for <see cref="ColorArgb"/> instances.
+        /// </summary>
+        public static double MaxValue { get; } = 1.0;
 
 	private double alpha;
 	private double red;
 	private double green;
 	private double blue;
 
-	public double Alpha
-	{
-		get => alpha;
+        /// <summary>
+        /// Gets or sets the alpha channel expressed in the [0,1] range.
+        /// </summary>
+        public double Alpha
+        {
+                get => alpha;
 
-		set
-		{
-			value.ArgMustBeBetween(MinValue, MaxValue);
-			this.alpha=value;
-		}
-	}
+                set
+                {
+                        value.ArgMustBeBetween(MinValue, MaxValue);
+                        this.alpha=value;
+                }
+        }
 
-	public double Red
-	{
-		get => red;
+        /// <summary>
+        /// Gets or sets the red channel expressed in the [0,1] range.
+        /// </summary>
+        public double Red
+        {
+                get => red;
 
-		set
-		{
+                set
+                {
 			value.ArgMustBeBetween(MinValue, MaxValue);
 			this.red=value;
 		}
 	}
 
-	public double Green
-	{
-		get => green;
+        /// <summary>
+        /// Gets or sets the green channel expressed in the [0,1] range.
+        /// </summary>
+        public double Green
+        {
+                get => green;
 
-		set
-		{
+                set
+                {
 			value.ArgMustBeBetween(MinValue, MaxValue);
 			this.green=value;
 		}
 	}
 
-	public double Blue
-	{
-		get => blue;
+        /// <summary>
+        /// Gets or sets the blue channel expressed in the [0,1] range.
+        /// </summary>
+        public double Blue
+        {
+                get => blue;
 
-		set
-		{
+                set
+                {
 			value.ArgMustBeBetween(MinValue, MaxValue);
 			this.blue=value;
 		}
 	}
 
-	public ColorArgb(double red, double green, double blue) : this(1D, red, green, blue) { }
+        /// <summary>
+        /// Initializes an opaque color with explicit RGB components.
+        /// </summary>
+        /// <param name="red">Red component in the [0,1] range.</param>
+        /// <param name="green">Green component in the [0,1] range.</param>
+        /// <param name="blue">Blue component in the [0,1] range.</param>
+        public ColorArgb(double red, double green, double blue) : this(1D, red, green, blue) { }
 
-	public ColorArgb( double alpha, double red, double green, double blue )
-	{
-		alpha.ArgMustBeBetween(MinValue, MaxValue);
-		red.ArgMustBeBetween(MinValue, MaxValue);
-		green.ArgMustBeBetween(MinValue, MaxValue);
-		blue.ArgMustBeBetween(MinValue, MaxValue);
+        /// <summary>
+        /// Initializes a color using explicit ARGB components.
+        /// </summary>
+        /// <param name="alpha">Alpha component in the [0,1] range.</param>
+        /// <param name="red">Red component in the [0,1] range.</param>
+        /// <param name="green">Green component in the [0,1] range.</param>
+        /// <param name="blue">Blue component in the [0,1] range.</param>
+        public ColorArgb(double alpha, double red, double green, double blue)
+        {
+                alpha.ArgMustBeBetween(MinValue, MaxValue);
+                red.ArgMustBeBetween(MinValue, MaxValue);
+                green.ArgMustBeBetween(MinValue, MaxValue);
+                blue.ArgMustBeBetween(MinValue, MaxValue);
 
 		this.alpha = alpha;
 		this.red = red;
@@ -78,50 +110,108 @@ public struct ColorArgb : IColorArgb<double>, IEquatable<ColorArgb>, IEqualityOp
 		this.blue = blue;
 	}
 
-	public ColorArgb(ColorArgb32 color) : this(color.Alpha / 255.0, color.Red / 255.0, color.Green / 255.0, color.Blue / 255.0) { }
+        /// <summary>
+        /// Initializes a color by converting from an 8-bit ARGB representation.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        public ColorArgb(ColorArgb32 color) : this(color.Alpha / 255.0, color.Red / 255.0, color.Green / 255.0, color.Blue / 255.0) { }
 
-	public ColorArgb( ColorArgb64 color ) : this(color.Alpha / 255.0, color.Red / 255.0, color.Green / 255.0, color.Blue / 255.0) { }
+        /// <summary>
+        /// Initializes a color by converting from a 16-bit ARGB representation.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        public ColorArgb(ColorArgb64 color) : this(color.Alpha / 255.0, color.Red / 255.0, color.Green / 255.0, color.Blue / 255.0) { }
 
+        /// <summary>
+        /// Initializes a color by converting from an HSV representation.
+        /// </summary>
+        /// <param name="color">The HSV color to convert.</param>
         public ColorArgb(ColorAhsv color) : this()
         {
                 this = color.ToArgbColor();
         }
 
-	public static implicit operator ColorArgb(ColorAhsv color) => new (color);
+        /// <summary>
+        /// Converts an HSV color to the floating-point ARGB representation.
+        /// </summary>
+        /// <param name="color">The HSV color to convert.</param>
+        /// <returns>The converted color.</returns>
+        public static implicit operator ColorArgb(ColorAhsv color) => new (color);
 
-	public static implicit operator ColorArgb(ColorArgb32 color) => new (color);
+        /// <summary>
+        /// Converts an 8-bit ARGB color to the floating-point representation.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The converted color.</returns>
+        public static implicit operator ColorArgb(ColorArgb32 color) => new (color);
 
-	public static implicit operator ColorArgb(ColorArgb64 color) => new (color);
+        /// <summary>
+        /// Converts a 16-bit ARGB color to the floating-point representation.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The converted color.</returns>
+        public static implicit operator ColorArgb(ColorArgb64 color) => new (color);
 
+        /// <summary>
+        /// Converts a <see cref="System.Drawing.Color"/> value to the floating-point representation.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The converted color.</returns>
         public static implicit operator ColorArgb(System.Drawing.Color color) => new (color.A / 255.0, color.R / 255.0, color.G / 255.0, color.B / 255.0);
 
+        /// <summary>
+        /// Blends two colors using a perceptual gradient.
+        /// </summary>
+        /// <param name="color1">The starting color.</param>
+        /// <param name="color2">The ending color.</param>
+        /// <param name="percent">Blend factor in the [0,1] range.</param>
+        /// <returns>The interpolated color.</returns>
         public static ColorArgb Gradient( ColorArgb color1, ColorArgb color2, double percent )
-	{
-		if (percent < 0) percent = 0;
-		else if (percent > 1) percent = 1;
-		return new ColorArgb(
-			color1.alpha * (1-percent) + color2.alpha * percent,
+        {
+                if (percent < 0) percent = 0;
+                else if (percent > 1) percent = 1;
+                return new ColorArgb(
+                        color1.alpha * (1-percent) + color2.alpha * percent,
 			Math.Sqrt(Math.Pow(color1.Red, 2) * (1-percent) + Math.Pow(color2.Red , 2) * percent),
 			Math.Sqrt(Math.Pow(color1.green, 2) * (1-percent) + Math.Pow(color2.green, 2) * percent),
 			Math.Sqrt(Math.Pow(color1.blue, 2) * (1-percent) + Math.Pow(color2.blue, 2) * percent)
 		);
 	}
-	public override readonly string ToString() => $"a:{alpha} R:{red} G:{green} B:{blue}";
+        /// <summary>
+        /// Returns a textual representation of the ARGB components.
+        /// </summary>
+        /// <returns>A string describing the ARGB values.</returns>
+        public override readonly string ToString() => $"a:{alpha} R:{red} G:{green} B:{blue}";
 
-	public IColorArgb<double> Over(IColorArgb<double> other) => new ColorArgb(
-		this.Alpha + (1.0 - this.Alpha) * other.Alpha,
-		this.Red * this.Alpha + (1.0 - this.Alpha) * other.Red,
-		this.Green * this.Alpha + (1.0 - this.Alpha) * other.Green,
-		this.Blue * this.Alpha + (1.0 - this.Alpha) * other.Blue
-	);
+        /// <summary>
+        /// Applies the Porter-Duff over operator using the current color as the foreground.
+        /// </summary>
+        /// <param name="other">The background color.</param>
+        /// <returns>The composited color.</returns>
+        public IColorArgb<double> Over(IColorArgb<double> other) => new ColorArgb(
+                this.Alpha + (1.0 - this.Alpha) * other.Alpha,
+                this.Red * this.Alpha + (1.0 - this.Alpha) * other.Red,
+                this.Green * this.Alpha + (1.0 - this.Alpha) * other.Green,
+                this.Blue * this.Alpha + (1.0 - this.Alpha) * other.Blue
+        );
 
-	public IColorArgb<double> Add(IColorArgb<double> other) => new ColorArgb(
-		MathEx.Min(1.0, this.Alpha + other.Alpha),
-		MathEx.Min(1.0, this.Red + other.Red),
-		MathEx.Min(1.0, this.Green + other.Green),
+        /// <summary>
+        /// Adds two colors while clamping each component to the [0,1] range.
+        /// </summary>
+        /// <param name="other">The color to add.</param>
+        /// <returns>The resulting color.</returns>
+        public IColorArgb<double> Add(IColorArgb<double> other) => new ColorArgb(
+                MathEx.Min(1.0, this.Alpha + other.Alpha),
+                MathEx.Min(1.0, this.Red + other.Red),
+                MathEx.Min(1.0, this.Green + other.Green),
                 MathEx.Min(1.0, this.Blue + other.Blue)
         );
 
+        /// <summary>
+        /// Produces a color using the component-wise minimum of the operands.
+        /// </summary>
+        /// <param name="other">The color compared with the current instance.</param>
+        /// <returns>The resulting color.</returns>
         public IColorArgb<double> Substract(IColorArgb<double> other) => new ColorArgb(
                         MathEx.Min(this.Alpha, other.Alpha),
                         MathEx.Min(this.Red, other.Red),

--- a/Utils.Imaging/Imaging/ColorArgb32.cs
+++ b/Utils.Imaging/Imaging/ColorArgb32.cs
@@ -11,8 +11,15 @@ namespace Utils.Imaging;
 /// </summary>
 public struct ColorArgb32 : IColorArgb<byte>, IEquatable<ColorArgb32>, IEqualityOperators<ColorArgb32, ColorArgb32, bool>
 {
-	public static byte MinValue { get; } = 0;
-	public static byte MaxValue { get; } = byte.MaxValue;
+        /// <summary>
+        /// Lowest component value available for the 8-bit representation.
+        /// </summary>
+        public static byte MinValue { get; } = 0;
+
+        /// <summary>
+        /// Highest component value available for the 8-bit representation.
+        /// </summary>
+        public static byte MaxValue { get; } = byte.MaxValue;
 
 	[FieldOffset(0)]
 	uint value;
@@ -26,94 +33,151 @@ public struct ColorArgb32 : IColorArgb<byte>, IEquatable<ColorArgb32>, IEquality
 	[FieldOffset(0)]
 	byte blue;
 
-	public uint Value
-	{
-		get { return value; }
-		set { this.value = value; }
-	}
+        /// <summary>
+        /// Gets or sets the packed ARGB value.
+        /// </summary>
+        public uint Value
+        {
+                get { return value; }
+                set { this.value = value; }
+        }
 
-	public byte Alpha
-	{
-		get { return alpha; }
-		set { this.alpha = value; }
-	}
+        /// <summary>
+        /// Gets or sets the alpha channel.
+        /// </summary>
+        public byte Alpha
+        {
+                get { return alpha; }
+                set { this.alpha = value; }
+        }
 
-	public byte Red
-	{
-		get { return red; }
-		set { this.red = value; }
-	}
+        /// <summary>
+        /// Gets or sets the red channel.
+        /// </summary>
+        public byte Red
+        {
+                get { return red; }
+                set { this.red = value; }
+        }
 
-	public byte Green
-	{
-		get { return green; }
-		set { this.green = value; }
-	}
+        /// <summary>
+        /// Gets or sets the green channel.
+        /// </summary>
+        public byte Green
+        {
+                get { return green; }
+                set { this.green = value; }
+        }
 
-	public byte Blue
-	{
-		get { return blue; }
-		set { this.blue = value; }
-	}
+        /// <summary>
+        /// Gets or sets the blue channel.
+        /// </summary>
+        public byte Blue
+        {
+                get { return blue; }
+                set { this.blue = value; }
+        }
 
+        /// <summary>
+        /// Initializes a color from a packed 32-bit ARGB value.
+        /// </summary>
+        /// <param name="color">The packed ARGB value.</param>
+        public ColorArgb32(uint color) : this()
+        {
+                this.alpha = (byte)(0xFF & color >> 24);
+                this.red = (byte)(0xFF & color >> 16);
+                this.green = (byte)(0xFF & color >> 8);
+                this.blue = (byte)(0xFF & color);
+        }
 
-	public ColorArgb32(uint color) : this()
-	{
-		this.alpha = (byte)(0xFF & color >> 24);
-		this.red = (byte)(0xFF & color >> 16);
-		this.green = (byte)(0xFF & color >> 8);
-		this.blue = (byte)(0xFF & color);
-	}
+        /// <summary>
+        /// Initializes an opaque color from explicit RGB components.
+        /// </summary>
+        /// <param name="red">Red component.</param>
+        /// <param name="green">Green component.</param>
+        /// <param name="blue">Blue component.</param>
+        public ColorArgb32(byte red, byte green, byte blue) : this(byte.MaxValue, red, green, blue) { }
 
-	public ColorArgb32(byte red, byte green, byte blue) : this(byte.MaxValue, red, green, blue) { }
-	public ColorArgb32(byte alpha, byte red, byte green, byte blue) : this()
-	{
-		this.alpha = alpha;
-		this.red = red;
-		this.green = green;
-		this.blue = blue;
-	}
+        /// <summary>
+        /// Initializes a color from explicit ARGB components.
+        /// </summary>
+        /// <param name="alpha">Alpha component.</param>
+        /// <param name="red">Red component.</param>
+        /// <param name="green">Green component.</param>
+        /// <param name="blue">Blue component.</param>
+        public ColorArgb32(byte alpha, byte red, byte green, byte blue) : this()
+        {
+                this.alpha = alpha;
+                this.red = red;
+                this.green = green;
+                this.blue = blue;
+        }
 
-	public ColorArgb32(byte[] array, int index) : this()
-	{
-		this.alpha = array[index];
-		this.red = array[index + 1];
-		this.green = array[index + 2];
-		this.blue = array[index + 3];
-	}
+        /// <summary>
+        /// Initializes a color by reading components from an array.
+        /// </summary>
+        /// <param name="array">The array containing ARGB values.</param>
+        /// <param name="index">The starting index for the alpha component.</param>
+        public ColorArgb32(byte[] array, int index) : this()
+        {
+                this.alpha = array[index];
+                this.red = array[index + 1];
+                this.green = array[index + 2];
+                this.blue = array[index + 3];
+        }
 
-	public ColorArgb32(IColorArgb<byte> colorArgb64) : this()
-	{
-		this.alpha = (byte)(colorArgb64.Alpha * 255);
-		this.red = (byte)(colorArgb64.Red * 255);
-		this.green = (byte)(colorArgb64.Green * 255);
-		this.blue = (byte)(colorArgb64.Blue * 255);
-	}
+        /// <summary>
+        /// Initializes a color by converting from another 8-bit color representation.
+        /// </summary>
+        /// <param name="colorArgb64">The source color.</param>
+        public ColorArgb32(IColorArgb<byte> colorArgb64) : this()
+        {
+                this.alpha = (byte)(colorArgb64.Alpha * 255);
+                this.red = (byte)(colorArgb64.Red * 255);
+                this.green = (byte)(colorArgb64.Green * 255);
+                this.blue = (byte)(colorArgb64.Blue * 255);
+        }
 
-	public ColorArgb32(ColorArgb colorArgb64) : this()
-	{
-		this.alpha = (byte)(colorArgb64.Alpha * 255);
-		this.red = (byte)(colorArgb64.Red * 255);
-		this.green = (byte)(colorArgb64.Green * 255);
-		this.blue = (byte)(colorArgb64.Blue * 255);
-	}
+        /// <summary>
+        /// Initializes a color by converting from a floating-point representation.
+        /// </summary>
+        /// <param name="colorArgb64">The source color.</param>
+        public ColorArgb32(ColorArgb colorArgb64) : this()
+        {
+                this.alpha = (byte)(colorArgb64.Alpha * 255);
+                this.red = (byte)(colorArgb64.Red * 255);
+                this.green = (byte)(colorArgb64.Green * 255);
+                this.blue = (byte)(colorArgb64.Blue * 255);
+        }
 
-	public ColorArgb32(ColorArgb64 colorArgb64) : this()
-	{
-		this.alpha = (byte)(colorArgb64.Alpha >> 8);
-		this.red = (byte)(colorArgb64.Red >> 8);
-		this.green = (byte)(colorArgb64.Green >> 8);
-		this.blue = (byte)(colorArgb64.Blue >> 8);
-	}
+        /// <summary>
+        /// Initializes a color by converting from a 16-bit representation.
+        /// </summary>
+        /// <param name="colorArgb64">The source color.</param>
+        public ColorArgb32(ColorArgb64 colorArgb64) : this()
+        {
+                this.alpha = (byte)(colorArgb64.Alpha >> 8);
+                this.red = (byte)(colorArgb64.Red >> 8);
+                this.green = (byte)(colorArgb64.Green >> 8);
+                this.blue = (byte)(colorArgb64.Blue >> 8);
+        }
 
-	public ColorArgb32(System.Drawing.Color color) : this()
-	{
-		Alpha = color.A;
-		Red = color.R;
-		Green = color.G;
-		Blue = color.B;
-	}
+        /// <summary>
+        /// Initializes a color from a <see cref="System.Drawing.Color"/> value.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        public ColorArgb32(System.Drawing.Color color) : this()
+        {
+                Alpha = color.A;
+                Red = color.R;
+                Green = color.G;
+                Blue = color.B;
+        }
 
+        /// <summary>
+        /// Initializes a color from an HSV representation.
+        /// </summary>
+        /// <param name="colorAHSV">The HSV color to convert.</param>
         public ColorArgb32(ColorAhsv32 colorAHSV) : this()
         {
                 this = colorAHSV.ToArgbColor();
@@ -138,65 +202,110 @@ public struct ColorArgb32 : IColorArgb<byte>, IEquatable<ColorArgb32>, IEquality
         /// </summary>
         public static bool operator !=(ColorArgb32 left, ColorArgb32 right) => !left.Equals(right);
 
-	public static implicit operator ColorArgb32(ColorAhsv32 color)
-	{
-		return new ColorArgb32(color);
-	}
+        /// <summary>
+        /// Converts an HSV color to the 8-bit ARGB representation.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The converted color.</returns>
+        public static implicit operator ColorArgb32(ColorAhsv32 color)
+        {
+                return new ColorArgb32(color);
+        }
 
-	public static implicit operator ColorArgb32(ColorArgb color)
-	{
-		return new ColorArgb32(color);
-	}
+        /// <summary>
+        /// Converts a floating-point ARGB color to the 8-bit representation.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The converted color.</returns>
+        public static implicit operator ColorArgb32(ColorArgb color)
+        {
+                return new ColorArgb32(color);
+        }
 
-	public static implicit operator ColorArgb32(ColorArgb64 color)
-	{
-		return new ColorArgb32(color);
-	}
+        /// <summary>
+        /// Converts a 16-bit ARGB color to the 8-bit representation.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The converted color.</returns>
+        public static implicit operator ColorArgb32(ColorArgb64 color)
+        {
+                return new ColorArgb32(color);
+        }
 
-	public static implicit operator ColorArgb32(System.Drawing.Color color)
-	{
-		return new ColorArgb32(color);
-	}
+        /// <summary>
+        /// Converts a <see cref="System.Drawing.Color"/> value to the 8-bit representation.
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The converted color.</returns>
+        public static implicit operator ColorArgb32(System.Drawing.Color color)
+        {
+                return new ColorArgb32(color);
+        }
 
-	public override string ToString() => $"a:{alpha} R:{red} G:{green} B:{blue}";
+        /// <summary>
+        /// Returns a textual representation of the ARGB components.
+        /// </summary>
+        /// <returns>A string describing the ARGB values.</returns>
+        public override string ToString() => $"a:{alpha} R:{red} G:{green} B:{blue}";
 
-	public IColorArgb<byte> Over(IColorArgb<byte> other)
-	{
-		return new ColorArgb32(
-				(byte)(this.Alpha + (byte.MaxValue - this.Alpha) * other.Alpha / byte.MaxValue),
-				(byte)(this.Red * this.Alpha + (byte.MaxValue - this.Alpha) * other.Red / byte.MaxValue),
-				(byte)(this.Green * this.Alpha + (byte.MaxValue - this.Alpha) * other.Green / byte.MaxValue),
-				(byte)(this.Blue * this.Alpha + (byte.MaxValue - this.Alpha) * other.Blue / byte.MaxValue)
-			);
-	}
+        /// <summary>
+        /// Applies the Porter-Duff over operator using the current color as the foreground.
+        /// </summary>
+        /// <param name="other">The background color.</param>
+        /// <returns>The composited color.</returns>
+        public IColorArgb<byte> Over(IColorArgb<byte> other)
+        {
+                return new ColorArgb32(
+                                (byte)(this.Alpha + (byte.MaxValue - this.Alpha) * other.Alpha / byte.MaxValue),
+                                (byte)(this.Red * this.Alpha + (byte.MaxValue - this.Alpha) * other.Red / byte.MaxValue),
+                                (byte)(this.Green * this.Alpha + (byte.MaxValue - this.Alpha) * other.Green / byte.MaxValue),
+                                (byte)(this.Blue * this.Alpha + (byte.MaxValue - this.Alpha) * other.Blue / byte.MaxValue)
+                        );
+        }
 
-	public IColorArgb<byte> Add(IColorArgb<byte> other)
-	{
-		return new ColorArgb32(
-				(byte)MathEx.Min(byte.MaxValue, this.Alpha + other.Alpha),
-				(byte)MathEx.Min(byte.MaxValue, this.Red + other.Red),
-				(byte)MathEx.Min(byte.MaxValue, this.Green + other.Green),
-				(byte)MathEx.Min(byte.MaxValue, this.Blue + other.Blue)
-			);
-	}
+        /// <summary>
+        /// Adds two colors while clamping each component to the valid range.
+        /// </summary>
+        /// <param name="other">The color to add.</param>
+        /// <returns>The resulting color.</returns>
+        public IColorArgb<byte> Add(IColorArgb<byte> other)
+        {
+                return new ColorArgb32(
+                                (byte)MathEx.Min(byte.MaxValue, this.Alpha + other.Alpha),
+                                (byte)MathEx.Min(byte.MaxValue, this.Red + other.Red),
+                                (byte)MathEx.Min(byte.MaxValue, this.Green + other.Green),
+                                (byte)MathEx.Min(byte.MaxValue, this.Blue + other.Blue)
+                        );
+        }
 
-	public IColorArgb<byte> Substract(IColorArgb<byte> other)
-	{
-		return new ColorArgb32(
-						MathEx.Min(this.Alpha, other.Alpha),
-						MathEx.Min(this.Red, other.Red),
-						MathEx.Min(this.Green, other.Green),
-						MathEx.Min(this.Blue, other.Blue)
-				);
-	}
+        /// <summary>
+        /// Produces a color using the component-wise minimum of the operands.
+        /// </summary>
+        /// <param name="other">The color compared with the current instance.</param>
+        /// <returns>The resulting color.</returns>
+        public IColorArgb<byte> Substract(IColorArgb<byte> other)
+        {
+                return new ColorArgb32(
+                                                MathEx.Min(this.Alpha, other.Alpha),
+                                                MathEx.Min(this.Red, other.Red),
+                                                MathEx.Min(this.Green, other.Green),
+                                                MathEx.Min(this.Blue, other.Blue)
+                                );
+        }
 
-
-	public static ColorArgb32 LinearGrandient(ColorArgb32 color1, ColorArgb32 color2, float position)
-	{
-		return new ColorArgb32(
-			(byte)(color1.alpha * (1 - position) + color2.alpha * position),
-			(byte)(color1.red * (1 - position) + color2.red * position),
-			(byte)(color1.green * (1 - position) + color2.green * position),
+        /// <summary>
+        /// Computes a linear gradient between two colors.
+        /// </summary>
+        /// <param name="color1">The starting color.</param>
+        /// <param name="color2">The ending color.</param>
+        /// <param name="position">Interpolation factor between 0 and 1.</param>
+        /// <returns>The interpolated color.</returns>
+        public static ColorArgb32 LinearGrandient(ColorArgb32 color1, ColorArgb32 color2, float position)
+        {
+                return new ColorArgb32(
+                        (byte)(color1.alpha * (1 - position) + color2.alpha * position),
+                        (byte)(color1.red * (1 - position) + color2.red * position),
+                        (byte)(color1.green * (1 - position) + color2.green * position),
 			(byte)(color1.blue * (1 - position) + color2.blue * position)
 		);
 	}

--- a/Utils.Imaging/Imaging/ColorArgb64.cs
+++ b/Utils.Imaging/Imaging/ColorArgb64.cs
@@ -12,8 +12,15 @@ namespace Utils.Imaging;
 [StructLayout(LayoutKind.Explicit)]
 public struct ColorArgb64 : IColorArgb<ushort>, IEquatable<ColorArgb64>, IEqualityOperators<ColorArgb64, ColorArgb64, bool>
 {
-	public static ushort MinValue { get; } = 0;
-	public static ushort MaxValue { get; } = ushort.MaxValue;
+        /// <summary>
+        /// Lowest component value available for the 16-bit representation.
+        /// </summary>
+        public static ushort MinValue { get; } = 0;
+
+        /// <summary>
+        /// Highest component value available for the 16-bit representation.
+        /// </summary>
+        public static ushort MaxValue { get; } = ushort.MaxValue;
 
 	[FieldOffset(0)]
 	ulong value;
@@ -27,35 +34,50 @@ public struct ColorArgb64 : IColorArgb<ushort>, IEquatable<ColorArgb64>, IEquali
 	[FieldOffset(0)]
 	ushort blue;
 
-	public ulong Value
-	{
-		get { return value; }
-		set { this.value = value; }
-	}
+        /// <summary>
+        /// Gets or sets the packed ARGB value.
+        /// </summary>
+        public ulong Value
+        {
+                get { return value; }
+                set { this.value = value; }
+        }
 
-	public ushort Alpha
-	{
-		get { return alpha; }
-		set { this.alpha = value; }
-	}
+        /// <summary>
+        /// Gets or sets the alpha channel.
+        /// </summary>
+        public ushort Alpha
+        {
+                get { return alpha; }
+                set { this.alpha = value; }
+        }
 
-	public ushort Red
-	{
-		get { return red; }
-		set { this.red = value; }
-	}
+        /// <summary>
+        /// Gets or sets the red channel.
+        /// </summary>
+        public ushort Red
+        {
+                get { return red; }
+                set { this.red = value; }
+        }
 
-	public ushort Green
-	{
-		get { return green; }
-		set { this.green = value; }
-	}
+        /// <summary>
+        /// Gets or sets the green channel.
+        /// </summary>
+        public ushort Green
+        {
+                get { return green; }
+                set { this.green = value; }
+        }
 
-	public ushort Blue
-	{
-		get { return blue; }
-		set { this.blue = value; }
-	}
+        /// <summary>
+        /// Gets or sets the blue channel.
+        /// </summary>
+        public ushort Blue
+        {
+                get { return blue; }
+                set { this.blue = value; }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ColorArgb64"/> struct from a 64-bit packed ARGB value.

--- a/Utils.Imaging/Imaging/IImageAccessor.cs
+++ b/Utils.Imaging/Imaging/IImageAccessor.cs
@@ -1,145 +1,239 @@
 ﻿using System;
 using System.Drawing;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 
 namespace Utils.Imaging;
 
+/// <summary>
+/// Provides strongly typed access to an image whose pixels are represented by an ARGB color structure.
+/// </summary>
+/// <typeparam name="A">ARGB color representation used for each pixel.</typeparam>
+/// <typeparam name="T">Numeric type describing the channel precision.</typeparam>
 public interface IImageAccessor<A, T> : IImageAccessor<A>
-	where T : struct, INumber<T>
-	where A : IColorArgb<T>
+    where T : struct, INumber<T>
+    where A : IColorArgb<T>
 { }
 
+/// <summary>
+/// Describes an abstraction capable of exposing read/write access to a two-dimensional image resource.
+/// </summary>
+/// <typeparam name="T">Pixel value representation.</typeparam>
 public interface IImageAccessor<T>
 {
-	/// <summary>
-	/// Image width
-	/// </summary>
-	int Width { get; }
-	/// <summary>
-	/// Image height
-	/// </summary>
-	int Height { get; }
+    /// <summary>
+    /// Gets the width of the region exposed by the accessor, in pixels.
+    /// </summary>
+    int Width { get; }
 
-	/// <summary>
-	/// Pixel accessor
-	/// </summary>
-	/// <param name="x">x coordinate</param>
-	/// <param name="y">y coordinate</param>
-	/// <returns></returns>
-	T this[int x, int y] { get; set; }
-	/// <summary>
-	/// Pixel accessor
-	/// </summary>
-	/// <param name="p">pixel coordinates</param>
-	/// <returns></returns>
-	T this[Point p] {
-		get => this[p.X, p.Y];
-		set => this[p.X, p.Y] = value;
-	}
-}
+    /// <summary>
+    /// Gets the height of the region exposed by the accessor, in pixels.
+    /// </summary>
+    int Height { get; }
 
-public interface IColorArgb<T> where T : struct, INumber<T>
-{
-	virtual static T MinValue { get; } = T.CreateChecked(0);
-	abstract static T MaxValue { get; }
+    /// <summary>
+    /// Gets or sets a pixel at the provided zero-based coordinates.
+    /// </summary>
+    /// <param name="x">Horizontal coordinate of the pixel to access.</param>
+    /// <param name="y">Vertical coordinate of the pixel to access.</param>
+    T this[int x, int y] { get; set; }
 
-	T Alpha { get; set; }
-	T Red { get; set; }
-	T Green { get; set; }
-	T Blue { get; set; }
-
-	IColorArgb<T> Over(IColorArgb<T> other);
-	IColorArgb<T> Add(IColorArgb<T> other);
-	IColorArgb<T> Substract(IColorArgb<T> other);
-	void Deconstruct(out T alpha, out T red, out T green, out T blue)
-	{
-		alpha = Alpha;
-		red = Red;
-		green = Green;
-		blue = Blue;
-	}
-	void Deconstruct(out T red, out T green, out T blue)
-	{
-		red = Red;
-		green = Green;
-		blue = Blue;
-	}
-
+    /// <summary>
+    /// Gets or sets a pixel at the provided zero-based coordinates.
+    /// </summary>
+    /// <param name="p">Location of the pixel to access.</param>
+    T this[Point p]
+    {
+        get => this[p.X, p.Y];
+        set => this[p.X, p.Y] = value;
+    }
 }
 
 /// <summary>
-/// Define the color system to be convertible with <typeparamref name="TArgb"/>
+/// Represents a color value expressed through alpha, red, green, and blue channels.
 /// </summary>
-/// <typeparam name="TSelf"></typeparam>
-/// <typeparam name="TArgb"></typeparam>
-/// <typeparam name="T"></typeparam>
-public interface IColorArgbConvertible<TSelf, TArgb, T>
-	where TSelf : IColorArgbConvertible<TSelf, TArgb, T>
-	where TArgb : IColorArgb<T>
-	where T : struct, INumber<T>
+/// <typeparam name="T">Numeric type describing the channel precision.</typeparam>
+public interface IColorArgb<T>
+    where T : struct, INumber<T>
 {
-	/// <summary>
-	/// Convert from ArgbColor
-	/// </summary>
-	/// <param name="color"><typeparamref name="TSelf"/> to convert from</param>
-	/// <returns><typeparamref name="TSelf"/></returns>
-	static abstract TSelf FromArgbColor(TArgb color);
+    /// <summary>
+    /// Gets the minimum representable value for each channel.
+    /// </summary>
+    static virtual T MinValue { get; } = T.CreateChecked(0);
 
-	/// <summary>
-	/// Implicitly convert from <typeparamref name="TArgb"/>
-	/// </summary>
-	/// <param name="color"></param>
-	static virtual implicit operator TSelf(TArgb color) => TSelf.FromArgbColor(color);
+    /// <summary>
+    /// Gets the maximum representable value for each channel.
+    /// </summary>
+    static abstract T MaxValue { get; }
 
-	/// <summary>
-	/// Converts to <typeparamref name="TArgb"/>
-	/// </summary>
-	/// <returns><typeparamref name="TArgb"/></returns>
-	TArgb ToArgbColor();
+    /// <summary>
+    /// Gets or sets the alpha channel component.
+    /// </summary>
+    T Alpha { get; set; }
 
-	/// <summary>
-	/// Implicitly convert to <typeparamref name="TArgb"/>
-	/// </summary>
-	/// <param name="color"></param>
-	static virtual implicit operator TArgb(TSelf color) => color.ToArgbColor();
+    /// <summary>
+    /// Gets or sets the red channel component.
+    /// </summary>
+    T Red { get; set; }
 
+    /// <summary>
+    /// Gets or sets the green channel component.
+    /// </summary>
+    T Green { get; set; }
+
+    /// <summary>
+    /// Gets or sets the blue channel component.
+    /// </summary>
+    T Blue { get; set; }
+
+    /// <summary>
+    /// Blends this color over <paramref name="other"/> using standard alpha compositing.
+    /// </summary>
+    /// <param name="other">Underlying color to blend onto.</param>
+    /// <returns>The composited color.</returns>
+    IColorArgb<T> Over(IColorArgb<T> other);
+
+    /// <summary>
+    /// Adds the channels of <paramref name="other"/> to this color and returns the result.
+    /// </summary>
+    /// <param name="other">Color to add channel values from.</param>
+    /// <returns>The channel-wise sum.</returns>
+    IColorArgb<T> Add(IColorArgb<T> other);
+
+    /// <summary>
+    /// Subtracts the channels of <paramref name="other"/> from this color and returns the result.
+    /// </summary>
+    /// <param name="other">Color providing channel values to subtract.</param>
+    /// <returns>The channel-wise difference.</returns>
+    IColorArgb<T> Substract(IColorArgb<T> other);
+
+    /// <summary>
+    /// Deconstructs the color into its alpha and RGB components.
+    /// </summary>
+    /// <param name="alpha">Receives the alpha component.</param>
+    /// <param name="red">Receives the red component.</param>
+    /// <param name="green">Receives the green component.</param>
+    /// <param name="blue">Receives the blue component.</param>
+    void Deconstruct(out T alpha, out T red, out T green, out T blue)
+    {
+        alpha = Alpha;
+        red = Red;
+        green = Green;
+        blue = Blue;
+    }
+
+    /// <summary>
+    /// Deconstructs the color into its RGB components, discarding alpha.
+    /// </summary>
+    /// <param name="red">Receives the red component.</param>
+    /// <param name="green">Receives the green component.</param>
+    /// <param name="blue">Receives the blue component.</param>
+    void Deconstruct(out T red, out T green, out T blue)
+    {
+        red = Red;
+        green = Green;
+        blue = Blue;
+    }
 }
 
-public interface IColorAhsv<T> where T : struct, INumber<T>
+/// <summary>
+/// Defines a color system that can convert to and from an ARGB representation.
+/// </summary>
+/// <typeparam name="TSelf">Implementing color type.</typeparam>
+/// <typeparam name="TArgb">ARGB representation compatible with <typeparamref name="TSelf"/>.</typeparam>
+/// <typeparam name="T">Numeric type describing the channel precision.</typeparam>
+public interface IColorArgbConvertible<TSelf, TArgb, T>
+    where TSelf : IColorArgbConvertible<TSelf, TArgb, T>
+    where TArgb : IColorArgb<T>
+    where T : struct, INumber<T>
 {
-	virtual static T MinValue { get; } = T.CreateChecked(0);
-	abstract static T MaxValue { get; }
+    /// <summary>
+    /// Converts an ARGB color into the implementing type.
+    /// </summary>
+    /// <param name="color">ARGB source color.</param>
+    /// <returns>Equivalent color expressed as <typeparamref name="TSelf"/>.</returns>
+    static abstract TSelf FromArgbColor(TArgb color);
 
-	/// <summary>
-	/// Alpha component
-	/// </summary>
-	T Alpha { get; set; }
-	/// <summary>
-	/// Hue component
-	/// </summary>
-	T Hue { get; set; }
-	/// <summary>
-	/// Saturation component
-	/// </summary>
-	T Saturation { get; set; }
-	/// <summary>
-	/// Value component
-	/// </summary>
-	T Value { get; set; }
-	void Deconstruct(out T alpha, out T hue, out T saturation, out T value)
-	{
-		alpha = Alpha;
-		hue = Hue;
-		saturation = Saturation;
-		value = Value;
-	}
+    /// <summary>
+    /// Implicitly convert from <typeparamref name="TArgb"/>.
+    /// </summary>
+    /// <param name="color">ARGB color to convert.</param>
+    static virtual implicit operator TSelf(TArgb color) => TSelf.FromArgbColor(color);
 
-	void Deconstruct(out T hue, out T saturation, out T value)
-	{
-		hue = Hue;
-		saturation = Saturation;
-		value = Value;
-	}
+    /// <summary>
+    /// Converts this color to its ARGB representation.
+    /// </summary>
+    /// <returns>Equivalent color expressed as <typeparamref name="TArgb"/>.</returns>
+    TArgb ToArgbColor();
 
+    /// <summary>
+    /// Implicitly convert to <typeparamref name="TArgb"/>.
+    /// </summary>
+    /// <param name="color">Color to convert.</param>
+    static virtual implicit operator TArgb(TSelf color) => color.ToArgbColor();
+}
+
+/// <summary>
+/// Represents a color value expressed through alpha, hue, saturation, and value channels.
+/// </summary>
+/// <typeparam name="T">Numeric type describing the channel precision.</typeparam>
+public interface IColorAhsv<T>
+    where T : struct, INumber<T>
+{
+    /// <summary>
+    /// Gets the minimum representable value for each channel.
+    /// </summary>
+    static virtual T MinValue { get; } = T.CreateChecked(0);
+
+    /// <summary>
+    /// Gets the maximum representable value for each channel.
+    /// </summary>
+    static abstract T MaxValue { get; }
+
+    /// <summary>
+    /// Gets or sets the alpha channel component.
+    /// </summary>
+    T Alpha { get; set; }
+
+    /// <summary>
+    /// Gets or sets the hue channel component.
+    /// </summary>
+    T Hue { get; set; }
+
+    /// <summary>
+    /// Gets or sets the saturation channel component.
+    /// </summary>
+    T Saturation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value (brightness) channel component.
+    /// </summary>
+    T Value { get; set; }
+
+    /// <summary>
+    /// Deconstructs the color into alpha, hue, saturation, and value components.
+    /// </summary>
+    /// <param name="alpha">Receives the alpha component.</param>
+    /// <param name="hue">Receives the hue component.</param>
+    /// <param name="saturation">Receives the saturation component.</param>
+    /// <param name="value">Receives the value component.</param>
+    void Deconstruct(out T alpha, out T hue, out T saturation, out T value)
+    {
+        alpha = Alpha;
+        hue = Hue;
+        saturation = Saturation;
+        value = Value;
+    }
+
+    /// <summary>
+    /// Deconstructs the color into hue, saturation, and value components, discarding alpha.
+    /// </summary>
+    /// <param name="hue">Receives the hue component.</param>
+    /// <param name="saturation">Receives the saturation component.</param>
+    /// <param name="value">Receives the value component.</param>
+    void Deconstruct(out T hue, out T saturation, out T value)
+    {
+        hue = Hue;
+        saturation = Saturation;
+        value = Value;
+    }
 }

--- a/Utils.Imaging/Imaging/ImageUtils.cs
+++ b/Utils.Imaging/Imaging/ImageUtils.cs
@@ -5,46 +5,65 @@ using System.Drawing.Imaging;
 
 namespace Utils.Imaging
 {
-	public static class ImageUtils
-	{
-        private static readonly Dictionary<string, ImageCodecInfo> ImageEncoderInfos = new Dictionary<string, ImageCodecInfo>();
-        private static readonly Dictionary<string, ImageCodecInfo> ImageDecoderInfos = new Dictionary<string, ImageCodecInfo>();
+    /// <summary>
+    /// Provides helpers to resolve image encoders and decoders by MIME type.
+    /// </summary>
+    public static class ImageUtils
+    {
+        private static readonly Dictionary<string, ImageCodecInfo> ImageEncoderInfos = new();
+        private static readonly Dictionary<string, ImageCodecInfo> ImageDecoderInfos = new();
 
+        /// <summary>
+        /// Retrieves the <see cref="ImageCodecInfo"/> encoder matching the provided MIME type.
+        /// </summary>
+        /// <param name="mimeType">Encoder MIME type to search.</param>
+        /// <returns>The matching encoder, or <see langword="null"/> when none exists.</returns>
         public static ImageCodecInfo GetEncoderInfo(string mimeType)
         {
-            if (ImageEncoderInfos.TryGetValue(mimeType, out ImageCodecInfo encoder)) return encoder;
+            if (ImageEncoderInfos.TryGetValue(mimeType, out ImageCodecInfo encoder))
+            {
+                return encoder;
+            }
 
-            int j;
             ImageCodecInfo result = null;
             var encoders = ImageCodecInfo.GetImageEncoders();
-            for (j = 0; j < encoders.Length; ++j)
+            for (var index = 0; index < encoders.Length; ++index)
             {
-                encoder = encoders[j];
+                encoder = encoders[index];
                 ImageEncoderInfos[encoder.MimeType] = encoder;
                 if (encoder.MimeType == mimeType)
                 {
                     result = encoder;
                 }
             }
+
             return result;
         }
 
+        /// <summary>
+        /// Retrieves the <see cref="ImageCodecInfo"/> decoder matching the provided MIME type.
+        /// </summary>
+        /// <param name="mimeType">Decoder MIME type to search.</param>
+        /// <returns>The matching decoder, or <see langword="null"/> when none exists.</returns>
         public static ImageCodecInfo GetDecoderInfo(string mimeType)
         {
-            if (ImageDecoderInfos.TryGetValue(mimeType, out ImageCodecInfo encoder)) return encoder;
-
-            int j;
-            ImageCodecInfo result = null;
-            var encoders = ImageCodecInfo.GetImageDecoders();
-            for (j = 0; j < encoders.Length; ++j)
+            if (ImageDecoderInfos.TryGetValue(mimeType, out ImageCodecInfo encoder))
             {
-                encoder = encoders[j];
+                return encoder;
+            }
+
+            ImageCodecInfo result = null;
+            var decoders = ImageCodecInfo.GetImageDecoders();
+            for (var index = 0; index < decoders.Length; ++index)
+            {
+                encoder = decoders[index];
                 ImageDecoderInfos[encoder.MimeType] = encoder;
                 if (encoder.MimeType == mimeType)
                 {
                     result = encoder;
                 }
             }
+
             return result;
         }
     }


### PR DESCRIPTION
## Summary
- add XML documentation to imaging accessor interfaces to explain pixel dimensions, ARGB channels, and conversion expectations
- document ImageUtils helpers and normalize indentation while keeping cached codec lookups intact

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68cc3191ff888326a8beba672868f0cc