### PR TITLE
Add ActiveParseState abstraction and integrate into ParserEngine alternative handling

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -56,12 +56,25 @@ If a grammar relies on one of these areas, validate it with targeted tests befor
 | `RuleContent` | Abstract base for grammar elements: `LiteralMatch`, `RangeMatch`, `CharSetMatch`, `Sequence`, `Alternation`, `Quantifier`, `RuleRef`, `Negation`, `LexerCommand`, … |
 | `LexerEngine` | Tokenizes a character stream using lexer rules (maximal-munch, lexer modes, `skip` / `more` / `pushMode` / `popMode`). |
 | `ParserEngine` | Builds a parse tree from a token list using parser rules (backtracking recursive-descent, left-recursion detection, precedence predicates). |
+| `ActiveParseState` *(internal)* | Infrastructure record representing an explicit active parser branch/state candidate. It currently preserves existing behavior while preparing future explicit scheduling work. |
 | `ParseTreeNavigator` | Fluent, index- and name-based navigation over a `ParseNode` tree. |
 | `ParseTreeCompiler<TContext,TResult>` | Generic depth-first compiler: descent handlers enrich context top-down; ascent handlers fold results bottom-up. |
 | `Antlr4GrammarConverter` | Compiles a `.g4` source string into a `ParserDefinition` at runtime. |
 | `RuleResolver` | Validates and enriches a `ParserDefinition` (rule-kind inference, reference validation). |
 
 ---
+
+
+### Parser runtime architecture notes
+
+`ParserEngine` keeps the current recursive/backtracking execution model, and introduces
+an internal `ActiveParseState` normalization layer for branch candidates.
+
+- This is **infrastructural only**: no public API changes.
+- Current diagnostics and parse-tree behavior remain unchanged.
+- The abstraction is used to prepare future explicit scheduling features (shared
+  alternative evaluation, continuation-driven orchestration, pruning strategies),
+  without enabling parallel parsing at this stage.
 
 ## Quick start
 

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -56,7 +56,9 @@ If a grammar relies on one of these areas, validate it with targeted tests befor
 | `RuleContent` | Abstract base for grammar elements: `LiteralMatch`, `RangeMatch`, `CharSetMatch`, `Sequence`, `Alternation`, `Quantifier`, `RuleRef`, `Negation`, `LexerCommand`, … |
 | `LexerEngine` | Tokenizes a character stream using lexer rules (maximal-munch, lexer modes, `skip` / `more` / `pushMode` / `popMode`). |
 | `ParserEngine` | Builds a parse tree from a token list using parser rules (backtracking recursive-descent, left-recursion detection, precedence predicates). |
-| `ActiveParseState` *(internal)* | Infrastructure record representing an explicit active parser branch/state candidate. It currently preserves existing behavior while preparing future explicit scheduling work. |
+| `ActiveParseState` *(internal)* | Infrastructure record representing an explicit active parser branch/state candidate. Exposes two distinct key projections: `ToStateKey()` (scheduler identity) and `ToBranchEquivalenceKey()` (semantic pruning equivalence). |
+| `ActiveParseStateKey` *(internal)* | **Scheduler identity key.** Uniquely identifies a parse state for registry/scheduling purposes. Includes alternative index, priority, and continuation — fields that distinguish every scheduler path but must not be used for ambiguity pruning. |
+| `ActiveParseBranchEquivalenceKey` *(internal)* | **Semantic pruning key.** Groups branches that reached the same parser-state shape (rule, origin, end position, cursor kind/index). Excludes alternative index, priority, and label — those are handled by `HasDistinctSemantics`. |
 | `ParseTreeNavigator` | Fluent, index- and name-based navigation over a `ParseNode` tree. |
 | `ParseTreeCompiler<TContext,TResult>` | Generic depth-first compiler: descent handlers enrich context top-down; ascent handlers fold results bottom-up. |
 | `Antlr4GrammarConverter` | Compiles a `.g4` source string into a `ParserDefinition` at runtime. |
@@ -75,6 +77,23 @@ an internal `ActiveParseState` normalization layer for branch candidates.
 - The abstraction is used to prepare future explicit scheduling features (shared
   alternative evaluation, continuation-driven orchestration, pruning strategies),
   without enabling parallel parsing at this stage.
+
+#### Two separate identity concepts on `ActiveParseState`
+
+`ActiveParseState` deliberately exposes two distinct key projections:
+
+| Method | Returns | Purpose | Fields included |
+|---|---|---|---|
+| `ToStateKey(precedence)` | `ActiveParseStateKey` | Scheduler identity — uniquely tags every parser path for registry and cycle detection | rule name, origin position, current position, alternative index, alternative priority, cursor index/kind, minimum precedence, continuation |
+| `ToBranchEquivalenceKey()` | `ActiveParseBranchEquivalenceKey` | Semantic pruning — groups branches that reached the same parser-state shape | rule name, origin position, end/current position, cursor kind, cursor index |
+
+`ActiveParseBranchEquivalenceKey` intentionally excludes alternative index, priority,
+label, and continuation. Two branches that consumed the same input span and left the
+cursor at the same shape are shape-equivalent regardless of which alternative produced
+them. Whether those branches are also *semantically* equivalent (i.e., safe to prune) is
+decided separately by `HasDistinctSemantics`, which checks label, associativity, and the
+presence of predicates or actions. Pruning occurs only when both conditions hold: same
+shape key **and** `HasDistinctSemantics` returns `false`.
 
 ## Quick start
 

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -166,6 +166,73 @@ internal sealed record BranchKey
 }
 
 /// <summary>
