### PR TITLE
Make vector components immutable

### DIFF
--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -12,7 +12,7 @@ namespace Utils.Mathematics.LinearAlgebra;
 public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEquatable<T[,]>, IEquatable<T[][]>, IEquatable<Vector<T>[]>, ICloneable
         where T : struct, IFloatingPoint<T>, IRootFunctions<T>
 {
-	internal readonly T[,] components;
+        private readonly T[,] components;
 	private bool? isDiagonalized;
 	private bool? isTriangularised;
 	private bool? isIdentity;

--- a/Utils.Mathematics/LinearAlgebra/Vector.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.cs
@@ -17,7 +17,7 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     /// <summary>
     /// Vector components.
     /// </summary>
-    internal readonly T[] components;
+    private readonly T[] components;
 
     /// <summary>
     /// Length of the vector (computed lazily).
@@ -31,7 +31,7 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     private Vector(int dimensions)
     {
         components = new T[dimensions];
-        norm = T.Zero;
+        norm = null;
     }
 
     /// <summary>

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -10,11 +10,87 @@ namespace UtilsTest.Mathematics.LinearAlgebra
 {
 
 	[TestClass]
-	public class MatrixTests
-	{
-		/*
-		[TestMethod]
-		public void TransformMatrixTests()
+        public class MatrixTests
+        {
+                /// <summary>
+                /// Ensures that LU factorisation preserves the source matrix and yields triangular factors.
+                /// </summary>
+                [TestMethod]
+                public void DiagonalizeLUProducesTriangularFactorsWithoutMutatingSource()
+                {
+                        Matrix<double> matrix = new Matrix<double>(new double[,]
+                        {
+                                { 4d, 3d },
+                                { 6d, 3d },
+                        });
+
+                        double[,] original = matrix.ToArray();
+                        (Matrix<double> L, Matrix<double> U) = matrix.DiagonalizeLU();
+                        AssertMatricesAreEqual(new Matrix<double>(original), matrix, 1e-12);
+
+                        for (int i = 0; i < matrix.Rows; i++)
+                        {
+                                Assert.AreEqual(1d, L[i, i], 1e-12, $"Diagonal entry at {i} was not one.");
+                                for (int j = 0; j < i; j++)
+                                {
+                                        Assert.AreEqual(0d, U[i, j], 1e-12, $"Upper matrix contained non-zero value at [{i}, {j}].");
+                                }
+                        }
+                }
+
+                /// <summary>
+                /// Verifies that inverting a matrix leaves the original unchanged and produces an identity when multiplied.
+                /// </summary>
+                [TestMethod]
+                public void InvertDoesNotMutateOriginalMatrix()
+                {
+                        Matrix<double> matrix = new Matrix<double>(new double[,]
+                        {
+                                { 4d, 7d },
+                                { 2d, 6d },
+                        });
+
+                        double[,] originalComponents = matrix.ToArray();
+                        Matrix<double> inverse = matrix.Invert();
+
+                        AssertMatricesAreEqual(new Matrix<double>(originalComponents), matrix, 1e-12);
+
+                        Matrix<double> identity = matrix * inverse;
+
+                        double tolerance = 1e-9;
+                        for (int row = 0; row < identity.Rows; row++)
+                        {
+                                for (int col = 0; col < identity.Columns; col++)
+                                {
+                                        double expected = row == col ? 1d : 0d;
+                                        Assert.AreEqual(expected, identity[row, col], tolerance, $"Unexpected value at [{row}, {col}]");
+                                }
+                        }
+                }
+
+                /// <summary>
+                /// Asserts that two matrices contain the same components within the provided tolerance.
+                /// </summary>
+                /// <param name="expected">Expected matrix.</param>
+                /// <param name="actual">Matrix produced by the computation.</param>
+                /// <param name="tolerance">Accepted numerical tolerance.</param>
+                private static void AssertMatricesAreEqual(Matrix<double> expected, Matrix<double> actual, double tolerance)
+                {
+                        Assert.AreEqual(expected.Rows, actual.Rows, "Row count mismatch.");
+                        Assert.AreEqual(expected.Columns, actual.Columns, "Column count mismatch.");
+
+                        for (int row = 0; row < expected.Rows; row++)
+                        {
+                                for (int col = 0; col < expected.Columns; col++)
+                                {
+                                        Assert.AreEqual(expected[row, col], actual[row, col], tolerance, $"Mismatch at [{row}, {col}]");
+                                }
+                        }
+                }
+
+                /*
+                [TestMethod]
+                public void TransformMatrixTests()
 		{
 			System.Drawing.Drawing2D.Matrix Create2D(params Action<System.Drawing.Drawing2D.Matrix>[] actions)
 			{

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -34,5 +34,59 @@ public class VectorTests
         Assert.AreEqual(1.5d, barycenter[0], 1e-9);
         Assert.AreEqual(0d, barycenter[1], 1e-9);
     }
+
+    /// <summary>
+    /// Ensures that vectors copy incoming component arrays to remain immutable.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_CopiesInputComponents()
+    {
+        double[] source = { 1d, 2d, 3d };
+        var vector = new Vector<double>(source);
+
+        source[0] = 10d;
+
+        Assert.AreEqual(1d, vector[0], 1e-12);
+        Assert.AreEqual(2d, vector[1], 1e-12);
+        Assert.AreEqual(3d, vector[2], 1e-12);
+    }
+
+    /// <summary>
+    /// Verifies that binary operations do not mutate their operands.
+    /// </summary>
+    [TestMethod]
+    public void Addition_DoesNotMutateOperands()
+    {
+        var left = new Vector<double>(1d, -2d, 5d);
+        var right = new Vector<double>(2d, 4d, -1d);
+
+        _ = left + right;
+
+        Assert.AreEqual(1d, left[0], 1e-12);
+        Assert.AreEqual(-2d, left[1], 1e-12);
+        Assert.AreEqual(5d, left[2], 1e-12);
+
+        Assert.AreEqual(2d, right[0], 1e-12);
+        Assert.AreEqual(4d, right[1], 1e-12);
+        Assert.AreEqual(-1d, right[2], 1e-12);
+    }
+
+    /// <summary>
+    /// Confirms that normalization produces a distinct vector instance without altering the source.
+    /// </summary>
+    [TestMethod]
+    public void Normalize_ReturnsNewVectorWithoutMutatingSource()
+    {
+        var vector = new Vector<double>(3d, 0d, 0d);
+
+        Vector<double> normalized = vector.Normalize();
+
+        Assert.AreNotSame(vector, normalized);
+        Assert.AreEqual(3d, vector[0], 1e-12);
+        Assert.AreEqual(0d, vector[1], 1e-12);
+        Assert.AreEqual(0d, vector[2], 1e-12);
+
+        Assert.AreEqual(1d, normalized.Norm, 1e-12);
+    }
 }
 


### PR DESCRIPTION
## Summary
- hide the backing storage of `Vector<T>` so components cannot be mutated externally
- ensure helper constructor leaves norm lazy to avoid stale cache values
- add regression tests that prove vectors copy inputs and keep operands untouched by operations

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68d5550c664c83268665c89598e71531