### PR TITLE
Introduce parser look-ahead cache for scheduled alternatives

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -82,6 +82,7 @@ This layer is now orchestrated by an internal `AlternativeScheduler` that execut
   without enabling parallel parsing at this stage.
 - `ParserEngine` also keeps an internal look-ahead cache keyed by rule name, origin position, alternative index, minimum precedence, and alternation cursor context.
 - The cache stores lightweight start observations only (can-start flag + first token snapshot), does not store parse trees, does not replace `ParserStateRegistry`, and does not change alternative selection semantics.
+- The current implementation only applies negative shortcut reuse to top-level rule alternative scheduling and left-recursive seed scheduling. Nested alternations are intentionally excluded in this step to preserve diagnostic stability and keep the optimization conservative.
 - Execution remains sequential: no parallel alternative parsing, no continuation queue, and no shared look-ahead graph in this step.
 
 #### Two separate identity concepts on `ActiveParseState`

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -46,6 +46,7 @@ If a grammar relies on one of these areas, validate it with targeted tests befor
 | Declared `tokens { ... }` and `channels { ... }` metadata | Partial | Available in model/runtime, but must be validated against your grammar set. |
 | Runtime lexer extensions (`ILexerExtension`) | Implemented | Hooks are available (`TryReadTokens`, `OnAfterToken`, `OnEndOfInput`). |
 | Full ANTLR4 grammar compatibility | Not guaranteed | Advanced/edge constructs may differ from ANTLR4 behavior. |
+| Scheduled alternative look-ahead | Implemented (internal) | Lightweight cache records alternative-start observations to avoid repeated obviously impossible starts during deterministic sequential scheduling. |
 
 ## Key concepts
 
@@ -79,6 +80,9 @@ This layer is now orchestrated by an internal `AlternativeScheduler` that execut
 - The abstraction is used to prepare future explicit scheduling features (shared
   alternative evaluation, continuation-driven orchestration, pruning strategies),
   without enabling parallel parsing at this stage.
+- `ParserEngine` also keeps an internal look-ahead cache keyed by rule name, origin position, alternative index, and minimum precedence.
+- The cache stores lightweight start observations only (can-start flag + first token snapshot), does not store parse trees, does not replace `ParserStateRegistry`, and does not change alternative selection semantics.
+- Execution remains sequential: no parallel alternative parsing, no continuation queue, and no shared look-ahead graph in this step.
 
 #### Two separate identity concepts on `ActiveParseState`
 

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -80,7 +80,7 @@ This layer is now orchestrated by an internal `AlternativeScheduler` that execut
 - The abstraction is used to prepare future explicit scheduling features (shared
   alternative evaluation, continuation-driven orchestration, pruning strategies),
   without enabling parallel parsing at this stage.
-- `ParserEngine` also keeps an internal look-ahead cache keyed by rule name, origin position, alternative index, and minimum precedence.
+- `ParserEngine` also keeps an internal look-ahead cache keyed by rule name, origin position, alternative index, minimum precedence, and alternation cursor context.
 - The cache stores lightweight start observations only (can-start flag + first token snapshot), does not store parse trees, does not replace `ParserStateRegistry`, and does not change alternative selection semantics.
 - Execution remains sequential: no parallel alternative parsing, no continuation queue, and no shared look-ahead graph in this step.
 

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -649,9 +649,12 @@ public sealed class ParserEngine
                 }
 
                 var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, alternativeIndex, precedence, cursorKind, cursorIndex);
+                var allowNegativeShortcut =
+                    diagnostics is null
+                    && (cursorKind == "rule-root"
+                        || cursorKind == "left-recursive-seed");
                 var token = context.Peek();
-                if (diagnostics is null
-                    && (cursorKind == "rule-root" || cursorKind == "left-recursive-seed")
+                if (allowNegativeShortcut
                     && _lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead)
                     && !cachedLookahead.CanStart)
                 {
@@ -663,7 +666,9 @@ public sealed class ParserEngine
                 if (result is null)
                 {
                     var consumed = context.Position > savedPosition;
-                    if (!consumed && !ContainsPredicateOrAction(alternative.Content))
+                    if (allowNegativeShortcut
+                        && !consumed
+                        && !ContainsPredicateOrAction(alternative.Content))
                     {
                         _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(false, token?.RuleName, token?.Text));
                     }

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -651,6 +651,7 @@ public sealed class ParserEngine
                 var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, alternativeIndex, precedence, cursorKind, cursorIndex);
                 var token = context.Peek();
                 if (diagnostics is null
+                    && (cursorKind == "rule-root" || cursorKind == "left-recursive-seed")
                     && _lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead)
                     && !cachedLookahead.CanStart)
                 {

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -650,10 +650,10 @@ public sealed class ParserEngine
 
                 var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, alternativeIndex, precedence, cursorKind, cursorIndex);
                 var token = context.Peek();