+/// Represents an active parser state/branch candidate during alternative exploration.
+/// This data container is intentionally immutable and infrastructure-only.
+/// It prepares explicit scheduling of parser work without changing current execution semantics.
+/// </summary>
+internal sealed record ActiveParseState
+{
+    /// <summary>Gets the parser rule that owns the active state.</summary>
+    public required Rule Rule { get; init; }
+
+    /// <summary>Gets the alternative currently represented by this state.</summary>
+    public required Alternative Alternative { get; init; }
+
+    /// <summary>Gets the input position at which this state started.</summary>
+    public required int InputPosition { get; init; }
+
+    /// <summary>Gets the logical cursor within the rule content traversal.</summary>
+    public required RuleContentCursor Cursor { get; init; }
+
+    /// <summary>Gets the partially built parse node for this state.</summary>
+    public required ParseNode PartialNode { get; init; }
+
+    /// <summary>Gets the input end position reached by this state.</summary>
+    public required int EndPosition { get; init; }
+
+    /// <summary>Gets a value indicating whether this state completed successfully.</summary>
+    public bool IsComplete { get; init; }
+
+    /// <summary>
+    /// Creates an active state from a completed branch.
+    /// </summary>
+    /// <param name="branch">Completed branch produced by the current runtime.</param>
+    /// <returns>A normalized active parser state.</returns>
+    public static ActiveParseState FromBranch(ParseBranch branch)
+    {
+        return new ActiveParseState
+        {
+            Rule = branch.Rule,
+            Alternative = branch.Alternative,
+            InputPosition = branch.InputPosition,
+            Cursor = branch.Cursor,
+            PartialNode = branch.PartialNode,
+            EndPosition = branch.EndPosition,
+            IsComplete = branch.IsComplete
+        };
+    }
+
+    /// <summary>
+    /// Converts this active state back to the legacy branch representation.
+    /// </summary>
+    /// <returns>A <see cref="ParseBranch"/> with equivalent data.</returns>
+    public ParseBranch ToBranch()
+    {
+        return new ParseBranch
+        {
+            Rule = Rule,
+            Alternative = Alternative,
+            InputPosition = InputPosition,
+            Cursor = Cursor,
+            PartialNode = PartialNode,
+            EndPosition = EndPosition,
+            IsComplete = IsComplete
+        };
+    }
+}
+
+
+/// <summary>
 /// Builds a parse tree from a flat token list using the rules in a
 /// <see cref="ParserDefinition"/>.
 /// <para>
@@ -784,7 +851,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         var alternativeList = alternatives.OrderBy(a => a.Priority).ToList();
         var startPosition = context.Position;
         var startToken = context.Peek();
-        var survivingBranches = new List<ParseBranch>();
+        var activeStates = new List<ActiveParseState>();
         var visitedStates = new HashSet<ParserStateKey>();
 
         for (int index = 0; index < alternativeList.Count; index++)
@@ -835,7 +902,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                 continue;
             }
 
-            survivingBranches.Add(new ParseBranch
+            activeStates.Add(new ActiveParseState
             {
                 Rule = rule,
                 Alternative = alt,
@@ -848,18 +915,20 @@ public sealed class ParserEngine(ParserDefinition definition)
             context.RestorePosition(savedPos);
         }
 
-        if (survivingBranches.Count == 0)
+        if (activeStates.Count == 0)
         {
             return null;
         }
 
-        var pruned = PruneEquivalentBranches(survivingBranches, diagnostics);
-        var winner = pruned[0];
-        for (int i = 1; i < pruned.Count; i++)
+        var prunedStates = PruneEquivalentBranches([.. activeStates.Select(static state => state.ToBranch())], diagnostics)
+            .Select(static branch => ActiveParseState.FromBranch(branch))
+            .ToList();
+        var winner = prunedStates[0];
+        for (int i = 1; i < prunedStates.Count; i++)
         {
-            if (IsBetterBranch(pruned[i], winner))
+            if (IsBetterBranch(prunedStates[i].ToBranch(), winner.ToBranch()))
             {
-                winner = pruned[i];
+                winner = prunedStates[i];
             }
         }
 

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -165,6 +165,14 @@ internal sealed record BranchKey
     public required string ParentContextKey { get; init; }
 }
 
+
+internal readonly record struct ActiveParseStateKey(
+    string RuleName,
+    int InputPosition,
+    int AlternativePriority,
+    int CursorIndex,
+    int MinimumPrecedence);
+
 /// <summary>
 /// Represents an active parser state/branch candidate during alternative exploration.
 /// This data container is intentionally immutable and infrastructure-only.
@@ -192,6 +200,21 @@ internal sealed record ActiveParseState
 
     /// <summary>Gets a value indicating whether this state completed successfully.</summary>
     public bool IsComplete { get; init; }
+
+    /// <summary>
+    /// Creates a deterministic identity key for registry/scheduling-oriented state comparisons.
+    /// </summary>
+    /// <param name="minimumPrecedence">Minimum precedence associated with this active state evaluation.</param>
+    /// <returns>A stable identity key for this active parse state.</returns>
+    public ActiveParseStateKey ToStateKey(int minimumPrecedence)
+    {
+        return new ActiveParseStateKey(
+            Rule.Name,
+            InputPosition,
+            Alternative.Priority,
+            Cursor.Index,
+            minimumPrecedence);
+    }
 
     /// <summary>
     /// Creates an active state from a completed branch.
@@ -902,7 +925,7 @@ public sealed class ParserEngine(ParserDefinition definition)
                 continue;
             }
 
-            activeStates.Add(new ActiveParseState
+            var activeState = new ActiveParseState
             {
                 Rule = rule,
                 Alternative = alt,
@@ -911,7 +934,9 @@ public sealed class ParserEngine(ParserDefinition definition)
                 PartialNode = result,
                 EndPosition = context.Position,
                 IsComplete = true
-            });
+            };
+            _ = activeState.ToStateKey(precedence);
+            activeStates.Add(activeState);
             context.RestorePosition(savedPos);
         }
 

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -170,8 +170,7 @@ internal readonly record struct ActiveParseBranchEquivalenceKey(
     int OriginInputPosition,
     int CurrentOrEndPosition,
     string CursorKind,
-    int CursorIndex,
-    string ParentSemanticContextKey);
+    int CursorIndex);
 
 internal enum ActiveParseStateStatus
 {
@@ -259,8 +258,7 @@ internal sealed record ActiveParseState
             OriginInputPosition,
             EndPosition ?? CurrentInputPosition,
             Cursor.Kind,
-            Cursor.Index,
-            Alternative.Label ?? string.Empty);
+            Cursor.Index);
     }
 
     /// <summary>Creates a new state marked as completed.</summary>
@@ -1099,39 +1097,57 @@ public sealed class ParserEngine(ParserDefinition definition)
         IReadOnlyList<ActiveParseState> states,
         DiagnosticBag? diagnostics)
     {
-        var map = new Dictionary<ActiveParseBranchEquivalenceKey, ActiveParseState>();
+        // Each shape-key bucket holds one representative per distinct semantic class.
+        // States with the same shape but different semantics (label/assoc/predicates) are
+        // kept as separate entries within the same bucket rather than being dropped.
+        var groups = new Dictionary<ActiveParseBranchEquivalenceKey, List<ActiveParseState>>();
         foreach (var state in states)
         {
             var key = state.ToBranchEquivalenceKey();
-            if (!map.TryGetValue(key, out var existing))
+            if (!groups.TryGetValue(key, out var group))
             {
-                map[key] = state;
+                groups[key] = [state];
                 continue;
             }
 
-            if (HasDistinctSemantics(existing.Alternative, state.Alternative))
+            bool merged = false;
+            for (int i = 0; i < group.Count; i++)
             {
-                continue;
+                if (HasDistinctSemantics(group[i].Alternative, state.Alternative))
+                {
+                    continue;
+                }
+
+                if (state.Alternative.Priority < group[i].Alternative.Priority)
+                {
+                    group[i] = state;
+                }
+
+                diagnostics?.AddWithContext(
+                    ParserDiagnostics.AmbiguousAlternativesPruned,
+                    state.PartialNode.Span.Position,
+                    state.PartialNode.Span.Length,
+                    state.Rule.Name,
+                    null,
+                    state.Rule.Name);
+
+                merged = true;
+                break;
             }
 
-            if (state.Alternative.Priority < existing.Alternative.Priority)
+            if (!merged)
             {
-                map[key] = state;
+                group.Add(state);
             }
-
-            diagnostics?.AddWithContext(
-                ParserDiagnostics.AmbiguousAlternativesPruned,
-                state.PartialNode.Span.Position,
-                state.PartialNode.Span.Length,
-                state.Rule.Name,
-                null,
-                state.Rule.Name);
         }
 
-        return map.Values.OrderBy(static s => s.Alternative.Priority).ToList();
+        return groups.Values
+            .SelectMany(static g => g)
+            .OrderBy(static s => s.Alternative.Priority)
+            .ToList();
     }
 
