### PR TITLE
Extract scheduled alternative execution helper from ParserEngine

### DIFF
--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -31,12 +31,14 @@ public sealed class ParserEngine
     private readonly ParserStateRegistry _stateRegistry = new();
     private readonly AlternativeScheduler _alternativeScheduler;
     private readonly ParserLookaheadCache _lookaheadCache = new();
+    private readonly ScheduledAlternativeExecutor _scheduledAlternativeExecutor;
 
     public ParserEngine(ParserDefinition definition)
     {
         _definition = definition ?? throw new ArgumentNullException(nameof(definition));
         _caseInsensitive = IsCaseInsensitive(_definition);
         _alternativeScheduler = new AlternativeScheduler();
+        _scheduledAlternativeExecutor = new ScheduledAlternativeExecutor(_stateRegistry, _lookaheadCache);
     }
 
     /// <summary>
@@ -641,67 +643,20 @@ public sealed class ParserEngine
             startPosition,
             precedence,
             diagnostics,
-            parseAlternative: (alternative, alternativeIndex) =>
-            {
-                var stateKey = new ParserStateKey(rule.Name, startPosition, alternativeIndex, alternativeIndex, precedence);
-                _stateRegistry.TryEnterState(stateKey);
-
-                if (!CheckPrecedence(alternative, precedence))
-                {
-                    return null;
-                }
-
-                var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, alternativeIndex, precedence, cursorKind, cursorIndex);
-                var allowNegativeShortcut =
-                    diagnostics is null
-                    && ScheduledAlternativeCursorKinds.AllowsNegativeLookaheadShortcut(cursorKind);
-                var token = context.Peek();
-                if (allowNegativeShortcut
-                    && _lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead)
-                    && !cachedLookahead.CanStart)
-                {
-                    return null;
-                }
-
-                var savedPosition = context.SavePosition();
-                var result = TryParseContent(context, alternative.Content, rule, precedence, alternativeIndex, alternativeIndex, diagnostics);
-                if (result is null)
-                {
-                    var consumed = context.Position > savedPosition;
-                    if (allowNegativeShortcut
-                        && !consumed
-                        && !ContainsPredicateOrAction(alternative.Content))
-                    {
-                        _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(false, token?.RuleName, token?.Text));
-                    }
-
-                    var diagnosticSpan = ResolveDiagnosticSpan(context);
-                    diagnostics?.AddWithContext(ParserDiagnostics.BacktrackingUsed, diagnosticSpan.Start, diagnosticSpan.Length, rule.Name, null, rule.Name);
-                    context.RestorePosition(savedPosition);
-                    return null;
-                }
-
-                _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(true, token?.RuleName, token?.Text));
-
-                var state = new ActiveParseState
-                {
-                    Rule = rule,
-                    Alternative = alternative,
-                    OriginInputPosition = startPosition,
-                    CurrentInputPosition = context.Position,
-                    AlternativeIndex = alternativeIndex,
-                    Cursor = new RuleContentCursor { Index = 0, Kind = "alternative-root" },
-                    PartialNode = result,
-                    EndPosition = context.Position,
-                    Status = ActiveParseStateStatus.Completed,
-                    ParentStateKey = null,
-                    Depth = 0,
-                    Continuation = null
-                };
-
-                context.RestorePosition(savedPosition);
-                return state;
-            });
+            parseAlternative: (alternative, alternativeIndex) => _scheduledAlternativeExecutor.Execute(
+                context,
+                rule,
+                alternative,
+                alternativeIndex,
+                startPosition,
+                precedence,
+                cursorKind,
+                cursorIndex,
+                diagnostics,
+                checkPrecedence: candidate => CheckPrecedence(candidate, precedence),
+                containsPredicateOrAction: ContainsPredicateOrAction,
+                resolveDiagnosticSpan: ResolveDiagnosticSpan,
+                parseAlternative: candidate => TryParseContent(context, candidate.Content, rule, precedence, alternativeIndex, alternativeIndex, diagnostics)));
 
         if (scheduling.SelectedState is null)
         {

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
@@ -1,0 +1,101 @@
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Model;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Executes a single scheduled alternative attempt while keeping parser semantics
+/// in runtime components owned by <see cref="ParserEngine"/>.
+/// </summary>
+internal sealed class ScheduledAlternativeExecutor
+{
+    private readonly ParserStateRegistry _stateRegistry;
+    private readonly ParserLookaheadCache _lookaheadCache;
+
+    /// <summary>
+    /// Creates an executor bound to parser runtime registries.
+    /// </summary>
+    public ScheduledAlternativeExecutor(ParserStateRegistry stateRegistry, ParserLookaheadCache lookaheadCache)
+    {
+        _stateRegistry = stateRegistry;
+        _lookaheadCache = lookaheadCache;
+    }
+
+    /// <summary>
+    /// Executes one alternative from the scheduler and returns a completed parse state when successful.
+    /// </summary>
+    public ActiveParseState? Execute(
+        ParseContext context,
+        Rule rule,
+        Alternative alternative,
+        int alternativeIndex,
+        int startPosition,
+        int precedence,
+        string cursorKind,
+        int cursorIndex,
+        DiagnosticBag? diagnostics,
+        Func<Alternative, bool> checkPrecedence,
+        Func<RuleContent, bool> containsPredicateOrAction,
+        Func<ParseContext, (int? Start, int? Length)> resolveDiagnosticSpan,
+        Func<Alternative, ParseNode?> parseAlternative)
+    {
+        var stateKey = new ParserStateKey(rule.Name, startPosition, alternativeIndex, alternativeIndex, precedence);
+        _stateRegistry.TryEnterState(stateKey);
+
+        if (!checkPrecedence(alternative))
+        {
+            return null;
+        }
+
+        var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, alternativeIndex, precedence, cursorKind, cursorIndex);
+        var allowNegativeShortcut =
+            diagnostics is null
+            && ScheduledAlternativeCursorKinds.AllowsNegativeLookaheadShortcut(cursorKind);
+        var token = context.Peek();
+        if (allowNegativeShortcut
+            && _lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead)
+            && !cachedLookahead.CanStart)
+        {
+            return null;
+        }
+
+        var savedPosition = context.SavePosition();
+        var result = parseAlternative(alternative);
+        if (result is null)
+        {
+            var consumed = context.Position > savedPosition;
+            if (allowNegativeShortcut
+                && !consumed
+                && !containsPredicateOrAction(alternative.Content))
+            {
+                _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(false, token?.RuleName, token?.Text));
+            }
+
+            var diagnosticSpan = resolveDiagnosticSpan(context);
+            diagnostics?.AddWithContext(ParserDiagnostics.BacktrackingUsed, diagnosticSpan.Start, diagnosticSpan.Length, rule.Name, null, rule.Name);
+            context.RestorePosition(savedPosition);
+            return null;
+        }
+
+        _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(true, token?.RuleName, token?.Text));
+
+        var state = new ActiveParseState
+        {
+            Rule = rule,
+            Alternative = alternative,
+            OriginInputPosition = startPosition,
+            CurrentInputPosition = context.Position,
+            AlternativeIndex = alternativeIndex,
+            Cursor = new RuleContentCursor { Index = 0, Kind = "alternative-root" },
+            PartialNode = result,
+            EndPosition = context.Position,
+            Status = ActiveParseStateStatus.Completed,
+            ParentStateKey = null,
+            Depth = 0,
+            Continuation = null
+        };
+
+        context.RestorePosition(savedPosition);
+        return state;
+    }
+}

