### PR TITLE
Add shared Parser diagnostics model and propagate diagnostics through parser, lexer, converter and generator

### DIFF
--- a/DrawTest/README.md
+++ b/DrawTest/README.md
@@ -1,35 +1,35 @@
 # DrawTest
 
-`DrawTest` est une application Windows Forms de démonstration pour les primitives de dessin de `Utils.Imaging` et `Utils.Fonts`.
+`DrawTest` is a Windows Forms demo application for the drawing primitives provided by `Utils.Imaging` and `Utils.Fonts`.
 
-## Objectif
+## Purpose
 
-Ce projet permet de visualiser rapidement des tracés (lignes, courbes de Bézier, ellipses, texte) pour valider le rendu graphique.
+This project helps you quickly visualize rendering outputs (lines, Bézier curves, ellipses, text) to validate graphics behavior.
 
-## Exemples
+## Examples
 
-### 1) Lancer l'application
+### 1) Run the application
 
 ```bash
 dotnet run --project DrawTest/DrawTest.csproj
 ```
 
-### 2) Construire uniquement le projet
+### 2) Build only this project
 
 ```bash
 dotnet build DrawTest/DrawTest.csproj
 ```
 
-### 3) Explorer un exemple de rendu
+### 3) Explore a rendering example
 
-Le rendu principal se trouve dans `TestForm.Draw()` :
-- tracés de lignes et de courbes,
-- rendu de texte vectoriel,
-- remplissages et contours.
+The main rendering logic is in `TestForm.Draw()`:
+- line and curve drawing,
+- vector text rendering,
+- fill and stroke operations.
 
-Voir le code : `DrawTest/TestForm.cs`.
+See the code: `DrawTest/TestForm.cs`.
 
-## Projets liés
+## Related projects
 
 - [`Utils.Imaging`](../Utils.Imaging/README.md)
 - [`Utils.Fonts`](../Utils.Fonts/README.md)

--- a/Fractals/README.md
+++ b/Fractals/README.md
@@ -1,32 +1,32 @@
 # Fractals
 
-`Fractals` est une application Windows Forms de démonstration qui génère des fractales avec les bibliothèques utilitaires du dépôt.
+`Fractals` is a Windows Forms demo application that generates fractals using the utility libraries from this repository.
 
-## Objectif
+## Purpose
 
-Permettre un test visuel rapide des algorithmes de calcul/rendu de fractales (Mandelbrot, Julia).
+Provide a quick visual test bed for fractal computation/rendering algorithms (Mandelbrot, Julia).
 
-## Exemples
+## Examples
 
-### 1) Lancer l'application
+### 1) Run the application
 
 ```bash
 dotnet run --project Fractals/Fractals.csproj
 ```
 
-### 2) Construire le projet
+### 2) Build the project
 
 ```bash
 dotnet build Fractals/Fractals.csproj
 ```
 
-### 3) Explorer les implémentations
+### 3) Explore implementations
 
-- Logique de calcul : `Fractals/ComputeFractal.cs`
-- Types de fractales : `Fractals/IFractal.cs`
-- Formulaire principal : `Fractals/FactalsForm.cs`
+- Compute logic: `Fractals/ComputeFractal.cs`
+- Fractal types: `Fractals/IFractal.cs`
+- Main form: `Fractals/FactalsForm.cs`
 
-## Projets liés
+## Related projects
 
 - [`Utils.Imaging`](../Utils.Imaging/README.md)
 - [`Utils`](../Utils/README.md)

--- a/Utils.Data/Utils.Data.csproj
+++ b/Utils.Data/Utils.Data.csproj
@@ -26,6 +26,7 @@
         </AdditionalFiles>
         <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Namespace" />
         <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="ClassName" />
+            <ProjectReference Include="..\Utils.Parser.Diagnostics\Utils.Parser.Diagnostics.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Utils.Expressions.CSyntax/Utils.Expressions.CSyntax.csproj
+++ b/Utils.Expressions.CSyntax/Utils.Expressions.CSyntax.csproj
@@ -10,6 +10,7 @@
         <ProjectReference Include="..\Utils.Parser\Utils.Parser.csproj" />
         <ProjectReference Include="..\Utils\Utils.csproj" />
         <ProjectReference Include="..\Utils.Parser.Generators\Utils.Parser.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+            <ProjectReference Include="..\Utils.Parser.Diagnostics\Utils.Parser.Diagnostics.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Utils.Expressions.CSyntax/readme.md
+++ b/Utils.Expressions.CSyntax/readme.md
@@ -1,14 +1,14 @@
 # Utils.Expressions.CSyntax
 
-`Utils.Expressions.CSyntax` fournit un compilateur d'expressions **C-like** vers des arbres LINQ (`System.Linq.Expressions`).
+`Utils.Expressions.CSyntax` provides a **C-like** expression compiler that targets LINQ expression trees (`System.Linq.Expressions`).
 
-Le composant principal est `CSyntaxExpressionCompiler` dans le namespace `Utils.Expressions.CSyntax.Runtime`.
+The main component is `CSyntaxExpressionCompiler` in the `Utils.Expressions.CSyntax.Runtime` namespace.
 
-## À quoi ça sert
+## What it is for
 
-- Compiler des expressions textuelles vers des `Expression` .NET.
-- Exécuter des expressions dynamiques avec un contexte de symboles.
-- Déclarer des fonctions et les réutiliser dans le même source.
+- Compile textual expressions into .NET `Expression` trees.
+- Execute dynamic expressions with a symbol context.
+- Declare functions and reuse them in the same source.
 
 ## Installation
 
@@ -16,9 +16,9 @@ Le composant principal est `CSyntaxExpressionCompiler` dans le namespace `Utils.
 dotnet add package omy.Utils.Expressions.CSyntax
 ```
 
-## Exemples
+## Examples
 
-### 1) One-liner arithmétique
+### 1) Arithmetic one-liner
 
 ```csharp
 using System.Linq.Expressions;
@@ -31,7 +31,7 @@ var lambda = Expression.Lambda<Func<double>>(Expression.Convert(expression, type
 double result = lambda(); // 7
 ```
 
-### 2) One-liner booléen
+### 2) Boolean one-liner
 
 ```csharp
 using System.Linq.Expressions;
@@ -44,7 +44,7 @@ var lambda = Expression.Lambda<Func<bool>>(Expression.Convert(expression, typeof
 bool result = lambda(); // true
 ```
 
-### 3) Compiler avec des symboles
+### 3) Compile with symbols
 
 ```csharp
 using System.Linq.Expressions;
@@ -63,7 +63,7 @@ var lambda = Expression.Lambda<Func<double, double>>(Expression.Convert(expressi
 double result = lambda(4); // 9
 ```
 
-### 4) Compiler une lambda typée (one-liner)
+### 4) Compile a strongly typed lambda (one-liner)
 
 ```csharp
 using Utils.Expressions.CSyntax.Runtime;
@@ -75,7 +75,7 @@ Func<int, int> function = expression.Compile();
 int result = function(41); // 42
 ```
 
-### 5) Fonctions déclarées dans le source
+### 5) Functions declared in source
 
 ```csharp
 using Utils.Expressions.CSyntax.Runtime;
@@ -94,7 +94,7 @@ var twice = (Func<double, double>)context.Get("twice");
 double result = twice(5); // 10
 ```
 
-### 6) Lambda dans le contexte + appel
+### 6) Lambda in context + invocation
 
 ```csharp
 using System.Linq.Expressions;
@@ -110,7 +110,7 @@ var lambda = Expression.Lambda<Func<double>>(Expression.Convert(expression, type
 double result = lambda(); // 42
 ```
 
-### 7) Structures standard: `if / else`
+### 7) Standard control flow: `if / else`
 
 ```csharp
 using Utils.Expressions.CSyntax.Runtime;
@@ -133,7 +133,7 @@ double a = abs(3);   // 3
 double b = abs(-3);  // 3
 ```
 
-### 8) Structures standard: `for`
+### 8) Standard control flow: `for`
 
 ```csharp
 using Utils.Expressions.CSyntax.Runtime;
@@ -157,7 +157,7 @@ var sumTo = (Func<int, double>)context.Get("sumTo");
 double result = sumTo(4); // 10
 ```
 