-                if (_lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead) && !cachedLookahead.CanStart)
+                if (diagnostics is null
+                    && _lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead)
+                    && !cachedLookahead.CanStart)
                 {
-                    var diagnosticSpan = ResolveDiagnosticSpan(context);
-                    diagnostics?.AddWithContext(ParserDiagnostics.BacktrackingUsed, diagnosticSpan.Start, diagnosticSpan.Length, rule.Name, null, rule.Name);
                     return null;
                 }
 

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -141,7 +141,7 @@ public sealed class ParserEngine
             }
             else
             {
-                parsed = TryParseScheduledAlternatives(context, rule.Content.Alternatives, rule, precedence, diagnostics);
+                parsed = TryParseScheduledAlternatives(context, rule.Content.Alternatives, rule, precedence, diagnostics, "rule-root", -1);
             }
 
             _stateRegistry.AddCompletedResult(invocationKey, new ParserRuleResult(parsed, context.Position, parsed is null));
@@ -170,7 +170,9 @@ public sealed class ParserEngine
             info.BaseAlternatives,
             info.Rule,
             minimumPrecedence,
-            diagnostics);
+            diagnostics,
+            "left-recursive-seed",
+            -1);
         if (seed is null)
         {
             return null;
@@ -446,7 +448,7 @@ public sealed class ParserEngine
                 return TryParseSequence(context, seq, rule, precedence, alternativeIndex, diagnostics);
 
             case Alternation alternation:
-                return TryParseAlternation(context, alternation, rule, precedence, diagnostics);
+                return TryParseAlternation(context, alternation, rule, precedence, alternativeIndex, elementIndex, diagnostics);
 
             case Alternative alt:
                 return TryParseAlternative(context, alt, rule, precedence, alternativeIndex, elementIndex, diagnostics);
@@ -612,9 +614,11 @@ public sealed class ParserEngine
         Alternation alternation,
         Rule rule,
         int precedence = 0,
+        int alternativeIndex = -1,
+        int elementIndex = -1,
         DiagnosticBag? diagnostics = null)
     {
-        return TryParseScheduledAlternatives(context, alternation.Alternatives, rule, precedence, diagnostics);
+        return TryParseScheduledAlternatives(context, alternation.Alternatives, rule, precedence, diagnostics, "alternation", elementIndex >= 0 ? elementIndex : alternativeIndex);
     }
 
     private ParseNode? TryParseScheduledAlternatives(
@@ -622,7 +626,9 @@ public sealed class ParserEngine
         IEnumerable<Alternative> alternatives,
         Rule rule,
         int precedence,
-        DiagnosticBag? diagnostics)
+        DiagnosticBag? diagnostics,
+        string cursorKind,
+        int cursorIndex)
     {
         var startPosition = context.Position;
         var startToken = context.Peek();
@@ -642,7 +648,7 @@ public sealed class ParserEngine
                     return null;
                 }
 