-    private static bool HasDistinctSemantics(Alternative left, Alternative right)
+    internal static bool HasDistinctSemantics(Alternative left, Alternative right)
     {
         return !string.Equals(left.Label, right.Label, StringComparison.Ordinal)
             || left.Assoc != right.Assoc

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -168,10 +168,22 @@ internal sealed record BranchKey
 
 internal readonly record struct ActiveParseStateKey(
     string RuleName,
-    int InputPosition,
+    int OriginInputPosition,
+    int CurrentInputPosition,
+    int AlternativeIndex,
     int AlternativePriority,
     int CursorIndex,
-    int MinimumPrecedence);
+    string CursorKind,
+    int MinimumPrecedence,
+    ContinuationKey? Continuation);
+
+internal enum ActiveParseStateStatus
+{
+    Active,
+    Completed,
+    Failed,
+    Pruned
+}
 
 /// <summary>
 /// Represents an active parser state/branch candidate during alternative exploration.
@@ -187,7 +199,13 @@ internal sealed record ActiveParseState
     public required Alternative Alternative { get; init; }
 
     /// <summary>Gets the input position at which this state started.</summary>
-    public required int InputPosition { get; init; }
+    public required int OriginInputPosition { get; init; }
+
+    /// <summary>Gets the current input position reached while evaluating this state.</summary>
+    public required int CurrentInputPosition { get; init; }
+
+    /// <summary>Gets the alternative index within ordered evaluation.</summary>
+    public required int AlternativeIndex { get; init; }
 
     /// <summary>Gets the logical cursor within the rule content traversal.</summary>
     public required RuleContentCursor Cursor { get; init; }
@@ -195,11 +213,20 @@ internal sealed record ActiveParseState
     /// <summary>Gets the partially built parse node for this state.</summary>
     public required ParseNode PartialNode { get; init; }
 
-    /// <summary>Gets the input end position reached by this state.</summary>
-    public required int EndPosition { get; init; }
+    /// <summary>Gets the input end position reached by this state when completed.</summary>
+    public int? EndPosition { get; init; }
 
-    /// <summary>Gets a value indicating whether this state completed successfully.</summary>
-    public bool IsComplete { get; init; }
+    /// <summary>Gets the current lifecycle status of this active parse state.</summary>
+    public ActiveParseStateStatus Status { get; init; }
+
+    /// <summary>Gets the parent state key for lineage tracking, when available.</summary>
+    public ActiveParseStateKey? ParentStateKey { get; init; }
+
+    /// <summary>Gets the depth of this branch in lineage tracking.</summary>
+    public int Depth { get; init; }
+
+    /// <summary>Gets the continuation identity associated with this state, when known.</summary>
+    public ContinuationKey? Continuation { get; init; }
 
     /// <summary>
     /// Creates a deterministic identity key for registry/scheduling-oriented state comparisons.
@@ -210,10 +237,68 @@ internal sealed record ActiveParseState
     {
         return new ActiveParseStateKey(
             Rule.Name,
-            InputPosition,
+            OriginInputPosition,
+            CurrentInputPosition,
+            AlternativeIndex,
             Alternative.Priority,
             Cursor.Index,
-            minimumPrecedence);
+            Cursor.Kind,
+            minimumPrecedence,
+            Continuation);
+    }
+
+    /// <summary>Creates a new state marked as completed.</summary>
+    public ActiveParseState Complete(int endPosition)
+    {
+        return this with { Status = ActiveParseStateStatus.Completed, CurrentInputPosition = endPosition, EndPosition = endPosition };
+    }
+
+    /// <summary>Creates a new state marked as failed.</summary>
+    public ActiveParseState Fail()
+    {
+        return this with { Status = ActiveParseStateStatus.Failed, EndPosition = null };
+    }
+
+    /// <summary>Creates a new state marked as pruned.</summary>
+    public ActiveParseState Prune()
+    {
+        return this with { Status = ActiveParseStateStatus.Pruned };
+    }
+
+    /// <summary>Creates a new state with an attached continuation identity.</summary>
+    public ActiveParseState WithContinuation(ContinuationKey continuation)
+    {
+        return this with { Continuation = continuation };
+    }
+
+    /// <summary>Creates a new state advanced to a new cursor and input position.</summary>
+    public ActiveParseState Advance(int currentInputPosition, RuleContentCursor cursor)
+    {
+        return this with { CurrentInputPosition = currentInputPosition, Cursor = cursor };
+    }
+
+    /// <summary>Creates a new state with explicit lineage metadata.</summary>
+    public ActiveParseState WithLineage(ActiveParseStateKey? parentStateKey, int depth)
+    {
+        return this with { ParentStateKey = parentStateKey, Depth = depth };
+    }
+
+    /// <summary>Creates a parser-state key projection for visited-state integration.</summary>
+    public ParserStateKey ToParserStateKey(int minimumPrecedence)
+    {
+        return new ParserStateKey(Rule.Name, CurrentInputPosition, AlternativeIndex, Cursor.Index, minimumPrecedence);
+    }
+
+    /// <summary>Creates a rule invocation projection for completion registry integration.</summary>
+    public RuleInvocationKey ToRuleInvocationKey(int minimumPrecedence)
+    {
+        return new RuleInvocationKey(Rule.Name, OriginInputPosition, minimumPrecedence);
+    }
+
+    /// <summary>Creates a continuation key projection for future resumable scheduling.</summary>
+    public ContinuationKey ToContinuationKey(int resumePosition, int minimumPrecedence)
+    {
+        return new ContinuationKey(Rule.Name, AlternativeIndex, Cursor.Index, resumePosition, minimumPrecedence);
     }
 
     /// <summary>