--- a/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
+++ b/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Model;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ScheduledAlternativeExecutorTests
+{
+    [TestMethod]
+    public void Execute_UsesNegativeShortcutForRuleRootWhenDiagnosticsAreNull()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache);
+        var rule = CreateRule();
+        var alternative = rule.Content.Alternatives[0];
+        var context = new ParseContext([]);
+        var attemptCount = 0;
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.RuleRoot,
+            cursorIndex: -1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.RuleRoot,
+            cursorIndex: -1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        Assert.AreEqual(1, attemptCount);
+    }
+
+    [TestMethod]
+    public void Execute_DoesNotUseNegativeShortcutForNestedAlternation()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache);
+        var rule = CreateRule();
+        var alternative = rule.Content.Alternatives[0];
+        var context = new ParseContext([]);
+        var attemptCount = 0;
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.Alternation,
+            cursorIndex: 1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.Alternation,
+            cursorIndex: 1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        Assert.AreEqual(2, attemptCount);
+    }
+
+    private static Rule CreateRule()
+    {
+        return new Rule("root", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"), null)
+        ]));
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce concentrated complexity and technical debt inside `ParserEngine.TryParseScheduledAlternatives(...)` by isolating the alternative execution responsibilities. 
- Preserve the existing parser architecture and deterministic sequential behavior while making the execution logic easier to audit and maintain for future shared look-ahead / continuation work.

### Description
- Added a new internal helper `Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs` which owns state-key registration, precedence gating, look-ahead keying/negative-shortcut checks, save/restore handling, alternative parse invocation, look-ahead cache writes, `BacktrackingUsed` diagnostics, and `ActiveParseState` construction. 
- Simplified `ParserEngine` by adding a `_scheduledAlternativeExecutor` field and delegating per-alternative execution inside `TryParseScheduledAlternatives(...)` to `_scheduledAlternativeExecutor.Execute(...)`, keeping `AlternativeScheduler` responsible for orchestration only. 
- Added focused unit tests `UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs` that validate the negative look-ahead shortcut scope (enabled for `rule-root` when diagnostics are null and disabled for nested alternation contexts). 
- No public API changes, no async/parallel/thread-safety changes, and no change to scheduling semantics or diagnostics ordering were introduced.

### Testing
- Ran parser-focused tests with `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~UtilsTest.Parser"`. 
- Test result: all parser tests passed as part of the filtered run (`Passed: 354, Failed: 0`). 
- The new `ScheduledAlternativeExecutorTests` were included in the run and succeeded (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc0428891c832683c467cb50401ac8)