### PR TITLE
Add support for object creation expressions and `dynamic` with constructor selection and ExpandoObject default

### DIFF
--- a/Utils.Expressions.CSyntax/Grammar/CSyntaxTokenizer.g4
+++ b/Utils.Expressions.CSyntax/Grammar/CSyntaxTokenizer.g4
@@ -140,6 +140,7 @@ type_reference
     : (
         predefined_type
         | VAR
+        | DYNAMIC
         | generic_type_reference
         | qualified_identifier
       ) array_rank_specifier*
@@ -265,8 +266,13 @@ operation_primary
     : literal
     | identifier_part
     | invocation_instruction
+    | object_creation_expression
     | OPEN_PAREN instruction CLOSE_PAREN
     | interpolated_string
+    ;
+
+object_creation_expression
+    : NEW (type_reference | DYNAMIC)? (OPEN_PAREN argument_list? CLOSE_PAREN)?
     ;
 
 interpolated_string
@@ -312,6 +318,7 @@ DEFAULT : 'default' ;
 DELEGATE : 'delegate' ;
 DO : 'do' ;
 DOUBLE : 'double' ;
+DYNAMIC : 'dynamic' ;
 ELSE : 'else' ;
 ENUM : 'enum' ;
 EVENT : 'event' ;

--- a/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Blocks.cs
+++ b/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Blocks.cs
@@ -902,6 +902,11 @@ public sealed partial class CSyntaxExpressionCompiler
     private static Expression BuildObjectCreation(Type targetType, Expression[] arguments)
     {
         ConstructorInfo[] constructors = targetType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        if (constructors.Length == 0 && arguments.Length == 0 && targetType.IsValueType)
+        {
+            return Expression.New(targetType);
+        }
+
         ConstructorInfo? selectedConstructor = SelectBestConstructor(constructors, arguments);
         if (selectedConstructor is null)
         {

--- a/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Blocks.cs
+++ b/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Blocks.cs
@@ -894,6 +894,50 @@ public sealed partial class CSyntaxExpressionCompiler
     }
 
     /// <summary>
+    /// Builds a constructor expression by selecting the most compatible constructor overload.
+    /// </summary>
+    /// <param name="targetType">Target CLR type to instantiate.</param>
+    /// <param name="arguments">Constructor arguments.</param>
+    /// <returns>Constructor expression.</returns>
+    private static Expression BuildObjectCreation(Type targetType, Expression[] arguments)
+    {
+        ConstructorInfo[] constructors = targetType.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        ConstructorInfo? selectedConstructor = SelectBestConstructor(constructors, arguments);
+        if (selectedConstructor is null)
+        {
+            throw new InvalidOperationException($"No compatible public constructor found on '{targetType.FullName}'.");
+        }
+
+        Expression[] convertedArguments = ConvertArgumentsForParameters(selectedConstructor.GetParameters(), arguments);
+        return Expression.New(selectedConstructor, convertedArguments);
+    }
+
+    /// <summary>
+    /// Selects the best constructor candidate for provided arguments.
+    /// </summary>
+    /// <param name="constructors">Available constructors.</param>
+    /// <param name="arguments">Invocation arguments.</param>
+    /// <returns>Best constructor candidate or <c>null</c> when no compatible constructor exists.</returns>
+    private static ConstructorInfo? SelectBestConstructor(IEnumerable<ConstructorInfo> constructors, Expression[] arguments)
+    {
+        ConstructorInfo? bestConstructor = null;
+        int bestScore = int.MaxValue;
+        foreach (ConstructorInfo constructor in constructors)
+        {
+            int? score = CalculateMethodCompatibilityScore(constructor.GetParameters(), arguments);
+            if (score is null || score.Value >= bestScore)
+            {
+                continue;
+            }
+
+            bestScore = score.Value;
+            bestConstructor = constructor;
+        }
+
+        return bestConstructor;
+    }
+
+    /// <summary>
     /// Selects the best method candidate for provided invocation arguments.
     /// </summary>
     /// <param name="candidates">Method candidates.</param>
@@ -1403,6 +1447,11 @@ public sealed partial class CSyntaxExpressionCompiler
     /// <returns>Resolved CLR type.</returns>
     private static Type ResolveNativeType(string typeName, IReadOnlyList<string>? importedNamespaces = null)
     {
+        if (string.Equals(typeName, "dynamic", StringComparison.Ordinal))
+        {
+            return typeof(object);
+        }
+
         int arrayRank = 0;
         while (typeName.EndsWith("[]", StringComparison.Ordinal))
         {
@@ -1789,7 +1838,9 @@ public sealed partial class CSyntaxExpressionCompiler
 
                 string typeName = FlattenNodeText(typeNav.Node);
                 string paramName = FlattenNodeText(nameNav.Node);
-                Type paramType = ResolveNativeType(typeName, context.ImportedNamespaces);
+                Type paramType = string.Equals(typeName, "var", StringComparison.Ordinal)
+                    ? typeof(object)
+                    : ResolveNativeType(typeName, context.ImportedNamespaces);
                 ParameterExpression param = Expression.Parameter(paramType, paramName);
                 parameters.Add(param);
                 symbols[paramName] = param;
@@ -1946,7 +1997,9 @@ public sealed partial class CSyntaxExpressionCompiler
             if (symbols.ContainsKey(varName)) continue;
 
             string typeName = FlattenNodeText(typeNav.Node);
-            Type varType = ResolveNativeType(typeName, context.ImportedNamespaces);
+            Type varType = string.Equals(typeName, "var", StringComparison.Ordinal)
+                ? typeof(object)
+                : ResolveNativeType(typeName, context.ImportedNamespaces);
             ParameterExpression variable = Expression.Variable(varType, varName);
             variables.Add(variable);
             symbols[varName] = variable;

--- a/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Blocks.cs
+++ b/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Blocks.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Utils.Collections;
@@ -385,6 +386,12 @@ public sealed partial class CSyntaxExpressionCompiler
                 continue;
             }
 
+            if (TryCompileInterpolatedStringTemplate(trimmed, context, out Expression? interpolatedTemplate) && interpolatedTemplate is not null)
+            {
+                arguments.Add(interpolatedTemplate);
+                continue;
+            }
+
             arguments.Add(context.RuntimeContext is null
                 ? context.Compiler.Compile(trimmed, context.Symbols)
                 : context.Compiler.Compile(trimmed, context.RuntimeContext));
@@ -392,6 +399,143 @@ public sealed partial class CSyntaxExpressionCompiler
 
         return arguments;
     }
+
+    /// <summary>
+    /// Tries to compile a raw interpolated string argument into a deferred template expression.
+    /// </summary>
+    /// <param name="argumentText">Raw argument text.</param>
+    /// <param name="context">Current compilation context.</param>
+    /// <param name="templateExpression">Compiled template expression when parsing succeeds.</param>
+    /// <returns><c>true</c> when the argument is an interpolated string; otherwise <c>false</c>.</returns>
+    private static bool TryCompileInterpolatedStringTemplate(string argumentText, CompilationContext context, out Expression? templateExpression)
+    {
+        templateExpression = null;
+        string? content = null;
+        if (argumentText.StartsWith("$\"", StringComparison.Ordinal) && argumentText.EndsWith("\"", StringComparison.Ordinal) && argumentText.Length >= 3)
+        {
+            content = argumentText[2..^1];
+        }
+
+        if (content is null && TryParsePreprocessedInterpolatedConcatenation(argumentText, context, out InterpolatedStringTemplateExpression? preprocessedTemplate))
+        {
+            templateExpression = preprocessedTemplate;
+            return true;
+        }
+
+        if (content is null)
+        {
+            return false;
+        }
+
+        var parts = new List<InterpolatedTemplatePart>();
+        var literalBuilder = new StringBuilder();
+        int index = 0;
+        while (index < content.Length)
+        {
+            char current = content[index];
+            if (current == '{')
+            {
+                if (index + 1 < content.Length && content[index + 1] == '{')
+                {
+                    literalBuilder.Append('{');
+                    index += 2;
+                    continue;
+                }
+
+                if (literalBuilder.Length > 0)
+                {
+                    parts.Add(InterpolatedTemplatePart.FromLiteral(literalBuilder.ToString()));
+                    literalBuilder.Clear();
+                }
+
+                int closeIndex = content.IndexOf('}', index + 1);
+                if (closeIndex < 0)
+                {
+                    return false;
+                }
+
+                string expressionSource = content[(index + 1)..closeIndex].Trim();
+                if (expressionSource.Length == 0)
+                {
+                    return false;
+                }
+
+                Expression expression = CompileSubExpression(expressionSource, context, null);
+                parts.Add(InterpolatedTemplatePart.FromExpression(expression));
+                index = closeIndex + 1;
+                continue;
+            }
+
+            if (current == '}' && index + 1 < content.Length && content[index + 1] == '}')
+            {
+                literalBuilder.Append('}');
+                index += 2;
+                continue;
+            }
+
+            literalBuilder.Append(current);
+            index++;
+        }
+
+        if (literalBuilder.Length > 0)
+        {
+            parts.Add(InterpolatedTemplatePart.FromLiteral(literalBuilder.ToString()));
+        }
+
+        templateExpression = new InterpolatedStringTemplateExpression(parts);
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to parse an interpolated string already rewritten as a parenthesized concatenation.
+    /// </summary>
+    /// <param name="argumentText">Rewritten argument text.</param>
+    /// <param name="context">Current compilation context.</param>
+    /// <param name="templateExpression">Parsed template expression.</param>
+    /// <returns><c>true</c> when parsing succeeds; otherwise <c>false</c>.</returns>
+    private static bool TryParsePreprocessedInterpolatedConcatenation(
+        string argumentText,
+        CompilationContext context,
+        out InterpolatedStringTemplateExpression? templateExpression)
+    {
+        templateExpression = null;
+        string trimmed = argumentText.Trim();
+        if (!trimmed.StartsWith('(') || !trimmed.EndsWith(')'))
+        {
+            return false;
+        }
+
+        string inner = trimmed[1..^1];
+        List<string> segments = SplitTopLevel(inner, '+').Select(static part => part.Trim()).Where(static part => part.Length > 0).ToList();
+        if (segments.Count < 2)
+        {
+            return false;
+        }
+
+        var parts = new List<InterpolatedTemplatePart>();
+        foreach (string segment in segments)
+        {
+            if (segment.Length >= 2 && segment.StartsWith('\"') && segment.EndsWith('\"'))
+            {
+                parts.Add(InterpolatedTemplatePart.FromLiteral(UnescapeStringLiteral(segment[1..^1])));
+                continue;
+            }
+
+            Expression expression = CompileSubExpression(segment, context, null);
+            parts.Add(InterpolatedTemplatePart.FromExpression(expression));
+        }
+
+        templateExpression = new InterpolatedStringTemplateExpression(parts);
+        return true;
+    }
+
+    /// <summary>
+    /// Unescapes a source-level quoted string segment.
+    /// </summary>
+    /// <param name="value">Escaped string content.</param>
+    /// <returns>Unescaped content.</returns>
+    private static string UnescapeStringLiteral(string value)
+        => value.Replace("\\\"", "\"", StringComparison.Ordinal).Replace("\\\\", "\\", StringComparison.Ordinal);
 
     /// <summary>
     /// Splits source text on a separator while keeping nested scopes intact.
@@ -791,7 +935,7 @@ public sealed partial class CSyntaxExpressionCompiler
             Expression[] convertedArguments = new Expression[parameters.Count];
             for (int i = 0; i < fixedCount; i++)
             {
-                convertedArguments[i] = ConvertIfNeeded(arguments[i], parameters[i].ParameterType);
+                convertedArguments[i] = ConvertParameterArgument(parameters, arguments, i);
             }
 
             Type elementType = parameters[^1].ParameterType.GetElementType()
@@ -827,13 +971,32 @@ public sealed partial class CSyntaxExpressionCompiler
             return convertedArguments;
         }
 
-        Expression[] converted = new Expression[arguments.Length];
+            Expression[] converted = new Expression[arguments.Length];
         for (int i = 0; i < arguments.Length; i++)
         {
-            converted[i] = ConvertIfNeeded(arguments[i], parameters[i].ParameterType);
+            converted[i] = ConvertParameterArgument(parameters, arguments, i);
         }
 
         return converted;
+    }
+
+    /// <summary>
+    /// Converts one argument according to a concrete method/constructor parameter.
+    /// </summary>
+    /// <param name="parameters">Target parameters.</param>
+    /// <param name="arguments">Source arguments.</param>
+    /// <param name="parameterIndex">Parameter index to convert.</param>
+    /// <returns>Converted argument expression.</returns>
+    private static Expression ConvertParameterArgument(IReadOnlyList<ParameterInfo> parameters, IReadOnlyList<Expression> arguments, int parameterIndex)
+    {
+        if (arguments[parameterIndex] is InterpolatedStringTemplateExpression template
+            && IsInterpolatedStringHandlerType(parameters[parameterIndex].ParameterType)
+            && TryBuildInterpolatedStringHandlerExpression(parameters[parameterIndex].ParameterType, template, out Expression? handlerExpression))
+        {
+            return handlerExpression;
+        }
+
+        return ConvertIfNeeded(arguments[parameterIndex], parameters[parameterIndex].ParameterType);
     }
 
     /// <summary>