@@ -227,11 +312,16 @@ internal sealed record ActiveParseState
         {
             Rule = branch.Rule,
             Alternative = branch.Alternative,
-            InputPosition = branch.InputPosition,
+            OriginInputPosition = branch.InputPosition,
+            CurrentInputPosition = branch.EndPosition,
+            AlternativeIndex = -1,
             Cursor = branch.Cursor,
             PartialNode = branch.PartialNode,
             EndPosition = branch.EndPosition,
-            IsComplete = branch.IsComplete
+            Status = branch.IsComplete ? ActiveParseStateStatus.Completed : ActiveParseStateStatus.Failed,
+            ParentStateKey = null,
+            Depth = 0,
+            Continuation = null
         };
     }
 
@@ -245,11 +335,11 @@ internal sealed record ActiveParseState
         {
             Rule = Rule,
             Alternative = Alternative,
-            InputPosition = InputPosition,
+            InputPosition = OriginInputPosition,
             Cursor = Cursor,
             PartialNode = PartialNode,
-            EndPosition = EndPosition,
-            IsComplete = IsComplete
+            EndPosition = EndPosition ?? CurrentInputPosition,
+            IsComplete = Status == ActiveParseStateStatus.Completed
         };
     }
 }
@@ -929,12 +1019,17 @@ public sealed class ParserEngine(ParserDefinition definition)
             {
                 Rule = rule,
                 Alternative = alt,
-                InputPosition = startPosition,
+                OriginInputPosition = startPosition,
+                CurrentInputPosition = context.Position,
+                AlternativeIndex = index,
                 Cursor = new RuleContentCursor { Index = 0, Kind = "alternative-root" },
                 PartialNode = result,
-                EndPosition = context.Position,
-                IsComplete = true
-            };
+                EndPosition = null,
+                Status = ActiveParseStateStatus.Active,
+                ParentStateKey = null,
+                Depth = 0,
+                Continuation = null
+            }.Complete(context.Position);
             _ = activeState.ToStateKey(precedence);
             activeStates.Add(activeState);
             context.RestorePosition(savedPos);
@@ -957,7 +1052,7 @@ public sealed class ParserEngine(ParserDefinition definition)
             }
         }
 
-        context.RestorePosition(winner.EndPosition);
+        context.RestorePosition(winner.EndPosition ?? winner.CurrentInputPosition);
         if (winner.PartialNode is ParserNode parserNode && ReferenceEquals(parserNode.Rule, rule))
         {
             return parserNode;

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -1040,13 +1040,11 @@ public sealed class ParserEngine(ParserDefinition definition)
             return null;
         }
 
-        var prunedStates = PruneEquivalentBranches([.. activeStates.Select(static state => state.ToBranch())], diagnostics)
-            .Select(static branch => ActiveParseState.FromBranch(branch))
-            .ToList();
+        var prunedStates = PruneEquivalentActiveStates(activeStates, diagnostics, precedence);
         var winner = prunedStates[0];
         for (int i = 1; i < prunedStates.Count; i++)
         {
-            if (IsBetterBranch(prunedStates[i].ToBranch(), winner.ToBranch()))
+            if (IsBetterActiveState(prunedStates[i], winner))
             {
                 winner = prunedStates[i];
             }
@@ -1060,6 +1058,16 @@ public sealed class ParserEngine(ParserDefinition definition)
 
         var span = ComputeSpan(startToken, context, startPosition);
         return new ParserNode(span, winner.PartialNode.ModeName, rule, [winner.PartialNode]);
+    }
+
+    private static bool IsBetterActiveState(ActiveParseState candidate, ActiveParseState current)
+    {
+        if (candidate.CurrentInputPosition != current.CurrentInputPosition)
+        {
+            return candidate.CurrentInputPosition > current.CurrentInputPosition;
+        }
+
+        return candidate.Alternative.Priority < current.Alternative.Priority;
     }
 
     private static bool IsBetterBranch(ParseBranch candidate, ParseBranch current)
@@ -1113,6 +1121,43 @@ public sealed class ParserEngine(ParserDefinition definition)
         }
 
         return map.Values.OrderBy(b => b.Alternative.Priority).ToList();
+    }
+
+    private List<ActiveParseState> PruneEquivalentActiveStates(
+        IReadOnlyList<ActiveParseState> states,
+        DiagnosticBag? diagnostics,
+        int precedence)
+    {
+        var map = new Dictionary<ActiveParseStateKey, ActiveParseState>();
+        foreach (var state in states)
+        {
+            var key = state.ToStateKey(precedence);
+            if (!map.TryGetValue(key, out var existing))
+            {
+                map[key] = state;
+                continue;
+            }
+
+            if (HasDistinctSemantics(existing.Alternative, state.Alternative))
+            {
+                continue;
+            }
+
+            if (state.Alternative.Priority < existing.Alternative.Priority)
+            {
+                map[key] = state;
+            }
+
+            diagnostics?.AddWithContext(
+                ParserDiagnostics.AmbiguousAlternativesPruned,
+                state.PartialNode.Span.Position,
+                state.PartialNode.Span.Length,
+                state.Rule.Name,
+                null,
+                state.Rule.Name);
+        }
+
+        return map.Values.OrderBy(static s => s.Alternative.Priority).ToList();
     }
 
     private static bool HasDistinctSemantics(Alternative left, Alternative right)

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -226,6 +226,8 @@ internal sealed record ActiveParseState
 
     /// <summary>
     /// Creates a deterministic identity key for registry/scheduling-oriented state comparisons.
+    /// Includes scheduler-specific fields (alternative index, priority, continuation) that must
+    /// NOT be used for semantic-equivalence pruning.
     /// </summary>
     /// <param name="minimumPrecedence">Minimum precedence associated with this active state evaluation.</param>
     /// <returns>A stable identity key for this active parse state.</returns>
@@ -241,6 +243,24 @@ internal sealed record ActiveParseState
             Cursor.Kind,
             minimumPrecedence,
             Continuation);
+    }
+
+    /// <summary>
+    /// Creates a semantic equivalence key used exclusively for ambiguity pruning.
+    /// Excludes scheduler-identity fields (alternative index, priority, continuation) so that
+    /// two alternatives reaching the same parser position are considered equivalent regardless
+    /// of which alternative produced them.
+    /// </summary>
+    /// <returns>A key that identifies semantically equivalent active parse states.</returns>
+    public ActiveParseBranchEquivalenceKey ToBranchEquivalenceKey()
+    {
+        return new ActiveParseBranchEquivalenceKey(
+            Rule.Name,
+            OriginInputPosition,
+            EndPosition ?? CurrentInputPosition,
+            Cursor.Kind,
+            Cursor.Index,
+            Alternative.Label ?? string.Empty);
     }
 
     /// <summary>Creates a new state marked as completed.</summary>
