### PR TITLE
Refactor ArrayAccessor caches

### DIFF
--- a/Utils/Arrays/ArrayAccessor.cs
+++ b/Utils/Arrays/ArrayAccessor.cs
@@ -116,13 +116,10 @@ public class ArrayAccessor<T> : ArrayAccessor<T, T[]>
 	/// </summary>
 	public int Offset { get; }
 
-	/// <summary>
-	/// Pre-computed offsets for each dimension except the last one.
-	/// Each inner array contains the offsets for a given dimension.
-	/// </summary>
-	private readonly ImmutableArray<ImmutableArray<int>> offsetTables;
-
-	private readonly ImmutableArray<int> dimmensionElementsCount;
+        /// <summary>
+        /// Cache describing each dimension to accelerate offset and length calculations.
+        /// </summary>
+        private readonly ImmutableArray<DimensionCache> dimensionCaches;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ArrayAccessor{T}"/> class.
@@ -133,51 +130,45 @@ public class ArrayAccessor<T> : ArrayAccessor<T, T[]>
 	public ArrayAccessor(T[] array, int offset, params int[] dimensions) : base(array, dimensions)
 	{
 		this.Offset = offset.ArgMustBeGreaterOrEqualsThan(0);
-		offsetTables = CreateOffsets(dimensions);
-		dimmensionElementsCount = CreateDimmensionElementsCount(dimensions);
-	}
+                dimensionCaches = CreateDimensionCaches(dimensions);
+        }
 
-	/// <summary>
-	/// Compute the number of elements in each dimension.
-	/// </summary>
-	/// <param name="dimensions">dimensions definitions</param>
-	/// <returns>Dimensions sizes</returns>
-	public static ImmutableArray<int> CreateDimmensionElementsCount(int[] dimensions)
-	{
-		int[] results = new int[dimensions.Length];
-		int length = 1;
-		for (int i = dimensions.Length - 1; i >= 0; i--)
-		{
-			results[i] = length;
-			length *= dimensions[i];
-		}
+        /// <summary>
+        /// Creates the cache describing each dimension of the accessor.
+        /// </summary>
+        /// <param name="dimensions">The sizes of each dimension.</param>
+        /// <returns>The cache entries for every dimension.</returns>
+        private static ImmutableArray<DimensionCache> CreateDimensionCaches(int[] dimensions)
+        {
+                DimensionCache[] caches = new DimensionCache[dimensions.Length];
+                int elementCount = 1;
 
-		return [.. results];
-	}
+                for (int i = dimensions.Length - 1; i >= 0; i--)
+                {
+                        int[] offsets = i < dimensions.Length - 1 ? CreateOffsetsForDimension(dimensions[i], elementCount) : Array.Empty<int>();
+                        caches[i] = new DimensionCache(offsets, elementCount, dimensions[i]);
+                        elementCount *= dimensions[i];
+                }
 
-	/// <summary>
-	/// Compute offsets for each dimension to facilitate index calculations.
-	/// </summary>
-	/// <param name="dimensions">dimensions definitions</param>
-	/// <returns>Offsets</returns>
-	private static ImmutableArray<ImmutableArray<int>> CreateOffsets(int[] dimensions)
-	{
-		ImmutableArray<int>[] result = new ImmutableArray<int>[dimensions.Length - 1];
+                return [.. caches];
+        }
 
-		int dimensionLength = dimensions[^1];
+        /// <summary>
+        /// Creates the offsets for a specific dimension.
+        /// </summary>
+        /// <param name="size">The size of the dimension.</param>
+        /// <param name="elementCount">The number of elements contained in a single entry of the dimension.</param>
+        /// <returns>The pre-computed offsets for the dimension.</returns>
+        private static int[] CreateOffsetsForDimension(int size, int elementCount)
+        {
+                int[] offsets = new int[size];
+                for (int index = 0; index < size; index++)
+                {
+                        offsets[index] = index * elementCount;
+                }
 
-		for (int i = dimensions.Length - 2; i >= 0; i--)
-		{
-			int[] currentOffsets = new int[dimensions[i]];
-			for (int j = 0, k = 0; k < dimensions[i]; j += dimensionLength, k++)
-			{
-				currentOffsets[k] = j;
-			}
-			result[i] = [.. currentOffsets];
-			dimensionLength *= dimensions[i];
-		}
-		return [.. result];
-	}
+                return offsets;
+        }
 
 	/// <summary>
 	/// Validates that the underlying array has sufficient size for the specified dimensions.
@@ -198,14 +189,14 @@ public class ArrayAccessor<T> : ArrayAccessor<T, T[]>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private int Position(int[] references)
 	{
-		int position = Offset;
-		for (int i = 0; i < references.Length - 1; i++)
-		{
-			position += offsetTables[i][references[i]];
-		}
-		position += references[^1];
-		return position;
-	}
+                int position = Offset;
+                for (int i = 0; i < references.Length - 1; i++)
+                {
+                        position += dimensionCaches[i].Offsets[references[i]];
+                }
+                position += references[^1];
+                return position;
+        }
 
 	/// <summary>
 	/// Retrieves the element at the specified multi-dimensional index.