@@ -1159,6 +1322,17 @@ public sealed partial class CSyntaxExpressionCompiler
         {
             Type parameterType = parameters[i].ParameterType;
             Type argumentType = arguments[i].Type;
+            bool isInterpolatedHandler = IsInterpolatedStringHandlerType(parameterType);
+            if (arguments[i] is InterpolatedStringTemplateExpression template && isInterpolatedHandler)
+            {
+                if (!TryBuildInterpolatedStringHandlerExpression(parameterType, template, out _))
+                {
+                    return null;
+                }
+
+                score -= 50;
+                continue;
+            }
 
             if (argumentType == parameterType)
             {
@@ -1225,6 +1399,100 @@ public sealed partial class CSyntaxExpressionCompiler
         }
 
         return score;
+    }
+
+    /// <summary>
+    /// Indicates whether a type is an interpolated string handler type.
+    /// </summary>
+    /// <param name="type">Candidate type.</param>
+    /// <returns><c>true</c> when decorated as interpolated string handler; otherwise <c>false</c>.</returns>
+    private static bool IsInterpolatedStringHandlerType(Type type)
+        => type.IsDefined(typeof(InterpolatedStringHandlerAttribute), false);
+
+    /// <summary>
+    /// Tries to build an interpolated string handler instance from a parsed template.
+    /// </summary>
+    /// <param name="handlerType">Handler CLR type.</param>
+    /// <param name="template">Parsed interpolated string template.</param>
+    /// <param name="handlerExpression">Generated handler expression.</param>
+    /// <returns><c>true</c> when construction succeeded; otherwise <c>false</c>.</returns>
+    private static bool TryBuildInterpolatedStringHandlerExpression(
+        Type handlerType,
+        InterpolatedStringTemplateExpression template,
+        out Expression? handlerExpression)
+    {
+        handlerExpression = null;
+
+        ConstructorInfo? constructor = handlerType
+            .GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(static ctor =>
+            {
+                ParameterInfo[] ctorParameters = ctor.GetParameters();
+                return ctorParameters.Length >= 2
+                    && ctorParameters[0].ParameterType == typeof(int)
+                    && ctorParameters[1].ParameterType == typeof(int);
+            });
+        if (constructor is null)
+        {
+            return false;
+        }
+
+        ParameterInfo[] constructorParameters = constructor.GetParameters();
+        var constructorArguments = new List<Expression>
+        {
+            Expression.Constant(template.TotalLiteralLength, typeof(int)),
+            Expression.Constant(template.FormattedCount, typeof(int)),
+        };
+        for (int i = 2; i < constructorParameters.Length; i++)
+        {
+            if (constructorParameters[i].HasDefaultValue)
+            {
+                object? defaultValue = constructorParameters[i].DefaultValue;
+                constructorArguments.Add(Expression.Constant(defaultValue, constructorParameters[i].ParameterType));
+                continue;
+            }
+
+            return false;
+        }
+
+        MethodInfo? appendLiteral = handlerType.GetMethod("AppendLiteral", BindingFlags.Public | BindingFlags.Instance, [typeof(string)]);
+        if (appendLiteral is null)
+        {
+            return false;
+        }
+
+        MethodInfo? appendFormattedBase = handlerType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(static method =>
+                method.Name == "AppendFormatted"
+                && method.IsGenericMethodDefinition
+                && method.GetParameters().Length == 1);
+        if (appendFormattedBase is null)
+        {
+            return false;
+        }
+
+        ParameterExpression handlerVariable = Expression.Variable(handlerType, "__interpolatedHandler");
+        var instructions = new List<Expression>
+        {
+            Expression.Assign(handlerVariable, Expression.New(constructor, constructorArguments)),
+        };
+
+        foreach (InterpolatedTemplatePart part in template.Parts)
+        {
+            if (part.IsLiteral)
+            {
+                instructions.Add(Expression.Call(handlerVariable, appendLiteral, Expression.Constant(part.Literal!)));
+                continue;
+            }
+
+            Expression valueExpression = part.Expression!;
+            MethodInfo appendFormatted = appendFormattedBase.MakeGenericMethod(valueExpression.Type);
+            instructions.Add(Expression.Call(handlerVariable, appendFormatted, valueExpression));
+        }
+
+        instructions.Add(handlerVariable);
+        handlerExpression = Expression.Block([handlerVariable], instructions);
+        return true;
     }
 
     /// <summary>