@@ -1026,7 +1046,6 @@ public sealed class ParserEngine(ParserDefinition definition)
                 Depth = 0,
                 Continuation = null
             }.Complete(context.Position);
-            _ = activeState.ToStateKey(precedence);
             activeStates.Add(activeState);
             context.RestorePosition(savedPos);
         }
@@ -1083,13 +1102,7 @@ public sealed class ParserEngine(ParserDefinition definition)
         var map = new Dictionary<ActiveParseBranchEquivalenceKey, ActiveParseState>();
         foreach (var state in states)
         {
-            var key = new ActiveParseBranchEquivalenceKey(
-                state.Rule.Name,
-                state.OriginInputPosition,
-                state.EndPosition ?? state.CurrentInputPosition,
-                state.Cursor.Kind,
-                state.Cursor.Index,
-                state.Alternative.Label ?? string.Empty);
+            var key = state.ToBranchEquivalenceKey();
             if (!map.TryGetValue(key, out var existing))
             {
                 map[key] = state;

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -154,18 +154,6 @@ internal sealed record ParseBranch
     public bool IsComplete { get; init; }
 }
 
-internal sealed record BranchKey
-{
-    public required string RuleName { get; init; }
-
-    public required int InputPosition { get; init; }
-
-    public required string CursorKey { get; init; }
-
-    public required string ParentContextKey { get; init; }
-}
-
-
 internal readonly record struct ActiveParseStateKey(
     string RuleName,
     int OriginInputPosition,
@@ -176,6 +164,14 @@ internal readonly record struct ActiveParseStateKey(
     string CursorKind,
     int MinimumPrecedence,
     ContinuationKey? Continuation);
+
+internal readonly record struct ActiveParseBranchEquivalenceKey(
+    string RuleName,
+    int OriginInputPosition,
+    int CurrentOrEndPosition,
+    string CursorKind,
+    int CursorIndex,
+    string ParentSemanticContextKey);
 
 internal enum ActiveParseStateStatus
 {
@@ -1040,7 +1036,7 @@ public sealed class ParserEngine(ParserDefinition definition)
             return null;
         }
 
-        var prunedStates = PruneEquivalentActiveStates(activeStates, diagnostics, precedence);
+        var prunedStates = PruneEquivalentActiveStates(activeStates, diagnostics);
         var winner = prunedStates[0];
         for (int i = 1; i < prunedStates.Count; i++)
         {
@@ -1080,58 +1076,20 @@ public sealed class ParserEngine(ParserDefinition definition)
         return candidate.Alternative.Priority < current.Alternative.Priority;
     }
 
-    private List<ParseBranch> PruneEquivalentBranches(
-        IReadOnlyList<ParseBranch> branches,
-        DiagnosticBag? diagnostics)
-    {
-        var map = new Dictionary<BranchKey, ParseBranch>();
-        foreach (var branch in branches)
-        {
-            var key = new BranchKey
-            {
-                RuleName = branch.Rule.Name,
-                InputPosition = branch.InputPosition,
-                CursorKey = $"{branch.Cursor.Kind}:{branch.Cursor.Index}:{branch.EndPosition}",
-                ParentContextKey = branch.Alternative.Label ?? string.Empty
-            };
-
-            if (!map.TryGetValue(key, out var existing))
-            {
-                map[key] = branch;
-                continue;
-            }
-
-            if (HasDistinctSemantics(existing.Alternative, branch.Alternative))
-            {
-                continue;
-            }
-
-            if (branch.Alternative.Priority < existing.Alternative.Priority)
-            {
-                map[key] = branch;
-            }
-
-            diagnostics?.AddWithContext(
-                ParserDiagnostics.AmbiguousAlternativesPruned,
-                branch.PartialNode.Span.Position,
-                branch.PartialNode.Span.Length,
-                branch.Rule.Name,
-                null,
-                branch.Rule.Name);
-        }
-
-        return map.Values.OrderBy(b => b.Alternative.Priority).ToList();
-    }
-
     private List<ActiveParseState> PruneEquivalentActiveStates(
         IReadOnlyList<ActiveParseState> states,
-        DiagnosticBag? diagnostics,
-        int precedence)
+        DiagnosticBag? diagnostics)
     {
-        var map = new Dictionary<ActiveParseStateKey, ActiveParseState>();
+        var map = new Dictionary<ActiveParseBranchEquivalenceKey, ActiveParseState>();
         foreach (var state in states)
         {
-            var key = state.ToStateKey(precedence);
+            var key = new ActiveParseBranchEquivalenceKey(
+                state.Rule.Name,
+                state.OriginInputPosition,
+                state.EndPosition ?? state.CurrentInputPosition,
+                state.Cursor.Kind,
+                state.Cursor.Index,
+                state.Alternative.Label ?? string.Empty);
             if (!map.TryGetValue(key, out var existing))
             {
                 map[key] = state;

--- a/UtilsTest/Parser/ActiveParseStateTests.cs
+++ b/UtilsTest/Parser/ActiveParseStateTests.cs
@@ -4,15 +4,9 @@ using Utils.Parser.Runtime;
 
 namespace UtilsTest.Parser;
 
-/// <summary>
-/// Tests for the ActiveParseState infrastructure mapping and identity semantics.
-/// </summary>
 [TestClass]
 public class ActiveParseStateTests
 {
-    /// <summary>
-    /// Ensures conversion from legacy branch representation to active parse state and back preserves data.
-    /// </summary>
     [TestMethod]
     public void ActiveParseState_BranchRoundTrip_PreservesStateData()
     {
@@ -32,14 +26,11 @@ public class ActiveParseStateTests
         Assert.AreSame(branch.PartialNode, restoredBranch.PartialNode);
     }
 
-    /// <summary>
-    /// Ensures state keys built from equivalent active states are equal and produce the same hash code.
-    /// </summary>
     [TestMethod]
     public void ActiveParseState_ToStateKey_EquivalentStatesAreEqual()
     {
-        var left = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 0));
-        var right = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 0));
+        var left = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 0, currentPosition: 6);
+        var right = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 0, currentPosition: 6);
 
         var leftKey = left.ToStateKey(minimumPrecedence: 3);
         var rightKey = right.ToStateKey(minimumPrecedence: 3);
@@ -48,20 +39,70 @@ public class ActiveParseStateTests
         Assert.AreEqual(leftKey.GetHashCode(), rightKey.GetHashCode());
     }
 
