### PR TITLE
Normalize scheduled alternative cursor identity

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -83,6 +83,7 @@ This layer is now orchestrated by an internal `AlternativeScheduler` that execut
 - `ParserEngine` also keeps an internal look-ahead cache keyed by rule name, origin position, alternative index, minimum precedence, and alternation cursor context.
 - The cache stores lightweight start observations only (can-start flag + first token snapshot), does not store parse trees, does not replace `ParserStateRegistry`, and does not change alternative selection semantics.
 - The current implementation only applies negative shortcut reuse to top-level rule alternative scheduling and left-recursive seed scheduling. Nested alternations are intentionally excluded in this step to preserve diagnostic stability and keep the optimization conservative.
+- The scheduled alternative cursor context is part of the cache key so observations cannot be reused across different parser-shape positions, such as a rule-root choice and a nested alternation.
 - Execution remains sequential: no parallel alternative parsing, no continuation queue, and no shared look-ahead graph in this step.
 
 #### Two separate identity concepts on `ActiveParseState`

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -141,7 +141,7 @@ public sealed class ParserEngine
             }
             else
             {
-                parsed = TryParseScheduledAlternatives(context, rule.Content.Alternatives, rule, precedence, diagnostics, "rule-root", -1);
+                parsed = TryParseScheduledAlternatives(context, rule.Content.Alternatives, rule, precedence, diagnostics, ScheduledAlternativeCursorKinds.RuleRoot, -1);
             }
 
             _stateRegistry.AddCompletedResult(invocationKey, new ParserRuleResult(parsed, context.Position, parsed is null));
@@ -171,7 +171,7 @@ public sealed class ParserEngine
             info.Rule,
             minimumPrecedence,
             diagnostics,
-            "left-recursive-seed",
+            ScheduledAlternativeCursorKinds.LeftRecursiveSeed,
             -1);
         if (seed is null)
         {
@@ -618,9 +618,12 @@ public sealed class ParserEngine
         int elementIndex = -1,
         DiagnosticBag? diagnostics = null)
     {
-        return TryParseScheduledAlternatives(context, alternation.Alternatives, rule, precedence, diagnostics, "alternation", elementIndex >= 0 ? elementIndex : alternativeIndex);
+        return TryParseScheduledAlternatives(context, alternation.Alternatives, rule, precedence, diagnostics, ScheduledAlternativeCursorKinds.Alternation, elementIndex >= 0 ? elementIndex : alternativeIndex);
     }
 
+    // cursorKind/cursorIndex identify the scheduling context for look-ahead observations.
+    // They deliberately distinguish rule-root, left-recursive seed, and nested alternation
+    // attempts so conservative negative look-ahead reuse cannot cross parser-shape boundaries.
     private ParseNode? TryParseScheduledAlternatives(
         ParseContext context,
         IEnumerable<Alternative> alternatives,
@@ -651,8 +654,7 @@ public sealed class ParserEngine
                 var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, alternativeIndex, precedence, cursorKind, cursorIndex);
                 var allowNegativeShortcut =
                     diagnostics is null
-                    && (cursorKind == "rule-root"
-                        || cursorKind == "left-recursive-seed");
+                    && ScheduledAlternativeCursorKinds.AllowsNegativeLookaheadShortcut(cursorKind);
                 var token = context.Peek();
                 if (allowNegativeShortcut
                     && _lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead)

--- a/Utils.Parser/Runtime/ParserLookaheadKey.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadKey.cs
@@ -1,7 +1,8 @@
 namespace Utils.Parser.Runtime;
 
 /// <summary>