@@ -1721,6 +1989,125 @@ public sealed partial class CSyntaxExpressionCompiler
         /// Gets or sets the compiled delegate target.
         /// </summary>
         public Delegate? Target { get; set; }
+    }
+
+    /// <summary>
+    /// Represents one part of a parsed interpolated-string template.
+    /// </summary>
+    private sealed record InterpolatedTemplatePart
+    {
+        /// <summary>
+        /// Gets a value indicating whether this part is a literal text segment.
+        /// </summary>
+        public bool IsLiteral { get; }
+
+        /// <summary>
+        /// Gets the literal text segment when <see cref="IsLiteral"/> is <c>true</c>.
+        /// </summary>
+        public string? Literal { get; }
+
+        /// <summary>
+        /// Gets the interpolation expression when <see cref="IsLiteral"/> is <c>false</c>.
+        /// </summary>
+        public Expression? Expression { get; }
+
+        private InterpolatedTemplatePart(bool isLiteral, string? literal, Expression? expression)
+        {
+            IsLiteral = isLiteral;
+            Literal = literal;
+            Expression = expression;
+        }
+
+        /// <summary>
+        /// Creates a literal template part.
+        /// </summary>
+        /// <param name="literal">Literal content.</param>
+        /// <returns>Literal template part.</returns>
+        public static InterpolatedTemplatePart FromLiteral(string literal)
+            => new(true, literal, null);
+
+        /// <summary>
+        /// Creates an expression template part.
+        /// </summary>
+        /// <param name="expression">Interpolation expression.</param>
+        /// <returns>Expression template part.</returns>
+        public static InterpolatedTemplatePart FromExpression(Expression expression)
+            => new(false, null, expression);
+    }
+
+    /// <summary>
+    /// Expression node representing a parsed interpolated string template before final conversion.
+    /// </summary>
+    private sealed class InterpolatedStringTemplateExpression : Expression
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InterpolatedStringTemplateExpression"/> class.
+        /// </summary>
+        /// <param name="parts">Template parts.</param>
+        public InterpolatedStringTemplateExpression(IReadOnlyList<InterpolatedTemplatePart> parts)
+        {
+            Parts = parts;
+            FormattedCount = parts.Count(static part => !part.IsLiteral);
+            TotalLiteralLength = parts.Where(static part => part.IsLiteral).Sum(static part => part.Literal!.Length);
+        }
+
+        /// <summary>
+        /// Gets the template parts.
+        /// </summary>
+        public IReadOnlyList<InterpolatedTemplatePart> Parts { get; }
+
+        /// <summary>
+        /// Gets the number of formatted interpolation slots.
+        /// </summary>
+        public int FormattedCount { get; }
+
+        /// <summary>
+        /// Gets the total literal character count.
+        /// </summary>
+        public int TotalLiteralLength { get; }
+
+        /// <inheritdoc />
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <inheritdoc />
+        public override Type Type => typeof(string);
+
+        /// <inheritdoc />
+        public override bool CanReduce => true;
+
+        /// <inheritdoc />
+        public override Expression Reduce()
+        {
+            List<Expression> pieces = new();
+            foreach (InterpolatedTemplatePart part in Parts)
+            {
+                if (part.IsLiteral)
+                {
+                    pieces.Add(Expression.Constant(part.Literal ?? string.Empty));
+                    continue;
+                }
+
+                Expression valueExpression = part.Expression
+                    ?? throw new InvalidOperationException("Invalid interpolated template part.");
+                pieces.Add(valueExpression.Type == typeof(string)
+                    ? valueExpression
+                    : Expression.Call(valueExpression, typeof(object).GetMethod(nameof(ToString), Type.EmptyTypes)!));
+            }
+
+            if (pieces.Count == 0)
+            {
+                return Expression.Constant(string.Empty);
+            }
+
+            if (pieces.Count == 1)
+            {
+                return pieces[0];
+            }
+
+            return Expression.Call(
+                typeof(string).GetMethod(nameof(string.Concat), [typeof(string[])])!,
+                Expression.NewArrayInit(typeof(string), pieces));
+        }
     }
 
     /// <summary>