-                var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, alternativeIndex, precedence);
+                var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, alternativeIndex, precedence, cursorKind, cursorIndex);
                 var token = context.Peek();
                 if (_lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead) && !cachedLookahead.CanStart)
                 {
@@ -655,7 +661,8 @@ public sealed class ParserEngine
                 var result = TryParseContent(context, alternative.Content, rule, precedence, alternativeIndex, alternativeIndex, diagnostics);
                 if (result is null)
                 {
-                    if (!ContainsPredicateOrAction(alternative.Content))
+                    var consumed = context.Position > savedPosition;
+                    if (!consumed && !ContainsPredicateOrAction(alternative.Content))
                     {
                         _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(false, token?.RuleName, token?.Text));
                     }

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -30,6 +30,7 @@ public sealed class ParserEngine
     private readonly bool _caseInsensitive;
     private readonly ParserStateRegistry _stateRegistry = new();
     private readonly AlternativeScheduler _alternativeScheduler;
+    private readonly ParserLookaheadCache _lookaheadCache = new();
 
     public ParserEngine(ParserDefinition definition)
     {
@@ -60,6 +61,7 @@ public sealed class ParserEngine
 
         _activeRuleFrames.Clear();
         _stateRegistry.Clear();
+        _lookaheadCache.Clear();
         var context = new ParseContext(tokenList);
         var result = ParseRule(context, root, precedence: 0, diagnostics);
 
@@ -640,15 +642,31 @@ public sealed class ParserEngine
                     return null;
                 }
 
+                var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, alternativeIndex, precedence);
+                var token = context.Peek();
+                if (_lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead) && !cachedLookahead.CanStart)
+                {
+                    var diagnosticSpan = ResolveDiagnosticSpan(context);
+                    diagnostics?.AddWithContext(ParserDiagnostics.BacktrackingUsed, diagnosticSpan.Start, diagnosticSpan.Length, rule.Name, null, rule.Name);
+                    return null;
+                }
+
                 var savedPosition = context.SavePosition();
                 var result = TryParseContent(context, alternative.Content, rule, precedence, alternativeIndex, alternativeIndex, diagnostics);
                 if (result is null)
                 {
+                    if (!ContainsPredicateOrAction(alternative.Content))
+                    {
+                        _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(false, token?.RuleName, token?.Text));
+                    }
+
                     var diagnosticSpan = ResolveDiagnosticSpan(context);
                     diagnostics?.AddWithContext(ParserDiagnostics.BacktrackingUsed, diagnosticSpan.Start, diagnosticSpan.Length, rule.Name, null, rule.Name);
                     context.RestorePosition(savedPosition);
                     return null;
                 }
+
+                _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(true, token?.RuleName, token?.Text));
 
                 var state = new ActiveParseState
                 {

--- a/Utils.Parser/Runtime/ParserLookaheadCache.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadCache.cs
@@ -1,0 +1,39 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Caches lightweight scheduled-alternative look-ahead observations for the current parse execution.
+/// </summary>
+internal sealed class ParserLookaheadCache
+{
+    private readonly Dictionary<ParserLookaheadKey, ParserLookaheadResult> _results = [];
+
+    /// <summary>
+    /// Clears all cached look-ahead observations.
+    /// </summary>
+    public void Clear()
+    {
+        _results.Clear();
+    }
+
+    /// <summary>
+    /// Tries to get a cached look-ahead observation for the provided key.
+    /// </summary>
+    public bool TryGet(ParserLookaheadKey key, out ParserLookaheadResult result)
+    {
+        return _results.TryGetValue(key, out result);
+    }
+
+    /// <summary>
+    /// Adds a look-ahead observation when no value exists for the same key.
+    /// </summary>
+    public bool TryAdd(ParserLookaheadKey key, ParserLookaheadResult result)
+    {
+        if (_results.ContainsKey(key))
+        {
+            return false;
+        }
+
+        _results.Add(key, result);
+        return true;
+    }
+}

--- a/Utils.Parser/Runtime/ParserLookaheadKey.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadKey.cs
@@ -7,4 +7,6 @@ internal readonly record struct ParserLookaheadKey(
     string RuleName,
     int OriginPosition,
     int AlternativeIndex,
-    int MinimumPrecedence);
+    int MinimumPrecedence,
+    string CursorKind,
+    int CursorIndex);

--- a/Utils.Parser/Runtime/ParserLookaheadKey.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadKey.cs
@@ -1,0 +1,10 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Identifies a scheduled alternative look-ahead observation for a parser rule at a specific input position.
+/// </summary>
+internal readonly record struct ParserLookaheadKey(
+    string RuleName,
+    int OriginPosition,
+    int AlternativeIndex,
+    int MinimumPrecedence);

--- a/Utils.Parser/Runtime/ParserLookaheadResult.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadResult.cs
@@ -1,0 +1,9 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Stores a lightweight look-ahead observation for a scheduled alternative start attempt.
+/// </summary>
+internal readonly record struct ParserLookaheadResult(
+    bool CanStart,
+    string? TokenRuleName,
+    string? TokenText);