@@ -235,25 +226,63 @@ public class ArrayAccessor<T> : ArrayAccessor<T, T[]>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public Span<T> AsSpan(params int[] indexes)
 	{
-		if (indexes.Length == 0) return this.innerObject.AsSpan(Offset, dimmensionElementsCount[0] * Sizes[0]);
+                if (indexes.Length == 0)
+                {
+                        DimensionCache root = dimensionCaches[0];
+                        return this.innerObject.AsSpan(Offset, root.ElementCount * root.Size);
+                }
 
-		indexes.ArgMustBe(a => a.Length <= Dimensions, "Too many indexes provided.");
+                indexes.ArgMustBe(a => a.Length <= Dimensions, "Too many indexes provided.");
 
-		int position = Offset;
-		for (int i = 0; i < indexes.Length; i++)
-		{
-			var index = indexes[i];
+                int position = Offset;
+                for (int i = 0; i < indexes.Length; i++)
+                {
+                        var index = indexes[i];
 
-			if (index < 0 || index >= Sizes[i])
-				throw new IndexOutOfRangeException($"Index {index} is out of bounds for dimension {i}.");
-			
-			if (i < offsetTables.Length)
-				position += offsetTables[i][index];
-			else
-				position += index;
-		}
+                        if (index < 0 || index >= Sizes[i])
+                                throw new IndexOutOfRangeException($"Index {index} is out of bounds for dimension {i}.");
 
-		int length = dimmensionElementsCount[indexes.Length -1];
-		return this.innerObject.AsSpan(position, length);
-	}
+                        if (i < dimensionCaches.Length - 1)
+                                position += dimensionCaches[i].Offsets[index];
+                        else
+                                position += index;
+                }
+
+                int length = dimensionCaches[indexes.Length - 1].ElementCount;
+                return this.innerObject.AsSpan(position, length);
+        }
+
+        /// <summary>
+        /// Cache entry describing a single dimension.
+        /// </summary>
+        private readonly struct DimensionCache
+        {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="DimensionCache"/> struct.
+                /// </summary>
+                /// <param name="offsets">Offsets allowing direct access to the underlying array.</param>
+                /// <param name="elementCount">Number of elements contained in a single entry of the dimension.</param>
+                /// <param name="size">Size of the dimension.</param>
+                public DimensionCache(int[] offsets, int elementCount, int size)
+                {
+                        Offsets = offsets;
+                        ElementCount = elementCount;
+                        Size = size;
+                }
+
+                /// <summary>
+                /// Gets the offsets for each element of the dimension.
+                /// </summary>
+                public int[] Offsets { get; }
+
+                /// <summary>
+                /// Gets the number of elements contained by a single entry of the dimension.
+                /// </summary>
+                public int ElementCount { get; }
+
+                /// <summary>
+                /// Gets the size of the dimension.
+                /// </summary>
+                public int Size { get; }
+        }
 }

--- a/Utils/Arrays/ArrayAccessor.cs
+++ b/Utils/Arrays/ArrayAccessor.cs
@@ -143,31 +143,21 @@ public class ArrayAccessor<T> : ArrayAccessor<T, T[]>
                 DimensionCache[] caches = new DimensionCache[dimensions.Length];
                 int elementCount = 1;
 
-                for (int i = dimensions.Length - 1; i >= 0; i--)
+                for (int dimensionIndex = dimensions.Length - 1; dimensionIndex >= 0; dimensionIndex--)
                 {
-                        int[] offsets = i < dimensions.Length - 1 ? CreateOffsetsForDimension(dimensions[i], elementCount) : Array.Empty<int>();
-                        caches[i] = new DimensionCache(offsets, elementCount, dimensions[i]);
-                        elementCount *= dimensions[i];
+                        int size = dimensions[dimensionIndex];
+                        int[] offsets = new int[size];
+
+                        for (int index = 0; index < size; index++)
+                        {
+                                offsets[index] = index * elementCount;
+                        }
+
+                        caches[dimensionIndex] = new DimensionCache(offsets, elementCount, size);
+                        elementCount *= size;
                 }
 
                 return [.. caches];
-        }
-
-        /// <summary>
-        /// Creates the offsets for a specific dimension.
-        /// </summary>
-        /// <param name="size">The size of the dimension.</param>
-        /// <param name="elementCount">The number of elements contained in a single entry of the dimension.</param>
-        /// <returns>The pre-computed offsets for the dimension.</returns>
-        private static int[] CreateOffsetsForDimension(int size, int elementCount)
-        {
-                int[] offsets = new int[size];
-                for (int index = 0; index < size; index++)
-                {
-                        offsets[index] = index * elementCount;
-                }
-
-                return offsets;
         }
 
 	/// <summary>

--- a/UtilsTest/Array/ArrayAccessorTests.cs
+++ b/UtilsTest/Array/ArrayAccessorTests.cs
@@ -53,10 +53,19 @@ public class ArrayAccessorTests
 	}
 
 	[TestMethod]
-	public void AsSpanThrowsOnIndexOutOfRange()
-	{
-		var accessor = CreateAccessor();
-		Assert.ThrowsExactly<IndexOutOfRangeException>(() => accessor.AsSpan([2]));
-	}
+        public void AsSpanThrowsOnIndexOutOfRange()
+        {
+                var accessor = CreateAccessor();
+                Assert.ThrowsExactly<IndexOutOfRangeException>(() => accessor.AsSpan([2]));
+        }
+
+        [TestMethod]
+        public void AsSpanAppliesOffset()
+        {
+                int[] data = [.. Enumerable.Range(0, 30)];
+                var accessor = new ArrayAccessor<int>(data, 3, 2, 3, 4);
+                var span = accessor.AsSpan([1]);
+                CollectionAssert.AreEqual(Enumerable.Range(15, 12).ToArray(), span.ToArray());
+        }
 }
 


### PR DESCRIPTION
## Summary
- replace the separate offset and element count caches with a unified dimension cache in `ArrayAccessor`
- reuse the cache when computing positions and spans for multi-dimensional indexing
- add a unit test ensuring spans respect configured offsets

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68cd52179bf88326a66bcfea4062af2c