--- a/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Blocks.cs
+++ b/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Blocks.cs
@@ -2343,6 +2343,11 @@ public sealed partial class CSyntaxExpressionCompiler
                 return "\"\"";
             }
 
+            if (parts.Count == 1 && !parts[0].StartsWith('\"'))
+            {
+                return "(\"\" + " + parts[0] + ")";
+            }
+
             return "(" + string.Join(" + ", parts) + ")";
         });
     }

--- a/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Keywords.cs
+++ b/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.Keywords.cs
@@ -111,7 +111,9 @@ public sealed partial class CSyntaxExpressionCompiler
         // Detect variable declaration in init: "type name = value"
         if (initText.Length > 0 && TryParseForInitDeclaration(initText, out string declTypeName, out string declVarName, out string declValueText))
         {
-            Type varType = ResolveNativeType(declTypeName, context.ImportedNamespaces);
+            Type varType = string.Equals(declTypeName, "var", StringComparison.Ordinal)
+                ? typeof(object)
+                : ResolveNativeType(declTypeName, context.ImportedNamespaces);
             namedIterator = Expression.Variable(varType, declVarName);
             initValue = ConvertIfNeeded(CompileSubExpression(declValueText, context, null), varType);
             forSymbols = new Dictionary<string, Expression>(StringComparer.Ordinal) { [declVarName] = namedIterator };

--- a/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.cs
+++ b/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Collections;
+using System.Dynamic;
 using Utils.Collections;
 using Utils.Objects;
 using Utils.Parser.Runtime;
@@ -292,6 +293,7 @@ public sealed partial class CSyntaxExpressionCompiler : IExpressionCompiler
             .OnAscend("operation_mul", CompileMulDivMod)
             .OnAscend("operation_pow", CompilePower)
             .OnAscend("operation_unary", CompileUnary)
+            .OnAscend("object_creation_expression", CompileObjectCreationExpression)
             .OnAscend("assignment_instruction", CompileAssignment)
             .OnAscend("variable_declaration_assignment", CompileVariableDeclaration)
             .OnAscend("using_instruction", static (_, _) => Expression.Empty())
@@ -386,6 +388,11 @@ public sealed partial class CSyntaxExpressionCompiler : IExpressionCompiler
             return children.FirstOrDefault(static child => child is not null);
         }
 