--- a/UtilsTest/Parser/ParserLookaheadCacheTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadCacheTests.cs
@@ -1,0 +1,135 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Model;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ParserLookaheadCacheTests
+{
+    [TestMethod]
+    public void ParserLookaheadCache_StoresAndRetrievesResult()
+    {
+        var cache = new ParserLookaheadCache();
+        var key = new ParserLookaheadKey("root", 0, 0, 0);
+        var expected = new ParserLookaheadResult(false, "ID", "id");
+
+        Assert.IsTrue(cache.TryAdd(key, expected));
+        Assert.IsTrue(cache.TryGet(key, out var actual));
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void ParserLookaheadCache_IsolatesByAlternativeIndex()
+    {
+        var cache = new ParserLookaheadCache();
+        var first = new ParserLookaheadKey("root", 0, 0, 0);
+        var second = new ParserLookaheadKey("root", 0, 1, 0);
+
+        cache.TryAdd(first, new ParserLookaheadResult(false, "ID", "id"));
+
+        Assert.IsFalse(cache.TryGet(second, out _));
+    }
+
+    [TestMethod]
+    public void ParserLookaheadCache_IsolatesByPrecedence()
+    {
+        var cache = new ParserLookaheadCache();
+        var lower = new ParserLookaheadKey("root", 0, 0, 0);
+        var higher = new ParserLookaheadKey("root", 0, 0, 1);
+
+        cache.TryAdd(lower, new ParserLookaheadResult(false, "ID", "id"));
+
+        Assert.IsFalse(cache.TryGet(higher, out _));
+    }
+
+    [TestMethod]
+    public void ScheduledAlternatives_PreservesParseTreeWithSharedPrefix()
+    {
+        const string grammar = """
+            grammar G;
+            root : common 'X'
+                 | common 'Y'
+                 ;
+            common : ID ;
+            ID : ('a'..'z')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+
+        var treeX = Parse(grammar, "id X", out _);
+        var treeY = Parse(grammar, "id Y", out _);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(treeX);
+        Assert.IsNotInstanceOfType<ErrorNode>(treeY);
+        Assert.AreEqual(1, CountTokenText(treeX, "X"));
+        Assert.AreEqual(1, CountTokenText(treeY, "Y"));
+    }
+
+    [TestMethod]
+    public void FailedAlternativeLookahead_DoesNotPoisonLaterSuccess()
+    {
+        const string grammar = """
+            grammar G;
+            root : bad | good ;
+            bad : 'a' 'x' ;
+            good : 'a' 'y' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+
+        var tree = Parse(grammar, "a y", out _);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.AreEqual(1, CountTokenText(tree, "y"));
+    }
+
+    [TestMethod]
+    public void ExistingDiagnostics_AreNotLost()
+    {
+        const string grammar = """
+            grammar G;
+            root : ('a' | 'a') EOF ;
+            EOF : '<EOF>' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+
+        _ = Parse(grammar, "a <EOF>", out var diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
+    }
+
+    private static ParseNode Parse(string grammarText, string input, out DiagnosticBag diagnostics)
+    {
+        diagnostics = new DiagnosticBag();
+        var definition = Antlr4GrammarConverter.Parse(grammarText, diagnostics);
+        var lexer = new LexerEngine(definition);
+        var parser = new ParserEngine(definition);
+        var tokens = lexer.Tokenize(new System.IO.StringReader(input), null);
+        return parser.Parse(tokens, diagnostics: diagnostics);
+    }
+
+    private static int CountTokenText(ParseNode node, string text)
+    {
+        var count = 0;
+        CountTokenText(node, text, ref count);
+        return count;
+    }
+
+    private static void CountTokenText(ParseNode node, string text, ref int count)
+    {
+        if (node is LexerNode lexerNode && lexerNode.Token.Text == text)
+        {
+            count++;
+        }
+
+        if (node is ParserNode parserNode)
+        {
+            foreach (var child in parserNode.Children)
+            {
+                CountTokenText(child, text, ref count);
+            }
+        }
+    }
+}

--- a/UtilsTest/Parser/ParserLookaheadCacheTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadCacheTests.cs
@@ -112,6 +112,36 @@ public class ParserLookaheadCacheTests
         Assert.IsFalse(cache.TryGet(second, out _));
     }
 
+    [TestMethod]
+    public void DiagnosticsProvided_NegativeLookaheadDoesNotSkipRuleDiagnostics()
+    {
+        const string grammar = """
+            grammar G;
+            root : failing 'X'
+                 | failing 'Y'
+                 | ok
+                 ;
+            failing : 'z' ;
+            ok : 'a' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+
+        var tree = Parse(grammar, "a", out var diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.AreEqual(1, CountTokenText(tree, "a"));
+
+        var failingMisses = diagnostics.Count(d =>
+            d.Code == ParserDiagnostics.ParseMemoMiss.Code
+            && d.RuleName == "failing");
+        var failingHits = diagnostics.Count(d =>
+            d.Code == ParserDiagnostics.ParseMemoHit.Code
+            && d.RuleName == "failing");
+
+        Assert.AreEqual(1, failingMisses);
+        Assert.IsTrue(failingHits >= 1);
+    }
+
     private static ParseNode Parse(string grammarText, string input, out DiagnosticBag diagnostics)
     {
         diagnostics = new DiagnosticBag();

--- a/UtilsTest/Parser/ParserLookaheadCacheTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadCacheTests.cs
@@ -14,7 +14,7 @@ public class ParserLookaheadCacheTests
     public void ParserLookaheadCache_StoresAndRetrievesResult()
     {
         var cache = new ParserLookaheadCache();
-        var key = new ParserLookaheadKey("root", 0, 0, 0);
+        var key = new ParserLookaheadKey("root", 0, 0, 0, "rule-root", -1);
         var expected = new ParserLookaheadResult(false, "ID", "id");
 
         Assert.IsTrue(cache.TryAdd(key, expected));
@@ -26,8 +26,8 @@ public class ParserLookaheadCacheTests
     public void ParserLookaheadCache_IsolatesByAlternativeIndex()
     {
         var cache = new ParserLookaheadCache();
-        var first = new ParserLookaheadKey("root", 0, 0, 0);
-        var second = new ParserLookaheadKey("root", 0, 1, 0);
+        var first = new ParserLookaheadKey("root", 0, 0, 0, "rule-root", -1);
+        var second = new ParserLookaheadKey("root", 0, 1, 0, "rule-root", -1);
 
         cache.TryAdd(first, new ParserLookaheadResult(false, "ID", "id"));
 
@@ -38,8 +38,8 @@ public class ParserLookaheadCacheTests
     public void ParserLookaheadCache_IsolatesByPrecedence()
     {
         var cache = new ParserLookaheadCache();
-        var lower = new ParserLookaheadKey("root", 0, 0, 0);
-        var higher = new ParserLookaheadKey("root", 0, 0, 1);
+        var lower = new ParserLookaheadKey("root", 0, 0, 0, "rule-root", -1);
+        var higher = new ParserLookaheadKey("root", 0, 0, 1, "rule-root", -1);
 
         cache.TryAdd(lower, new ParserLookaheadResult(false, "ID", "id"));
 
@@ -98,6 +98,18 @@ public class ParserLookaheadCacheTests
         _ = Parse(grammar, "a <EOF>", out var diagnostics);
 
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
+    }
+
+    [TestMethod]
+    public void ParserLookaheadCache_IsolatesByCursorContext()
+    {
+        var cache = new ParserLookaheadCache();
+        var first = new ParserLookaheadKey("root", 0, 0, 0, "alternation", 1);
+        var second = new ParserLookaheadKey("root", 0, 0, 0, "alternation", 2);
+
+        cache.TryAdd(first, new ParserLookaheadResult(false, "ID", "id"));
+
+        Assert.IsFalse(cache.TryGet(second, out _));
     }
 
     private static ParseNode Parse(string grammarText, string input, out DiagnosticBag diagnostics)


### PR DESCRIPTION
### Motivation
- Reduce obviously duplicated work during deterministic sequential alternative evaluation while preserving existing parser behavior and public API compatibility. 
- Prepare a minimal internal building block for future shared look-ahead / duplicate-work reduction and continuation-driven scheduling without introducing concurrency or runtime behavior changes. 
- Be conservative about diagnostics and semantic predicates so observable parser results and diagnostic emissions remain unchanged.

### Description
- Added three internal runtime types: `ParserLookaheadKey`, `ParserLookaheadResult`, and `ParserLookaheadCache` to record lightweight alternative-start observations (keyed by rule name, origin position, alternative index, minimum precedence). 
- Wired a `ParserLookaheadCache` instance into `ParserEngine` and clear it at parse start alongside existing engine state. 
- Integrated conservative look-ahead checks into `TryParseScheduledAlternatives(...)` so previously-observed exact-key failures (`CanStart == false`) skip re-evaluation; negative results are not cached for alternatives that contain predicates/actions, and successful attempts record `CanStart == true` (no parse trees are cached). 
- Updated `Utils.Parser/README.md` notes and feature matrix to document the internal scheduled-alternative look-ahead behavior and explicitly call out non-goals (no parallel parsing, no continuation queue, no parse-tree caching, no registry replacement). 

### Testing
- Added `UtilsTest/Parser/ParserLookaheadCacheTests.cs` covering cache storage/retrieval, isolation by alternative index and precedence, shared-prefix parse preservation, failed-alternative non-poisoning, and diagnostics non-regression. 
- Ran `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~UtilsTest.Parser.ParserLookaheadCacheTests"`, which passed (6 passed, 0 failed). 
- No public API changes were introduced and the change is internal-only; existing parser diagnostics and selection semantics were preserved in tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9ba02b5083269fb5ff9832dbedab)