-    /// <summary>
-    /// Ensures state key identity changes when alternative priority, cursor index, or precedence differs.
-    /// </summary>
     [TestMethod]
     public void ActiveParseState_ToStateKey_DifferentDimensionsProduceDifferentKeys()
     {
-        var baseline = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 0)).ToStateKey(minimumPrecedence: 2);
-        var differentAlternative = ActiveParseState.FromBranch(CreateBranch(priority: 2, cursorIndex: 0)).ToStateKey(minimumPrecedence: 2);
-        var differentCursor = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 1)).ToStateKey(minimumPrecedence: 2);
-        var differentPrecedence = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 0)).ToStateKey(minimumPrecedence: 4);
+        var baseline = CreateActiveState(1, 0, 0, 6).ToStateKey(2);
+        Assert.AreNotEqual(baseline, CreateActiveState(2, 0, 1, 6).ToStateKey(2));
+        Assert.AreNotEqual(baseline, CreateActiveState(1, 1, 0, 6).ToStateKey(2));
+        Assert.AreNotEqual(baseline, CreateActiveState(1, 0, 0, 7).ToStateKey(2));
+        Assert.AreNotEqual(baseline, CreateActiveState(1, 0, 0, 6).ToStateKey(4));
+        Assert.AreNotEqual(baseline, CreateActiveState(1, 0, 0, 6).WithContinuation(new ContinuationKey("r", 0, 0, 6, 2)).ToStateKey(2));
+    }
 
-        Assert.AreNotEqual(baseline, differentAlternative);
-        Assert.AreNotEqual(baseline, differentCursor);
-        Assert.AreNotEqual(baseline, differentPrecedence);
+    [TestMethod]
+    public void ActiveParseState_LifecycleTransitions_AreExplicit()
+    {
+        var active = CreateActiveState(1, 0, 0, 4);
+        Assert.AreEqual(ActiveParseStateStatus.Active, active.Status);
+
+        var completed = active.Complete(8);
+        Assert.AreEqual(ActiveParseStateStatus.Completed, completed.Status);
+        Assert.AreEqual(8, completed.EndPosition);
+
+        var failed = active.Fail();
+        Assert.AreEqual(ActiveParseStateStatus.Failed, failed.Status);
+        Assert.IsNull(failed.EndPosition);
+
+        var pruned = active.Prune();
+        Assert.AreEqual(ActiveParseStateStatus.Pruned, pruned.Status);
+    }
+
+    [TestMethod]
+    public void ActiveParseState_RegistryProjection_UsesExpectedKeys()
+    {
+        var state = CreateActiveState(3, 2, 5, 10);
+
+        var parserStateKey = state.ToParserStateKey(4);
+        Assert.AreEqual(new ParserStateKey("sampleRule", 10, 5, 2, 4), parserStateKey);
+
+        var invocationKey = state.ToRuleInvocationKey(4);
+        Assert.AreEqual(new RuleInvocationKey("sampleRule", 4, 4), invocationKey);
+
+        var continuationKey = state.ToContinuationKey(11, 4);
+        Assert.AreEqual(new ContinuationKey("sampleRule", 5, 2, 11, 4), continuationKey);
+    }
+
+    private static ActiveParseState CreateActiveState(int priority, int cursorIndex, int alternativeIndex, int currentPosition)
+    {
+        var alternative = new Alternative(priority, Associativity.Left, new LiteralMatch("A"), $"alt{priority}");
+        var rule = new Rule("sampleRule", 0, false, new Alternation([alternative]));
+
+        return new ActiveParseState
+        {
+            Rule = rule,
+            Alternative = alternative,
+            OriginInputPosition = 4,
+            CurrentInputPosition = currentPosition,
+            AlternativeIndex = alternativeIndex,
+            Cursor = new RuleContentCursor { Index = cursorIndex, Kind = "alternative-root" },
+            PartialNode = new ParserNode(new SourceSpan(2, 3), "DEFAULT_MODE", rule, []),
+            EndPosition = null,
+            Status = ActiveParseStateStatus.Active,
+            ParentStateKey = null,
+            Depth = 0,
+            Continuation = null
+        };
     }
 
     private static ParseBranch CreateBranch(int priority, int cursorIndex)

--- a/UtilsTest/Parser/ActiveParseStateTests.cs
+++ b/UtilsTest/Parser/ActiveParseStateTests.cs
@@ -5,7 +5,7 @@ using Utils.Parser.Runtime;
 namespace UtilsTest.Parser;
 
 /// <summary>
-/// Tests for the ActiveParseState infrastructure mapping.
+/// Tests for the ActiveParseState infrastructure mapping and identity semantics.
 /// </summary>
 [TestClass]
 public class ActiveParseStateTests
@@ -16,23 +16,7 @@ public class ActiveParseStateTests
     [TestMethod]
     public void ActiveParseState_BranchRoundTrip_PreservesStateData()
     {
-        var alternative = new Alternative(2, Associativity.Left, new LiteralMatch("A"), "altLabel");
-        var rule = new Rule(
-            "sampleRule",
-            0,
-            false,
-            new Alternation([alternative]));
-
-        var branch = new ParseBranch
-        {
-            Rule = rule,
-            Alternative = alternative,
-            InputPosition = 4,
-            Cursor = new RuleContentCursor { Index = 1, Kind = "alternative-root" },
-            PartialNode = new ParserNode(new SourceSpan(2, 3), "DEFAULT_MODE", rule, []),
-            EndPosition = 7,
-            IsComplete = true
-        };
+        var branch = CreateBranch(priority: 2, cursorIndex: 1);
 
         var activeState = ActiveParseState.FromBranch(branch);
         var restoredBranch = activeState.ToBranch();
@@ -46,5 +30,58 @@ public class ActiveParseStateTests
         Assert.AreEqual(branch.EndPosition, restoredBranch.EndPosition);
         Assert.AreEqual(branch.IsComplete, restoredBranch.IsComplete);
         Assert.AreSame(branch.PartialNode, restoredBranch.PartialNode);
+    }
+
+    /// <summary>
+    /// Ensures state keys built from equivalent active states are equal and produce the same hash code.
+    /// </summary>
+    [TestMethod]
+    public void ActiveParseState_ToStateKey_EquivalentStatesAreEqual()
+    {
+        var left = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 0));
+        var right = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 0));
+
+        var leftKey = left.ToStateKey(minimumPrecedence: 3);
+        var rightKey = right.ToStateKey(minimumPrecedence: 3);
+
+        Assert.AreEqual(leftKey, rightKey);
+        Assert.AreEqual(leftKey.GetHashCode(), rightKey.GetHashCode());
+    }
+
+    /// <summary>
+    /// Ensures state key identity changes when alternative priority, cursor index, or precedence differs.
+    /// </summary>
+    [TestMethod]
+    public void ActiveParseState_ToStateKey_DifferentDimensionsProduceDifferentKeys()
+    {
+        var baseline = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 0)).ToStateKey(minimumPrecedence: 2);
+        var differentAlternative = ActiveParseState.FromBranch(CreateBranch(priority: 2, cursorIndex: 0)).ToStateKey(minimumPrecedence: 2);
+        var differentCursor = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 1)).ToStateKey(minimumPrecedence: 2);
+        var differentPrecedence = ActiveParseState.FromBranch(CreateBranch(priority: 1, cursorIndex: 0)).ToStateKey(minimumPrecedence: 4);
+
+        Assert.AreNotEqual(baseline, differentAlternative);
+        Assert.AreNotEqual(baseline, differentCursor);
+        Assert.AreNotEqual(baseline, differentPrecedence);
+    }
+
+    private static ParseBranch CreateBranch(int priority, int cursorIndex)
+    {
+        var alternative = new Alternative(priority, Associativity.Left, new LiteralMatch("A"), $"alt{priority}");
+        var rule = new Rule(
+            "sampleRule",
+            0,
+            false,
+            new Alternation([alternative]));
+
+        return new ParseBranch
+        {
+            Rule = rule,
+            Alternative = alternative,
+            InputPosition = 4,
+            Cursor = new RuleContentCursor { Index = cursorIndex, Kind = "alternative-root" },
+            PartialNode = new ParserNode(new SourceSpan(2, 3), "DEFAULT_MODE", rule, []),
+            EndPosition = 7,
+            IsComplete = true
+        };
     }
 }