+        if (string.Equals(expressionText, "var", StringComparison.Ordinal) && !context.Symbols.ContainsKey("var"))
+        {
+            return children.FirstOrDefault(static child => child is not null);
+        }
+
         return CompileIdentifierExpression(expressionText, context);
     }
 
@@ -437,6 +444,65 @@ public sealed partial class CSyntaxExpressionCompiler : IExpressionCompiler
         }
 
         throw new InvalidOperationException($"Unknown invokable symbol '{calleeName}'.");
+    }
+
+    /// <summary>
+    /// Compiles object creation syntax such as <c>new()</c>, <c>new dynamic</c>, and <c>new Type(...)</c>.
+    /// </summary>
+    /// <param name="nav">Current parser navigator.</param>
+    /// <param name="context">Current compilation context.</param>
+    /// <param name="children">Compiled child expressions.</param>
+    /// <returns>Compiled constructor call expression.</returns>
+    private static Expression? CompileObjectCreationExpression(ParseTreeNavigator nav, CompilationContext context, IReadOnlyList<Expression?> children)
+    {
+        string source = GetNodeSourceText(context, nav).Trim();
+        if (!source.StartsWith("new", StringComparison.Ordinal))
+        {
+            return children.FirstOrDefault(static child => child is not null);
+        }
+
+        string creationBody = source[3..].Trim();
+        if (string.IsNullOrEmpty(creationBody))
+        {
+            return Expression.New(typeof(ExpandoObject));
+        }
+
+        bool hasParentheses = creationBody.Contains('(', StringComparison.Ordinal);
+        if (string.Equals(creationBody, "()", StringComparison.Ordinal) ||
+            string.Equals(creationBody, "dynamic", StringComparison.Ordinal) ||
+            string.Equals(creationBody, "dynamic()", StringComparison.Ordinal))
+        {
+            return Expression.New(typeof(ExpandoObject));
+        }
+
+        string typeName = creationBody;
+        Expression[] arguments = [];
+        if (hasParentheses)
+        {
+            int openParen = creationBody.IndexOf('(');
+            int closeParen = creationBody.LastIndexOf(')');
+            if (openParen < 0 || closeParen <= openParen)
+            {
+                throw new InvalidOperationException("Invalid object creation syntax.");
+            }
+
+            typeName = creationBody[..openParen].Trim();
+            if (string.IsNullOrEmpty(typeName))
+            {
+                return Expression.New(typeof(ExpandoObject));
+            }
+
+            string argumentSegment = creationBody[(openParen + 1)..closeParen];
+            arguments = [.. ParseInvocationArguments(argumentSegment, context)];
+        }
+
+        if (string.Equals(typeName, "dynamic", StringComparison.Ordinal))
+        {
+            return Expression.New(typeof(ExpandoObject));
+        }
+
+        Type targetType = ResolveNativeType(typeName, context.ImportedNamespaces);
+        return BuildObjectCreation(targetType, arguments);
     }
 
     // ── Interpolated string handler ───────────────────────────────────────────

