### PR TITLE
Harden ParserEngine against cyclic states and non-progressive loops

### DIFF
--- a/Utils.Parser.Diagnostics/ParserDiagnosticDescriptor.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnosticDescriptor.cs
@@ -8,12 +8,12 @@ namespace Utils.Parser.Diagnostics;
 /// </summary>
 public sealed class ParserDiagnosticDescriptor
 {
-    private static readonly Regex s_codeRegex = new("^UP[0-9]{4}$", RegexOptions.Compiled);
+    private static readonly Regex s_codeRegex = new("^(UP[0-9]{4}|PARSER[0-9]{3})$", RegexOptions.Compiled);
 
     /// <summary>
     /// Initializes a new diagnostic descriptor and validates the diagnostic code format.
     /// </summary>
-    /// <param name="code">Diagnostic code in the form <c>UPxxxx</c>.</param>
+    /// <param name="code">Diagnostic code in the form <c>UPxxxx</c> or <c>PARSERxxx</c>.</param>
     /// <param name="title">Short diagnostic title.</param>
     /// <param name="messageFormat">Composite format string used to build diagnostic messages.</param>
     /// <param name="category">Optional diagnostic category.</param>
@@ -22,7 +22,7 @@ public sealed class ParserDiagnosticDescriptor
     {
         if (!s_codeRegex.IsMatch(code))
         {
-            throw new ArgumentException($"Invalid diagnostic code '{code}'. Expected format UPxxxx.", nameof(code));
+            throw new ArgumentException($"Invalid diagnostic code '{code}'. Expected format UPxxxx or PARSERxxx.", nameof(code));
         }
 
         Code = code;

--- a/Utils.Parser.Diagnostics/ParserDiagnosticSeverityMapper.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnosticSeverityMapper.cs
@@ -9,8 +9,9 @@ public static class ParserDiagnosticSeverityMapper
 {
     /// <summary>
     /// Resolves severity from a code using the first digit after <c>UP</c>.
+    /// Codes using the <c>PARSERxxx</c> convention map to warning severity.
     /// </summary>
-    /// <param name="code">Diagnostic code in the form <c>UPxxxx</c>.</param>
+    /// <param name="code">Diagnostic code in the form <c>UPxxxx</c> or <c>PARSERxxx</c>.</param>
     /// <returns>Mapped diagnostic severity.</returns>
     /// <exception cref="ArgumentException">Thrown when the code prefix is invalid.</exception>
     public static DiagnosticSeverity FromCode(string code)
@@ -18,6 +19,15 @@ public static class ParserDiagnosticSeverityMapper
         if (code is null)
         {
             throw new ArgumentNullException(nameof(code));
+        }
+
+        if (code.StartsWith("PARSER", StringComparison.Ordinal) &&
+            code.Length == 9 &&
+            char.IsDigit(code[6]) &&
+            char.IsDigit(code[7]) &&
+            char.IsDigit(code[8]))
+        {
+            return DiagnosticSeverity.Warning;
         }
 
         if (code.Length != 6 || !code.StartsWith("UP", StringComparison.Ordinal) || !char.IsDigit(code[2]))

--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -149,6 +149,18 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor AmbiguousConstructResolvedHeuristically =
         new("UP5005", "Ambiguous construct resolved", "Ambiguous construct resolved heuristically: {0}", DefaultCategory);
 
+    /// <summary>Parsing branch aborted because the parser entered a repeated state.</summary>
+    public static readonly ParserDiagnosticDescriptor ParserStateCycleDetected =
+        new("PARSER001", "Parser state cycle detected", "Parsing branch aborted due to repeated parser state.", DefaultCategory);
+
+    /// <summary>Quantifier iteration stopped because the inner rule made no progress.</summary>
+    public static readonly ParserDiagnosticDescriptor NonProgressiveQuantifierStopped =
+        new("PARSER002", "Non-progressive quantifier stopped", "Quantifier stopped because inner rule matched without consuming input.", DefaultCategory);
+
+    /// <summary>Left-recursive extension stopped because no progress was observed.</summary>
+    public static readonly ParserDiagnosticDescriptor NonProgressiveLeftRecursionStopped =
+        new("PARSER003", "Non-progressive left recursion stopped", "Left-recursive extension stopped because no input progress was made.", DefaultCategory);
+
     // Info (UP8xxx)
     /// <summary>Default behavior applied.</summary>
     public static readonly ParserDiagnosticDescriptor DefaultBehaviorApplied =
@@ -175,6 +187,10 @@ public static class ParserDiagnostics
     /// <summary>Debug trace for backtracking usage.</summary>
     public static readonly ParserDiagnosticDescriptor BacktrackingUsed =
         new("UP9004", "Backtracking used", "Backtracking used in rule '{0}'.", DefaultCategory);
+
+    /// <summary>Debug trace for parser states rejected by runtime safeguards.</summary>
+    public static readonly ParserDiagnosticDescriptor ParserStateRejected =
+        new("UP9005", "Parser state rejected", "Parser state rejected in rule '{0}': {1}.", DefaultCategory);
 
     /// <summary>
     /// Gets all known parser diagnostics keyed by code.
@@ -216,12 +232,16 @@ public static class ParserDiagnostics
             [FallbackStrategyUsed.Code] = FallbackStrategyUsed,
             [TrailingTokensAfterParse.Code] = TrailingTokensAfterParse,
             [AmbiguousConstructResolvedHeuristically.Code] = AmbiguousConstructResolvedHeuristically,
+            [ParserStateCycleDetected.Code] = ParserStateCycleDetected,
+            [NonProgressiveQuantifierStopped.Code] = NonProgressiveQuantifierStopped,
+            [NonProgressiveLeftRecursionStopped.Code] = NonProgressiveLeftRecursionStopped,
             [DefaultBehaviorApplied.Code] = DefaultBehaviorApplied,
             [ImportedRuleIgnoredBecauseAlreadyDefined.Code] = ImportedRuleIgnoredBecauseAlreadyDefined,
             [EnteringRule.Code] = EnteringRule,
             [LeavingRule.Code] = LeavingRule,
             [TokenMatched.Code] = TokenMatched,
             [BacktrackingUsed.Code] = BacktrackingUsed,
+            [ParserStateRejected.Code] = ParserStateRejected,
         };
 
     /// <summary>

--- a/Utils.Parser.Diagnostics/README.md
+++ b/Utils.Parser.Diagnostics/README.md
@@ -22,41 +22,43 @@ dotnet add package omy.Utils.Parser.Diagnostics
 
 All named descriptors are defined in the `ParserDiagnostics` static class and accessible via `ParserDiagnostics.All` (a dictionary keyed by code string).
 
-### UP0xxx — Errors
+### UP0xxx — Blocking errors
 
 | Code | Name | Trigger |
 |---|---|---|
-| UP0001 | `UnexpectedToken` | Token did not match any expected alternative |
-| UP0002 | `UnexpectedEndOfInput` | Input ended while more tokens were expected |
-| UP0003 | `UnknownRule` | A rule reference could not be resolved |
-| UP0004 | `UnknownLexerCommand` | Lexer command name is not recognized |
-| UP0005 | `MissingImport` | An `import` target grammar could not be found |
-| UP0006 | `ImportedGrammarNotFound` | Imported grammar file is absent from the resolver |
-| UP0007 | `LexerRuleNotAllowedInParserGrammar` | A lexer rule was declared inside a `parser grammar` |
-| UP0008 | `ParserRuleNotAllowedInLexerGrammar` | A parser rule was declared inside a `lexer grammar` |
+| UP0001 | `UnexpectedToken` | A token did not match any expected alternative |
+| UP0002 | `InvalidGrammarRoot` | The grammar root node is not a recognized grammar declaration |
+| UP0003 | `UnknownRuleReference` | A rule refers to another rule that cannot be resolved |
+| UP0004 | `UnknownLexerMode` | A lexer command references a mode that is not declared |
+| UP0005 | `ParseFailure` | The parser failed to match input from the root rule |
+| UP0006 | `InternalInconsistency` | An internal consistency check failed |
+| UP0010 | `ImportedGrammarNotFound` | An `import` target grammar could not be located by the resolver |
+| UP0011 | `ImportCycleDetected` | A circular dependency was found while resolving grammar imports |
+| UP0012 | `ParserRuleNotAllowedInLexerGrammar` | A parser rule was declared inside a `lexer grammar` |
+| UP0013 | `LexerRuleNotAllowedInParserGrammar` | A lexer rule was declared inside a `parser grammar` |
 
 ### UP1xxx — Unsupported / ignored / partial behavior
 
 | Code | Name | Trigger |
 |---|---|---|
-| UP1001 | `EmbeddedActionStoredNotExecuted` | An embedded `{...}` action is stored but not executed at runtime |
-| UP1002 | `SemanticPredicateStoredNotEnforced` | A `{...}?` predicate is stored but not enforced |
-| UP1003 | `ReturnsPartiallyApplied` | A `returns [...]` clause is parsed but only partially applied |
-| UP1004 | `TokensBlockIgnored` | A `tokens { ... }` block is parsed but not converted |
-| UP1005 | `ChannelsBlockIgnored` | A `channels { ... }` block is parsed but not converted |
-| UP1006 | `ActionIgnored` | A top-level `@...` action block is recognized but not executed |
-| UP1007 | `InlineActionStoredNotExecuted` | An inline `@init`/`@after` action is stored but not executed |
-| UP1008 | `LocalsIgnored` | A `locals [...]` clause is parsed but ignored |
-| UP1009 | `RuntimeGeneratorMismatch` | A feature is supported in one pipeline (runtime or generator) but not the other |
-| UP1010 | `DirectLeftRecursionDetected` | Direct left recursion was detected and handled in a parser rule |
-| UP1011 | `IndirectLeftRecursionNotSupported` | Indirect left recursion is not currently supported |
-| UP1012 | `LeftRecursiveRuleWithoutBaseAlternative` | A left-recursive rule has no non-recursive base alternative |
-| UP1013 | `AmbiguousAlternativesPruned` | Equivalent alternatives were pruned using alternative priority |
-| UP1014 | `StaticDuplicateAlternativeRemoved` | A duplicate alternative was removed at resolution time |
-| UP1015 | `ParseBranchPruned` | A parse branch was eliminated during runtime branch selection |
-| UP1016 | `ParseMemoHit` | A memoized result was reused for a parser rule evaluation |
-| UP1017 | `ParseMemoMiss` | No memoized result existed for a parser rule evaluation |
-| UP1018 | `LeftRecursivePrecedencePartiallySupported` | Left-recursive precedence predicates are only partially handled compared to ANTLR4 |
+| UP1001 | `ImportParsedButNotResolved` | An `import` directive was recognized but not resolved at runtime |
+| UP1002 | `TokensBlockIgnored` | A `tokens { ... }` block is recognized but not mapped into the model |
+| UP1003 | `ChannelsBlockIgnored` | A `channels { ... }` block is recognized but not mapped into the model |
+| UP1004 | `ActionIgnored` | A top-level `@...` action block is recognized but not executed |
+| UP1005 | `InlineActionStoredNotExecuted` | An inline `@init` / `@after` action is stored but not executed at runtime |
+| UP1006 | `SemanticPredicateNotEnforced` | A `{...}?` predicate is recognized but not evaluated; it always succeeds |
+| UP1007 | `ReturnsPartiallyApplied` | A `returns [...]` clause is parsed but stored only as raw text |
+| UP1008 | `LocalsIgnored` | `locals`, `throws`, `catch`, `finally` metadata is parsed but not applied |
+| UP1009 | `RuntimeGeneratorMismatch` | A feature behaves differently between the runtime and the source generator |
+| UP1010 | `DirectLeftRecursionDetected` | Direct left recursion was detected and restructured during rule resolution |
+| UP1011 | `IndirectLeftRecursionNotSupported` | Indirect left recursion is not supported and raises `GrammarValidationException` |
+| UP1012 | `LeftRecursiveRuleWithoutBaseAlternative` | A left-recursive rule defines no non-recursive (base) alternative |
+| UP1013 | `AmbiguousAlternativesPruned` | Structurally equivalent alternatives were pruned; the lower-priority winner is kept |
+| UP1014 | `StaticDuplicateAlternativeRemoved` | A duplicate alternative was eliminated at resolution time |
+| UP1015 | `ParseBranchPruned` | A parse branch was discarded during runtime best-match selection |
+| UP1016 | `ParseMemoHit` | A cached result was reused for a (rule, position, precedence) triple |
+| UP1017 | `ParseMemoMiss` | No cached result existed for a (rule, position, precedence) triple |
+| UP1018 | `LeftRecursivePrecedencePartiallySupported` | Left-recursive precedence predicates are only partially handled |
 | UP1019 | `UnsupportedAntlrLanguageOptionIgnored` | The ANTLR4 `language` option is not supported and is silently ignored |
 
 ### UP5xxx — Warnings (recovery / best-effort)
@@ -66,8 +68,37 @@ All named descriptors are defined in the `ParserDiagnostics` static class and ac
 | UP5001 | `BestEffortRecoveryUsed` | Best-effort recovery was applied during parsing |
 | UP5002 | `ExpectedTokenMissing` | An expected token was absent |
 | UP5003 | `FallbackStrategyUsed` | A fallback parsing strategy was activated |
-| UP5004 | `TrailingTokensAfterParse` | Unconsumed tokens remained after the root rule |
-| UP5005 | `AmbiguousConstructResolvedHeuristically` | An ambiguous construct was resolved by heuristic |
+| UP5004 | `TrailingTokensAfterParse` | Unconsumed tokens remain after the root rule matched; `Parse()` returns an `ErrorNode` |
+| UP5005 | `AmbiguousConstructResolvedHeuristically` | An ambiguous construct was resolved by heuristic rather than by grammar priority |
+
+### UP8xxx — Informational
+
+| Code | Name | Trigger |
+|---|---|---|
+| UP8001 | `DefaultBehaviorApplied` | A grammar construct fell back to a built-in default behavior |
+| UP8002 | `ImportedRuleIgnoredBecauseAlreadyDefined` | An imported rule was skipped because the entry grammar already defines the same name |
+
+### PARSER0xx — Runtime safety guards
+
+These codes are emitted by `ParserEngine` when built-in loop-termination guards activate.
+
+| Code | Name | Trigger |
+|---|---|---|
+| PARSER001 | `ParserStateCycleDetected` | A repeated parser state (same rule, position, and alternative) was detected and skipped to prevent infinite recursion |
+| PARSER002 | `NonProgressiveQuantifierStopped` | A quantifier iteration matched without consuming any token; the loop is stopped |
+| PARSER003 | `NonProgressiveLeftRecursionStopped` | A left-recursive extension produced no token progress; the seed-and-extend loop is stopped |
+
+### UP9xxx — Debug traces
+
+These codes are emitted only when a `DiagnosticBag` is passed to the parse call; they are not emitted in production builds unless explicitly requested.
+
+| Code | Name | Trigger |
+|---|---|---|
+| UP9001 | `EnteringRule` | The engine entered a parser rule |
+| UP9002 | `LeavingRule` | The engine finished a parser rule |
+| UP9003 | `TokenMatched` | A token was consumed by a lexer rule reference |
+| UP9004 | `BacktrackingUsed` | The cursor was restored after a failed alternative |
+| UP9005 | `ParserStateRejected` | A parser state was rejected by a safety guard |
 | UP5006 | `DefaultBehaviorApplied` | A grammar construct fell back to a default behavior |
 
 ## Related packages

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -344,6 +344,27 @@ The parser framework targets broad ANTLR4 compatibility, but some constructs are
 parsed in a simplified way, stored without full semantics, or ignored by one pipeline.
 The points below reflect the current implementation behavior.
 
+### ANTLR4 G4 feature support matrix
+
+| ANTLR4 feature | Runtime converter + engine (`Antlr4GrammarConverter` / `LexerEngine` / `ParserEngine`) | Source generator parser (`G4Parser`) | Notes |
+| --- | --- | --- | --- |
+| Grammar options (`options { ... }`) | ✅ Supported (ingested) | ⚠️ Partially supported | Runtime keeps effective options. |
+| Grammar imports (`import ...`) | ⚠️ Partially supported | ❌ Not supported | Runtime parses imports with resolver constraints. |
+| `tokens { ... }` block | ⚠️ Parsed but not mapped | ❌ Not supported | Recognized but ignored in model conversion. |
+| `channels { ... }` block | ⚠️ Parsed but not mapped | ❌ Not supported | Recognized but ignored in model conversion. |
+| Top-level grammar actions (`@... { ... }`) | ⚠️ Parsed but not executed | ❌ Not supported | Stored metadata only. |
+| Rule actions (`@init`, `@after`, inline `{...}`) | ⚠️ Partially supported | ⚠️ Parsed as raw blocks | Runtime stores actions and does not execute them. |
+| Semantic predicates (`{...}?`) | ⚠️ Parsed but not enforced | ⚠️ Parsed as raw blocks | Runtime accepts as empty successful matches. |
+| `returns [...]` | ⚠️ Partially supported | ❌ Not supported | Runtime stores raw return text. |
+| `locals`, `throws`, `catch`, `finally` | ⚠️ Parsed but ignored | ❌ Not supported | No runtime semantics yet. |
+| Rule labels | ⚠️ Partially supported | ⚠️ Partially supported | Runtime applies labels on `RuleRef` paths. |
+| Lexer commands (`skip`, `more`, `channel`, `type`, `pushMode`, `popMode`, `mode`) | ✅ Supported | ⚠️ Parsed without full validation | Runtime validates command names and known behaviors. |
+| Unknown lexer commands | ❌ Not supported (explicit error) | ⚠️ Kept as parsed tokens | Runtime rejects unknown commands. |
+| Direct left recursion | ⚠️ Partially supported | N/A | Runtime supports guarded direct left recursion. |
+| Indirect left recursion | ❌ Not supported | ❌ Not supported | Explicitly diagnosed as unsupported. |
+| Precedence predicates (`precpred(_ctx, N)`) | ⚠️ Partially supported | ❌ Not supported | Runtime extraction is pattern-based. |
+| Error recovery during parsing | ❌ Not supported | ⚠️ Best-effort parser behavior | Runtime returns `ErrorNode` on failure. |
+
 ### Grammar ingestion (runtime converter: `Antlr4GrammarConverter`)
 
 - `options { ... }`, `import ...`, and top-level `@... { ... }` actions are ingested.

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -271,10 +271,15 @@ a comprehensive real-world example.
 | Feature | Description |
 |---|---|
 | Backtracking | Each alternative is tried in priority order; the cursor is restored on failure. |
-| Left-recursion detection | Cycles (same rule at the same token position) are detected and skipped. |
-| Precedence predicates | `<assoc=right>` / priority-annotated alternatives are respected. |
+| Parallel alternative exploration | All alternatives are tried at each choice point; the best match (longest, then lowest priority) is selected. |
+| Left-recursion handling | Direct left-recursive rules are detected at resolution time and parsed using a seed-and-extend loop. |
+| Precedence predicates | `<assoc=right>` / priority-annotated alternatives are respected during left-recursive extension. |
 | Trailing-token validation | `Parse()` returns an `ErrorNode` when unconsumed tokens remain after the root rule. |
-| Parse memoization | Results at each rule/position pair are cached to avoid redundant re-evaluation in backtracking scenarios. |
+| Parse memoization | Results at each (rule, position, precedence) triple are cached to avoid redundant re-evaluation. |
+| Non-progressive quantifier guard | Quantifier iterations (`*`, `+`) that match without consuming any token are stopped immediately (`PARSER002`). |
+| Non-progressive left-recursion guard | Left-recursive extensions that produce no token progress are stopped and reported (`PARSER003`). |
+| Parser state cycle detection | Repeated parser states (same rule, position, and alternative index) during alternative exploration are detected and skipped (`PARSER001`). |
+| Ambiguous alternative pruning | Structurally equivalent branches are pruned; the lower-priority winner is kept (`UP1013`). |
 
 ## Grammar validation
 
@@ -294,11 +299,14 @@ The runtime parser and the source generator now share the same diagnostic model
 
 ### Code scheme
 
-- `UP0xxx`: blocking errors (unknown rules, grammar type violations, …)
-- `UP1xxx`: unsupported / ignored / partial behavior (embedded actions, left-recursion handling, memoization traces, …)
-- `UP5xxx`: best-effort recovery warnings
-- `UP8xxx`: informational diagnostics
-- `UP9xxx`: debug traces
+| Prefix | Severity | Purpose |
+|---|---|---|
+| `UP0xxx` | Error | Blocking errors (unresolved rules, grammar type violations, import failures, …) |
+| `UP1xxx` | Warning | Unsupported / ignored / partial behavior (embedded actions, left-recursion handling, memoization traces, …) |
+| `UP5xxx` | Warning | Best-effort recovery warnings (trailing tokens, ambiguous constructs, …) |
+| `UP8xxx` | Info | Informational runtime events |
+| `UP9xxx` | Debug | Detailed execution traces (entering/leaving rules, backtracking, memo hits, …) |
+| `PARSER0xx` | Warning / Info | Runtime safety guard events (cycle detection, non-progressive loop termination) |
 
 Severity is derived from the code prefix (not manually assigned per call site).
 
@@ -394,6 +402,9 @@ The points below reflect the current implementation behavior.
 - Direct left-recursive extension is guarded by strict input-progress checks to avoid
   non-terminating expansion attempts.
 - Backtracking is still part of the current architecture and has not been removed yet.
+- Runtime safety guards (`PARSER001`–`PARSER003`) stop non-terminating patterns:
+  `PARSER001` aborts repeated parser states; `PARSER002` stops zero-progress quantifier iterations;
+  `PARSER003` stops zero-progress left-recursive extension loops.
 
 ### Source generator pipeline limitations (`G4Parser`)
 

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -368,6 +368,11 @@ The points below reflect the current implementation behavior.
   `pushMode`, `popMode`, `mode`); unknown command names raise a conversion error.
 - Parsing is not error-recovering: parsing failures return `ErrorNode`, and trailing tokens are
   reported as an error instead of attempting recovery.
+- Runtime safety guards stop non-progressive loops in quantifiers (`*`, `+`, `?`) and
+  repeated parser-state cycles during branch exploration.
+- Direct left-recursive extension is guarded by strict input-progress checks to avoid
+  non-terminating expansion attempts.
+- Backtracking is still part of the current architecture and has not been removed yet.
 
 ### Source generator pipeline limitations (`G4Parser`)
 

--- a/Utils.Parser/Runtime/ParseContext.cs
+++ b/Utils.Parser/Runtime/ParseContext.cs
@@ -40,4 +40,11 @@ internal sealed class ParseContext(IReadOnlyList<Token> tokens)
     /// <summary>Restores the position to a value previously returned by <see cref="SavePosition"/>.</summary>
     /// <param name="saved">Value returned by a prior call to <see cref="SavePosition"/>.</param>
     public void RestorePosition(int saved) => _position = saved;
+
+    /// <summary>
+    /// Returns <c>true</c> when the current position is strictly greater than
+    /// <paramref name="savedPosition"/>.
+    /// </summary>
+    /// <param name="savedPosition">Position snapshot captured before an operation.</param>
+    public bool HasStrictProgress(int savedPosition) => _position > savedPosition;
 }

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -45,6 +45,14 @@ internal sealed class ParserStateRegistry
     private readonly Dictionary<RuleInvocationKey, HashSet<ContinuationKey>> _continuations = [];
     private readonly Dictionary<RuleInvocationKey, List<ParserRuleResult>> _completedResults = [];
 