-/// Identifies a scheduled alternative look-ahead observation for a parser rule at a specific input position.
+/// Identifies a scheduled alternative look-ahead observation for a parser rule
+/// at a specific input position and scheduling cursor context.
 /// </summary>
 internal readonly record struct ParserLookaheadKey(
     string RuleName,

--- a/Utils.Parser/Runtime/ScheduledAlternativeCursorKinds.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeCursorKinds.cs
@@ -1,0 +1,23 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Defines scheduled alternative cursor identity values used by parser look-ahead observations.
+/// </summary>
+internal static class ScheduledAlternativeCursorKinds
+{
+    public const string RuleRoot = "rule-root";
+
+    public const string LeftRecursiveSeed = "left-recursive-seed";
+
+    public const string Alternation = "alternation";
+
+    /// <summary>
+    /// Returns <c>true</c> when the cursor kind supports conservative negative look-ahead shortcut reuse.
+    /// </summary>
+    /// <param name="cursorKind">Scheduled alternative cursor identity.</param>
+    public static bool AllowsNegativeLookaheadShortcut(string cursorKind)
+    {
+        return cursorKind == RuleRoot
+            || cursorKind == LeftRecursiveSeed;
+    }
+}

--- a/UtilsTest/Parser/ParserLookaheadCacheTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadCacheTests.cs
@@ -14,7 +14,7 @@ public class ParserLookaheadCacheTests
     public void ParserLookaheadCache_StoresAndRetrievesResult()
     {
         var cache = new ParserLookaheadCache();
-        var key = new ParserLookaheadKey("root", 0, 0, 0, "rule-root", -1);
+        var key = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
         var expected = new ParserLookaheadResult(false, "ID", "id");
 
         Assert.IsTrue(cache.TryAdd(key, expected));
@@ -26,8 +26,8 @@ public class ParserLookaheadCacheTests
     public void ParserLookaheadCache_IsolatesByAlternativeIndex()
     {
         var cache = new ParserLookaheadCache();
-        var first = new ParserLookaheadKey("root", 0, 0, 0, "rule-root", -1);
-        var second = new ParserLookaheadKey("root", 0, 1, 0, "rule-root", -1);
+        var first = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
+        var second = new ParserLookaheadKey("root", 0, 1, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
 
         cache.TryAdd(first, new ParserLookaheadResult(false, "ID", "id"));
 
@@ -38,8 +38,8 @@ public class ParserLookaheadCacheTests
     public void ParserLookaheadCache_IsolatesByPrecedence()
     {
         var cache = new ParserLookaheadCache();
-        var lower = new ParserLookaheadKey("root", 0, 0, 0, "rule-root", -1);
-        var higher = new ParserLookaheadKey("root", 0, 0, 1, "rule-root", -1);
+        var lower = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
+        var higher = new ParserLookaheadKey("root", 0, 0, 1, ScheduledAlternativeCursorKinds.RuleRoot, -1);
 
         cache.TryAdd(lower, new ParserLookaheadResult(false, "ID", "id"));
 
@@ -104,12 +104,25 @@ public class ParserLookaheadCacheTests
     public void ParserLookaheadCache_IsolatesByCursorContext()
     {
         var cache = new ParserLookaheadCache();
-        var first = new ParserLookaheadKey("root", 0, 0, 0, "alternation", 1);
-        var second = new ParserLookaheadKey("root", 0, 0, 0, "alternation", 2);
+        var first = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.Alternation, 1);
+        var second = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.Alternation, 2);
 
         cache.TryAdd(first, new ParserLookaheadResult(false, "ID", "id"));
 
         Assert.IsFalse(cache.TryGet(second, out _));
+    }
+
+
+    [TestMethod]
+    public void ParserLookaheadCache_IsolatesRuleRootAndNestedAlternationContexts()
+    {
+        var cache = new ParserLookaheadCache();
+        var ruleRoot = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
+        var nestedAlternation = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.Alternation, -1);
+
+        cache.TryAdd(ruleRoot, new ParserLookaheadResult(false, "ID", "id"));
+
+        Assert.IsFalse(cache.TryGet(nestedAlternation, out _));
     }
 
     [TestMethod]


### PR DESCRIPTION
### Motivation
- Remove fragile magic string usage for scheduled alternative cursor identities to make look-ahead key semantics explicit and safer for future look-ahead work. 
- Centralize the rule that limits conservative negative look-ahead shortcut reuse to the same, narrowly constrained contexts to avoid accidental scope expansion.

### Description
- Added an internal helper `ScheduledAlternativeCursorKinds` with constants `RuleRoot`, `LeftRecursiveSeed`, and `Alternation` and a helper `AllowsNegativeLookaheadShortcut` to centralize identity and shortcut eligibility. 
- Replaced raw cursor-kind string literals in `ParserEngine` with the new constants and swapped the inline negative-shortcut check for `ScheduledAlternativeCursorKinds.AllowsNegativeLookaheadShortcut(...)`. 
- Added a concise comment near `TryParseScheduledAlternatives(...)` documenting the meaning of `cursorKind` and `cursorIndex` as scheduling context boundaries. 
- Clarified the XML summary on `ParserLookaheadKey` to state the key includes the scheduling cursor context. 
- Updated `Utils.Parser/README.md` to explicitly mention that the scheduled alternative cursor context is part of the cache key. 
- Updated look-ahead cache tests to use the new constants and added `ParserLookaheadCache_IsolatesRuleRootAndNestedAlternationContexts` to assert that rule-root and alternation contexts do not collide.

### Testing
- Ran `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~UtilsTest.Parser.ParserLookaheadCacheTests"`, which passed (9 tests passed). 
- Ran `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~UtilsTest.Parser"`, which passed (352 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc00be899c8326829072b459d521e9)