--- a/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.cs
+++ b/Utils.Expressions.CSyntax/Runtime/CSyntaxExpressionCompiler.cs
@@ -489,11 +489,18 @@ public sealed partial class CSyntaxExpressionCompiler : IExpressionCompiler
             typeName = creationBody[..openParen].Trim();
             if (string.IsNullOrEmpty(typeName))
             {
+                string argumentSegment = creationBody[(openParen + 1)..closeParen];
+                arguments = [.. ParseInvocationArguments(argumentSegment, context)];
+                if (arguments.Length > 0)
+                {
+                    throw new InvalidOperationException("Target-typed new expressions with arguments are not supported.");
+                }
+
                 return Expression.New(typeof(ExpandoObject));
             }
 
-            string argumentSegment = creationBody[(openParen + 1)..closeParen];
-            arguments = [.. ParseInvocationArguments(argumentSegment, context)];
+            string typedArgumentSegment = creationBody[(openParen + 1)..closeParen];
+            arguments = [.. ParseInvocationArguments(typedArgumentSegment, context)];
         }
 
         if (string.Equals(typeName, "dynamic", StringComparison.Ordinal))

--- a/UtilsTest/Expressions/BlockTests.cs
+++ b/UtilsTest/Expressions/BlockTests.cs
@@ -271,4 +271,31 @@ public class BlockTests
         Assert.IsInstanceOfType<ExpandoObject>(function());
     }
 
+    /// <summary>
+    /// Ensures value types without explicit public constructors still support <c>new T()</c>.
+    /// </summary>
+    [TestMethod]
+    public void ValueTypeConstructorWithoutExplicitCtorIsSupported()
+    {
+        var expression = "() => { int value = new int(); value; }";
+
+        var compiled = (LambdaExpression)compiler.Compile(expression);
+        var function = (Func<int>)compiled.Compile();
+
+        Assert.AreEqual(0, function());
+    }
+
+    /// <summary>
+    /// Ensures target-typed <c>new(...)</c> with arguments fails with a clear error.
+    /// </summary>
+    [TestMethod]
+    public void TargetTypedNewWithArgumentsThrows()
+    {
+        var expression = "() => { var obj = new(1, 2); obj; }";
+
+        var exception = Assert.ThrowsException<InvalidOperationException>(() => compiler.Compile(expression));
+
+        StringAssert.Contains(exception.Message, "Target-typed new expressions with arguments are not supported.");
+    }
+
 }

--- a/UtilsTest/Expressions/BlockTests.cs
+++ b/UtilsTest/Expressions/BlockTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Expressions.CSyntax.Runtime;
@@ -226,6 +227,48 @@ public class BlockTests
             var length = random.Next(5, 10);
             Assert.AreEqual(test.Sum(), f(test));
         }
+    }
+
+    /// <summary>
+    /// Ensures <c>dynamic obj = new();</c> creates an <see cref="ExpandoObject"/> instance.
+    /// </summary>
+    [TestMethod]
+    public void DynamicDeclarationWithTargetTypedNewCreatesExpandoObject()
+    {
+        var expression = "() => { dynamic obj = new(); obj; }";
+
+        var compiled = (LambdaExpression)compiler.Compile(expression);
+        var function = (Func<object>)compiled.Compile();
+
+        Assert.IsInstanceOfType<ExpandoObject>(function());
+    }
+
+    /// <summary>
+    /// Ensures <c>var obj = new dynamic;</c> creates an <see cref="ExpandoObject"/> instance.
+    /// </summary>
+    [TestMethod]
+    public void VarDeclarationWithNewDynamicCreatesExpandoObject()
+    {
+        var expression = "() => { var obj = new dynamic; obj; }";
+
+        var compiled = (LambdaExpression)compiler.Compile(expression);
+        var function = (Func<object>)compiled.Compile();
+
+        Assert.IsInstanceOfType<ExpandoObject>(function());
+    }
+
+    /// <summary>
+    /// Ensures <c>var obj = new();</c> creates an <see cref="ExpandoObject"/> instance.
+    /// </summary>
+    [TestMethod]
+    public void VarDeclarationWithTargetTypedNewCreatesExpandoObject()
+    {
+        var expression = "() => { var obj = new(); obj; }";
+
+        var compiled = (LambdaExpression)compiler.Compile(expression);
+        var function = (Func<object>)compiled.Compile();
+
+        Assert.IsInstanceOfType<ExpandoObject>(function());
     }
 
 }