+    /// <summary>Resets all registry state for a new parse.</summary>
+    public void Clear()
+    {
+        _visitedStates.Clear();
+        _continuations.Clear();
+        _completedResults.Clear();
+    }
+
     /// <summary>Marks a state as visited and returns <c>true</c> when it was not seen before.</summary>
     public bool MarkVisited(ParseStateKey key) => _visitedStates.Add(key);
 
@@ -186,6 +194,7 @@ public sealed class ParserEngine(ParserDefinition definition)
 
         _activeRuleFrames.Clear();
         _memo.Clear();
+        _stateRegistry.Clear();
         var context = new ParseContext(tokenList);
         var result = ParseRule(context, root, precedence: 0, diagnostics);
 
@@ -326,6 +335,12 @@ public sealed class ParserEngine(ParserDefinition definition)
             if (!context.HasStrictProgress(currentEndPosition))
             {
                 var span = ResolveDiagnosticSpan(context);
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.ParserStateCycleDetected,
+                    span.Start,
+                    span.Length,
+                    info.Rule.Name,
+                    null);
                 diagnostics?.AddWithContext(
                     ParserDiagnostics.NonProgressiveLeftRecursionStopped,
                     span.Start,

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -9,12 +9,89 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal readonly record struct ParserFrameKey(string RuleName, int InputPosition);
 internal readonly record struct ParseMemoKey(string RuleName, int InputPosition, int MinimumPrecedence);
+internal readonly record struct ParseStateKey(
+    string RuleName,
+    int AlternativeIndex,
+    int ElementIndex,
+    int OriginPosition,
+    int CurrentPosition,
+    int MinimumPrecedence);
+internal readonly record struct RuleInvocationKey(
+    string RuleName,
+    int OriginPosition,
+    int MinimumPrecedence);
+internal readonly record struct ContinuationKey(
+    string CallerRuleName,
+    int CallerAlternativeIndex,
+    int CallerElementIndex,
+    int ResumePosition,
+    int MinimumPrecedence);
 internal readonly record struct ParserStateKey(
     string RuleName,
     int InputPosition,
     int AlternativeIndex,
     int ElementIndex,
     int MinimumPrecedence);
+
+internal readonly record struct ParserRuleResult(ParseNode? Node, int EndPosition, bool IsFailure);
+
+/// <summary>
+/// Stores visited parser states, shared rule invocations, and continuation metadata.
+/// This prepares a future no-backtracking parser model while keeping current behavior.
+/// </summary>
+internal sealed class ParserStateRegistry
+{
+    private readonly HashSet<ParseStateKey> _visitedStates = [];
+    private readonly Dictionary<RuleInvocationKey, HashSet<ContinuationKey>> _continuations = [];
+    private readonly Dictionary<RuleInvocationKey, List<ParserRuleResult>> _completedResults = [];
+
+    /// <summary>Marks a state as visited and returns <c>true</c> when it was not seen before.</summary>
+    public bool MarkVisited(ParseStateKey key) => _visitedStates.Add(key);
+
+    /// <summary>Adds a continuation for a shared rule invocation.</summary>
+    public bool AddContinuation(RuleInvocationKey invocation, ContinuationKey continuation)
+    {
+        if (!_continuations.TryGetValue(invocation, out var set))
+        {
+            set = [];
+            _continuations[invocation] = set;
+        }
+
+        return set.Add(continuation);
+    }
+
+    /// <summary>Adds a completed result for a shared rule invocation.</summary>
+    public bool AddCompletedResult(RuleInvocationKey invocation, ParserRuleResult result)
+    {
+        if (!_completedResults.TryGetValue(invocation, out var list))
+        {
+            list = [];
+            _completedResults[invocation] = list;
+        }
+
+        if (list.Any(existing => existing.EndPosition == result.EndPosition
+            && existing.IsFailure == result.IsFailure
+            && ReferenceEquals(existing.Node, result.Node)))
+        {
+            return false;
+        }
+
+        list.Add(result);
+        return true;
+    }
+
+    /// <summary>Gets continuations previously registered for an invocation.</summary>
+    public IReadOnlyList<ContinuationKey> GetContinuations(RuleInvocationKey invocation)
+    {
+        return _continuations.TryGetValue(invocation, out var set) ? [.. set] : [];
+    }
+
+    /// <summary>Gets completed results previously registered for an invocation.</summary>
+    public IReadOnlyList<ParserRuleResult> GetCompletedResults(RuleInvocationKey invocation)
+    {
+        return _completedResults.TryGetValue(invocation, out var list) ? list : [];
+    }
+}
 
 internal sealed record ParseMemoEntry
 {
@@ -85,6 +162,7 @@ public sealed class ParserEngine(ParserDefinition definition)
     private readonly HashSet<ParserFrameKey> _activeRuleFrames = new();
     private readonly Dictionary<ParseMemoKey, ParseMemoEntry> _memo = new();
     private readonly bool _caseInsensitive = IsCaseInsensitive(definition);
+    private readonly ParserStateRegistry _stateRegistry = new();
 
     /// <summary>
     /// Parses <paramref name="tokens"/> starting from <paramref name="startRule"/>
@@ -160,6 +238,7 @@ public sealed class ParserEngine(ParserDefinition definition)
 
         diagnostics?.AddWithContext(ParserDiagnostics.ParseMemoMiss, null, null, rule.Name, null, rule.Name);
         var initialPosition = context.Position;
+        var invocationKey = new RuleInvocationKey(rule.Name, initialPosition, precedence);
         var frameKey = new ParserFrameKey(rule.Name, context.Position);
         if (!_activeRuleFrames.Add(frameKey))
         {
@@ -191,6 +270,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                 EndPosition = context.Position,
                 IsFailure = parsed is null
             };
+            _stateRegistry.AddCompletedResult(invocationKey, new ParserRuleResult(parsed, context.Position, parsed is null));
 
             return parsed;
         }
@@ -278,6 +358,13 @@ public sealed class ParserEngine(ParserDefinition definition)
         {
             var alternative = recursiveAlternatives[index];
             var stateKey = new ParserStateKey(info.Rule.Name, startPosition, index, index, minimumPrecedence);
+            _stateRegistry.MarkVisited(new ParseStateKey(
+                info.Rule.Name,
+                index,
+                index,
+                startPosition,
+                context.Position,
+                minimumPrecedence));
             if (!visitedStates.Add(stateKey))
             {
                 var span = ResolveDiagnosticSpan(context);
@@ -521,6 +608,13 @@ public sealed class ParserEngine(ParserDefinition definition)
         if (!definition.AllRules.TryGetValue(ruleRef.RuleName, out var referencedRule))
             return null;
 
+        // The tuple (RuleName, Position) alone is not enough to reject a shared call:
+        // different callers can legitimately invoke the same rule at the same input position.
+        // We therefore keep lightweight continuation metadata for future state-based parsing.
+        _stateRegistry.AddContinuation(
+            new RuleInvocationKey(ruleRef.RuleName, context.Position, 0),
+            new ContinuationKey(parentRule.Name, -1, -1, context.Position, 0));
+
         if (referencedRule.Kind == RuleKind.Lexer)
         {
             // Direct token match: the next token must have been produced by this lexer rule.
@@ -582,6 +676,13 @@ public sealed class ParserEngine(ParserDefinition definition)
                 alternativeIndex,
                 itemIndex,
                 minimumPrecedence);
+            var parseStateKey = new ParseStateKey(
+                rule.Name,
+                alternativeIndex,
+                itemIndex,
+                startPos,
+                itemStartPosition,
+                minimumPrecedence);
             if (!visitedStates.Add(stateKey))
             {
                 var diagnosticSpan = ResolveDiagnosticSpan(context);
@@ -601,6 +702,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                     $"repeated sequence item state {stateKey}");
                 return null;
             }
+            _stateRegistry.MarkVisited(parseStateKey);
 
             var node = TryParseContent(context, item, rule, minimumPrecedence, alternativeIndex, diagnostics);
             if (node is null)
@@ -650,6 +752,13 @@ public sealed class ParserEngine(ParserDefinition definition)
         {
             var alt = alternativeList[index];
             var stateKey = new ParserStateKey(rule.Name, startPosition, index, index, precedence);
+            _stateRegistry.MarkVisited(new ParseStateKey(
+                rule.Name,
+                index,
+                index,
+                startPosition,
+                context.Position,
+                precedence));
             if (!visitedStates.Add(stateKey))
             {
                 var diagnosticSpan = ResolveDiagnosticSpan(context);

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -9,6 +9,12 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal readonly record struct ParserFrameKey(string RuleName, int InputPosition);
 internal readonly record struct ParseMemoKey(string RuleName, int InputPosition, int MinimumPrecedence);
+internal readonly record struct ParserStateKey(
+    string RuleName,
+    int InputPosition,
+    int AlternativeIndex,
+    int ElementIndex,
+    int MinimumPrecedence);
 
 internal sealed record ParseMemoEntry
 {
@@ -213,9 +219,10 @@ public sealed class ParserEngine(ParserDefinition definition)
 
         var current = seed;
         var currentEndPosition = context.Position;
+        var visitedStates = new HashSet<ParserStateKey>();
         while (true)
         {
-            var extension = TryExtendLeft(context, info, current, minimumPrecedence, diagnostics);
+            var extension = TryExtendLeft(context, info, current, minimumPrecedence, visitedStates, diagnostics);
             if (extension is null)
             {
                 break;
@@ -223,8 +230,22 @@ public sealed class ParserEngine(ParserDefinition definition)
 
             // Guard against infinite loops: if the extension did not consume any tokens,
             // further iterations cannot make progress either.
-            if (context.Position <= currentEndPosition)
+            if (!context.HasStrictProgress(currentEndPosition))
             {
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.NonProgressiveLeftRecursionStopped,
+                    null,
+                    null,
+                    info.Rule.Name,
+                    null);
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.ParserStateRejected,
+                    null,
+                    null,
+                    info.Rule.Name,
+                    null,
+                    info.Rule.Name,
+                    $"left recursion non-progressive at position {context.Position}");
                 break;
             }
 
@@ -240,6 +261,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         LeftRecursiveRuleInfo info,
         ParseNode current,
         int minimumPrecedence,
+        HashSet<ParserStateKey> visitedStates,
         DiagnosticBag? diagnostics)
     {
         var startPosition = context.Position;
@@ -249,6 +271,26 @@ public sealed class ParserEngine(ParserDefinition definition)
         for (int index = 0; index < recursiveAlternatives.Count; index++)
         {
             var alternative = recursiveAlternatives[index];
+            var stateKey = new ParserStateKey(info.Rule.Name, startPosition, index, 0, minimumPrecedence);
+            if (!visitedStates.Add(stateKey))
+            {
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.ParserStateCycleDetected,
+                    null,
+                    null,
+                    info.Rule.Name,
+                    null);
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.ParserStateRejected,
+                    null,
+                    null,
+                    info.Rule.Name,
+                    null,
+                    info.Rule.Name,
+                    $"repeated state {stateKey}");
+                continue;
+            }
+
             var precedenceLevel = recursiveAlternatives.Count - index;
             if (precedenceLevel < minimumPrecedence || !CheckPrecedence(alternative, minimumPrecedence))
             {
@@ -540,9 +582,31 @@ public sealed class ParserEngine(ParserDefinition definition)
         var startPosition = context.Position;
         var startToken = context.Peek();
         var survivingBranches = new List<ParseBranch>();
+        var visitedStates = new HashSet<ParserStateKey>();
 
-        foreach (var alt in alternativeList)
+        for (int index = 0; index < alternativeList.Count; index++)
         {
+            var alt = alternativeList[index];
+            var stateKey = new ParserStateKey(rule.Name, startPosition, index, 0, precedence);
+            if (!visitedStates.Add(stateKey))
+            {
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.ParserStateCycleDetected,
+                    null,
+                    null,
+                    rule.Name,
+                    null);
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.ParserStateRejected,
+                    null,
+                    null,
+                    rule.Name,
+                    null,
+                    rule.Name,
+                    $"repeated state {stateKey}");
+                continue;
+            }
+
             if (!CheckPrecedence(alt, precedence))
             {
                 continue;
@@ -680,6 +744,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         var startToken = context.Peek();
 
         int count = 0;
+        int previousPosition = context.Position;
         while (quant.Max is null || count < quant.Max.Value)
         {
             var savedPos = context.SavePosition();
@@ -691,11 +756,28 @@ public sealed class ParserEngine(ParserDefinition definition)
             }
 
             // Guard against zero-length matches.
-            if (context.Position == savedPos)
+            if (context.Position <= previousPosition)
+            {
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.NonProgressiveQuantifierStopped,
+                    null,
+                    null,
+                    rule.Name,
+                    null);
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.ParserStateRejected,
+                    null,
+                    null,
+                    rule.Name,
+                    null,
+                    rule.Name,
+                    $"quantifier inner matched without progress at position {context.Position}");
                 break;
+            }
 
             children.Add(node);
             count++;
+            previousPosition = context.Position;
 
             if (!quant.Greedy && count >= quant.Min)
                 break;

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -366,18 +366,16 @@ public sealed class ParserEngine(ParserDefinition definition)
         {
             var alternative = recursiveAlternatives[index];
             var stateKey = new ParserStateKey(info.Rule.Name, startPosition, index, index, minimumPrecedence);
-            if (!_stateRegistry.MarkVisited(new ParseStateKey(
+            // Registry state is currently preparatory for future active-state parsing.
+            // We keep recording here, but branch rejection remains driven by local state
+            // checks to avoid false positives across legitimate shared invocations.
+            _stateRegistry.MarkVisited(new ParseStateKey(
                 info.Rule.Name,
                 index,
                 index,
                 startPosition,
                 context.Position,
-                minimumPrecedence)))
-            {
-                var diagnosticSpan = ResolveDiagnosticSpan(context);
-                diagnostics?.AddWithContext(ParserDiagnostics.ParserStateCycleDetected, diagnosticSpan.Start, diagnosticSpan.Length, info.Rule.Name, null);
-                continue;
-            }
+                minimumPrecedence));
             if (!visitedStates.Add(stateKey))
             {
                 var span = ResolveDiagnosticSpan(context);
@@ -774,18 +772,16 @@ public sealed class ParserEngine(ParserDefinition definition)
         {
             var alt = alternativeList[index];
             var stateKey = new ParserStateKey(rule.Name, startPosition, index, index, precedence);
-            if (!_stateRegistry.MarkVisited(new ParseStateKey(
+            // Registry state is currently preparatory for future active-state parsing.
+            // We keep recording here, but branch rejection remains driven by local state
+            // checks to avoid false positives across legitimate shared invocations.
+            _stateRegistry.MarkVisited(new ParseStateKey(
                 rule.Name,
                 index,
                 index,
                 startPosition,
                 context.Position,
-                precedence)))
-            {
-                var diagnosticSpan = ResolveDiagnosticSpan(context);
-                diagnostics?.AddWithContext(ParserDiagnostics.ParserStateCycleDetected, diagnosticSpan.Start, diagnosticSpan.Length, rule.Name, null);
-                continue;
-            }
+                precedence));
             if (!visitedStates.Add(stateKey))
             {
                 var diagnosticSpan = ResolveDiagnosticSpan(context);

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -239,6 +239,14 @@ public sealed class ParserEngine(ParserDefinition definition)
         diagnostics?.AddWithContext(ParserDiagnostics.ParseMemoMiss, null, null, rule.Name, null, rule.Name);
         var initialPosition = context.Position;
         var invocationKey = new RuleInvocationKey(rule.Name, initialPosition, precedence);
+        var completed = _stateRegistry.GetCompletedResults(invocationKey);
+        var reusableSuccess = completed.FirstOrDefault(result => !result.IsFailure);
+        if (reusableSuccess.Node is not null)
+        {
+            context.RestorePosition(reusableSuccess.EndPosition);
+            diagnostics?.AddWithContext(ParserDiagnostics.ParseMemoHit, null, null, rule.Name, null, rule.Name);
+            return reusableSuccess.Node;
+        }
         var frameKey = new ParserFrameKey(rule.Name, context.Position);
         if (!_activeRuleFrames.Add(frameKey))
         {
@@ -358,13 +366,18 @@ public sealed class ParserEngine(ParserDefinition definition)
         {
             var alternative = recursiveAlternatives[index];
             var stateKey = new ParserStateKey(info.Rule.Name, startPosition, index, index, minimumPrecedence);
-            _stateRegistry.MarkVisited(new ParseStateKey(
+            if (!_stateRegistry.MarkVisited(new ParseStateKey(
                 info.Rule.Name,
                 index,
                 index,
                 startPosition,
                 context.Position,
-                minimumPrecedence));
+                minimumPrecedence)))
+            {
+                var diagnosticSpan = ResolveDiagnosticSpan(context);
+                diagnostics?.AddWithContext(ParserDiagnostics.ParserStateCycleDetected, diagnosticSpan.Start, diagnosticSpan.Length, info.Rule.Name, null);
+                continue;
+            }
             if (!visitedStates.Add(stateKey))
             {
                 var span = ResolveDiagnosticSpan(context);
@@ -532,9 +545,10 @@ public sealed class ParserEngine(ParserDefinition definition)
         Rule rule,
         int precedence = 0,
         int alternativeIndex = -1,
+        int elementIndex = -1,
         DiagnosticBag? diagnostics = null)
     {
-        return TryParseContent(context, alt.Content, rule, precedence, alternativeIndex, diagnostics);
+        return TryParseContent(context, alt.Content, rule, precedence, alternativeIndex, elementIndex, diagnostics);
     }
 
     /// <summary>
@@ -551,12 +565,13 @@ public sealed class ParserEngine(ParserDefinition definition)
         Rule rule,
         int precedence = 0,
         int alternativeIndex = -1,
+        int elementIndex = -1,
         DiagnosticBag? diagnostics = null)
     {
         switch (content)
         {
             case RuleRef ruleRef:
-                return TryParseRuleRef(context, ruleRef, rule, diagnostics);
+                return TryParseRuleRef(context, ruleRef, rule, precedence, alternativeIndex, elementIndex, diagnostics);
 
             case Sequence seq:
                 return TryParseSequence(context, seq, rule, precedence, alternativeIndex, diagnostics);
@@ -565,7 +580,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                 return TryParseAlternation(context, alternation, rule, precedence, diagnostics);
 
             case Alternative alt:
-                return TryParseAlternative(context, alt, rule, precedence, alternativeIndex, diagnostics);
+                return TryParseAlternative(context, alt, rule, precedence, alternativeIndex, elementIndex, diagnostics);
 
             case Quantifier quant:
                 return TryParseQuantifier(context, quant, rule, precedence, alternativeIndex, diagnostics);
@@ -603,7 +618,14 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="ruleRef">Reference to resolve.</param>
     /// <param name="parentRule">The rule in which this reference appears.</param>
-    private ParseNode? TryParseRuleRef(ParseContext context, RuleRef ruleRef, Rule parentRule, DiagnosticBag? diagnostics = null)
+    private ParseNode? TryParseRuleRef(
+        ParseContext context,
+        RuleRef ruleRef,
+        Rule parentRule,
+        int minimumPrecedence,
+        int alternativeIndex,
+        int elementIndex,
+        DiagnosticBag? diagnostics = null)
     {
         if (!definition.AllRules.TryGetValue(ruleRef.RuleName, out var referencedRule))
             return null;
@@ -612,8 +634,8 @@ public sealed class ParserEngine(ParserDefinition definition)
         // different callers can legitimately invoke the same rule at the same input position.
         // We therefore keep lightweight continuation metadata for future state-based parsing.
         _stateRegistry.AddContinuation(
-            new RuleInvocationKey(ruleRef.RuleName, context.Position, 0),
-            new ContinuationKey(parentRule.Name, -1, -1, context.Position, 0));
+            new RuleInvocationKey(ruleRef.RuleName, context.Position, minimumPrecedence),
+            new ContinuationKey(parentRule.Name, alternativeIndex, elementIndex, context.Position, minimumPrecedence));
 
         if (referencedRule.Kind == RuleKind.Lexer)
         {
@@ -704,7 +726,7 @@ public sealed class ParserEngine(ParserDefinition definition)
             }
             _stateRegistry.MarkVisited(parseStateKey);
 
-            var node = TryParseContent(context, item, rule, minimumPrecedence, alternativeIndex, diagnostics);
+            var node = TryParseContent(context, item, rule, minimumPrecedence, alternativeIndex, itemIndex, diagnostics);
             if (node is null)
                 return null;
 
@@ -752,13 +774,18 @@ public sealed class ParserEngine(ParserDefinition definition)
         {
             var alt = alternativeList[index];
             var stateKey = new ParserStateKey(rule.Name, startPosition, index, index, precedence);
-            _stateRegistry.MarkVisited(new ParseStateKey(
+            if (!_stateRegistry.MarkVisited(new ParseStateKey(
                 rule.Name,
                 index,
                 index,
                 startPosition,
                 context.Position,
-                precedence));
+                precedence)))
+            {
+                var diagnosticSpan = ResolveDiagnosticSpan(context);
+                diagnostics?.AddWithContext(ParserDiagnostics.ParserStateCycleDetected, diagnosticSpan.Start, diagnosticSpan.Length, rule.Name, null);
+                continue;
+            }
             if (!visitedStates.Add(stateKey))
             {
                 var diagnosticSpan = ResolveDiagnosticSpan(context);
@@ -785,7 +812,7 @@ public sealed class ParserEngine(ParserDefinition definition)
             }
 
             var savedPos = context.SavePosition();
-            var result = TryParseContent(context, alt.Content, rule, precedence, index, diagnostics);
+            var result = TryParseContent(context, alt.Content, rule, precedence, index, index, diagnostics);
             if (result is null)
             {
                 var diagnosticSpan = ResolveDiagnosticSpan(context);
@@ -933,7 +960,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         while (quant.Max is null || count < quant.Max.Value)
         {
             var savedPos = context.SavePosition();
-            var node = TryParseContent(context, quant.Inner, rule, minimumPrecedence, alternativeIndex, diagnostics);
+            var node = TryParseContent(context, quant.Inner, rule, minimumPrecedence, alternativeIndex, alternativeIndex, diagnostics);
             if (node is null)
             {
                 context.RestorePosition(savedPos);
@@ -1023,7 +1050,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         if (token is null) return null;
 
         var savedPos = context.SavePosition();
-        var matched = TryParseContent(context, neg.Inner, rule, minimumPrecedence, alternativeIndex, diagnostics);
+        var matched = TryParseContent(context, neg.Inner, rule, minimumPrecedence, alternativeIndex, alternativeIndex, diagnostics);
         context.RestorePosition(savedPos);
 
         if (matched is null)
@@ -1082,7 +1109,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                 }
                 else
                 {
-                    node = TryParseContent(context, item, ownerRule, precedenceLevel, itemIndex, diagnostics);
+                    node = TryParseContent(context, item, ownerRule, precedenceLevel, alternativeIndex, itemIndex, diagnostics);
                 }
 
                 if (node is null)
@@ -1099,7 +1126,7 @@ public sealed class ParserEngine(ParserDefinition definition)
             return result;
         }
 
-        var tailNode = TryParseContent(context, tailContent, ownerRule, precedenceLevel, alternativeIndex, diagnostics);
+        var tailNode = TryParseContent(context, tailContent, ownerRule, precedenceLevel, alternativeIndex, alternativeIndex, diagnostics);
         return tailNode is null ? null : [tailNode];
     }
 

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -70,6 +70,11 @@ internal sealed record BranchKey
 /// <c>null</c> when the same rule is re-entered at the same token position.
 /// </para>
 /// <para>
+/// Additional runtime guards stop repeated parser-state exploration and non-progressive
+/// iterations in quantifiers and left-recursive extensions. Backtracking remains active
+/// in this implementation and may be revisited in a future PR.
+/// </para>
+/// <para>
 /// Semantic predicates (<see cref="ValidatingPredicate"/>, <see cref="GatingPredicate"/>)
 /// and embedded actions (<see cref="EmbeddedAction"/>) are silently accepted without
 /// execution; they have no effect on the parse tree shape.
@@ -232,16 +237,17 @@ public sealed class ParserEngine(ParserDefinition definition)
             // further iterations cannot make progress either.
             if (!context.HasStrictProgress(currentEndPosition))
             {
+                var span = ResolveDiagnosticSpan(context);
                 diagnostics?.AddWithContext(
                     ParserDiagnostics.NonProgressiveLeftRecursionStopped,
-                    null,
-                    null,
+                    span.Start,
+                    span.Length,
                     info.Rule.Name,
                     null);
                 diagnostics?.AddWithContext(
                     ParserDiagnostics.ParserStateRejected,
-                    null,
-                    null,
+                    span.Start,
+                    span.Length,
                     info.Rule.Name,
                     null,
                     info.Rule.Name,
@@ -271,19 +277,20 @@ public sealed class ParserEngine(ParserDefinition definition)
         for (int index = 0; index < recursiveAlternatives.Count; index++)
         {
             var alternative = recursiveAlternatives[index];
-            var stateKey = new ParserStateKey(info.Rule.Name, startPosition, index, 0, minimumPrecedence);
+            var stateKey = new ParserStateKey(info.Rule.Name, startPosition, index, index, minimumPrecedence);
             if (!visitedStates.Add(stateKey))
             {
+                var span = ResolveDiagnosticSpan(context);
                 diagnostics?.AddWithContext(
                     ParserDiagnostics.ParserStateCycleDetected,
-                    null,
-                    null,
+                    span.Start,
+                    span.Length,
                     info.Rule.Name,
                     null);
                 diagnostics?.AddWithContext(
                     ParserDiagnostics.ParserStateRejected,
-                    null,
-                    null,
+                    span.Start,
+                    span.Length,
                     info.Rule.Name,
                     null,
                     info.Rule.Name,
@@ -302,6 +309,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                 context,
                 info.Rule,
                 alternative,
+                index,
                 current,
                 precedenceLevel,
                 diagnostics);
@@ -353,6 +361,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         ParseContext context,
         Rule ownerRule,
         Alternative alternative,
+        int alternativeIndex,
         ParseNode leftSeed,
         int precedenceLevel,
         DiagnosticBag? diagnostics)
@@ -369,6 +378,7 @@ public sealed class ParserEngine(ParserDefinition definition)
             context,
             tailContent,
             ownerRule,
+            alternativeIndex,
             alternative.Assoc,
             precedenceLevel,
             diagnostics);
@@ -429,9 +439,15 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="alt">Alternative to attempt.</param>
     /// <param name="rule">Parent rule (carried to child nodes).</param>
-    private ParseNode? TryParseAlternative(ParseContext context, Alternative alt, Rule rule, DiagnosticBag? diagnostics = null)
+    private ParseNode? TryParseAlternative(
+        ParseContext context,
+        Alternative alt,
+        Rule rule,
+        int precedence = 0,
+        int alternativeIndex = -1,
+        DiagnosticBag? diagnostics = null)
     {
-        return TryParseContent(context, alt.Content, rule, diagnostics);
+        return TryParseContent(context, alt.Content, rule, precedence, alternativeIndex, diagnostics);
     }
 
     /// <summary>
@@ -442,7 +458,13 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="content">Grammar element to match.</param>
     /// <param name="rule">Rule in whose context the element is being matched.</param>
-    private ParseNode? TryParseContent(ParseContext context, RuleContent content, Rule rule, DiagnosticBag? diagnostics = null)
+    private ParseNode? TryParseContent(
+        ParseContext context,
+        RuleContent content,
+        Rule rule,
+        int precedence = 0,
+        int alternativeIndex = -1,
+        DiagnosticBag? diagnostics = null)
     {
         switch (content)
         {
@@ -450,22 +472,22 @@ public sealed class ParserEngine(ParserDefinition definition)
                 return TryParseRuleRef(context, ruleRef, rule, diagnostics);
 
             case Sequence seq:
-                return TryParseSequence(context, seq, rule, diagnostics);
+                return TryParseSequence(context, seq, rule, precedence, alternativeIndex, diagnostics);
 
             case Alternation alternation:
-                return TryParseAlternation(context, alternation, rule, diagnostics);
+                return TryParseAlternation(context, alternation, rule, precedence, diagnostics);
 
             case Alternative alt:
-                return TryParseAlternative(context, alt, rule, diagnostics);
+                return TryParseAlternative(context, alt, rule, precedence, alternativeIndex, diagnostics);
 
             case Quantifier quant:
-                return TryParseQuantifier(context, quant, rule, diagnostics);
+                return TryParseQuantifier(context, quant, rule, precedence, alternativeIndex, diagnostics);
 
             case LiteralMatch lit:
                 return TryParseLiteral(context, lit, rule);
 
             case Negation neg:
-                return TryParseNegation(context, neg, rule, diagnostics);
+                return TryParseNegation(context, neg, rule, precedence, alternativeIndex, diagnostics);
 
             case ValidatingPredicate:
             case GatingPredicate:
@@ -534,18 +556,53 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="seq">Sequence to match.</param>
     /// <param name="rule">Owning rule for the returned node.</param>
-    private ParseNode? TryParseSequence(ParseContext context, Sequence seq, Rule rule, DiagnosticBag? diagnostics = null)
+    private ParseNode? TryParseSequence(
+        ParseContext context,
+        Sequence seq,
+        Rule rule,
+        int minimumPrecedence,
+        int alternativeIndex,
+        DiagnosticBag? diagnostics = null)
     {
         var children = new List<ParseNode>();
         var startPos = context.Position;
         var startToken = context.Peek();
+        var visitedStates = new HashSet<ParserStateKey>();
 
-        foreach (var item in seq.Items)
+        for (int itemIndex = 0; itemIndex < seq.Items.Count; itemIndex++)
         {
+            var item = seq.Items[itemIndex];
             if (item is EmbeddedAction or Model.LexerCommand)
                 continue;
 
-            var node = TryParseContent(context, item, rule, diagnostics);
+            var itemStartPosition = context.Position;
+            var stateKey = new ParserStateKey(
+                rule.Name,
+                itemStartPosition,
+                alternativeIndex,
+                itemIndex,
+                minimumPrecedence);
+            if (!visitedStates.Add(stateKey))
+            {
+                var diagnosticSpan = ResolveDiagnosticSpan(context);
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.ParserStateCycleDetected,
+                    diagnosticSpan.Start,
+                    diagnosticSpan.Length,
+                    rule.Name,
+                    null);
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.ParserStateRejected,
+                    diagnosticSpan.Start,
+                    diagnosticSpan.Length,
+                    rule.Name,
+                    null,
+                    rule.Name,
+                    $"repeated sequence item state {stateKey}");
+                return null;
+            }
+
+            var node = TryParseContent(context, item, rule, minimumPrecedence, alternativeIndex, diagnostics);
             if (node is null)
                 return null;
 
@@ -566,9 +623,14 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="alternation">Alternation to evaluate.</param>
     /// <param name="rule">Owning rule (carried to child matches).</param>
-    private ParseNode? TryParseAlternation(ParseContext context, Alternation alternation, Rule rule, DiagnosticBag? diagnostics = null)
+    private ParseNode? TryParseAlternation(
+        ParseContext context,
+        Alternation alternation,
+        Rule rule,
+        int precedence = 0,
+        DiagnosticBag? diagnostics = null)
     {
-        return TryParseAlternativesParallel(context, alternation.Alternatives, rule, precedence: 0, diagnostics);
+        return TryParseAlternativesParallel(context, alternation.Alternatives, rule, precedence, diagnostics);
     }
 
     private ParseNode? TryParseAlternativesParallel(
@@ -587,19 +649,20 @@ public sealed class ParserEngine(ParserDefinition definition)
         for (int index = 0; index < alternativeList.Count; index++)
         {
             var alt = alternativeList[index];
-            var stateKey = new ParserStateKey(rule.Name, startPosition, index, 0, precedence);
+            var stateKey = new ParserStateKey(rule.Name, startPosition, index, index, precedence);
             if (!visitedStates.Add(stateKey))
             {
+                var diagnosticSpan = ResolveDiagnosticSpan(context);
                 diagnostics?.AddWithContext(
                     ParserDiagnostics.ParserStateCycleDetected,
-                    null,
-                    null,
+                    diagnosticSpan.Start,
+                    diagnosticSpan.Length,
                     rule.Name,
                     null);
                 diagnostics?.AddWithContext(
                     ParserDiagnostics.ParserStateRejected,
-                    null,
-                    null,
+                    diagnosticSpan.Start,
+                    diagnosticSpan.Length,
                     rule.Name,
                     null,
                     rule.Name,
@@ -613,10 +676,11 @@ public sealed class ParserEngine(ParserDefinition definition)
             }
 
             var savedPos = context.SavePosition();
-            var result = TryParseContent(context, alt.Content, rule, diagnostics);
+            var result = TryParseContent(context, alt.Content, rule, precedence, index, diagnostics);
             if (result is null)
             {
-                diagnostics?.AddWithContext(ParserDiagnostics.BacktrackingUsed, null, null, rule.Name, null, rule.Name);
+                var diagnosticSpan = ResolveDiagnosticSpan(context);
+                diagnostics?.AddWithContext(ParserDiagnostics.BacktrackingUsed, diagnosticSpan.Start, diagnosticSpan.Length, rule.Name, null, rule.Name);
                 context.RestorePosition(savedPos);
                 continue;
             }
@@ -700,7 +764,13 @@ public sealed class ParserEngine(ParserDefinition definition)
                 map[key] = branch;
             }
 
-            diagnostics?.AddWithContext(ParserDiagnostics.AmbiguousAlternativesPruned, null, null, branch.Rule.Name, null, branch.Rule.Name);
+            diagnostics?.AddWithContext(
+                ParserDiagnostics.AmbiguousAlternativesPruned,
+                branch.PartialNode.Span.Position,
+                branch.PartialNode.Span.Length,
+                branch.Rule.Name,
+                null,
+                branch.Rule.Name);
         }
 
         return map.Values.OrderBy(b => b.Alternative.Priority).ToList();
@@ -737,7 +807,13 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="quant">Quantifier to evaluate.</param>
     /// <param name="rule">Owning rule for the returned node.</param>
-    private ParseNode? TryParseQuantifier(ParseContext context, Quantifier quant, Rule rule, DiagnosticBag? diagnostics = null)
+    private ParseNode? TryParseQuantifier(
+        ParseContext context,
+        Quantifier quant,
+        Rule rule,
+        int minimumPrecedence,
+        int alternativeIndex,
+        DiagnosticBag? diagnostics = null)
     {
         var children = new List<ParseNode>();
         var startPos = context.Position;
@@ -748,7 +824,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         while (quant.Max is null || count < quant.Max.Value)
         {
             var savedPos = context.SavePosition();
-            var node = TryParseContent(context, quant.Inner, rule, diagnostics);
+            var node = TryParseContent(context, quant.Inner, rule, minimumPrecedence, alternativeIndex, diagnostics);
             if (node is null)
             {
                 context.RestorePosition(savedPos);
@@ -758,20 +834,22 @@ public sealed class ParserEngine(ParserDefinition definition)
             // Guard against zero-length matches.
             if (context.Position <= previousPosition)
             {
+                context.RestorePosition(savedPos);
+                var diagnosticSpan = ResolveDiagnosticSpan(context);
                 diagnostics?.AddWithContext(
                     ParserDiagnostics.NonProgressiveQuantifierStopped,
-                    null,
-                    null,
+                    diagnosticSpan.Start,
+                    diagnosticSpan.Length,
                     rule.Name,
                     null);
                 diagnostics?.AddWithContext(
                     ParserDiagnostics.ParserStateRejected,
-                    null,
-                    null,
+                    diagnosticSpan.Start,
+                    diagnosticSpan.Length,
                     rule.Name,
                     null,
                     rule.Name,
-                    $"quantifier inner matched without progress at position {context.Position}");
+                    $"quantifier inner matched without progress at position {savedPos}");
                 break;
             }
 
@@ -824,13 +902,19 @@ public sealed class ParserEngine(ParserDefinition definition)
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="neg">Negation element to evaluate.</param>
     /// <param name="rule">Owning rule for the returned node.</param>
-    private ParseNode? TryParseNegation(ParseContext context, Negation neg, Rule rule, DiagnosticBag? diagnostics = null)
+    private ParseNode? TryParseNegation(
+        ParseContext context,
+        Negation neg,
+        Rule rule,
+        int minimumPrecedence,
+        int alternativeIndex,
+        DiagnosticBag? diagnostics = null)
     {
         var token = context.Peek();
         if (token is null) return null;
 
         var savedPos = context.SavePosition();
-        var matched = TryParseContent(context, neg.Inner, rule, diagnostics);
+        var matched = TryParseContent(context, neg.Inner, rule, minimumPrecedence, alternativeIndex, diagnostics);
         context.RestorePosition(savedPos);
 
         if (matched is null)
@@ -868,6 +952,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         ParseContext context,
         RuleContent tailContent,
         Rule ownerRule,
+        int alternativeIndex,
         Associativity associativity,
         int precedenceLevel,
         DiagnosticBag? diagnostics)
@@ -875,8 +960,9 @@ public sealed class ParserEngine(ParserDefinition definition)
         if (tailContent is Sequence sequence)
         {
             var result = new List<ParseNode>();
-            foreach (var item in sequence.Items)
+            for (int itemIndex = 0; itemIndex < sequence.Items.Count; itemIndex++)
             {
+                var item = sequence.Items[itemIndex];
                 ParseNode? node;
                 if (item is RuleRef rr &&
                     string.Equals(rr.RuleName, ownerRule.Name, StringComparison.Ordinal) &&
@@ -887,7 +973,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                 }
                 else
                 {
-                    node = TryParseContent(context, item, ownerRule, diagnostics);
+                    node = TryParseContent(context, item, ownerRule, precedenceLevel, itemIndex, diagnostics);
                 }
 
                 if (node is null)
@@ -904,7 +990,7 @@ public sealed class ParserEngine(ParserDefinition definition)
             return result;
         }
 
-        var tailNode = TryParseContent(context, tailContent, ownerRule, diagnostics);
+        var tailNode = TryParseContent(context, tailContent, ownerRule, precedenceLevel, alternativeIndex, diagnostics);
         return tailNode is null ? null : [tailNode];
     }
 
@@ -916,6 +1002,12 @@ public sealed class ParserEngine(ParserDefinition definition)
         }
 
         return precedenceLevel + 1;
+    }
+
+    private static (int? Start, int? Length) ResolveDiagnosticSpan(ParseContext context)
+    {
+        var token = context.Peek() ?? context.Peek(-1);
+        return (token?.Span.Position, token?.Span.Length);
     }
 
     /// <summary>

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -26,6 +26,7 @@ public class ParserDiagnosticsTests
         Assert.AreEqual(DiagnosticSeverity.Warning, ParserDiagnosticSeverityMapper.FromCode("UP5001"));
         Assert.AreEqual(DiagnosticSeverity.Info, ParserDiagnosticSeverityMapper.FromCode("UP8001"));
         Assert.AreEqual(DiagnosticSeverity.Debug, ParserDiagnosticSeverityMapper.FromCode("UP9001"));
+        Assert.AreEqual(DiagnosticSeverity.Warning, ParserDiagnosticSeverityMapper.FromCode("PARSER001"));
     }
 
     [TestMethod]

--- a/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
+++ b/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
@@ -33,6 +33,24 @@ public class ParserEngineSafetyGuardsTests
     }
 
     /// <summary>
+    /// Ensures nested star inside plus also stops on non-progressive matches.
+    /// </summary>
+    [TestMethod]
+    public void Quantifier_NestedStarInsidePlus_FailsCleanlyAndReportsDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics("""
+            grammar G;
+            start : (B*)+ ;
+            B : 'b' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, string.Empty, diagnostics);
+
+        Assert.IsInstanceOfType<ErrorNode>(tree);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.NonProgressiveQuantifierStopped.Code));
+    }
+
+    /// <summary>
     /// Ensures plus quantifiers with optional inner content do not loop forever and fail when no consuming match exists.
     /// </summary>
     [TestMethod]
@@ -66,6 +84,28 @@ public class ParserEngineSafetyGuardsTests
         Assert.IsNotInstanceOfType<ErrorNode>(tree);
         Assert.AreEqual(3, CountTokens(tree, "a"));
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
+    }
+
+    /// <summary>
+    /// Ensures the parser emits cycle-related diagnostics on recursive non-progressive patterns.
+    /// </summary>
+    [TestMethod]
+    public void RecursiveNonProgressivePattern_EmitsCycleDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        _ = ParseWithDiagnostics("""
+            grammar G;
+            start : expr ;
+            expr : expr
+                 | INT
+                 ;
+            INT : ('0'..'9')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "1", diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(d =>
+            d.Code == ParserDiagnostics.ParserStateCycleDetected.Code
+            || d.Code == ParserDiagnostics.NonProgressiveLeftRecursionStopped.Code));
     }
 
     /// <summary>

--- a/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
+++ b/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
@@ -244,10 +244,14 @@ public class ParserEngineSafetyGuardsTests
     }
 
     /// <summary>
-    /// Ensures a duplicate full parser state is detected and reported.
+    /// Ensures a non-progressive left-recursive extension (same rule, no token progress)
+    /// is reported by at least one termination diagnostic.
+    /// The engine currently emits both <c>ParserStateCycleDetected</c> and
+    /// <c>NonProgressiveLeftRecursionStopped</c>; accepting either keeps the test
+    /// robust against future refinements that may distinguish the two cases.
     /// </summary>
     [TestMethod]
-    public void DuplicateFullState_ReportsCycleDiagnostic()
+    public void NonProgressiveLeftRecursion_ReportsTerminationDiagnostic()
     {
         var diagnostics = new DiagnosticBag();
         _ = ParseWithDiagnostics("""
@@ -260,14 +264,19 @@ public class ParserEngineSafetyGuardsTests
             WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
             """, "1", diagnostics);
 
-        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
+        Assert.IsTrue(
+            diagnostics.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code
+                              || d.Code == ParserDiagnostics.NonProgressiveLeftRecursionStopped.Code),
+            "expected at least one termination diagnostic for a non-progressive left-recursive rule");
     }
 
     /// <summary>
-    /// Ensures repeated shared rule evaluations do not corrupt parse-tree structure.
+    /// Ensures that a sub-rule memoized during the first alternative is not re-emitted
+    /// (duplicated) when the same rule is encountered in a second alternative at the same
+    /// position.  Exactly one ID token and one literal token must appear in the tree.
     /// </summary>
     [TestMethod]
-    public void CompletedRuleReuse_DoesNotCorruptTreeShape()
+    public void MemoizedSubrule_SharedAcrossAlternatives_DoesNotDuplicateNodes()
     {
         var diagnostics = new DiagnosticBag();
         var tree = ParseWithDiagnostics("""
@@ -281,8 +290,8 @@ public class ParserEngineSafetyGuardsTests
             """, "id X", diagnostics);
 
         Assert.IsNotInstanceOfType<ErrorNode>(tree);
-        Assert.AreEqual(1, CountTokens(tree, "ID"));
-        Assert.AreEqual(1, CountTokens(tree, "X"));
+        Assert.AreEqual(1, CountTokens(tree, "ID"), "ID token must appear exactly once");
+        Assert.AreEqual(1, CountTokens(tree, "X"), "literal 'X' must appear exactly once");
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
     }
 

--- a/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
+++ b/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
@@ -204,6 +204,79 @@ public class ParserEngineSafetyGuardsTests
         Assert.IsFalse(diagnosticsB.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
     }
 
+    /// <summary>
+    /// Ensures same rule invocation key can feed distinct parent continuations without false cycle diagnostics.
+    /// </summary>
+    [TestMethod]
+    public void SameRuleSamePositionDifferentContinuation_IsAllowed()
+    {
+        var diagnosticsA = new DiagnosticBag();
+        var treeA = ParseWithDiagnostics("""
+            grammar G;
+            root : common 'X' ;
+            common : ID ;
+            ID : ('a'..'z')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "id X", diagnosticsA);
+
+        var diagnosticsB = new DiagnosticBag();
+        var treeB = ParseWithDiagnostics("""
+            grammar G;
+            root : common 'Y' ;
+            common : ID ;
+            ID : ('a'..'z')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "id Y", diagnosticsB);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(treeA);
+        Assert.IsNotInstanceOfType<ErrorNode>(treeB);
+        Assert.IsFalse(diagnosticsA.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
+        Assert.IsFalse(diagnosticsB.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
+    }
+
+    /// <summary>
+    /// Ensures a duplicate full parser state is detected and reported.
+    /// </summary>
+    [TestMethod]
+    public void DuplicateFullState_ReportsCycleDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        _ = ParseWithDiagnostics("""
+            grammar G;
+            start : expr ;
+            expr : expr
+                 | INT
+                 ;
+            INT : ('0'..'9')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "1", diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
+    }
+
+    /// <summary>
+    /// Ensures repeated shared rule evaluations do not corrupt parse-tree structure.
+    /// </summary>
+    [TestMethod]
+    public void CompletedRuleReuse_DoesNotCorruptTreeShape()
+    {
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics("""
+            grammar G;
+            root : common 'X'
+                 | common 'Y'
+                 ;
+            common : ID ;
+            ID : ('a'..'z')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "id X", diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.AreEqual(1, CountTokens(tree, "ID"));
+        Assert.AreEqual(1, CountTokens(tree, "X"));
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
+    }
+
     private static ParseNode ParseWithDiagnostics(string grammar, string input, DiagnosticBag diagnostics)
     {
         var definition = Antlr4GrammarConverter.Parse(grammar, diagnostics);

--- a/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
+++ b/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
@@ -33,6 +33,24 @@ public class ParserEngineSafetyGuardsTests
     }
 
     /// <summary>
+    /// Ensures plus quantifiers with optional inner content do not loop forever and fail when no consuming match exists.
+    /// </summary>
+    [TestMethod]
+    public void Quantifier_EmptyMatchPlus_FailsCleanlyAndReportsDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics("""
+            grammar G;
+            start : (A?)+ ;
+            A : 'a' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, string.Empty, diagnostics);
+
+        Assert.IsInstanceOfType<ErrorNode>(tree);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.NonProgressiveQuantifierStopped.Code));
+    }
+
+    /// <summary>
     /// Ensures ambiguous repeated alternatives are parsed without entering repeated parser states forever.
     /// </summary>
     [TestMethod]
@@ -46,6 +64,7 @@ public class ParserEngineSafetyGuardsTests
             """, "a a a", diagnostics);
 
         Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.AreEqual(3, CountTokens(tree, "a"));
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
     }
 
@@ -68,6 +87,27 @@ public class ParserEngineSafetyGuardsTests
 
         Assert.IsNotInstanceOfType<ErrorNode>(tree);
         Assert.AreEqual(3, CountTokens(tree, "INT"));
+    }
+
+    /// <summary>
+    /// Ensures directly recursive rules without consuming tail content terminate with a non-progressive diagnostic.
+    /// </summary>
+    [TestMethod]
+    public void DirectLeftRecursion_NoProgress_TerminatesAndReportsDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics("""
+            grammar G;
+            start : expr ;
+            expr : expr
+                 | INT
+                 ;
+            INT : ('0'..'9')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "1", diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.NonProgressiveLeftRecursionStopped.Code));
     }
 
     /// <summary>
@@ -98,11 +138,14 @@ public class ParserEngineSafetyGuardsTests
         return parser.Parse(tokens, diagnostics: diagnostics);
     }
 
-    private static int CountTokens(ParseNode node, string ruleName)
+    private static int CountTokens(ParseNode node, string ruleNameOrText)
     {
         if (node is LexerNode lexerNode)
         {
-            return string.Equals(lexerNode.Token.RuleName, ruleName, StringComparison.Ordinal) ? 1 : 0;
+            return string.Equals(lexerNode.Token.RuleName, ruleNameOrText, StringComparison.Ordinal)
+                || string.Equals(lexerNode.Token.Text, ruleNameOrText, StringComparison.Ordinal)
+                ? 1
+                : 0;
         }
 
         if (node is not ParserNode parserNode)
@@ -110,6 +153,6 @@ public class ParserEngineSafetyGuardsTests
             return 0;
         }
 
-        return parserNode.Children.Sum(child => CountTokens(child, ruleName));
+        return parserNode.Children.Sum(child => CountTokens(child, ruleNameOrText));
     }
 }

--- a/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
+++ b/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
@@ -87,10 +87,13 @@ public class ParserEngineSafetyGuardsTests
     }
 
     /// <summary>
-    /// Ensures the parser emits cycle-related diagnostics on recursive non-progressive patterns.
+    /// Ensures the parser emits both a cycle diagnostic and a non-progressive diagnostic
+    /// for left-recursive rules whose extension produces no token progress.
+    /// Both codes are expected because a non-progressive extension is simultaneously
+    /// a cycle state and a termination trigger.
     /// </summary>
     [TestMethod]
-    public void RecursiveNonProgressivePattern_EmitsCycleDiagnostic()
+    public void RecursiveNonProgressivePattern_EmitsBothCycleAndNonProgressiveDiagnostics()
     {
         var diagnostics = new DiagnosticBag();
         _ = ParseWithDiagnostics("""
@@ -103,9 +106,10 @@ public class ParserEngineSafetyGuardsTests
             WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
             """, "1", diagnostics);
 
-        Assert.IsTrue(diagnostics.Any(d =>
-            d.Code == ParserDiagnostics.ParserStateCycleDetected.Code
-            || d.Code == ParserDiagnostics.NonProgressiveLeftRecursionStopped.Code));
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code),
+            "expected ParserStateCycleDetected for non-progressive left-recursive extension");
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.NonProgressiveLeftRecursionStopped.Code),
+            "expected NonProgressiveLeftRecursionStopped for non-progressive left-recursive extension");
     }
 
     /// <summary>
@@ -205,33 +209,38 @@ public class ParserEngineSafetyGuardsTests
     }
 
     /// <summary>
-    /// Ensures same rule invocation key can feed distinct parent continuations without false cycle diagnostics.
+    /// Ensures same rule invoked at the same position from two different alternatives
+    /// (distinct continuations) is not rejected as a false cycle.
+    /// Within a single parse, both alternatives of root call 'common' at position 0:
+    /// alt[0] continues with 'X', alt[1] continues with 'Y'.
+    /// The engine must allow both and select the correct winner for each input.
     /// </summary>
     [TestMethod]
     public void SameRuleSamePositionDifferentContinuation_IsAllowed()
     {
-        var diagnosticsA = new DiagnosticBag();
-        var treeA = ParseWithDiagnostics("""
+        const string grammar = """
             grammar G;
-            root : common 'X' ;
+            root : common 'X'
+                 | common 'Y'
+                 ;
             common : ID ;
             ID : ('a'..'z')+ ;
             WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
-            """, "id X", diagnosticsA);
+            """;
 
-        var diagnosticsB = new DiagnosticBag();
-        var treeB = ParseWithDiagnostics("""
-            grammar G;
-            root : common 'Y' ;
-            common : ID ;
-            ID : ('a'..'z')+ ;
-            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
-            """, "id Y", diagnosticsB);
+        var diagnosticsX = new DiagnosticBag();
+        var treeX = ParseWithDiagnostics(grammar, "id X", diagnosticsX);
 
-        Assert.IsNotInstanceOfType<ErrorNode>(treeA);
-        Assert.IsNotInstanceOfType<ErrorNode>(treeB);
-        Assert.IsFalse(diagnosticsA.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
-        Assert.IsFalse(diagnosticsB.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
+        var diagnosticsY = new DiagnosticBag();
+        var treeY = ParseWithDiagnostics(grammar, "id Y", diagnosticsY);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(treeX);
+        Assert.IsNotInstanceOfType<ErrorNode>(treeY);
+        // The correct continuation wins: 'X' terminal in first parse, 'Y' in second.
+        Assert.AreEqual(1, CountTokens(treeX, "X"), "alt[0] continuation should win for 'id X'");
+        Assert.AreEqual(1, CountTokens(treeY, "Y"), "alt[1] continuation should win for 'id Y'");
+        Assert.IsFalse(diagnosticsX.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
+        Assert.IsFalse(diagnosticsY.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
     }
 
     /// <summary>

--- a/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
+++ b/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Model;
+using Utils.Parser.Resolution;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Verifies runtime safeguards that prevent non-terminating parser execution.
+/// </summary>
+[TestClass]
+public class ParserEngineSafetyGuardsTests
+{
+    /// <summary>
+    /// Ensures nested optional-star quantifiers terminate even when inner content can match empty.
+    /// </summary>
+    [TestMethod]
+    public void Quantifier_EmptyMatchLoop_TerminatesAndReportsDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics("""
+            grammar G;
+            start : (A?)* ;
+            A : 'a' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, string.Empty, diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.NonProgressiveQuantifierStopped.Code));
+    }
+
+    /// <summary>
+    /// Ensures ambiguous repeated alternatives are parsed without entering repeated parser states forever.
+    /// </summary>
+    [TestMethod]
+    public void AmbiguousRepeatedAlternatives_Terminates()
+    {
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics("""
+            grammar G;
+            start : ('a' | 'a')* ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "a a a", diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
+    }
+
+    /// <summary>
+    /// Ensures direct left recursion remains bounded and can parse simple infix expressions.
+    /// </summary>
+    [TestMethod]
+    public void DirectLeftRecursion_TerminatesAndParsesExpression()
+    {
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics("""
+            grammar G;
+            start : expr ;
+            expr : expr '+' expr
+                 | INT
+                 ;
+            INT : ('0'..'9')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "1 + 2 + 3", diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.AreEqual(3, CountTokens(tree, "INT"));
+    }
+
+    /// <summary>
+    /// Ensures indirect recursion cycles are still rejected with a clear validation diagnostic.
+    /// </summary>
+    [TestMethod]
+    public void IndirectCycle_IsRejectedCleanly()
+    {
+        var diagnostics = new DiagnosticBag();
+        Assert.ThrowsException<GrammarValidationException>(() => Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : a ;
+            a : b ;
+            b : a '+' INT | INT ;
+            INT : ('0'..'9')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, diagnostics));
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.IndirectLeftRecursionNotSupported.Code));
+    }
+
+    private static ParseNode ParseWithDiagnostics(string grammar, string input, DiagnosticBag diagnostics)
+    {
+        var definition = Antlr4GrammarConverter.Parse(grammar, diagnostics);
+        var lexer = new LexerEngine(definition);
+        var tokens = lexer.Tokenize(new StringReader(input), diagnostics: diagnostics).ToList();
+        var parser = new ParserEngine(definition);
+        return parser.Parse(tokens, diagnostics: diagnostics);
+    }
+
+    private static int CountTokens(ParseNode node, string ruleName)
+    {
+        if (node is LexerNode lexerNode)
+        {
+            return string.Equals(lexerNode.Token.RuleName, ruleName, StringComparison.Ordinal) ? 1 : 0;
+        }
+
+        if (node is not ParserNode parserNode)
+        {
+            return 0;
+        }
+
+        return parserNode.Children.Sum(child => CountTokens(child, ruleName));
+    }
+}

--- a/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
+++ b/UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs
@@ -169,6 +169,41 @@ public class ParserEngineSafetyGuardsTests
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.IndirectLeftRecursionNotSupported.Code));
     }
 
+    /// <summary>
+    /// Ensures shared rule invocations from different parent alternatives are not rejected as false cycles.
+    /// </summary>
+    [TestMethod]
+    public void SharedRuleInvocation_FromDifferentParents_IsAllowed()
+    {
+        var diagnosticsA = new DiagnosticBag();
+        var treeA = ParseWithDiagnostics("""
+            grammar G;
+            root : a | b ;
+            a : common 'X' ;
+            b : common 'Y' ;
+            common : ID ;
+            ID : ('a'..'z')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "id X", diagnosticsA);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(treeA);
+
+        var diagnosticsB = new DiagnosticBag();
+        var treeB = ParseWithDiagnostics("""
+            grammar G;
+            root : a | b ;
+            a : common 'X' ;
+            b : common 'Y' ;
+            common : ID ;
+            ID : ('a'..'z')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """, "id Y", diagnosticsB);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(treeB);
+        Assert.IsFalse(diagnosticsA.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
+        Assert.IsFalse(diagnosticsB.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
+    }
+
     private static ParseNode ParseWithDiagnostics(string grammar, string input, DiagnosticBag diagnostics)
     {
         var definition = Antlr4GrammarConverter.Parse(grammar, diagnostics);


### PR DESCRIPTION
### Motivation

- Prevent non-terminating parser execution caused by ambiguous alternatives, indirect/direct left-recursion expansion, and quantifiers that can match without consuming input. 
- Add lightweight runtime safeguards that stop repeated exploration of identical parser states and non-progressive quantifier/left-recursion iterations while preserving existing public APIs and runtime behavior. 
- Provide clearer diagnostics when a branch is aborted for safety reasons and optional debug traces for instrumentation. 

### Description

- Added an internal `record struct ParserStateKey(...)` and per-pass `HashSet<ParserStateKey>` state tracking used during alternative exploration and left-recursive extension to detect/reject repeated parser states without boxing. (changes in `Utils.Parser/Runtime/ParserEngine.cs`).
- Introduced strict input-progress checks via `ParseContext.HasStrictProgress(int)` and applied them to left-recursive extension and quantifiers so iterations stop when no token progress is made (changes in `Utils.Parser/Runtime/ParseContext.cs` and `ParserEngine.cs`).
- Hardened quantifier evaluation to track `previousPosition` and emit diagnostics when the inner element matches without consuming input, and similarly emit diagnostics when left-recursive extensions make no progress. (changes in `ParserEngine.cs`).
- Added standardized safeguard diagnostics `PARSER001` (state cycle), `PARSER002` (non-progressive quantifier), `PARSER003` (non-progressive left recursion) and a debug trace `UP9005` for rejected states, and extended diagnostic infrastructure to accept `PARSERxxx` codes and map them to warning severity (changes in `Utils.Parser.Diagnostics/*`).
- Added unit tests that exercise safety guards and diagnostics (`UtilsTest/Parser/ParserEngineSafetyGuardsTests.cs`) and extended diagnostics mapping tests (`ParserDiagnosticsTests.cs`), and updated the `Utils.Parser` README to mention the runtime safety guards. 

### Testing

- Built generator helper to provide required artifacts with `dotnet build Utils.IO.Serialization.Generators/Utils.IO.Serialization.Generators.csproj --no-restore` which completed successfully. 
- Ran targeted parser tests with `dotnet test UtilsTest/UtilsTest.csproj --no-restore --filter "FullyQualifiedName~ParserEngineSafetyGuardsTests|FullyQualifiedName~ParserDiagnosticsTests" /p:BuildProjectReferences=false` and the filtered test set completed successfully (all matched tests passed). 
- A prior broader test invocation failed due to unrelated workspace/project dependency bootstrap (missing project assets for an unrelated VisualStudio worker project), which was resolved by building the required generator before running the focused tests. 
- New tests added: `ParserEngineSafetyGuardsTests` verifying empty-quantifier termination, ambiguous repeated-alternatives termination, bounded direct left-recursion parsing, and clean rejection of indirect cycles; and `ParserDiagnosticsTests` updated to assert `PARSER001` severity mapping.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede745886c8326bf84e5579fb2751c)