--- a/UtilsTest/Parser/ActiveParseStateTests.cs
+++ b/UtilsTest/Parser/ActiveParseStateTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Model;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Tests for the ActiveParseState infrastructure mapping.
+/// </summary>
+[TestClass]
+public class ActiveParseStateTests
+{
+    /// <summary>
+    /// Ensures conversion from legacy branch representation to active parse state and back preserves data.
+    /// </summary>
+    [TestMethod]
+    public void ActiveParseState_BranchRoundTrip_PreservesStateData()
+    {
+        var alternative = new Alternative(2, Associativity.Left, new LiteralMatch("A"), "altLabel");
+        var rule = new Rule(
+            "sampleRule",
+            0,
+            false,
+            new Alternation([alternative]));
+
+        var branch = new ParseBranch
+        {
+            Rule = rule,
+            Alternative = alternative,
+            InputPosition = 4,
+            Cursor = new RuleContentCursor { Index = 1, Kind = "alternative-root" },
+            PartialNode = new ParserNode(new SourceSpan(2, 3), "DEFAULT_MODE", rule, []),
+            EndPosition = 7,
+            IsComplete = true
+        };
+
+        var activeState = ActiveParseState.FromBranch(branch);
+        var restoredBranch = activeState.ToBranch();
+
+        Assert.AreEqual(branch.Rule.Name, restoredBranch.Rule.Name);
+        Assert.AreEqual(branch.Alternative.Priority, restoredBranch.Alternative.Priority);
+        Assert.AreEqual(branch.Alternative.Label, restoredBranch.Alternative.Label);
+        Assert.AreEqual(branch.InputPosition, restoredBranch.InputPosition);
+        Assert.AreEqual(branch.Cursor.Index, restoredBranch.Cursor.Index);
+        Assert.AreEqual(branch.Cursor.Kind, restoredBranch.Cursor.Kind);
+        Assert.AreEqual(branch.EndPosition, restoredBranch.EndPosition);
+        Assert.AreEqual(branch.IsComplete, restoredBranch.IsComplete);
+        Assert.AreSame(branch.PartialNode, restoredBranch.PartialNode);
+    }
+}

--- a/UtilsTest/Parser/ActiveParseStateTests.cs
+++ b/UtilsTest/Parser/ActiveParseStateTests.cs
@@ -84,6 +84,40 @@ public class ActiveParseStateTests
     }
 
     [TestMethod]
+    public void ActiveParseState_ToBranchEquivalenceKey_SameKeyForDifferentAlternativeIndices()
+    {
+        // Two states that reach the same semantic position from different alternatives must share
+        // the same equivalence key so that ambiguity pruning can collapse them.
+        // Both use priority=1 so the label ("alt1") is identical; only AlternativeIndex differs.
+        var stateA = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 0, currentPosition: 10).Complete(10);
+        var stateB = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 3, currentPosition: 10).Complete(10);
+
+        Assert.AreEqual(stateA.ToBranchEquivalenceKey(), stateB.ToBranchEquivalenceKey());
+        // Scheduler identity must still distinguish them.
+        Assert.AreNotEqual(stateA.ToStateKey(2), stateB.ToStateKey(2));
+    }
+
+    [TestMethod]
+    public void ActiveParseState_ToBranchEquivalenceKey_DifferentKeyForDifferentEndPosition()
+    {
+        var stateA = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 0, currentPosition: 10).Complete(10);
+        var stateB = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 0, currentPosition: 12).Complete(12);
+
+        Assert.AreNotEqual(stateA.ToBranchEquivalenceKey(), stateB.ToBranchEquivalenceKey());
+    }
+
+    [TestMethod]
+    public void ActiveParseState_ToBranchEquivalenceKey_IndependentOfSchedulerIdentity()
+    {
+        // Equivalence key must be independent of scheduler-identity fields so it does not
+        // accidentally prevent pruning of semantically identical states on different paths.
+        var state = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 0, currentPosition: 6).Complete(6);
+        var withContinuation = state.WithContinuation(new ContinuationKey("sampleRule", 0, 0, 6, 2));
+
+        Assert.AreEqual(state.ToBranchEquivalenceKey(), withContinuation.ToBranchEquivalenceKey());
+    }
+
+    [TestMethod]
     public void ActiveParseState_RegistryIntegration_StableReuseKeys()
     {
         var state = CreateActiveState(1, 0, 0, 4).Complete(9);

--- a/UtilsTest/Parser/ActiveParseStateTests.cs
+++ b/UtilsTest/Parser/ActiveParseStateTests.cs
@@ -83,6 +83,24 @@ public class ActiveParseStateTests
         Assert.AreEqual(new ContinuationKey("sampleRule", 5, 2, 11, 4), continuationKey);
     }
 