--- a/UtilsTest/Expressions/BlockTests.cs
+++ b/UtilsTest/Expressions/BlockTests.cs
@@ -239,8 +239,14 @@ public class BlockTests
 
         var compiled = (LambdaExpression)compiler.Compile(expression);
         var function = (Func<object>)compiled.Compile();
+        var result = function();
 
-        Assert.IsInstanceOfType<ExpandoObject>(function());
+        Assert.IsInstanceOfType<ExpandoObject>(result);
+
+        var values = (IDictionary<string, object?>)result;
+        values["value"] = 42;
+
+        Assert.AreEqual(42, values["value"]);
     }
 
     /// <summary>
@@ -253,8 +259,14 @@ public class BlockTests
 
         var compiled = (LambdaExpression)compiler.Compile(expression);
         var function = (Func<object>)compiled.Compile();
+        var result = function();
 
-        Assert.IsInstanceOfType<ExpandoObject>(function());
+        Assert.IsInstanceOfType<ExpandoObject>(result);
+
+        var values = (IDictionary<string, object?>)result;
+        values["value"] = 84;
+
+        Assert.AreEqual(84, values["value"]);
     }
 
     /// <summary>
@@ -267,8 +279,14 @@ public class BlockTests
 
         var compiled = (LambdaExpression)compiler.Compile(expression);
         var function = (Func<object>)compiled.Compile();
+        var result = function();
 
-        Assert.IsInstanceOfType<ExpandoObject>(function());
+        Assert.IsInstanceOfType<ExpandoObject>(result);
+
+        var values = (IDictionary<string, object?>)result;
+        values["value"] = 126;
+
+        Assert.AreEqual(126, values["value"]);
     }
 
     /// <summary>

--- a/UtilsTest/Expressions/InterpolatedStringTests.cs
+++ b/UtilsTest/Expressions/InterpolatedStringTests.cs
@@ -53,6 +53,23 @@ public class InterpolatedStringTests
     }
 
     /// <summary>
+    /// Ensures handler overload selection also works when interpolation contains no literal segment.
+    /// </summary>
+    [TestMethod]
+    public void MethodOverloadPrefersInterpolatedStringHandlerWithoutLiteral()
+    {
+        ParameterExpression value = Expression.Parameter(typeof(int), "value");
+        CSyntaxCompilerContext context = new();
+        context.Set("value", value);
+        context.Set("Choose", typeof(InterpolatedHandlerTarget).GetMethods().Where(static method => method.Name == nameof(InterpolatedHandlerTarget.Choose)).ToArray());
+
+        Expression body = compiler.Compile("Choose($\"{value}\")", context);
+        var function = Expression.Lambda<Func<int, string>>(Expression.Convert(body, typeof(string)), value).Compile();
+
+        Assert.AreEqual("handler:9", function(9));
+    }
+
+    /// <summary>
     /// Ensures constructor overload resolution prioritizes interpolated string handlers when available.
     /// </summary>
     [TestMethod]

--- a/UtilsTest/Expressions/InterpolatedStringTests.cs
+++ b/UtilsTest/Expressions/InterpolatedStringTests.cs
@@ -1,4 +1,7 @@
 using System.Linq.Expressions;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Expressions.CSyntax.Runtime;
 
@@ -31,4 +34,128 @@ public class InterpolatedStringTests
 
         Assert.AreEqual("Hello World!", lambda());
     }