-### 9) Structures standard: `foreach`
+### 9) Standard control flow: `foreach`
 
 ```csharp
 using Utils.Expressions.CSyntax.Runtime;
@@ -183,6 +183,6 @@ int result = sumValues(); // 10
 
 ## Notes
 
-- Le compilateur accepte une syntaxe C-like (opérations arithmétiques, blocs, `if`, `for`, `foreach`, fonctions, etc.).
-- Le type final dépend du contexte et des conversions LINQ générées.
-- Pour les scénarios avancés, utiliser `CSyntaxCompilerContext` pour enregistrer symboles et fonctions.
+- The compiler accepts C-like syntax (arithmetic operations, blocks, `if`, `for`, `foreach`, functions, etc.).
+- The final expression type depends on context and generated LINQ conversions.
+- For advanced scenarios, use `CSyntaxCompilerContext` to register symbols and functions.

--- a/Utils.Parser.Diagnostics/DiagnosticBag.cs
+++ b/Utils.Parser.Diagnostics/DiagnosticBag.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Utils.Parser.Diagnostics;
+
+/// <summary>
+/// Mutable collection of parser diagnostics.
+/// </summary>
+public sealed class DiagnosticBag : IReadOnlyCollection<ParserDiagnostic>
+{
+    private readonly List<ParserDiagnostic> _items = new();
+
+    /// <summary>
+    /// Adds a diagnostic instance to the bag.
+    /// </summary>
+    /// <param name="diagnostic">Diagnostic to add.</param>
+    public void Add(ParserDiagnostic diagnostic)
+    {
+        if (diagnostic is null)
+        {
+            throw new ArgumentNullException(nameof(diagnostic));
+        }
+
+        _items.Add(diagnostic);
+    }
+
+    /// <summary>
+    /// Creates and adds a diagnostic from a descriptor.
+    /// </summary>
+    /// <param name="descriptor">Diagnostic descriptor.</param>
+    /// <param name="arguments">Message format arguments.</param>
+    /// <returns>The added diagnostic.</returns>
+    public ParserDiagnostic Add(
+        ParserDiagnosticDescriptor descriptor,
+        params object?[] arguments)
+    {
+        return AddWithContext(
+            descriptor,
+            spanStart: null,
+            spanLength: null,
+            ruleName: null,
+            exception: null,
+            arguments: arguments);
+    }
+
+    /// <summary>
+    /// Creates and adds a diagnostic from a descriptor with contextual information.
+    /// </summary>
+    /// <param name="descriptor">Diagnostic descriptor.</param>
+    /// <param name="spanStart">Optional source span start.</param>
+    /// <param name="spanLength">Optional source span length.</param>
+    /// <param name="ruleName">Optional rule context.</param>
+    /// <param name="exception">Optional related exception.</param>
+    /// <param name="arguments">Message format arguments.</param>
+    /// <returns>The added diagnostic.</returns>
+    public ParserDiagnostic AddWithContext(
+        ParserDiagnosticDescriptor descriptor,
+        int? spanStart,
+        int? spanLength,
+        string? ruleName,
+        Exception? exception,
+        params object?[] arguments)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        var diagnostic = new ParserDiagnostic(
+            descriptor,
+            descriptor.FormatMessage(arguments),
+            spanStart,
+            spanLength,
+            ruleName,
+            exception);
+
+        _items.Add(diagnostic);
+        return diagnostic;
+    }
+
+    /// <summary>
+    /// Adds all diagnostics from another sequence.
+    /// </summary>
+    /// <param name="diagnostics">Diagnostics to append.</param>
+    public void AddRange(IEnumerable<ParserDiagnostic> diagnostics)
+    {
+        if (diagnostics is null)
+        {
+            throw new ArgumentNullException(nameof(diagnostics));
+        }
+
+        _items.AddRange(diagnostics);
+    }
+
+    /// <summary>
+    /// Gets all diagnostics whose severity is at least as important as <paramref name="severity"/>.
+    /// </summary>
+    /// <param name="severity">Minimum severity threshold.</param>
+    /// <returns>Filtered diagnostics.</returns>
+    public IReadOnlyList<ParserDiagnostic> GetAtLeast(DiagnosticSeverity severity)
+    {
+        return _items.Where(item => item.Severity <= severity).ToList();
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether at least one error diagnostic is present.
+    /// </summary>
+    public bool HasErrors => _items.Any(item => item.Severity == DiagnosticSeverity.Error);
+
+    /// <summary>
+    /// Gets the total diagnostic count.
+    /// </summary>
+    public int Count => _items.Count;
+
+    /// <summary>
+    /// Returns a read-only snapshot of the diagnostics.
+    /// </summary>
+    /// <returns>Snapshot list.</returns>
+    public IReadOnlyList<ParserDiagnostic> ToList() => _items.ToList();
+
+    /// <inheritdoc />
+    public IEnumerator<ParserDiagnostic> GetEnumerator() => _items.GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/Utils.Parser.Diagnostics/DiagnosticSeverity.cs
+++ b/Utils.Parser.Diagnostics/DiagnosticSeverity.cs
@@ -1,0 +1,27 @@
+namespace Utils.Parser.Diagnostics;
+
+/// <summary>
+/// Severity level associated with a parser diagnostic.
+/// </summary>
+public enum DiagnosticSeverity
+{
+    /// <summary>
+    /// Blocking error that prevents reliable continuation.
+    /// </summary>
+    Error = 0,
+
+    /// <summary>
+    /// Non-blocking warning indicating unsupported or suspicious behavior.
+    /// </summary>
+    Warning = 1,
+
+    /// <summary>
+    /// Informational diagnostic describing default behavior.
+    /// </summary>
+    Info = 2,
+
+    /// <summary>
+    /// Debug trace diagnostic.
+    /// </summary>
+    Debug = 3
+}

--- a/Utils.Parser.Diagnostics/ParserDiagnostic.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostic.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace Utils.Parser.Diagnostics;
+
+/// <summary>
+/// Represents one emitted diagnostic message instance.
+/// </summary>
+public sealed class ParserDiagnostic
+{
+    /// <summary>
+    /// Initializes a new diagnostic instance.
+    /// </summary>
+    /// <param name="descriptor">Diagnostic descriptor.</param>
+    /// <param name="message">Resolved diagnostic message.</param>
+    /// <param name="spanStart">Optional source span start position.</param>
+    /// <param name="spanLength">Optional source span length.</param>
+    /// <param name="ruleName">Optional rule name context.</param>
+    /// <param name="exception">Optional related exception.</param>
+    public ParserDiagnostic(
+        ParserDiagnosticDescriptor descriptor,
+        string message,
+        int? spanStart = null,
+        int? spanLength = null,
+        string? ruleName = null,
+        Exception? exception = null)
+    {
+        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+        SpanStart = spanStart;
+        SpanLength = spanLength;
+        RuleName = ruleName;
+        Exception = exception;
+    }
+
+    /// <summary>
+    /// Gets the descriptor.
+    /// </summary>
+    public ParserDiagnosticDescriptor Descriptor { get; }
+
+    /// <summary>
+    /// Gets the diagnostic code.
+    /// </summary>
+    public string Code => Descriptor.Code;
+
+    /// <summary>
+    /// Gets the diagnostic severity.
+    /// </summary>
+    public DiagnosticSeverity Severity => Descriptor.Severity;
+
+    /// <summary>
+    /// Gets the resolved message.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>
+    /// Gets the optional source span start position.
+    /// </summary>
+    public int? SpanStart { get; }
+
+    /// <summary>
+    /// Gets the optional source span length.
+    /// </summary>
+    public int? SpanLength { get; }
+
+    /// <summary>
+    /// Gets the optional rule name context.
+    /// </summary>
+    public string? RuleName { get; }
+
+    /// <summary>
+    /// Gets the optional related exception.
+    /// </summary>
+    public Exception? Exception { get; }
+}

--- a/Utils.Parser.Diagnostics/ParserDiagnosticDescriptor.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnosticDescriptor.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Utils.Parser.Diagnostics;
+
+/// <summary>
+/// Immutable descriptor that defines a reusable parser diagnostic template.
+/// </summary>
+public sealed class ParserDiagnosticDescriptor
+{
+    private static readonly Regex s_codeRegex = new("^UP[0-9]{4}$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Initializes a new diagnostic descriptor and validates the diagnostic code format.
+    /// </summary>
+    /// <param name="code">Diagnostic code in the form <c>UPxxxx</c>.</param>
+    /// <param name="title">Short diagnostic title.</param>
+    /// <param name="messageFormat">Composite format string used to build diagnostic messages.</param>
+    /// <param name="category">Optional diagnostic category.</param>
+    /// <exception cref="ArgumentException">Thrown when the code format is invalid.</exception>
+    public ParserDiagnosticDescriptor(string code, string title, string messageFormat, string? category = null)
+    {
+        if (!s_codeRegex.IsMatch(code))
+        {
+            throw new ArgumentException($"Invalid diagnostic code '{code}'. Expected format UPxxxx.", nameof(code));
+        }
+
+        Code = code;
+        Title = title ?? throw new ArgumentNullException(nameof(title));
+        MessageFormat = messageFormat ?? throw new ArgumentNullException(nameof(messageFormat));
+        Category = category;
+        Severity = ParserDiagnosticSeverityMapper.FromCode(code);
+    }
+
+    /// <summary>
+    /// Gets the diagnostic code.
+    /// </summary>
+    public string Code { get; }
+
+    /// <summary>
+    /// Gets the short diagnostic title.
+    /// </summary>
+    public string Title { get; }
+
+    /// <summary>
+    /// Gets the message format.
+    /// </summary>
+    public string MessageFormat { get; }
+
+    /// <summary>
+    /// Gets the severity derived from <see cref="Code"/>.
+    /// </summary>
+    public DiagnosticSeverity Severity { get; }
+
+    /// <summary>
+    /// Gets the optional category.
+    /// </summary>
+    public string? Category { get; }
+
+    /// <summary>
+    /// Creates a formatted message using <see cref="MessageFormat"/>.
+    /// </summary>
+    /// <param name="arguments">Message format arguments.</param>
+    /// <returns>Formatted diagnostic message.</returns>
+    public string FormatMessage(params object?[] arguments)
+    {
+        return arguments.Length == 0
+            ? MessageFormat
+            : string.Format(MessageFormat, arguments);
+    }
+}

--- a/Utils.Parser.Diagnostics/ParserDiagnosticSeverityMapper.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnosticSeverityMapper.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Utils.Parser.Diagnostics;
+
+/// <summary>
+/// Provides severity mapping from diagnostic code prefixes.
+/// </summary>
+public static class ParserDiagnosticSeverityMapper
+{
+    /// <summary>
+    /// Resolves severity from a code using the first digit after <c>UP</c>.
+    /// </summary>
+    /// <param name="code">Diagnostic code in the form <c>UPxxxx</c>.</param>
+    /// <returns>Mapped diagnostic severity.</returns>
+    /// <exception cref="ArgumentException">Thrown when the code prefix is invalid.</exception>
+    public static DiagnosticSeverity FromCode(string code)
+    {
+        if (code is null)
+        {
+            throw new ArgumentNullException(nameof(code));
+        }
+
+        if (code.Length != 6 || !code.StartsWith("UP", StringComparison.Ordinal) || !char.IsDigit(code[2]))
+        {
+            throw new ArgumentException($"Invalid diagnostic code '{code}'.", nameof(code));
+        }
+
+        return code[2] switch
+        {
+            '0' => DiagnosticSeverity.Error,
+            '1' or '2' or '3' or '4' or '5' or '6' or '7' => DiagnosticSeverity.Warning,
+            '8' => DiagnosticSeverity.Info,
+            '9' => DiagnosticSeverity.Debug,
+            _ => throw new ArgumentException($"Invalid diagnostic code '{code}'.", nameof(code))
+        };
+    }
+}

--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+
+namespace Utils.Parser.Diagnostics;
+
+/// <summary>
+/// Central registry of parser diagnostic descriptors shared by runtime and generator pipelines.
+/// </summary>
+public static class ParserDiagnostics
+{
+    private const string DefaultCategory = "Utils.Parser";
+
+    // Blocking errors (UP0xxx)
+    /// <summary>Unexpected token encountered.</summary>
+    public static readonly ParserDiagnosticDescriptor UnexpectedToken =
+        new("UP0001", "Unexpected token", "Unexpected token '{0}'.", DefaultCategory);
+
+    /// <summary>Invalid grammar root node.</summary>
+    public static readonly ParserDiagnosticDescriptor InvalidGrammarRoot =
+        new("UP0002", "Invalid grammar root", "Invalid grammar root: '{0}'.", DefaultCategory);
+
+    /// <summary>Unknown referenced rule.</summary>
+    public static readonly ParserDiagnosticDescriptor UnknownRuleReference =
+        new("UP0003", "Unknown rule reference", "Rule '{0}' references unknown rule '{1}'.", DefaultCategory);
+
+    /// <summary>Unknown lexer mode referenced by a lexer command.</summary>
+    public static readonly ParserDiagnosticDescriptor UnknownLexerMode =
+        new("UP0004", "Unknown lexer mode", "Unknown lexer mode '{0}' used by command '{1}'.", DefaultCategory);
+
+    /// <summary>Parsing failure.</summary>
+    public static readonly ParserDiagnosticDescriptor ParseFailure =
+        new("UP0005", "Parse failure", "Parse failure: {0}", DefaultCategory);
+
+    /// <summary>Internal consistency failure.</summary>
+    public static readonly ParserDiagnosticDescriptor InternalInconsistency =
+        new("UP0006", "Internal inconsistency", "Internal inconsistency: {0}", DefaultCategory);
+
+    // Unsupported / ignored / partial support (UP1xxx)
+    /// <summary>Import parsed but not resolved.</summary>
+    public static readonly ParserDiagnosticDescriptor ImportParsedButNotResolved =
+        new("UP1001", "Import parsed but not resolved", "Import '{0}' is parsed but not resolved at runtime.", DefaultCategory);
+
+    /// <summary>tokens block ignored.</summary>
+    public static readonly ParserDiagnosticDescriptor TokensBlockIgnored =
+        new("UP1002", "tokens block ignored", "tokens { ... } is recognized but ignored.", DefaultCategory);
+
+    /// <summary>channels block ignored.</summary>
+    public static readonly ParserDiagnosticDescriptor ChannelsBlockIgnored =
+        new("UP1003", "channels block ignored", "channels { ... } is recognized but ignored.", DefaultCategory);
+
+    /// <summary>Action ignored by the current pipeline.</summary>
+    public static readonly ParserDiagnosticDescriptor ActionIgnored =
+        new("UP1004", "Action ignored", "Action '{0}' is ignored in this pipeline.", DefaultCategory);
+
+    /// <summary>Inline action stored but not executed.</summary>
+    public static readonly ParserDiagnosticDescriptor InlineActionStoredNotExecuted =
+        new("UP1005", "Inline action not executed", "Inline action is stored but not executed.", DefaultCategory);
+
+    /// <summary>Semantic predicate recognized but not enforced.</summary>
+    public static readonly ParserDiagnosticDescriptor SemanticPredicateNotEnforced =
+        new("UP1006", "Semantic predicate not enforced", "Semantic predicate is recognized but not enforced semantically.", DefaultCategory);
+
+    /// <summary>returns clause partially applied.</summary>
+    public static readonly ParserDiagnosticDescriptor ReturnsPartiallyApplied =
+        new("UP1007", "Returns partially applied", "returns clause for rule '{0}' is parsed but only stored as raw text.", DefaultCategory);
+
+    /// <summary>locals/throws/exception metadata ignored.</summary>
+    public static readonly ParserDiagnosticDescriptor LocalsIgnored =
+        new("UP1008", "Locals ignored", "locals/throws/exception metadata for rule '{0}' is parsed but ignored.", DefaultCategory);
+
+    /// <summary>Runtime and generator support mismatch.</summary>
+    public static readonly ParserDiagnosticDescriptor RuntimeGeneratorMismatch =
+        new("UP1009", "Runtime/generator mismatch", "Runtime and source generator support differ for '{0}'.", DefaultCategory);
+
+    // Warnings (UP5xxx)
+    /// <summary>Best-effort recovery used.</summary>
+    public static readonly ParserDiagnosticDescriptor BestEffortRecoveryUsed =
+        new("UP5001", "Best-effort recovery used", "Best-effort recovery was used while parsing '{0}'.", DefaultCategory);
+
+    /// <summary>Expected token missing.</summary>
+    public static readonly ParserDiagnosticDescriptor ExpectedTokenMissing =
+        new("UP5002", "Expected token missing", "Expected token '{0}' was not found.", DefaultCategory);
+
+    /// <summary>Fallback strategy used.</summary>
+    public static readonly ParserDiagnosticDescriptor FallbackStrategyUsed =
+        new("UP5003", "Fallback strategy used", "Fallback strategy used: {0}", DefaultCategory);
+
+    /// <summary>Trailing tokens remain after parse.</summary>
+    public static readonly ParserDiagnosticDescriptor TrailingTokensAfterParse =
+        new("UP5004", "Trailing tokens after parse", "Trailing tokens remain after parse: '{0}'.", DefaultCategory);
+
+    /// <summary>Ambiguous construct resolved heuristically.</summary>
+    public static readonly ParserDiagnosticDescriptor AmbiguousConstructResolvedHeuristically =
+        new("UP5005", "Ambiguous construct resolved", "Ambiguous construct resolved heuristically: {0}", DefaultCategory);
+
+    // Info (UP8xxx)
+    /// <summary>Default behavior applied.</summary>
+    public static readonly ParserDiagnosticDescriptor DefaultBehaviorApplied =
+        new("UP8001", "Default behavior applied", "Default behavior applied: {0}", DefaultCategory);
+
+    // Debug (UP9xxx)
+    /// <summary>Debug trace for entering a rule.</summary>
+    public static readonly ParserDiagnosticDescriptor EnteringRule =
+        new("UP9001", "Entering rule", "Entering rule '{0}'.", DefaultCategory);
+
+    /// <summary>Debug trace for leaving a rule.</summary>
+    public static readonly ParserDiagnosticDescriptor LeavingRule =
+        new("UP9002", "Leaving rule", "Leaving rule '{0}'.", DefaultCategory);
+
+    /// <summary>Debug trace for matched token.</summary>
+    public static readonly ParserDiagnosticDescriptor TokenMatched =
+        new("UP9003", "Token matched", "Token matched by rule '{0}': '{1}'.", DefaultCategory);
+
+    /// <summary>Debug trace for backtracking usage.</summary>
+    public static readonly ParserDiagnosticDescriptor BacktrackingUsed =
+        new("UP9004", "Backtracking used", "Backtracking used in rule '{0}'.", DefaultCategory);
+
+    /// <summary>
+    /// Gets all known parser diagnostics keyed by code.
+    /// </summary>
+    public static IReadOnlyDictionary<string, ParserDiagnosticDescriptor> All { get; } =
+        new Dictionary<string, ParserDiagnosticDescriptor>
+        {
+            [UnexpectedToken.Code] = UnexpectedToken,
+            [InvalidGrammarRoot.Code] = InvalidGrammarRoot,
+            [UnknownRuleReference.Code] = UnknownRuleReference,
+            [UnknownLexerMode.Code] = UnknownLexerMode,
+            [ParseFailure.Code] = ParseFailure,
+            [InternalInconsistency.Code] = InternalInconsistency,
+            [ImportParsedButNotResolved.Code] = ImportParsedButNotResolved,
+            [TokensBlockIgnored.Code] = TokensBlockIgnored,
+            [ChannelsBlockIgnored.Code] = ChannelsBlockIgnored,
+            [ActionIgnored.Code] = ActionIgnored,
+            [InlineActionStoredNotExecuted.Code] = InlineActionStoredNotExecuted,
+            [SemanticPredicateNotEnforced.Code] = SemanticPredicateNotEnforced,
+            [ReturnsPartiallyApplied.Code] = ReturnsPartiallyApplied,
+            [LocalsIgnored.Code] = LocalsIgnored,
+            [RuntimeGeneratorMismatch.Code] = RuntimeGeneratorMismatch,
+            [BestEffortRecoveryUsed.Code] = BestEffortRecoveryUsed,
+            [ExpectedTokenMissing.Code] = ExpectedTokenMissing,
+            [FallbackStrategyUsed.Code] = FallbackStrategyUsed,
+            [TrailingTokensAfterParse.Code] = TrailingTokensAfterParse,
+            [AmbiguousConstructResolvedHeuristically.Code] = AmbiguousConstructResolvedHeuristically,
+            [DefaultBehaviorApplied.Code] = DefaultBehaviorApplied,
+            [EnteringRule.Code] = EnteringRule,
+            [LeavingRule.Code] = LeavingRule,
+            [TokenMatched.Code] = TokenMatched,
+            [BacktrackingUsed.Code] = BacktrackingUsed,
+        };
+
+    /// <summary>
+    /// Looks up a descriptor by diagnostic code.
+    /// </summary>
+    /// <param name="code">Diagnostic code.</param>
+    /// <param name="descriptor">Resolved descriptor when found.</param>
+    /// <returns><c>true</c> when the code exists.</returns>
+    public static bool TryGet(string code, out ParserDiagnosticDescriptor descriptor)
+    {
+        return All.TryGetValue(code, out descriptor!);
+    }
+}

--- a/Utils.Parser.Diagnostics/Utils.Parser.Diagnostics.csproj
+++ b/Utils.Parser.Diagnostics/Utils.Parser.Diagnostics.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+        <PackageId>omy.Utils.Parser.Diagnostics</PackageId>
+        <Version>0.1.0</Version>
+        <Authors>Olivier MARTY</Authors>
+        <Description>Shared diagnostics model and descriptor catalog for Utils.Parser runtime and source generator.</Description>
+        <PackageTags>omy;utilities;parser;diagnostics;antlr4;generator</PackageTags>
+        <RepositoryUrl>https://github.com/warny/All-purpose-Utilities</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageProjectUrl>https://github.com/warny/All-purpose-Utilities</PackageProjectUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    </PropertyGroup>
+
+</Project>

--- a/Utils.Parser.Generators/Antlr4GrammarGenerator.cs
+++ b/Utils.Parser.Generators/Antlr4GrammarGenerator.cs
@@ -4,7 +4,9 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
+using Utils.Parser.Diagnostics;
 using Utils.Parser.Generators.Internal;
+using RoslynDiagnosticSeverity = Microsoft.CodeAnalysis.DiagnosticSeverity;
 
 namespace Utils.Parser.Generators;
 
@@ -39,7 +41,7 @@ public sealed class Antlr4GrammarGenerator : IIncrementalGenerator
         title:              "Grammar generation failed",
         messageFormat:      "Failed to generate grammar for '{0}': {1}",
         category:           "Utils.Parser.Generators",
-        defaultSeverity:    DiagnosticSeverity.Error,
+        defaultSeverity:    RoslynDiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description:        "An error occurred while parsing or emitting the ANTLR4 .g4 grammar file.");
 
@@ -48,7 +50,7 @@ public sealed class Antlr4GrammarGenerator : IIncrementalGenerator
         title:              "Invalid source generator metadata",
         messageFormat:      "Invalid source generator metadata for '{0}': {1}",
         category:           "Utils.Parser.Generators",
-        defaultSeverity:    DiagnosticSeverity.Error,
+        defaultSeverity:    RoslynDiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description:        "AdditionalFiles metadata contains invalid namespace or class name values.");
 
@@ -57,7 +59,7 @@ public sealed class Antlr4GrammarGenerator : IIncrementalGenerator
         title:              "Invalid syntax colorization descriptor",
         messageFormat:      "Invalid syntax colorization descriptor '{0}': {1}",
         category:           "Utils.Parser.Generators",
-        defaultSeverity:    DiagnosticSeverity.Error,
+        defaultSeverity:    RoslynDiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description:        "The syntax colorization descriptor does not contain required sections or directives.");
 
@@ -123,8 +125,10 @@ public sealed class Antlr4GrammarGenerator : IIncrementalGenerator
         {
             var source    = text.ToString();
             var tokens    = new G4Tokenizer(source).Tokenize();
-            var grammar   = new G4Parser(tokens).Parse();
+            var diagnostics = new DiagnosticBag();
+            var grammar   = new G4Parser(tokens, diagnostics).Parse();
             var generated = GrammarEmitter.Emit(grammar, namespaceName!, className!, fileName);
+            ReportParserDiagnostics(context, diagnostics, fileName);
 
             context.AddSource($"{className}.Grammar.g.cs", SourceText.From(generated, Encoding.UTF8));
         }
@@ -133,6 +137,44 @@ public sealed class Antlr4GrammarGenerator : IIncrementalGenerator
             context.ReportDiagnostic(
                 Diagnostic.Create(s_errorDescriptor, Location.None, fileName, ex.Message));
         }
+    }
+
+    /// <summary>
+    /// Reports shared parser diagnostics into Roslyn's diagnostic pipeline.
+    /// </summary>
+    /// <param name="context">Source production context.</param>
+    /// <param name="diagnostics">Collected parser diagnostics.</param>
+    /// <param name="fileName">Source file name used in message formatting.</param>
+    private static void ReportParserDiagnostics(SourceProductionContext context, DiagnosticBag diagnostics, string fileName)
+    {
+        foreach (var diagnostic in diagnostics)
+        {
+            var descriptor = new DiagnosticDescriptor(
+                id: diagnostic.Code,
+                title: diagnostic.Descriptor.Title,
+                messageFormat: "{0}",
+                category: diagnostic.Descriptor.Category ?? "Utils.Parser",
+                defaultSeverity: ToRoslynSeverity(diagnostic.Severity),
+                isEnabledByDefault: true);
+
+            context.ReportDiagnostic(Diagnostic.Create(descriptor, Location.None, $"{fileName}: {diagnostic.Message}"));
+        }
+    }
+
+    /// <summary>
+    /// Converts shared parser diagnostic severity to Roslyn severity.
+    /// </summary>
+    /// <param name="severity">Shared diagnostic severity.</param>
+    /// <returns>Roslyn severity value.</returns>
+    private static RoslynDiagnosticSeverity ToRoslynSeverity(Utils.Parser.Diagnostics.DiagnosticSeverity severity)
+    {
+        return severity switch
+        {
+            Utils.Parser.Diagnostics.DiagnosticSeverity.Error => RoslynDiagnosticSeverity.Error,
+            Utils.Parser.Diagnostics.DiagnosticSeverity.Warning => RoslynDiagnosticSeverity.Warning,
+            Utils.Parser.Diagnostics.DiagnosticSeverity.Info => RoslynDiagnosticSeverity.Info,
+            _ => RoslynDiagnosticSeverity.Hidden,
+        };
     }
 
     /// <summary>

--- a/Utils.Parser.Generators/Internal/G4Parser.cs
+++ b/Utils.Parser.Generators/Internal/G4Parser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Utils.Parser.Diagnostics;
 
 namespace Utils.Parser.Generators.Internal;
 
@@ -11,9 +12,14 @@ namespace Utils.Parser.Generators.Internal;
 internal sealed class G4Parser
 {
     private readonly List<G4Token> _tokens;
+    private readonly DiagnosticBag _diagnostics;
     private int _pos;
 
-    public G4Parser(List<G4Token> tokens) => _tokens = tokens;
+    public G4Parser(List<G4Token> tokens, DiagnosticBag? diagnostics = null)
+    {
+        _tokens = tokens;
+        _diagnostics = diagnostics ?? new DiagnosticBag();
+    }
 
     // ── Public entry point ───────────────────────────────────────────
 
@@ -51,16 +57,16 @@ internal sealed class G4Parser
             if (PeekValue("options")) { ParseOptionsBlock(grammar.Options); continue; }
 
             // tokens { ... } — skip
-            if (PeekValue("tokens")) { SkipBlock(); continue; }
+            if (PeekValue("tokens")) { _diagnostics.Add(ParserDiagnostics.TokensBlockIgnored); SkipBlock(); continue; }
 
             // @ action — skip
-            if (Peek().Kind == G4TokenKind.At) { SkipAction(); continue; }
+            if (Peek().Kind == G4TokenKind.At) { _diagnostics.Add(ParserDiagnostics.ActionIgnored, "@action"); SkipAction(); continue; }
 
             // import — skip line
-            if (PeekValue("import")) { while (!AtEof() && Peek().Kind != G4TokenKind.Semi) Consume(); TryConsume(G4TokenKind.Semi); continue; }
+            if (PeekValue("import")) { _diagnostics.Add(ParserDiagnostics.ImportParsedButNotResolved, "import"); while (!AtEof() && Peek().Kind != G4TokenKind.Semi) Consume(); TryConsume(G4TokenKind.Semi); continue; }
 
             // channels { ... } — skip
-            if (PeekValue("channels")) { SkipBlock(); continue; }
+            if (PeekValue("channels")) { _diagnostics.Add(ParserDiagnostics.ChannelsBlockIgnored); SkipBlock(); continue; }
 
             // mode Name; — starts a new lexer mode
             if (PeekValue("mode"))
@@ -176,6 +182,8 @@ internal sealed class G4Parser
             var code = Consume().Value;
             bool isPred = Peek().Kind == G4TokenKind.QMark;
             if (isPred) Consume();
+            if (isPred) _diagnostics.Add(ParserDiagnostics.SemanticPredicateNotEnforced);
+            else _diagnostics.Add(ParserDiagnostics.InlineActionStoredNotExecuted);
             return new G4EmbeddedAction { Code = code, IsPredicate = isPred };
         }
 
@@ -353,6 +361,8 @@ internal sealed class G4Parser
             if (Peek().Kind == G4TokenKind.Identifier)
                 arg = Consume().Value;
             TryConsume(G4TokenKind.RParen);
+            if (arg is null)
+                _diagnostics.Add(ParserDiagnostics.FallbackStrategyUsed, $"Lexer command '{name}' without identifier argument.");
         }
 
         return new G4LexerCommand { Name = name, Arg = arg };
@@ -426,26 +436,41 @@ internal sealed class G4Parser
 
     private void Expect(G4TokenKind kind)
     {
-        if (Peek().Kind == kind) Consume();
-        // silently skip if not found (best-effort parsing)
+        if (Peek().Kind == kind)
+        {
+            Consume();
+            return;
+        }
+
+        _diagnostics.Add(ParserDiagnostics.ExpectedTokenMissing, kind.ToString());
+        _diagnostics.Add(ParserDiagnostics.BestEffortRecoveryUsed, kind.ToString());
     }
 
     private void Expect(string keyword)
     {
         if (Peek().Kind == G4TokenKind.Identifier && Peek().Value == keyword)
             Consume();
+        else
+        {
+            _diagnostics.Add(ParserDiagnostics.ExpectedTokenMissing, keyword);
+            _diagnostics.Add(ParserDiagnostics.BestEffortRecoveryUsed, keyword);
+        }
     }
 
     private string ExpectIdentifier()
     {
         if (Peek().Kind == G4TokenKind.Identifier)
             return Consume().Value;
+        _diagnostics.Add(ParserDiagnostics.ExpectedTokenMissing, "Identifier");
+        _diagnostics.Add(ParserDiagnostics.BestEffortRecoveryUsed, "Identifier");
         return "";
     }
 
     private string ExpectToken(G4TokenKind kind)
     {
         if (Peek().Kind == kind) return Consume().Value;
+        _diagnostics.Add(ParserDiagnostics.ExpectedTokenMissing, kind.ToString());
+        _diagnostics.Add(ParserDiagnostics.BestEffortRecoveryUsed, kind.ToString());
         return "";
     }
 

--- a/Utils.Parser.Generators/Internal/G4Parser.cs
+++ b/Utils.Parser.Generators/Internal/G4Parser.cs
@@ -12,13 +12,13 @@ namespace Utils.Parser.Generators.Internal;
 internal sealed class G4Parser
 {
     private readonly List<G4Token> _tokens;
-    private readonly DiagnosticBag _diagnostics;
+    private readonly DiagnosticBag? _diagnostics;
     private int _pos;
 
     public G4Parser(List<G4Token> tokens, DiagnosticBag? diagnostics = null)
     {
         _tokens = tokens;
-        _diagnostics = diagnostics ?? new DiagnosticBag();
+        _diagnostics = diagnostics;
     }
 
     // ── Public entry point ───────────────────────────────────────────
@@ -57,16 +57,16 @@ internal sealed class G4Parser
             if (PeekValue("options")) { ParseOptionsBlock(grammar.Options); continue; }
 
             // tokens { ... } — skip
-            if (PeekValue("tokens")) { _diagnostics.Add(ParserDiagnostics.TokensBlockIgnored); SkipBlock(); continue; }
+            if (PeekValue("tokens")) { _diagnostics?.Add(ParserDiagnostics.TokensBlockIgnored); SkipBlock(); continue; }
 
             // @ action — skip
-            if (Peek().Kind == G4TokenKind.At) { _diagnostics.Add(ParserDiagnostics.ActionIgnored, "@action"); SkipAction(); continue; }
+            if (Peek().Kind == G4TokenKind.At) { _diagnostics?.Add(ParserDiagnostics.ActionIgnored, "@action"); SkipAction(); continue; }
 
             // import — skip line
-            if (PeekValue("import")) { _diagnostics.Add(ParserDiagnostics.ImportParsedButNotResolved, "import"); while (!AtEof() && Peek().Kind != G4TokenKind.Semi) Consume(); TryConsume(G4TokenKind.Semi); continue; }
+            if (PeekValue("import")) { _diagnostics?.Add(ParserDiagnostics.ImportParsedButNotResolved, "import"); while (!AtEof() && Peek().Kind != G4TokenKind.Semi) Consume(); TryConsume(G4TokenKind.Semi); continue; }
 
             // channels { ... } — skip
-            if (PeekValue("channels")) { _diagnostics.Add(ParserDiagnostics.ChannelsBlockIgnored); SkipBlock(); continue; }
+            if (PeekValue("channels")) { _diagnostics?.Add(ParserDiagnostics.ChannelsBlockIgnored); SkipBlock(); continue; }
 
             // mode Name; — starts a new lexer mode
             if (PeekValue("mode"))
@@ -182,8 +182,8 @@ internal sealed class G4Parser
             var code = Consume().Value;
             bool isPred = Peek().Kind == G4TokenKind.QMark;
             if (isPred) Consume();
-            if (isPred) _diagnostics.Add(ParserDiagnostics.SemanticPredicateNotEnforced);
-            else _diagnostics.Add(ParserDiagnostics.InlineActionStoredNotExecuted);
+            if (isPred) _diagnostics?.Add(ParserDiagnostics.SemanticPredicateNotEnforced);
+            else _diagnostics?.Add(ParserDiagnostics.InlineActionStoredNotExecuted);
             return new G4EmbeddedAction { Code = code, IsPredicate = isPred };
         }
 
@@ -362,7 +362,7 @@ internal sealed class G4Parser
                 arg = Consume().Value;
             TryConsume(G4TokenKind.RParen);
             if (arg is null)
-                _diagnostics.Add(ParserDiagnostics.FallbackStrategyUsed, $"Lexer command '{name}' without identifier argument.");
+                _diagnostics?.Add(ParserDiagnostics.FallbackStrategyUsed, $"Lexer command '{name}' without identifier argument.");
         }
 
         return new G4LexerCommand { Name = name, Arg = arg };
@@ -442,8 +442,8 @@ internal sealed class G4Parser
             return;
         }
 
-        _diagnostics.Add(ParserDiagnostics.ExpectedTokenMissing, kind.ToString());
-        _diagnostics.Add(ParserDiagnostics.BestEffortRecoveryUsed, kind.ToString());
+        _diagnostics?.Add(ParserDiagnostics.ExpectedTokenMissing, kind.ToString());
+        _diagnostics?.Add(ParserDiagnostics.BestEffortRecoveryUsed, kind.ToString());
     }
 
     private void Expect(string keyword)
@@ -452,8 +452,8 @@ internal sealed class G4Parser
             Consume();
         else
         {
-            _diagnostics.Add(ParserDiagnostics.ExpectedTokenMissing, keyword);
-            _diagnostics.Add(ParserDiagnostics.BestEffortRecoveryUsed, keyword);
+            _diagnostics?.Add(ParserDiagnostics.ExpectedTokenMissing, keyword);
+            _diagnostics?.Add(ParserDiagnostics.BestEffortRecoveryUsed, keyword);
         }
     }
 
@@ -461,16 +461,16 @@ internal sealed class G4Parser
     {
         if (Peek().Kind == G4TokenKind.Identifier)
             return Consume().Value;
-        _diagnostics.Add(ParserDiagnostics.ExpectedTokenMissing, "Identifier");
-        _diagnostics.Add(ParserDiagnostics.BestEffortRecoveryUsed, "Identifier");
+        _diagnostics?.Add(ParserDiagnostics.ExpectedTokenMissing, "Identifier");
+        _diagnostics?.Add(ParserDiagnostics.BestEffortRecoveryUsed, "Identifier");
         return "";
     }
 
     private string ExpectToken(G4TokenKind kind)
     {
         if (Peek().Kind == kind) return Consume().Value;
-        _diagnostics.Add(ParserDiagnostics.ExpectedTokenMissing, kind.ToString());
-        _diagnostics.Add(ParserDiagnostics.BestEffortRecoveryUsed, kind.ToString());
+        _diagnostics?.Add(ParserDiagnostics.ExpectedTokenMissing, kind.ToString());
+        _diagnostics?.Add(ParserDiagnostics.BestEffortRecoveryUsed, kind.ToString());
         return "";
     }
 

--- a/Utils.Parser.Generators/Utils.Parser.Generators.csproj
+++ b/Utils.Parser.Generators/Utils.Parser.Generators.csproj
@@ -37,4 +37,9 @@
         <None Include="buildTransitive\Utils.Parser.Generators.targets" Pack="true" PackagePath="buildTransitive\Utils.Parser.Generators.targets" />
     </ItemGroup>
 
+
+    <ItemGroup>
+        <ProjectReference Include="..\Utils.Parser.Diagnostics\Utils.Parser.Diagnostics.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/Utils.Parser.VisualStudio.Worker/README.md
+++ b/Utils.Parser.VisualStudio.Worker/README.md
@@ -1,36 +1,36 @@
 # Utils.Parser.VisualStudio.Worker
 
-`Utils.Parser.VisualStudio.Worker` est un exécutable worker utilisé par l'intégration Visual Studio pour la classification de tokens via un protocole JSON sur pipe nommé.
+`Utils.Parser.VisualStudio.Worker` is a worker executable used by the Visual Studio integration for token classification through a named-pipe JSON protocol.
 
-## Objectif
+## Purpose
 
-Découpler la classification/parsing du processus principal Visual Studio en exécutant la logique dans un processus dédié.
+Decouple classification/parsing work from the main Visual Studio process by running parser logic in a dedicated process.
 
-## Exemples
+## Examples
 
-### 1) Exécuter le worker avec un nom de pipe
+### 1) Run the worker with a pipe name
 
 ```bash
 dotnet run --project Utils.Parser.VisualStudio.Worker/Utils.Parser.VisualStudio.Worker.csproj -- my-pipe-name
 ```
 
-### 2) Construire le worker
+### 2) Build the worker
 
 ```bash
 dotnet build Utils.Parser.VisualStudio.Worker/Utils.Parser.VisualStudio.Worker.csproj
 ```
 
-### 3) Format de message (JSON line)
+### 3) Message format (JSON line)
 
-Le worker lit des lignes JSON et répond en JSON (voir `WorkerProtocol.cs`) :
+The worker reads JSON lines and responds with JSON (see `WorkerProtocol.cs`):
 
 ```json
 {"assemblyPath":"...","typeName":"...","tokens":["if","var","customId"]}
 ```
 
-Le point d'entrée et la gestion pipe se trouvent dans `Program.cs`.
+The entry point and named-pipe handling are in `Program.cs`.
 
-## Projets liés
+## Related projects
 
 - [`Utils.Parser`](../Utils.Parser/README.md)
 - [`Utils.Parser.VisualStudio`](../Utils.Parser.VisualStudio/README.md)

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Diagnostics.CodeAnalysis;
+using Utils.Parser.Diagnostics;
 using Utils.Parser.Model;
 using Utils.Parser.Resolution;
 using Utils.Parser.Runtime;
@@ -26,10 +27,14 @@ public sealed class Antlr4GrammarConverter
 {
     /// <summary>Declaration-order counter incremented as rules are created during conversion.</summary>
     private int _order;
+    private readonly DiagnosticBag _diagnostics;
 
     /// <summary>Initialises a new converter instance. The <paramref name="sourceText"/> parameter is reserved for future use.</summary>
     /// <param name="sourceText">The original grammar source text (currently unused).</param>
-    public Antlr4GrammarConverter(string sourceText) { }
+    public Antlr4GrammarConverter(string sourceText, DiagnosticBag? diagnostics = null)
+    {
+        _diagnostics = diagnostics ?? new DiagnosticBag();
+    }
 
     // ─── Full pipeline ────────────────────────────────────────────────────
 
@@ -45,8 +50,8 @@ public sealed class Antlr4GrammarConverter
     /// <exception cref="GrammarParseException">
     /// Thrown when the input cannot be parsed as a valid ANTLR4 grammar.
     /// </exception>
-    public static Runtime.CompiledGrammar Compile([StringSyntax("ANTLR4")] string grammarText)
-        => new Runtime.CompiledGrammar(Parse(grammarText));
+    public static Runtime.CompiledGrammar Compile([StringSyntax("ANTLR4")] string grammarText, DiagnosticBag? diagnostics = null)
+        => new Runtime.CompiledGrammar(Parse(grammarText, diagnostics));
 
     /// <summary>
     /// Full pipeline: ANTLR4 grammar text → resolved <see cref="Utils.Parser.Model.ParserDefinition"/>.
@@ -62,8 +67,9 @@ public sealed class Antlr4GrammarConverter
     /// <exception cref="GrammarParseException">
     /// Thrown when the input cannot be parsed as a valid ANTLR4 grammar.
     /// </exception>
-    public static ParserDefinition Parse([StringSyntax("ANTLR4")] string grammarText)
+    public static ParserDefinition Parse([StringSyntax("ANTLR4")] string grammarText, DiagnosticBag? diagnostics = null)
     {
+        diagnostics ??= new DiagnosticBag();
         var metaDefinition = RuleResolver.Resolve(Antlr4Grammar.Build());
         var lexer = new LexerEngine(metaDefinition);
         var stream = new StringCharStream(grammarText);
@@ -76,10 +82,21 @@ public sealed class Antlr4GrammarConverter
         tokens.Add(new Token(new SourceSpan(grammarText.Length, 0), "EOF", "DEFAULT_MODE", ""));
 
         var parser = new ParserEngine(metaDefinition);
-        var root = parser.Parse(tokens);
+        var root = parser.Parse(tokens, diagnostics: diagnostics);
+        if (root is ErrorNode errorNode)
+        {
+            diagnostics.AddWithContext(
+                ParserDiagnostics.ParseFailure,
+                errorNode.Span.Position,
+                errorNode.Span.Length,
+                null,
+                new GrammarParseException(errorNode.Message),
+                errorNode.Message);
+            throw new GrammarParseException(errorNode.Message);
+        }
 
-        var converter = new Antlr4GrammarConverter(grammarText);
-        return converter.Convert(root);
+        var converter = new Antlr4GrammarConverter(grammarText, diagnostics);
+        return converter.Convert(root, diagnostics);
     }
 
     /// <summary>
@@ -91,11 +108,21 @@ public sealed class Antlr4GrammarConverter
     /// <exception cref="GrammarParseException">
     /// Thrown when <paramref name="root"/> is not a <c>grammarSpec</c> parser node.
     /// </exception>
-    public ParserDefinition Convert(ParseNode root)
+    public ParserDefinition Convert(ParseNode root, DiagnosticBag? diagnostics = null)
     {
+        diagnostics ??= _diagnostics;
         if (root is not ParserNode grammarSpec || grammarSpec.Rule?.Name != "grammarSpec")
+        {
+            diagnostics.AddWithContext(
+                ParserDiagnostics.InvalidGrammarRoot,
+                null,
+                null,
+                root.Rule?.Name,
+                null,
+                root.Rule?.Name ?? "(null)");
             throw new GrammarParseException(
                 $"Root must be a grammarSpec node, got: {root.Rule?.Name ?? "(null)"}");
+        }
 
         _order = 0;
 
@@ -106,7 +133,7 @@ public sealed class Antlr4GrammarConverter
         var imports = new List<GrammarImport>();
         var actions = new List<GrammarAction>();
         foreach (var prequel in All(grammarSpec, "prequelConstruct"))
-            ProcessPrequelConstruct(prequel, ref options, imports, actions);
+            ProcessPrequelConstruct(prequel, ref options, imports, actions, diagnostics);
 
         var rulesNode = First(grammarSpec, "rules");
         var (lexerRules, parserRules) = rulesNode != null
@@ -133,7 +160,7 @@ public sealed class Antlr4GrammarConverter
             RootRule: rootRule
         );
 
-        return RuleResolver.Resolve(definition);
+        return RuleResolver.Resolve(definition, diagnostics);
     }
 
     // ─── grammarDecl / grammarType ────────────────────────────────────────────
@@ -170,18 +197,31 @@ public sealed class Antlr4GrammarConverter
         ParserNode node,
         ref GrammarOptions? options,
         List<GrammarImport> imports,
-        List<GrammarAction> actions)
+        List<GrammarAction> actions,
+        DiagnosticBag diagnostics)
     {
         var optSpec = First(node, "optionsSpec");
         if (optSpec != null) { options = ConvertOptionsSpec(optSpec); return; }
 
         var delegGrammars = First(node, "delegateGrammars");
-        if (delegGrammars != null) { imports.AddRange(ConvertDelegateGrammars(delegGrammars)); return; }
+        if (delegGrammars != null) { imports.AddRange(ConvertDelegateGrammars(delegGrammars, diagnostics)); return; }
+
+        if (First(node, "tokensSpec") != null)
+        {
+            diagnostics.Add(ParserDiagnostics.TokensBlockIgnored);
+            return;
+        }
+
+        if (First(node, "channelsSpec") != null)
+        {
+            diagnostics.Add(ParserDiagnostics.ChannelsBlockIgnored);
+            return;
+        }
 
         var actionNode = First(node, "action_");
         if (actionNode != null)
         {
-            var ga = ConvertGrammarAction(actionNode);
+            var ga = ConvertGrammarAction(actionNode, diagnostics);
             if (ga != null) actions.Add(ga);
         }
     }
@@ -202,7 +242,7 @@ public sealed class Antlr4GrammarConverter
     }
 
     /// <summary>Yields <see cref="GrammarImport"/> records from a <c>delegateGrammars</c> node.</summary>
-    private static IEnumerable<GrammarImport> ConvertDelegateGrammars(ParserNode node)
+    private static IEnumerable<GrammarImport> ConvertDelegateGrammars(ParserNode node, DiagnosticBag diagnostics)
     {
         foreach (var dg in All(node, "delegateGrammar"))
         {
@@ -211,17 +251,29 @@ public sealed class Antlr4GrammarConverter
                 .Where(c => c.Rule?.Name == "identifier")
                 .ToList();
             if (idents.Count >= 2)
-                yield return new GrammarImport(GetIdentifierText(idents[1]), GetIdentifierText(idents[0]));
+            {
+                var import = new GrammarImport(GetIdentifierText(idents[1]), GetIdentifierText(idents[0]));
+                diagnostics.Add(ParserDiagnostics.ImportParsedButNotResolved, import.GrammarName);
+                yield return import;
+            }
             else if (idents.Count == 1)
-                yield return new GrammarImport(GetIdentifierText(idents[0]));
+            {
+                var import = new GrammarImport(GetIdentifierText(idents[0]));
+                diagnostics.Add(ParserDiagnostics.ImportParsedButNotResolved, import.GrammarName);
+                yield return import;
+            }
         }
     }
 
     /// <summary>Converts an <c>action_</c> node into a <see cref="GrammarAction"/>, or <c>null</c> when the node lacks an identifier.</summary>
-    private static GrammarAction? ConvertGrammarAction(ParserNode node)
+    private static GrammarAction? ConvertGrammarAction(ParserNode node, DiagnosticBag diagnostics)
     {
         var identNode = First(node, "identifier");
-        if (identNode == null) return null;
+        if (identNode == null)
+        {
+            diagnostics.Add(ParserDiagnostics.ActionIgnored, "@action(without identifier)");
+            return null;
+        }
         var name = GetIdentifierText(identNode);
 
         var scopeNode = First(node, "actionScopeName");
@@ -344,8 +396,10 @@ public sealed class Antlr4GrammarConverter
             if (HasToken(node, "QUESTION"))
             {
                 if (IsPrecpred(code)) return new PrecedencePredicate(ParsePrecpredLevel(code));
+                _diagnostics.Add(ParserDiagnostics.SemanticPredicateNotEnforced);
                 return new ValidatingPredicate(code);
             }
+            _diagnostics.Add(ParserDiagnostics.InlineActionStoredNotExecuted);
             return new EmbeddedAction(code, ActionContext.Alternative, ActionPosition.Inline, ExtractLabels(code));
         }
 
@@ -417,10 +471,21 @@ public sealed class Antlr4GrammarConverter
             "pushMode" => LexerCommandType.PushMode,
             "popMode"  => LexerCommandType.PopMode,
             "mode"     => LexerCommandType.Mode,
-            _          => throw new GrammarParseException($"Unknown lexer command: '{nameText}'")
+            _          => throw UnknownLexerCommand(nameText)
         };
 
         return new LexerCommand(type, arg);
+    }
+
+    /// <summary>
+    /// Creates an exception for an unknown lexer command and records a diagnostic.
+    /// </summary>
+    /// <param name="commandName">Unsupported command name.</param>
+    /// <returns>Exception to throw.</returns>
+    private GrammarParseException UnknownLexerCommand(string commandName)
+    {
+        _diagnostics.Add(ParserDiagnostics.UnexpectedToken, commandName);
+        return new GrammarParseException($"Unknown lexer command: '{commandName}'");
     }
 
     // ─── parserRuleSpec ───────────────────────────────────────────────────────
@@ -438,13 +503,21 @@ public sealed class Antlr4GrammarConverter
             if (argBlock != null)
             {
                 var raw = GetArgActionBlockText(argBlock);
-                if (raw.Length > 0) returns = [new RuleReturn(raw, raw)];
+                if (raw.Length > 0)
+                {
+                    returns = [new RuleReturn(raw, raw)];
+                    _diagnostics.AddWithContext(ParserDiagnostics.ReturnsPartiallyApplied, null, null, name, null, name);
+                }
             }
         }
 
         EmbeddedAction? initAction = null, afterAction = null;
+        bool hasIgnoredRuleMetadata = false;
         foreach (var prequel in All(node, "rulePrequel"))
         {
+            if (First(prequel, "localsSpec") != null || First(prequel, "throwsSpec") != null)
+                hasIgnoredRuleMetadata = true;
+
             var ruleAction = First(prequel, "ruleAction");
             if (ruleAction == null) continue;
 
@@ -459,7 +532,14 @@ public sealed class Antlr4GrammarConverter
 
             if (actionName == "init") initAction = action;
             else if (actionName == "after") afterAction = action;
+            else _diagnostics.AddWithContext(ParserDiagnostics.ActionIgnored, null, null, name, null, $"rule action @{actionName}");
         }
+
+        if (First(node, "exceptionGroup") != null)
+            hasIgnoredRuleMetadata = true;
+
+        if (hasIgnoredRuleMetadata)
+            _diagnostics.AddWithContext(ParserDiagnostics.LocalsIgnored, null, null, name, null, name);
 
         var ruleBlock = Require(First(node, "ruleBlock"), "Missing ruleBlock");
         var ruleAltList = Require(First(ruleBlock, "ruleAltList"), "Missing ruleAltList");
@@ -525,8 +605,10 @@ public sealed class Antlr4GrammarConverter
             if (HasToken(node, "QUESTION"))
             {
                 if (IsPrecpred(code)) return new PrecedencePredicate(ParsePrecpredLevel(code));
+                _diagnostics.Add(ParserDiagnostics.SemanticPredicateNotEnforced);
                 return new ValidatingPredicate(code);
             }
+            _diagnostics.Add(ParserDiagnostics.InlineActionStoredNotExecuted);
             return new EmbeddedAction(code, ActionContext.Alternative, ActionPosition.Inline, ExtractLabels(code));
         }
 

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -27,13 +27,13 @@ public sealed class Antlr4GrammarConverter
 {
     /// <summary>Declaration-order counter incremented as rules are created during conversion.</summary>
     private int _order;
-    private readonly DiagnosticBag _diagnostics;
+    private readonly DiagnosticBag? _diagnostics;
 
     /// <summary>Initialises a new converter instance. The <paramref name="sourceText"/> parameter is reserved for future use.</summary>
     /// <param name="sourceText">The original grammar source text (currently unused).</param>
     public Antlr4GrammarConverter(string sourceText, DiagnosticBag? diagnostics = null)
     {
-        _diagnostics = diagnostics ?? new DiagnosticBag();
+        _diagnostics = diagnostics;
     }
 
     // ─── Full pipeline ────────────────────────────────────────────────────
@@ -69,7 +69,6 @@ public sealed class Antlr4GrammarConverter
     /// </exception>
     public static ParserDefinition Parse([StringSyntax("ANTLR4")] string grammarText, DiagnosticBag? diagnostics = null)
     {
-        diagnostics ??= new DiagnosticBag();
         var metaDefinition = RuleResolver.Resolve(Antlr4Grammar.Build());
         var lexer = new LexerEngine(metaDefinition);
         var stream = new StringCharStream(grammarText);
@@ -85,7 +84,7 @@ public sealed class Antlr4GrammarConverter
         var root = parser.Parse(tokens, diagnostics: diagnostics);
         if (root is ErrorNode errorNode)
         {
-            diagnostics.AddWithContext(
+            diagnostics?.AddWithContext(
                 ParserDiagnostics.ParseFailure,
                 errorNode.Span.Position,
                 errorNode.Span.Length,
@@ -110,10 +109,9 @@ public sealed class Antlr4GrammarConverter
     /// </exception>
     public ParserDefinition Convert(ParseNode root, DiagnosticBag? diagnostics = null)
     {
-        diagnostics ??= _diagnostics;
         if (root is not ParserNode grammarSpec || grammarSpec.Rule?.Name != "grammarSpec")
         {
-            diagnostics.AddWithContext(
+            diagnostics?.AddWithContext(
                 ParserDiagnostics.InvalidGrammarRoot,
                 null,
                 null,
@@ -198,7 +196,7 @@ public sealed class Antlr4GrammarConverter
         ref GrammarOptions? options,
         List<GrammarImport> imports,
         List<GrammarAction> actions,
-        DiagnosticBag diagnostics)
+        DiagnosticBag? diagnostics)
     {
         var optSpec = First(node, "optionsSpec");
         if (optSpec != null) { options = ConvertOptionsSpec(optSpec); return; }
@@ -208,13 +206,13 @@ public sealed class Antlr4GrammarConverter
 
         if (First(node, "tokensSpec") != null)
         {
-            diagnostics.Add(ParserDiagnostics.TokensBlockIgnored);
+            diagnostics?.Add(ParserDiagnostics.TokensBlockIgnored);
             return;
         }
 
         if (First(node, "channelsSpec") != null)
         {
-            diagnostics.Add(ParserDiagnostics.ChannelsBlockIgnored);
+            diagnostics?.Add(ParserDiagnostics.ChannelsBlockIgnored);
             return;
         }
 
@@ -242,7 +240,7 @@ public sealed class Antlr4GrammarConverter
     }
 
     /// <summary>Yields <see cref="GrammarImport"/> records from a <c>delegateGrammars</c> node.</summary>
-    private static IEnumerable<GrammarImport> ConvertDelegateGrammars(ParserNode node, DiagnosticBag diagnostics)
+    private static IEnumerable<GrammarImport> ConvertDelegateGrammars(ParserNode node, DiagnosticBag? diagnostics)
     {
         foreach (var dg in All(node, "delegateGrammar"))
         {
@@ -253,25 +251,25 @@ public sealed class Antlr4GrammarConverter
             if (idents.Count >= 2)
             {
                 var import = new GrammarImport(GetIdentifierText(idents[1]), GetIdentifierText(idents[0]));
-                diagnostics.Add(ParserDiagnostics.ImportParsedButNotResolved, import.GrammarName);
+                diagnostics?.Add(ParserDiagnostics.ImportParsedButNotResolved, import.GrammarName);
                 yield return import;
             }
             else if (idents.Count == 1)
             {
                 var import = new GrammarImport(GetIdentifierText(idents[0]));
-                diagnostics.Add(ParserDiagnostics.ImportParsedButNotResolved, import.GrammarName);
+                diagnostics?.Add(ParserDiagnostics.ImportParsedButNotResolved, import.GrammarName);
                 yield return import;
             }
         }
     }
 
     /// <summary>Converts an <c>action_</c> node into a <see cref="GrammarAction"/>, or <c>null</c> when the node lacks an identifier.</summary>
-    private static GrammarAction? ConvertGrammarAction(ParserNode node, DiagnosticBag diagnostics)
+    private static GrammarAction? ConvertGrammarAction(ParserNode node, DiagnosticBag? diagnostics)
     {
         var identNode = First(node, "identifier");
         if (identNode == null)
         {
-            diagnostics.Add(ParserDiagnostics.ActionIgnored, "@action(without identifier)");
+            diagnostics?.Add(ParserDiagnostics.ActionIgnored, "@action(without identifier)");
             return null;
         }
         var name = GetIdentifierText(identNode);
@@ -396,10 +394,10 @@ public sealed class Antlr4GrammarConverter
             if (HasToken(node, "QUESTION"))
             {
                 if (IsPrecpred(code)) return new PrecedencePredicate(ParsePrecpredLevel(code));
-                _diagnostics.Add(ParserDiagnostics.SemanticPredicateNotEnforced);
+                _diagnostics?.Add(ParserDiagnostics.SemanticPredicateNotEnforced);
                 return new ValidatingPredicate(code);
             }
-            _diagnostics.Add(ParserDiagnostics.InlineActionStoredNotExecuted);
+            _diagnostics?.Add(ParserDiagnostics.InlineActionStoredNotExecuted);
             return new EmbeddedAction(code, ActionContext.Alternative, ActionPosition.Inline, ExtractLabels(code));
         }
 
@@ -484,7 +482,7 @@ public sealed class Antlr4GrammarConverter
     /// <returns>Exception to throw.</returns>
     private GrammarParseException UnknownLexerCommand(string commandName)
     {
-        _diagnostics.Add(ParserDiagnostics.UnexpectedToken, commandName);
+        _diagnostics?.Add(ParserDiagnostics.UnexpectedToken, commandName);
         return new GrammarParseException($"Unknown lexer command: '{commandName}'");
     }
 
@@ -506,7 +504,7 @@ public sealed class Antlr4GrammarConverter
                 if (raw.Length > 0)
                 {
                     returns = [new RuleReturn(raw, raw)];
-                    _diagnostics.AddWithContext(ParserDiagnostics.ReturnsPartiallyApplied, null, null, name, null, name);
+                    _diagnostics?.AddWithContext(ParserDiagnostics.ReturnsPartiallyApplied, null, null, name, null, name);
                 }
             }
         }
@@ -532,14 +530,14 @@ public sealed class Antlr4GrammarConverter
 
             if (actionName == "init") initAction = action;
             else if (actionName == "after") afterAction = action;
-            else _diagnostics.AddWithContext(ParserDiagnostics.ActionIgnored, null, null, name, null, $"rule action @{actionName}");
+            else _diagnostics?.AddWithContext(ParserDiagnostics.ActionIgnored, null, null, name, null, $"rule action @{actionName}");
         }
 
         if (First(node, "exceptionGroup") != null)
             hasIgnoredRuleMetadata = true;
 
         if (hasIgnoredRuleMetadata)
-            _diagnostics.AddWithContext(ParserDiagnostics.LocalsIgnored, null, null, name, null, name);
+            _diagnostics?.AddWithContext(ParserDiagnostics.LocalsIgnored, null, null, name, null, name);
 
         var ruleBlock = Require(First(node, "ruleBlock"), "Missing ruleBlock");
         var ruleAltList = Require(First(ruleBlock, "ruleAltList"), "Missing ruleAltList");
@@ -605,10 +603,10 @@ public sealed class Antlr4GrammarConverter
             if (HasToken(node, "QUESTION"))
             {
                 if (IsPrecpred(code)) return new PrecedencePredicate(ParsePrecpredLevel(code));
-                _diagnostics.Add(ParserDiagnostics.SemanticPredicateNotEnforced);
+                _diagnostics?.Add(ParserDiagnostics.SemanticPredicateNotEnforced);
                 return new ValidatingPredicate(code);
             }
-            _diagnostics.Add(ParserDiagnostics.InlineActionStoredNotExecuted);
+            _diagnostics?.Add(ParserDiagnostics.InlineActionStoredNotExecuted);
             return new EmbeddedAction(code, ActionContext.Alternative, ActionPosition.Inline, ExtractLabels(code));
         }
 

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -245,11 +245,107 @@ a comprehensive real-world example.
 
 ---
 
+## Diagnostics
+
+The runtime parser and the source generator now share the same diagnostic model
+(`Utils.Parser.Diagnostics`), including descriptor codes and message templates.
+
+### Code scheme
+
+- `UP0xxx`: blocking errors
+- `UP1xxx` to `UP7xxx`: warnings for unsupported/ignored/partial behavior
+- `UP8xxx`: informational diagnostics
+- `UP9xxx`: debug traces
+
+Severity is derived from the code prefix (not manually assigned per call site).
+
+### Shared descriptor table
+
+Use `ParserDiagnostics` to access named descriptors and global lookup:
+
+```csharp
+var descriptor = ParserDiagnostics.UnexpectedToken;
+var allByCode = ParserDiagnostics.All;
+```
+
+### Collecting diagnostics at runtime
+
+```csharp
+using Utils.Parser.Diagnostics;
+
+var diagnostics = new DiagnosticBag();
+var definition = Antlr4GrammarConverter.Parse(grammarText, diagnostics);
+```
+
+`DiagnosticBag` supports direct `Add(...)`, descriptor-based `Add(...)`, range merge,
+read-only enumeration, and severity filtering (`GetAtLeast(...)`).
+
+### Generator compatibility
+
+`Utils.Parser.Generators` uses the same `ParserDiagnostics` descriptors and `DiagnosticBag`
+during `.g4` parsing, then maps emitted diagnostics to Roslyn diagnostics.
+
+---
+
 ## Self-describing design
 
 The ANTLR4 grammar reader is itself built with the same `ParserDefinition`, `Rule`, and
 `RuleContent` objects that every other grammar uses. There is no special-cased code for the
 meta-grammar — it is a first-class consumer of the framework.
+
+---
+
+## Current limitations
+
+The parser framework targets broad ANTLR4 compatibility, but some constructs are currently
+parsed in a simplified way, stored without full semantics, or ignored by one pipeline.
+The points below reflect the current implementation behavior.
+
+### Grammar ingestion (runtime converter: `Antlr4GrammarConverter`)
+
+- `options { ... }`, `import ...`, and top-level `@... { ... }` actions are ingested.
+- `tokens { ... }` and `channels { ... }` are recognized by the meta-grammar but not mapped
+  into `ParserDefinition` during conversion.
+- `returns [...]` is currently stored as one raw argument-block string (`RuleReturn(raw, raw)`),
+  not as structured typed returns.
+- `throws`, `locals`, `catch`, `finally`, rule arguments, and rule modifiers are parsed by the
+  meta-grammar but not converted into dedicated runtime semantics.
+- Only `@init` and `@after` rule actions are mapped to dedicated rule-level action slots.
+- Labels on `labeledElement` are applied when the labeled item is a `RuleRef`; labels on
+  non-reference items are currently ignored.
+
+### Runtime semantics (`LexerEngine` / `ParserEngine`)
+
+- Embedded actions and semantic predicates are parsed and stored, but the parser engine does
+  not execute them; they are accepted as successful empty matches.
+- Precedence is only enforced through recognized `precpred(_ctx, N)` patterns.
+- `precpred` extraction is regex-based; if the level cannot be parsed, precedence falls back
+  to `0`.
+- Lexer commands are restricted to known commands (`skip`, `more`, `channel`, `type`,
+  `pushMode`, `popMode`, `mode`); unknown command names raise a conversion error.
+- Parsing is not error-recovering: parsing failures return `ErrorNode`, and trailing tokens are
+  reported as an error instead of attempting recovery.
+
+### Source generator pipeline limitations (`G4Parser`)
+
+- The generator parser is best-effort by design: `Expect(...)` methods do not fail hard and may
+  silently continue on missing tokens.
+- `tokens { ... }`, `channels { ... }`, `import ...`, and `@...` actions are skipped.
+- Rule headers are simplified: text before `:` (such as `returns`, `throws`, `locals`, and other
+  pre-`:` constructs) is skipped rather than modeled.
+- Embedded actions/predicates are represented as raw block text (`G4EmbeddedAction`) without
+  semantic execution in the generator parser itself.
+- Lexer command arguments are currently parsed only from parenthesized identifiers.
+
+### Runtime vs source generator differences
+
+- Runtime conversion keeps a subset of prequel metadata (`options`, `imports`, grammar actions),
+  while the source generator skips imports and grammar actions entirely.
+- Runtime conversion throws explicit errors for unknown lexer commands; the source generator keeps
+  lexer commands as parsed name/argument pairs without command-name validation at parse time.
+- Both pipelines recognize large parts of ANTLR4 syntax, but they do not currently provide full
+  ANTLR4 semantic equivalence for actions, predicates, exception handlers, and advanced rule
+  header metadata.
 
 ---
 

--- a/Utils.Parser/Resolution/RuleResolver.cs
+++ b/Utils.Parser/Resolution/RuleResolver.cs
@@ -1,4 +1,5 @@
 using Utils.Parser.Model;
+using Utils.Parser.Diagnostics;
 
 namespace Utils.Parser.Resolution;
 
@@ -28,8 +29,9 @@ public static class RuleResolver
     /// Thrown when duplicate rule names are detected, a rule references an unknown rule,
     /// rule kinds cannot be consistently resolved, or structural constraints are violated.
     /// </exception>
-    public static ParserDefinition Resolve(ParserDefinition definition)
+    public static ParserDefinition Resolve(ParserDefinition definition, DiagnosticBag? diagnostics = null)
     {
+        diagnostics ??= new DiagnosticBag();
         // 1. Build AllRules, assigning known kinds at registration time.
         var allRules = new Dictionary<string, Rule>();
 
@@ -38,7 +40,10 @@ public static class RuleResolver
             foreach (var rule in mode.Rules)
             {
                 if (!allRules.TryAdd(rule.Name, rule))
+                {
+                    diagnostics.Add(ParserDiagnostics.InternalInconsistency, $"Duplicate rule name: {rule.Name}");
                     throw new GrammarValidationException($"Duplicate rule name: {rule.Name}");
+                }
                 rule.Kind = RuleKind.Lexer;
             }
         }
@@ -46,7 +51,10 @@ public static class RuleResolver
         foreach (var rule in definition.ParserRules)
         {
             if (!allRules.TryAdd(rule.Name, rule))
+            {
+                diagnostics.Add(ParserDiagnostics.InternalInconsistency, $"Duplicate rule name: {rule.Name}");
                 throw new GrammarValidationException($"Duplicate rule name: {rule.Name}");
+            }
             rule.Kind = RuleKind.Parser;
         }
 
@@ -56,7 +64,7 @@ public static class RuleResolver
         // 2. Verify that all RuleRefs point to existing rules.
         foreach (var rule in allRules.Values)
         {
-            ValidateRuleRefs(rule.Content, allRules, rule.Name);
+            ValidateRuleRefs(rule.Content, allRules, rule.Name, diagnostics);
         }
 
         // 3. Infer RuleKind for any rules still marked Unresolved.
@@ -109,7 +117,7 @@ public static class RuleResolver
         // 6. Validate labels: ensure every label's target rule exists.
         foreach (var rule in allRules.Values)
         {
-            ValidateLabels(rule.Content, allRules, rule.Name);
+            ValidateLabels(rule.Content, allRules, rule.Name, diagnostics);
         }
 
         return definition;
@@ -125,31 +133,35 @@ public static class RuleResolver
     private static void ValidateRuleRefs(
         RuleContent content,
         IDictionary<string, Rule> rules,
-        string contextRuleName)
+        string contextRuleName,
+        DiagnosticBag diagnostics)
     {
         switch (content)
         {
             case RuleRef r:
                 if (!rules.ContainsKey(r.RuleName))
+                {
+                    diagnostics.AddWithContext(ParserDiagnostics.UnknownRuleReference, null, null, contextRuleName, null, contextRuleName, r.RuleName);
                     throw new GrammarValidationException(
                         $"Rule '{contextRuleName}' references unknown rule '{r.RuleName}'");
+                }
                 break;
             case Sequence s:
                 foreach (var item in s.Items)
-                    ValidateRuleRefs(item, rules, contextRuleName);
+                    ValidateRuleRefs(item, rules, contextRuleName, diagnostics);
                 break;
             case Alternation a:
                 foreach (var alt in a.Alternatives)
-                    ValidateRuleRefs(alt.Content, rules, contextRuleName);
+                    ValidateRuleRefs(alt.Content, rules, contextRuleName, diagnostics);
                 break;
             case Alternative alt:
-                ValidateRuleRefs(alt.Content, rules, contextRuleName);
+                ValidateRuleRefs(alt.Content, rules, contextRuleName, diagnostics);
                 break;
             case Quantifier q:
-                ValidateRuleRefs(q.Inner, rules, contextRuleName);
+                ValidateRuleRefs(q.Inner, rules, contextRuleName, diagnostics);
                 break;
             case Negation n:
-                ValidateRuleRefs(n.Inner, rules, contextRuleName);
+                ValidateRuleRefs(n.Inner, rules, contextRuleName, diagnostics);
                 break;
         }
     }
@@ -164,32 +176,36 @@ public static class RuleResolver
     private static void ValidateLabels(
         RuleContent content,
         IDictionary<string, Rule> rules,
-        string contextRuleName)
+        string contextRuleName,
+        DiagnosticBag diagnostics)
     {
         switch (content)
         {
             case RuleRef r when r.Label is not null:
                 if (!rules.ContainsKey(r.Label.RuleName))
+                {
+                    diagnostics.AddWithContext(ParserDiagnostics.UnknownRuleReference, null, null, contextRuleName, null, contextRuleName, r.Label.RuleName);
                     throw new GrammarValidationException(
                         $"Rule '{contextRuleName}' has label '{r.Label.Label}' " +
                         $"referencing unknown rule '{r.Label.RuleName}'");
+                }
                 break;
             case Sequence s:
                 foreach (var item in s.Items)
-                    ValidateLabels(item, rules, contextRuleName);
+                    ValidateLabels(item, rules, contextRuleName, diagnostics);
                 break;
             case Alternation a:
                 foreach (var alt in a.Alternatives)
-                    ValidateLabels(alt.Content, rules, contextRuleName);
+                    ValidateLabels(alt.Content, rules, contextRuleName, diagnostics);
                 break;
             case Alternative alt:
-                ValidateLabels(alt.Content, rules, contextRuleName);
+                ValidateLabels(alt.Content, rules, contextRuleName, diagnostics);
                 break;
             case Quantifier q:
-                ValidateLabels(q.Inner, rules, contextRuleName);
+                ValidateLabels(q.Inner, rules, contextRuleName, diagnostics);
                 break;
             case Negation n:
-                ValidateLabels(n.Inner, rules, contextRuleName);
+                ValidateLabels(n.Inner, rules, contextRuleName, diagnostics);
                 break;
         }
     }

--- a/Utils.Parser/Resolution/RuleResolver.cs
+++ b/Utils.Parser/Resolution/RuleResolver.cs
@@ -31,7 +31,6 @@ public static class RuleResolver
     /// </exception>
     public static ParserDefinition Resolve(ParserDefinition definition, DiagnosticBag? diagnostics = null)
     {
-        diagnostics ??= new DiagnosticBag();
         // 1. Build AllRules, assigning known kinds at registration time.
         var allRules = new Dictionary<string, Rule>();
 
@@ -41,7 +40,7 @@ public static class RuleResolver
             {
                 if (!allRules.TryAdd(rule.Name, rule))
                 {
-                    diagnostics.Add(ParserDiagnostics.InternalInconsistency, $"Duplicate rule name: {rule.Name}");
+                    diagnostics?.Add(ParserDiagnostics.InternalInconsistency, $"Duplicate rule name: {rule.Name}");
                     throw new GrammarValidationException($"Duplicate rule name: {rule.Name}");
                 }
                 rule.Kind = RuleKind.Lexer;
@@ -52,7 +51,7 @@ public static class RuleResolver
         {
             if (!allRules.TryAdd(rule.Name, rule))
             {
-                diagnostics.Add(ParserDiagnostics.InternalInconsistency, $"Duplicate rule name: {rule.Name}");
+                diagnostics?.Add(ParserDiagnostics.InternalInconsistency, $"Duplicate rule name: {rule.Name}");
                 throw new GrammarValidationException($"Duplicate rule name: {rule.Name}");
             }
             rule.Kind = RuleKind.Parser;
@@ -134,14 +133,14 @@ public static class RuleResolver
         RuleContent content,
         IDictionary<string, Rule> rules,
         string contextRuleName,
-        DiagnosticBag diagnostics)
+        DiagnosticBag? diagnostics)
     {
         switch (content)
         {
             case RuleRef r:
                 if (!rules.ContainsKey(r.RuleName))
                 {
-                    diagnostics.AddWithContext(ParserDiagnostics.UnknownRuleReference, null, null, contextRuleName, null, contextRuleName, r.RuleName);
+                    diagnostics?.AddWithContext(ParserDiagnostics.UnknownRuleReference, null, null, contextRuleName, null, contextRuleName, r.RuleName);
                     throw new GrammarValidationException(
                         $"Rule '{contextRuleName}' references unknown rule '{r.RuleName}'");
                 }
@@ -177,14 +176,14 @@ public static class RuleResolver
         RuleContent content,
         IDictionary<string, Rule> rules,
         string contextRuleName,
-        DiagnosticBag diagnostics)
+        DiagnosticBag? diagnostics)
     {
         switch (content)
         {
             case RuleRef r when r.Label is not null:
                 if (!rules.ContainsKey(r.Label.RuleName))
                 {
-                    diagnostics.AddWithContext(ParserDiagnostics.UnknownRuleReference, null, null, contextRuleName, null, contextRuleName, r.Label.RuleName);
+                    diagnostics?.AddWithContext(ParserDiagnostics.UnknownRuleReference, null, null, contextRuleName, null, contextRuleName, r.Label.RuleName);
                     throw new GrammarValidationException(
                         $"Rule '{contextRuleName}' has label '{r.Label.Label}' " +
                         $"referencing unknown rule '{r.Label.RuleName}'");

--- a/Utils.Parser/Runtime/LexerEngine.cs
+++ b/Utils.Parser/Runtime/LexerEngine.cs
@@ -50,7 +50,6 @@ public sealed class LexerEngine(ParserDefinition definition)
     /// <returns>Lazy sequence of tokens.</returns>
     public IEnumerable<Token> Tokenize(ICharStream stream, DiagnosticBag? diagnostics = null)
     {
-        diagnostics ??= new DiagnosticBag();
         _modeStack.Clear();
         _modeStack.Push(GetDefaultMode());
         _moreTextBuilder.Clear();
@@ -68,7 +67,7 @@ public sealed class LexerEngine(ParserDefinition definition)
                 var pos = stream.Position;
                 var ch = stream.Peek();
                 stream.Consume();
-                diagnostics.AddWithContext(ParserDiagnostics.ParseFailure, pos, 1, null, null, $"Unrecognized character '{ch}'.");
+                diagnostics?.AddWithContext(ParserDiagnostics.ParseFailure, pos, 1, null, null, $"Unrecognized character '{ch}'.");
                 yield return new Token(
                     new SourceSpan(pos, 1), "ERROR", mode.Name, ch.ToString());
                 continue;
@@ -408,7 +407,7 @@ public sealed class LexerEngine(ParserDefinition definition)
     /// <param name="commands">Commands from the matched path (may be empty).</param>
     /// <param name="token">The matched token; may be passed for context but is not mutated here.</param>
     /// <returns><c>true</c> if the token should be suppressed from output.</returns>
-    private bool ExecuteLexerCommands(List<Model.LexerCommand> commands, ref Token token, DiagnosticBag diagnostics)
+    private bool ExecuteLexerCommands(List<Model.LexerCommand> commands, ref Token token, DiagnosticBag? diagnostics)
     {
         bool skip = false;
         bool more = false;
@@ -432,7 +431,7 @@ public sealed class LexerEngine(ParserDefinition definition)
                         if (mode is not null)
                             _modeStack.Push(mode);
                         else
-                            diagnostics.AddWithContext(ParserDiagnostics.UnknownLexerMode, token.Span.Position, token.Span.Length, null, null, cmd.Argument, "pushMode");
+                            diagnostics?.AddWithContext(ParserDiagnostics.UnknownLexerMode, token.Span.Position, token.Span.Length, null, null, cmd.Argument, "pushMode");
                     }
                     break;
 
@@ -453,7 +452,7 @@ public sealed class LexerEngine(ParserDefinition definition)
                         }
                         else
                         {
-                            diagnostics.AddWithContext(ParserDiagnostics.UnknownLexerMode, token.Span.Position, token.Span.Length, null, null, cmd.Argument, "mode");
+                            diagnostics?.AddWithContext(ParserDiagnostics.UnknownLexerMode, token.Span.Position, token.Span.Length, null, null, cmd.Argument, "mode");
                         }
                     }
                     break;

--- a/Utils.Parser/Runtime/LexerEngine.cs
+++ b/Utils.Parser/Runtime/LexerEngine.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Utils.Parser.Diagnostics;
 using Utils.Parser.Model;
 
 namespace Utils.Parser.Runtime;
@@ -47,8 +48,9 @@ public sealed class LexerEngine(ParserDefinition definition)
     /// </summary>
     /// <param name="stream">Character stream to tokenize.</param>
     /// <returns>Lazy sequence of tokens.</returns>
-    public IEnumerable<Token> Tokenize(ICharStream stream)
+    public IEnumerable<Token> Tokenize(ICharStream stream, DiagnosticBag? diagnostics = null)
     {
+        diagnostics ??= new DiagnosticBag();
         _modeStack.Clear();
         _modeStack.Push(GetDefaultMode());
         _moreTextBuilder.Clear();
@@ -66,13 +68,14 @@ public sealed class LexerEngine(ParserDefinition definition)
                 var pos = stream.Position;
                 var ch = stream.Peek();
                 stream.Consume();
+                diagnostics.AddWithContext(ParserDiagnostics.ParseFailure, pos, 1, null, null, $"Unrecognized character '{ch}'.");
                 yield return new Token(
                     new SourceSpan(pos, 1), "ERROR", mode.Name, ch.ToString());
                 continue;
             }
 
             // Execute commands collected only from the matched path.
-            bool skip = ExecuteLexerCommands(commands, ref token);
+            bool skip = ExecuteLexerCommands(commands, ref token, diagnostics);
 
             if (rule!.IsFragment || skip)
                 continue;
@@ -405,7 +408,7 @@ public sealed class LexerEngine(ParserDefinition definition)
     /// <param name="commands">Commands from the matched path (may be empty).</param>
     /// <param name="token">The matched token; may be passed for context but is not mutated here.</param>
     /// <returns><c>true</c> if the token should be suppressed from output.</returns>
-    private bool ExecuteLexerCommands(List<Model.LexerCommand> commands, ref Token token)
+    private bool ExecuteLexerCommands(List<Model.LexerCommand> commands, ref Token token, DiagnosticBag diagnostics)
     {
         bool skip = false;
         bool more = false;
@@ -428,6 +431,8 @@ public sealed class LexerEngine(ParserDefinition definition)
                         var mode = definition.Modes.FirstOrDefault(m => m.Name == cmd.Argument);
                         if (mode is not null)
                             _modeStack.Push(mode);
+                        else
+                            diagnostics.AddWithContext(ParserDiagnostics.UnknownLexerMode, token.Span.Position, token.Span.Length, null, null, cmd.Argument, "pushMode");
                     }
                     break;
 
@@ -445,6 +450,10 @@ public sealed class LexerEngine(ParserDefinition definition)
                             if (_modeStack.Count > 0)
                                 _modeStack.Pop();
                             _modeStack.Push(targetMode);
+                        }
+                        else
+                        {
+                            diagnostics.AddWithContext(ParserDiagnostics.UnknownLexerMode, token.Span.Position, token.Span.Length, null, null, cmd.Argument, "mode");
                         }
                     }
                     break;

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -1,4 +1,5 @@
 using Utils.Parser.Model;
+using Utils.Parser.Diagnostics;
 
 namespace Utils.Parser.Runtime;
 
@@ -42,28 +43,40 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// Thrown when no start rule is available (neither <paramref name="startRule"/>
     /// nor <see cref="ParserDefinition.RootRule"/> is set).
     /// </exception>
-    public ParseNode Parse(IEnumerable<Token> tokens, Rule? startRule = null)
+    public ParseNode Parse(IEnumerable<Token> tokens, Rule? startRule = null, DiagnosticBag? diagnostics = null)
     {
+        diagnostics ??= new DiagnosticBag();
         var tokenList = tokens.ToList();
         var root = startRule ?? definition.RootRule
             ?? throw new InvalidOperationException("No root rule defined");
 
         _activeRuleFrames.Clear();
         var context = new ParseContext(tokenList);
-        var result = ParseRule(context, root, precedence: 0);
+        var result = ParseRule(context, root, precedence: 0, diagnostics);
 
         if (result is null)
+        {
+            diagnostics.Add(ParserDiagnostics.ParseFailure, "Failed to parse from root rule");
             return new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE",
                 "Failed to parse from root rule", root);
+        }
 
         // Reject parses that leave trailing tokens unconsumed.
         if (!context.IsEnd)
         {
             var trailing = context.Peek()!;
+            diagnostics.AddWithContext(
+                ParserDiagnostics.TrailingTokensAfterParse,
+                trailing.Span.Position,
+                trailing.Span.Length,
+                null,
+                null,
+                trailing.Text);
             return new ErrorNode(result.Span, result.ModeName,
                 $"Unexpected token '{trailing.Text}' at position {trailing.Span.Position}", root);
         }
 
+        diagnostics.Add(ParserDiagnostics.DefaultBehaviorApplied, "Parser completed without recovery.");
         return result;
     }
 
@@ -77,8 +90,9 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="rule">Parser rule to attempt.</param>
     /// <param name="precedence">Minimum precedence level accepted for this parse attempt.</param>
-    private ParseNode? ParseRule(ParseContext context, Rule rule, int precedence)
+    private ParseNode? ParseRule(ParseContext context, Rule rule, int precedence, DiagnosticBag? diagnostics = null)
     {
+        diagnostics?.AddWithContext(ParserDiagnostics.EnteringRule, null, null, rule.Name, null, rule.Name);
         // Detect left-recursive infinite cycles in O(1).
         var frameKey = new ParserFrameKey(rule.Name, context.Position);
         if (!_activeRuleFrames.Add(frameKey))
@@ -93,7 +107,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                     continue;
 
                 var savedPos = context.SavePosition();
-                var result = TryParseAlternative(context, alternative, rule);
+                var result = TryParseAlternative(context, alternative, rule, diagnostics);
                 if (result is not null)
                 {
                     // Ensure the returned node is tagged with this rule.
@@ -102,6 +116,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                     return new ParserNode(result.Span, result.ModeName, rule,
                         new List<ParseNode> { result });
                 }
+                diagnostics?.AddWithContext(ParserDiagnostics.BacktrackingUsed, null, null, rule.Name, null, rule.Name);
                 context.RestorePosition(savedPos);
             }
 
@@ -110,6 +125,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         finally
         {
             _activeRuleFrames.Remove(frameKey);
+            diagnostics?.AddWithContext(ParserDiagnostics.LeavingRule, null, null, rule.Name, null, rule.Name);
         }
     }
 
@@ -158,9 +174,9 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="alt">Alternative to attempt.</param>
     /// <param name="rule">Parent rule (carried to child nodes).</param>
-    private ParseNode? TryParseAlternative(ParseContext context, Alternative alt, Rule rule)
+    private ParseNode? TryParseAlternative(ParseContext context, Alternative alt, Rule rule, DiagnosticBag? diagnostics = null)
     {
-        return TryParseContent(context, alt.Content, rule);
+        return TryParseContent(context, alt.Content, rule, diagnostics);
     }
 
     /// <summary>
@@ -171,34 +187,35 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="content">Grammar element to match.</param>
     /// <param name="rule">Rule in whose context the element is being matched.</param>
-    private ParseNode? TryParseContent(ParseContext context, RuleContent content, Rule rule)
+    private ParseNode? TryParseContent(ParseContext context, RuleContent content, Rule rule, DiagnosticBag? diagnostics = null)
     {
         switch (content)
         {
             case RuleRef ruleRef:
-                return TryParseRuleRef(context, ruleRef, rule);
+                return TryParseRuleRef(context, ruleRef, rule, diagnostics);
 
             case Sequence seq:
-                return TryParseSequence(context, seq, rule);
+                return TryParseSequence(context, seq, rule, diagnostics);
 
             case Alternation alternation:
-                return TryParseAlternation(context, alternation, rule);
+                return TryParseAlternation(context, alternation, rule, diagnostics);
 
             case Alternative alt:
-                return TryParseAlternative(context, alt, rule);
+                return TryParseAlternative(context, alt, rule, diagnostics);
 
             case Quantifier quant:
-                return TryParseQuantifier(context, quant, rule);
+                return TryParseQuantifier(context, quant, rule, diagnostics);
 
             case LiteralMatch lit:
                 return TryParseLiteral(context, lit, rule);
 
             case Negation neg:
-                return TryParseNegation(context, neg, rule);
+                return TryParseNegation(context, neg, rule, diagnostics);
 
             case ValidatingPredicate:
             case GatingPredicate:
                 // Semantic predicates: silently accepted without evaluation.
+                diagnostics?.AddWithContext(ParserDiagnostics.SemanticPredicateNotEnforced, null, null, rule.Name, null);
                 return CreateEmptyNode(context, rule);
 
             case PrecedencePredicate:
@@ -207,6 +224,7 @@ public sealed class ParserEngine(ParserDefinition definition)
 
             case EmbeddedAction:
                 // Embedded actions: never executed, always succeed.
+                diagnostics?.AddWithContext(ParserDiagnostics.InlineActionStoredNotExecuted, null, null, rule.Name, null);
                 return CreateEmptyNode(context, rule);
 
             default:
@@ -221,7 +239,7 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="ruleRef">Reference to resolve.</param>
     /// <param name="parentRule">The rule in which this reference appears.</param>
-    private ParseNode? TryParseRuleRef(ParseContext context, RuleRef ruleRef, Rule parentRule)
+    private ParseNode? TryParseRuleRef(ParseContext context, RuleRef ruleRef, Rule parentRule, DiagnosticBag? diagnostics = null)
     {
         if (!definition.AllRules.TryGetValue(ruleRef.RuleName, out var referencedRule))
             return null;
@@ -235,13 +253,21 @@ public sealed class ParserEngine(ParserDefinition definition)
             if (token.RuleName == ruleRef.RuleName)
             {
                 context.Consume();
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.TokenMatched,
+                    token.Span.Position,
+                    token.Span.Length,
+                    ruleRef.RuleName,
+                    null,
+                    ruleRef.RuleName,
+                    token.Text);
                 return new LexerNode(token.Span, token.ModeName, referencedRule, token);
             }
             return null;
         }
 
         // Parser rule: recurse.
-        return ParseRule(context, referencedRule, precedence: 0);
+        return ParseRule(context, referencedRule, precedence: 0, diagnostics);
     }
 
     /// <summary>
@@ -253,7 +279,7 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="seq">Sequence to match.</param>
     /// <param name="rule">Owning rule for the returned node.</param>
-    private ParseNode? TryParseSequence(ParseContext context, Sequence seq, Rule rule)
+    private ParseNode? TryParseSequence(ParseContext context, Sequence seq, Rule rule, DiagnosticBag? diagnostics = null)
     {
         var children = new List<ParseNode>();
         var startPos = context.Position;
@@ -264,7 +290,7 @@ public sealed class ParserEngine(ParserDefinition definition)
             if (item is EmbeddedAction or Model.LexerCommand)
                 continue;
 
-            var node = TryParseContent(context, item, rule);
+            var node = TryParseContent(context, item, rule, diagnostics);
             if (node is null)
                 return null;
 
@@ -285,14 +311,15 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="alternation">Alternation to evaluate.</param>
     /// <param name="rule">Owning rule (carried to child matches).</param>
-    private ParseNode? TryParseAlternation(ParseContext context, Alternation alternation, Rule rule)
+    private ParseNode? TryParseAlternation(ParseContext context, Alternation alternation, Rule rule, DiagnosticBag? diagnostics = null)
     {
         foreach (var alt in alternation.Alternatives.OrderBy(a => a.Priority))
         {
             var savedPos = context.SavePosition();
-            var result = TryParseContent(context, alt.Content, rule);
+            var result = TryParseContent(context, alt.Content, rule, diagnostics);
             if (result is not null)
                 return result;
+            diagnostics?.AddWithContext(ParserDiagnostics.BacktrackingUsed, null, null, rule.Name, null, rule.Name);
             context.RestorePosition(savedPos);
         }
         return null;
@@ -307,7 +334,7 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="quant">Quantifier to evaluate.</param>
     /// <param name="rule">Owning rule for the returned node.</param>
-    private ParseNode? TryParseQuantifier(ParseContext context, Quantifier quant, Rule rule)
+    private ParseNode? TryParseQuantifier(ParseContext context, Quantifier quant, Rule rule, DiagnosticBag? diagnostics = null)
     {
         var children = new List<ParseNode>();
         var startPos = context.Position;
@@ -317,7 +344,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         while (quant.Max is null || count < quant.Max.Value)
         {
             var savedPos = context.SavePosition();
-            var node = TryParseContent(context, quant.Inner, rule);
+            var node = TryParseContent(context, quant.Inner, rule, diagnostics);
             if (node is null)
             {
                 context.RestorePosition(savedPos);
@@ -378,13 +405,13 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="neg">Negation element to evaluate.</param>
     /// <param name="rule">Owning rule for the returned node.</param>
-    private ParseNode? TryParseNegation(ParseContext context, Negation neg, Rule rule)
+    private ParseNode? TryParseNegation(ParseContext context, Negation neg, Rule rule, DiagnosticBag? diagnostics = null)
     {
         var token = context.Peek();
         if (token is null) return null;
 
         var savedPos = context.SavePosition();
-        var matched = TryParseContent(context, neg.Inner, rule);
+        var matched = TryParseContent(context, neg.Inner, rule, diagnostics);
         context.RestorePosition(savedPos);
 
         if (matched is null)

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -45,7 +45,6 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// </exception>
     public ParseNode Parse(IEnumerable<Token> tokens, Rule? startRule = null, DiagnosticBag? diagnostics = null)
     {
-        diagnostics ??= new DiagnosticBag();
         var tokenList = tokens.ToList();
         var root = startRule ?? definition.RootRule
             ?? throw new InvalidOperationException("No root rule defined");
@@ -56,7 +55,7 @@ public sealed class ParserEngine(ParserDefinition definition)
 
         if (result is null)
         {
-            diagnostics.Add(ParserDiagnostics.ParseFailure, "Failed to parse from root rule");
+            diagnostics?.Add(ParserDiagnostics.ParseFailure, "Failed to parse from root rule");
             return new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE",
                 "Failed to parse from root rule", root);
         }
@@ -65,7 +64,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         if (!context.IsEnd)
         {
             var trailing = context.Peek()!;
-            diagnostics.AddWithContext(
+            diagnostics?.AddWithContext(
                 ParserDiagnostics.TrailingTokensAfterParse,
                 trailing.Span.Position,
                 trailing.Span.Length,
@@ -76,7 +75,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                 $"Unexpected token '{trailing.Text}' at position {trailing.Span.Position}", root);
         }
 
-        diagnostics.Add(ParserDiagnostics.DefaultBehaviorApplied, "Parser completed without recovery.");
+        diagnostics?.Add(ParserDiagnostics.DefaultBehaviorApplied, "Parser completed without recovery.");
         return result;
     }
 

--- a/Utils.Parser/Utils.Parser.csproj
+++ b/Utils.Parser/Utils.Parser.csproj
@@ -26,4 +26,9 @@
 		<None Include="README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
+
+    <ItemGroup>
+        <ProjectReference Include="..\Utils.Parser.Diagnostics\Utils.Parser.Diagnostics.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -145,4 +145,58 @@ public class ParserDiagnosticsTests
         Assert.IsFalse(node is ErrorNode);
         Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
     }
+
+    [TestMethod]
+    public void RuntimeEngines_WithNullDiagnostics_DoNotThrow()
+    {
+        var definition = Antlr4GrammarConverter.Parse("""
+            grammar Exp;
+            eval   : Number ;
+            Number : ('0'..'9')+ ;
+            WS     : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """);
+
+        var lexer = new LexerEngine(definition);
+        var tokens = lexer.Tokenize(new StringCharStream("1 ?"), diagnostics: null).ToList();
+        var parser = new ParserEngine(definition);
+        var node = parser.Parse(tokens, diagnostics: null);
+
+        Assert.IsNotNull(node);
+        Assert.IsTrue(tokens.Any(t => t.RuleName == "ERROR"));
+    }
+
+    [TestMethod]
+    public void RuleResolver_WithNullDiagnostics_ThrowsExpectedExceptionOnly()
+    {
+        var parserRule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new RuleRef("MissingRule"))
+            ]));
+
+        var definition = new ParserDefinition(
+            Name: "G",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            ParserRules: [parserRule],
+            RootRule: parserRule);
+
+        Assert.ThrowsException<GrammarValidationException>(() => RuleResolver.Resolve(definition, diagnostics: null));
+    }
+
+    [TestMethod]
+    public void GeneratorParser_WithNullDiagnostics_DoesNotThrow()
+    {
+        var tokens = new G4Tokenizer("grammar G; tokens { A }; rule : 'a' ;").Tokenize();
+        var parser = new G4Parser(tokens, diagnostics: null);
+        var grammar = parser.Parse();
+
+        Assert.IsNotNull(grammar);
+        Assert.AreEqual("G", grammar.Name);
+    }
 }

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -1,0 +1,148 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Generators.Internal;
+using Utils.Parser.Model;
+using Utils.Parser.Resolution;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Tests for shared parser diagnostics used by runtime and source generator pipelines.
+/// </summary>
+[TestClass]
+public class ParserDiagnosticsTests
+{
+    [TestMethod]
+    public void DiagnosticCode_MapsToSeverity()
+    {
+        Assert.AreEqual(DiagnosticSeverity.Error, ParserDiagnosticSeverityMapper.FromCode("UP0001"));
+        Assert.AreEqual(DiagnosticSeverity.Warning, ParserDiagnosticSeverityMapper.FromCode("UP1001"));
+        Assert.AreEqual(DiagnosticSeverity.Warning, ParserDiagnosticSeverityMapper.FromCode("UP5001"));
+        Assert.AreEqual(DiagnosticSeverity.Info, ParserDiagnosticSeverityMapper.FromCode("UP8001"));
+        Assert.AreEqual(DiagnosticSeverity.Debug, ParserDiagnosticSeverityMapper.FromCode("UP9001"));
+    }
+
+    [TestMethod]
+    public void DescriptorTable_LookupByCode_Works()
+    {
+        var found = ParserDiagnostics.TryGet("UP1002", out var descriptor);
+        Assert.IsTrue(found);
+        Assert.IsNotNull(descriptor);
+        Assert.AreEqual(ParserDiagnostics.TokensBlockIgnored.Code, descriptor.Code);
+    }
+
+    [TestMethod]
+    public void Generator_UsesSharedDescriptors_ForIgnoredConstructs()
+    {
+        var diagnostics = new DiagnosticBag();
+        var tokens = new G4Tokenizer("grammar G; tokens { A }; rule : 'a' ;").Tokenize();
+
+        var parser = new G4Parser(tokens, diagnostics);
+        parser.Parse();
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.TokensBlockIgnored.Code));
+    }
+
+    [TestMethod]
+    public void RuntimeEngine_InlineActionAndPredicate_EmitDiagnostics()
+    {
+        var diagnostics = new DiagnosticBag();
+        var parserRule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([
+                new Alternative(
+                    0,
+                    Associativity.Left,
+                    new Sequence([
+                        new EmbeddedAction("var x = 1;", ActionContext.Alternative, ActionPosition.Inline, []),
+                        new ValidatingPredicate("true")
+                    ]))
+            ]));
+
+        var definition = RuleResolver.Resolve(new ParserDefinition(
+            Name: "G",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            ParserRules: [parserRule],
+            RootRule: parserRule));
+
+        var parser = new ParserEngine(definition);
+        parser.Parse([], diagnostics: diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.SemanticPredicateNotEnforced.Code));
+    }
+
+    [TestMethod]
+    public void Resolver_UnknownRule_EmitsBlockingDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        var parserRule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new RuleRef("MissingRule"))
+            ]));
+
+        var definition = new ParserDefinition(
+            Name: "G",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            ParserRules: [parserRule],
+            RootRule: parserRule);
+
+        Assert.ThrowsException<GrammarValidationException>(() => RuleResolver.Resolve(definition, diagnostics));
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.UnknownRuleReference.Code));
+    }
+
+    [TestMethod]
+    public void ParserEngine_TrailingTokens_EmitsWarningDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        var definition = Antlr4GrammarConverter.Parse("""
+            grammar Exp;
+            eval   : Number ;
+            Number : ('0'..'9')+ ;
+            WS     : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, diagnostics);
+
+        var lexer = new LexerEngine(definition);
+        var tokens = lexer.Tokenize(new StringCharStream("1 2"), diagnostics).ToList();
+        var parser = new ParserEngine(definition);
+        var node = parser.Parse(tokens, diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ErrorNode>(node);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
+    }
+
+    [TestMethod]
+    public void ValidCase_EmitsNoErrorDiagnostics()
+    {
+        var diagnostics = new DiagnosticBag();
+        var definition = Antlr4GrammarConverter.Parse("""
+            grammar Exp;
+            eval   : Number ;
+            Number : ('0'..'9')+ ;
+            WS     : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, diagnostics);
+
+        var lexer = new LexerEngine(definition);
+        var tokens = lexer.Tokenize(new StringCharStream("1"), diagnostics).ToList();
+        var parser = new ParserEngine(definition);
+        var node = parser.Parse(tokens, diagnostics: diagnostics);
+
+        Assert.IsFalse(node is ErrorNode);
+        Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+    }
+}

--- a/UtilsTest/README.md
+++ b/UtilsTest/README.md
@@ -1,34 +1,34 @@
 # UtilsTest
 
-`UtilsTest` contient les tests unitaires et tests d'intégration (MSTest + SpecFlow) pour l'ensemble des projets `Utils.*`.
+`UtilsTest` contains unit tests and integration tests (MSTest + SpecFlow) for the full `Utils.*` project set.
 
-## Objectif
+## Purpose
 
-Valider les comportements transverses des bibliothèques (collections, IO, réseau, mathématiques, parsing, imagerie, etc.).
+Validate cross-cutting library behavior (collections, IO, networking, mathematics, parsing, imaging, etc.).
 
-## Exemples
+## Examples
 
-### 1) Exécuter toute la suite
+### 1) Run the full suite
 
 ```bash
 dotnet test UtilsTest/UtilsTest.csproj
 ```
 
-### 2) Exécuter un sous-ensemble ciblé
+### 2) Run a targeted subset
 
 ```bash
 dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~CSyntaxExpressionCompilerTests"
 ```
 
-### 3) Exécuter un dossier de tests spécifique
+### 3) Run tests for a specific area
 
 ```bash
 dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~UtilsTest.Net"
 ```
 
-## Repères utiles
+## Useful landmarks
 
-- Tests d'expressions : `UtilsTest/Expressions/`
-- Tests réseau : `UtilsTest/Net/`
-- Tests mathématiques : `UtilsTest/Mathematics/`
-- Scénarios SpecFlow : `UtilsTest/Lists/` et `UtilsTest/Mathematics/LinearAlgebra/`
+- Expression tests: `UtilsTest/Expressions/`
+- Network tests: `UtilsTest/Net/`
+- Math tests: `UtilsTest/Mathematics/`
+- SpecFlow scenarios: `UtilsTest/Lists/` and `UtilsTest/Mathematics/LinearAlgebra/`

--- a/UtilsTest/UtilsTest.csproj
+++ b/UtilsTest/UtilsTest.csproj
@@ -71,6 +71,7 @@
                 <ProjectReference Include="..\Utils.DependencyInjection.Generators\Utils.DependencyInjection.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
                 <ProjectReference Include="..\Utils.IO.Serialization.Generators\Utils.IO.Serialization.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
                 <ProjectReference Include="..\Utils.Parser.Generators\Utils.Parser.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+                <ProjectReference Include="..\Utils.Parser.Diagnostics\Utils.Parser.Diagnostics.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
                 <ProjectReference Include="..\Utils.OData.Generators\Utils.OData.Generators.csproj" />
                 <ProjectReference Include="..\Utils.OData\Utils.OData.csproj" />
                 <ProjectReference Include="..\Utils.Parser\Utils.Parser.csproj" />


### PR DESCRIPTION
### Motivation

- Provide a unified diagnostics model for the parser runtime and the source-generator so both pipelines emit the same diagnostic codes and messages.
- Allow collection of structured diagnostics during tokenization/parsing/conversion so callers (and the Roslyn generator) can observe warnings, infos and debug traces in addition to errors.
- Improve observability and enable automated tests around parser behavior and non-fatal issues.

### Description

- Introduce a new `Utils.Parser.Diagnostics` project with `DiagnosticBag`, `ParserDiagnostic`, `ParserDiagnosticDescriptor`, `DiagnosticSeverity`, `ParserDiagnosticSeverityMapper`, and a shared `ParserDiagnostics` descriptor registry.
- Thread `DiagnosticBag` through the generator and runtime: `G4Parser`, `Antlr4GrammarConverter`, `LexerEngine`, `ParserEngine`, and `RuleResolver` now accept/emit diagnostics and record contextual messages at relevant events and recovery points.
- Map collected parser diagnostics to Roslyn `Diagnostic` instances inside `Antlr4GrammarGenerator` so generator runs report shared diagnostic codes back to the IDE/compilation pipeline.
- Update project files to reference the new diagnostics package, add documentation in `Utils.Parser/README.md` describing the scheme, and add `ParserDiagnosticsTests` exercising mapping, generator and runtime diagnostic emission.

### Testing

- Ran a full build with `dotnet build` for the solution which completed successfully.
- Executed unit tests with `dotnet test`, including the new `ParserDiagnosticsTests`, and all tests passed. 
- Verified that the source-generator mapping emits Roslyn diagnostics for parser-reported issues during generation via the added generator tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ace994148326a07e268afcc9bd41)