+    [TestMethod]
+    public void ActiveParseState_RegistryIntegration_StableReuseKeys()
+    {
+        var state = CreateActiveState(1, 0, 0, 4).Complete(9);
+        var registry = new ParserStateRegistry();
+        var invocationKey = state.ToRuleInvocationKey(2);
+        var parserKey = state.ToParserStateKey(2);
+
+        Assert.IsTrue(registry.TryEnterState(parserKey));
+        Assert.IsFalse(registry.TryEnterState(parserKey), "Same parser state key should deduplicate.");
+
+        var result = new ParserRuleResult(state.PartialNode, state.EndPosition ?? state.CurrentInputPosition, IsFailure: false);
+        Assert.IsTrue(registry.AddCompletedResult(invocationKey, result));
+        Assert.IsTrue(registry.TryGetReusableResult(invocationKey, out var reusable));
+        Assert.AreEqual(result.EndPosition, reusable.EndPosition);
+        Assert.AreSame(result.Node, reusable.Node);
+    }
+
     private static ActiveParseState CreateActiveState(int priority, int cursorIndex, int alternativeIndex, int currentPosition)
     {
         var alternative = new Alternative(priority, Associativity.Left, new LiteralMatch("A"), $"alt{priority}");

--- a/UtilsTest/Parser/ActiveParseStateTests.cs
+++ b/UtilsTest/Parser/ActiveParseStateTests.cs
@@ -84,13 +84,12 @@ public class ActiveParseStateTests
     }
 
     [TestMethod]
-    public void ActiveParseState_ToBranchEquivalenceKey_SameKeyForDifferentAlternativeIndices()
+    public void ActiveParseState_ToBranchEquivalenceKey_SameKeyForDifferentAlternativeIndicesAndLabels()
     {
-        // Two states that reach the same semantic position from different alternatives must share
-        // the same equivalence key so that ambiguity pruning can collapse them.
-        // Both use priority=1 so the label ("alt1") is identical; only AlternativeIndex differs.
+        // Two states that reach the same parser-state shape must share the equivalence key
+        // regardless of which alternative (index, priority, label) produced them.
         var stateA = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 0, currentPosition: 10).Complete(10);
-        var stateB = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 3, currentPosition: 10).Complete(10);
+        var stateB = CreateActiveState(priority: 2, cursorIndex: 0, alternativeIndex: 3, currentPosition: 10).Complete(10);
 
         Assert.AreEqual(stateA.ToBranchEquivalenceKey(), stateB.ToBranchEquivalenceKey());
         // Scheduler identity must still distinguish them.
@@ -104,6 +103,22 @@ public class ActiveParseStateTests
         var stateB = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 0, currentPosition: 12).Complete(12);
 
         Assert.AreNotEqual(stateA.ToBranchEquivalenceKey(), stateB.ToBranchEquivalenceKey());
+    }
+
+    [TestMethod]
+    public void ActiveParseState_ToBranchEquivalenceKey_DifferentLabels_SameShapeKey_NotPruned()
+    {
+        // States with different labels must map to the same shape key so that
+        // HasDistinctSemantics — not the key — is responsible for keeping them alive.
+        var stateA = CreateActiveStateWithLabel(priority: 1, alternativeIndex: 0, currentPosition: 10, label: "ExprAdd");
+        var stateB = CreateActiveStateWithLabel(priority: 2, alternativeIndex: 1, currentPosition: 10, label: "ExprSub");
+
+        // Same parser-state shape.
+        Assert.AreEqual(stateA.ToBranchEquivalenceKey(), stateB.ToBranchEquivalenceKey());
+
+        // HasDistinctSemantics returns true for different labels, so PruneEquivalentActiveStates
+        // keeps both states in the result instead of dropping the lower-priority one.
+        Assert.IsTrue(ParserEngine.HasDistinctSemantics(stateA.Alternative, stateB.Alternative));
     }
 
     [TestMethod]
@@ -155,6 +170,28 @@ public class ActiveParseStateTests
             Depth = 0,
             Continuation = null
         };
+    }
+
+    private static ActiveParseState CreateActiveStateWithLabel(int priority, int alternativeIndex, int currentPosition, string label)
+    {
+        var alternative = new Alternative(priority, Associativity.Left, new LiteralMatch("A"), label);
+        var rule = new Rule("sampleRule", 0, false, new Alternation([alternative]));
+
+        return new ActiveParseState
+        {
+            Rule = rule,
+            Alternative = alternative,
+            OriginInputPosition = 4,
+            CurrentInputPosition = currentPosition,
+            AlternativeIndex = alternativeIndex,
+            Cursor = new RuleContentCursor { Index = 0, Kind = "alternative-root" },
+            PartialNode = new ParserNode(new SourceSpan(2, 3), "DEFAULT_MODE", rule, []),
+            EndPosition = null,
+            Status = ActiveParseStateStatus.Active,
+            ParentStateKey = null,
+            Depth = 0,
+            Continuation = null
+        }.Complete(currentPosition);
     }
 
     private static ParseBranch CreateBranch(int priority, int cursorIndex)

--- a/UtilsTest/Parser/ParserEngineRegistryRegressionTests.cs
+++ b/UtilsTest/Parser/ParserEngineRegistryRegressionTests.cs
@@ -156,6 +156,26 @@ public class ParserEngineRegistryRegressionTests
     }
 
     /// <summary>
+    /// Ensures equivalent ambiguous alternatives are still pruned and diagnostics remain emitted.
+    /// </summary>
+    [TestMethod]
+    public void EquivalentAmbiguousAlternatives_ArePruned_WithDiagnostic()
+    {
+        const string grammar = """
+            grammar G;
+            root : ('a' | 'a') EOF ;
+            EOF : '<EOF>' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics(grammar, "a <EOF>", diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
+    }
+
+    /// <summary>
     /// Ensures observable behavior is preserved when the same parser rule is invoked
     /// from multiple alternatives at the same input position.
     /// </summary>


### PR DESCRIPTION
### Motivation

- Introduce an infrastructure-only normalization for active parser branches to prepare for explicit scheduling and alternative evaluation improvements without changing public behavior. 
- Surface the new internal concept in documentation so the runtime architecture and future roadmap are clearer to maintainers.

### Description

- Add an immutable `ActiveParseState` record with helpers `FromBranch` and `ToBranch` to map between the legacy `ParseBranch` representation and the new normalization. 
- Replace direct use of `ParseBranch` with `ActiveParseState` inside `ParserEngine.TryParseAlternativesParallel` while preserving existing branch selection, pruning, and semantics. 
- Update the public README `Utils.Parser/README.md` with a note about the parser runtime architecture and the internal `ActiveParseState` role. 
- Add unit tests in `UtilsTest/Parser/ActiveParseStateTests.cs` to verify round-trip conversion between `ParseBranch` and `ActiveParseState` preserves state data.

### Testing

- Added `ActiveParseState_BranchRoundTrip_PreservesStateData` in `UtilsTest/Parser/ActiveParseStateTests.cs` and ran unit tests with `dotnet test` for the test project, which succeeded. 
- Ran the repository unit test suite for `UtilsTest` projects with `dotnet test` and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb33284f08832692292a71ca97de6a)