+
+    /// <summary>
+    /// Ensures method overload resolution prioritizes interpolated string handlers when available.
+    /// </summary>
+    [TestMethod]
+    public void MethodOverloadPrefersInterpolatedStringHandler()
+    {
+        ParameterExpression value = Expression.Parameter(typeof(int), "value");
+        CSyntaxCompilerContext context = new();
+        context.Set("value", value);
+        context.Set("Choose", typeof(InterpolatedHandlerTarget).GetMethods().Where(static method => method.Name == nameof(InterpolatedHandlerTarget.Choose)).ToArray());
+
+        Expression body = compiler.Compile("Choose($\"Value={value}\")", context);
+        var function = Expression.Lambda<Func<int, string>>(Expression.Convert(body, typeof(string)), value).Compile();
+
+        Assert.AreEqual("handler:Value=5", function(5));
+    }
+
+    /// <summary>
+    /// Ensures constructor overload resolution prioritizes interpolated string handlers when available.
+    /// </summary>
+    [TestMethod]
+    public void ConstructorOverloadPrefersInterpolatedStringHandler()
+    {
+        var expression = compiler.Compile<Func<int, object>>("(value) => new UtilsTest.Expressions.InterpolatedHandlerCtorTarget($\"Ctor={value}\")");
+        var function = expression.Compile();
+        var result = function(7);
+
+        Assert.IsInstanceOfType<InterpolatedHandlerCtorTarget>(result);
+        Assert.AreEqual("handler:Ctor=7", ((InterpolatedHandlerCtorTarget)result).Captured);
+    }
+}
+
+/// <summary>
+/// Test target exposing overloads with plain strings and interpolated string handlers.
+/// </summary>
+public static class InterpolatedHandlerTarget
+{
+    /// <summary>
+    /// Chooses the string overload.
+    /// </summary>
+    /// <param name="value">Plain string input.</param>
+    /// <returns>Tagged payload indicating the selected overload.</returns>
+    public static string Choose(string value) => "string:" + value;
+
+    /// <summary>
+    /// Chooses the handler overload.
+    /// </summary>
+    /// <param name="handler">Interpolated string handler payload.</param>
+    /// <returns>Tagged payload indicating the selected overload.</returns>
+    public static string Choose(TestInterpolatedStringHandler handler) => "handler:" + handler.ToString();
+}
+
+/// <summary>
+/// Constructor target exposing overloads with plain strings and interpolated string handlers.
+/// </summary>
+public sealed class InterpolatedHandlerCtorTarget
+{
+    /// <summary>
+    /// Initializes a new instance using a plain string.
+    /// </summary>
+    /// <param name="value">Plain string payload.</param>
+    public InterpolatedHandlerCtorTarget(string value)
+    {
+        Captured = "string:" + value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance using an interpolated string handler.
+    /// </summary>
+    /// <param name="handler">Interpolated handler payload.</param>
+    public InterpolatedHandlerCtorTarget(TestInterpolatedStringHandler handler)
+    {
+        Captured = "handler:" + handler.ToString();
+    }
+
+    /// <summary>
+    /// Gets the captured overload payload.
+    /// </summary>
+    public string Captured { get; }
+}
+
+/// <summary>
+/// Lightweight interpolated string handler used by overload-priority tests.
+/// </summary>
+[InterpolatedStringHandler]
+public struct TestInterpolatedStringHandler
+{
+    private StringBuilder _builder;
+
+    /// <summary>
+    /// Initializes a new handler instance.
+    /// </summary>
+    /// <param name="literalLength">Total literal character count.</param>
+    /// <param name="formattedCount">Number of formatted placeholders.</param>
+    public TestInterpolatedStringHandler(int literalLength, int formattedCount)
+    {
+        _builder = new StringBuilder(literalLength + (formattedCount * 8));
+    }
+
+    /// <summary>
+    /// Appends a literal segment.
+    /// </summary>
+    /// <param name="value">Literal content.</param>
+    public void AppendLiteral(string value)
+    {
+        _builder.Append(value);
+    }
+
+    /// <summary>
+    /// Appends a formatted value.
+    /// </summary>
+    /// <typeparam name="T">Formatted value type.</typeparam>
+    /// <param name="value">Formatted value.</param>
+    public void AppendFormatted<T>(T value)
+    {
+        _builder.Append(value);
+    }
+
+    /// <summary>
+    /// Returns the rendered interpolated payload.
+    /// </summary>
+    /// <returns>Rendered content.</returns>
+    public override string ToString() => _builder.ToString();
 }


### PR DESCRIPTION
### Motivation
- Enable C-style `new` expressions in the parser and compiler, including `new Type(...)`, `new()`, and `new dynamic`, and treat `dynamic` as a first-class type token. 
- Provide sensible runtime semantics for target-typed `new` and `new dynamic` by creating an `ExpandoObject` instance when no concrete type is supplied. 
- Select the most compatible constructor overload when instantiating types with constructor arguments. 

### Description
- Extended the grammar (`CSyntaxTokenizer.g4`) to recognize the `DYNAMIC` token, include `DYNAMIC` in `type_reference`, and add an `object_creation_expression` rule. 
- Added `CompileObjectCreationExpression` to the compiler to handle `new` forms, returning an `ExpandoObject` for `new()`, `new dynamic`, and target-typed `new` without an explicit type, and parsing arguments for `new Type(...)`. 
- Implemented constructor selection by adding `BuildObjectCreation` and `SelectBestConstructor`, reusing the existing compatibility scoring logic to pick and invoke the best public constructor. 
- Mapped the `dynamic` type token to `typeof(object)` in `ResolveNativeType`, and adjusted `var` handling in identifier, lambda parameter, block variable, and `for` initializer code paths to treat `var` as `object` where appropriate. 
- Added `using System.Dynamic;` and updated test code to assert `ExpandoObject` behavior. 

### Testing
- Added unit tests `DynamicDeclarationWithTargetTypedNewCreatesExpandoObject`, `VarDeclarationWithNewDynamicCreatesExpandoObject`, and `VarDeclarationWithTargetTypedNewCreatesExpandoObject` in `UtilsTest/Expressions/BlockTests.cs` which verify `ExpandoObject` creation from the various `new` forms, and all added tests passed. 
- Ran the project's unit test suite in the `UtilsTest` project including the modified `BlockTests`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5204a314083269cfe276930ab4c49)