### PR TITLE
Introduce structured look-ahead probing for scheduled alternatives

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -81,7 +81,7 @@ This layer is now orchestrated by an internal `AlternativeScheduler` that execut
   alternative evaluation, continuation-driven orchestration, pruning strategies),
   without enabling parallel parsing at this stage.
 - `ParserEngine` also keeps an internal look-ahead cache keyed by rule name, origin position, alternative index, minimum precedence, and alternation cursor context.
-- The cache stores lightweight start observations only (can-start flag + first token snapshot), does not store parse trees, does not replace `ParserStateRegistry`, and does not change alternative selection semantics.
+- The cache stores lightweight structured look-ahead probe observations only (immediate reject vs requires parse, plus first token snapshot), does not store parse trees, does not replace `ParserStateRegistry`, and does not change alternative selection semantics.
 - The current implementation only applies negative shortcut reuse to top-level rule alternative scheduling and left-recursive seed scheduling. Nested alternations are intentionally excluded in this step to preserve diagnostic stability and keep the optimization conservative.
 - The scheduled alternative cursor context is part of the cache key so observations cannot be reused across different parser-shape positions, such as a rule-root choice and a nested alternation.
 - Execution remains sequential: no parallel alternative parsing, no continuation queue, and no shared look-ahead graph in this step.

--- a/Utils.Parser/Runtime/ParserLookaheadCache.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadCache.cs
@@ -5,7 +5,7 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class ParserLookaheadCache
 {
-    private readonly Dictionary<ParserLookaheadKey, ParserLookaheadResult> _results = [];
+    private readonly Dictionary<ParserLookaheadKey, ParserLookaheadProbeResult> _results = [];
 
     /// <summary>
     /// Clears all cached look-ahead observations.
@@ -18,7 +18,7 @@ internal sealed class ParserLookaheadCache
     /// <summary>
     /// Tries to get a cached look-ahead observation for the provided key.
     /// </summary>
-    public bool TryGet(ParserLookaheadKey key, out ParserLookaheadResult result)
+    public bool TryGet(ParserLookaheadKey key, out ParserLookaheadProbeResult result)
     {
         return _results.TryGetValue(key, out result);
     }
@@ -26,7 +26,7 @@ internal sealed class ParserLookaheadCache
     /// <summary>
     /// Adds a look-ahead observation when no value exists for the same key.
     /// </summary>
-    public bool TryAdd(ParserLookaheadKey key, ParserLookaheadResult result)
+    public bool TryAdd(ParserLookaheadKey key, ParserLookaheadProbeResult result)
     {
         if (_results.ContainsKey(key))
         {

--- a/Utils.Parser/Runtime/ParserLookaheadProbeKind.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbeKind.cs
@@ -1,0 +1,22 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Describes the outcome of a lightweight look-ahead probe for a scheduled alternative.
+/// </summary>
+internal enum ParserLookaheadProbeKind
+{
+    /// <summary>
+    /// Probe outcome is unknown.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The alternative is known to be impossible to start without consuming input.
+    /// </summary>
+    ImmediateReject,
+
+    /// <summary>
+    /// The alternative may start and requires an actual parse attempt.
+    /// </summary>
+    RequiresParse
+}

--- a/Utils.Parser/Runtime/ParserLookaheadProbeResult.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbeResult.cs
@@ -1,0 +1,9 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Stores a lightweight structured look-ahead probe observation for a scheduled alternative start attempt.
+/// </summary>
+internal readonly record struct ParserLookaheadProbeResult(
+    ParserLookaheadProbeKind Kind,
+    string? TokenRuleName,
+    string? TokenText);

--- a/Utils.Parser/Runtime/ParserLookaheadResult.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadResult.cs
@@ -1,9 +1,0 @@
-namespace Utils.Parser.Runtime;
-
-/// <summary>
-/// Stores a lightweight look-ahead observation for a scheduled alternative start attempt.
-/// </summary>
-internal readonly record struct ParserLookaheadResult(
-    bool CanStart,
-    string? TokenRuleName,
-    string? TokenText);

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
@@ -54,7 +54,7 @@ internal sealed class ScheduledAlternativeExecutor
         var token = context.Peek();
         if (allowNegativeShortcut
             && _lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead)
-            && !cachedLookahead.CanStart)
+            && cachedLookahead.Kind == ParserLookaheadProbeKind.ImmediateReject)
         {
             return null;
         }
@@ -68,7 +68,12 @@ internal sealed class ScheduledAlternativeExecutor
                 && !consumed
                 && !containsPredicateOrAction(alternative.Content))
             {
-                _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(false, token?.RuleName, token?.Text));
+                _lookaheadCache.TryAdd(
+                    lookaheadKey,
+                    new ParserLookaheadProbeResult(
+                        ParserLookaheadProbeKind.ImmediateReject,
+                        token?.RuleName,
+                        token?.Text));
             }
 
             var diagnosticSpan = resolveDiagnosticSpan(context);
@@ -77,7 +82,12 @@ internal sealed class ScheduledAlternativeExecutor
             return null;
         }
 
-        _lookaheadCache.TryAdd(lookaheadKey, new ParserLookaheadResult(true, token?.RuleName, token?.Text));
+        _lookaheadCache.TryAdd(
+            lookaheadKey,
+            new ParserLookaheadProbeResult(
+                ParserLookaheadProbeKind.RequiresParse,
+                token?.RuleName,
+                token?.Text));
 
         var state = new ActiveParseState
         {

--- a/UtilsTest/Parser/ParserLookaheadCacheTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadCacheTests.cs
@@ -15,7 +15,7 @@ public class ParserLookaheadCacheTests
     {
         var cache = new ParserLookaheadCache();
         var key = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
-        var expected = new ParserLookaheadResult(false, "ID", "id");
+        var expected = new ParserLookaheadProbeResult(ParserLookaheadProbeKind.ImmediateReject, "ID", "id");
 
         Assert.IsTrue(cache.TryAdd(key, expected));
         Assert.IsTrue(cache.TryGet(key, out var actual));
@@ -29,7 +29,7 @@ public class ParserLookaheadCacheTests
         var first = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
         var second = new ParserLookaheadKey("root", 0, 1, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
 
-        cache.TryAdd(first, new ParserLookaheadResult(false, "ID", "id"));
+        cache.TryAdd(first, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.ImmediateReject, "ID", "id"));
 
         Assert.IsFalse(cache.TryGet(second, out _));
     }
@@ -41,7 +41,7 @@ public class ParserLookaheadCacheTests
         var lower = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
         var higher = new ParserLookaheadKey("root", 0, 0, 1, ScheduledAlternativeCursorKinds.RuleRoot, -1);
 
-        cache.TryAdd(lower, new ParserLookaheadResult(false, "ID", "id"));
+        cache.TryAdd(lower, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.ImmediateReject, "ID", "id"));
 
         Assert.IsFalse(cache.TryGet(higher, out _));
     }
@@ -107,7 +107,7 @@ public class ParserLookaheadCacheTests
         var first = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.Alternation, 1);
         var second = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.Alternation, 2);
 
-        cache.TryAdd(first, new ParserLookaheadResult(false, "ID", "id"));
+        cache.TryAdd(first, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.ImmediateReject, "ID", "id"));
 
         Assert.IsFalse(cache.TryGet(second, out _));
     }
@@ -120,9 +120,33 @@ public class ParserLookaheadCacheTests
         var ruleRoot = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
         var nestedAlternation = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.Alternation, -1);
 
-        cache.TryAdd(ruleRoot, new ParserLookaheadResult(false, "ID", "id"));
+        cache.TryAdd(ruleRoot, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.ImmediateReject, "ID", "id"));
 
         Assert.IsFalse(cache.TryGet(nestedAlternation, out _));
+    }
+
+    [TestMethod]
+    public void ParserLookaheadProbeResult_StoresImmediateReject()
+    {
+        var cache = new ParserLookaheadCache();
+        var key = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
+        var expected = new ParserLookaheadProbeResult(ParserLookaheadProbeKind.ImmediateReject, "ID", "id");
+
+        Assert.IsTrue(cache.TryAdd(key, expected));
+        Assert.IsTrue(cache.TryGet(key, out var actual));
+        Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, actual.Kind);
+    }
+
+    [TestMethod]
+    public void ParserLookaheadProbeResult_StoresRequiresParse()
+    {
+        var cache = new ParserLookaheadCache();
+        var key = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
+        var expected = new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id");
+
+        Assert.IsTrue(cache.TryAdd(key, expected));
+        Assert.IsTrue(cache.TryGet(key, out var actual));
+        Assert.AreEqual(ParserLookaheadProbeKind.RequiresParse, actual.Kind);
     }
 
     [TestMethod]

--- a/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
+++ b/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
@@ -111,6 +111,76 @@ public class ScheduledAlternativeExecutorTests
         Assert.AreEqual(2, attemptCount);
     }
 
+    [TestMethod]
+    public void Execute_UsesImmediateRejectShortcutOnly()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache);
+        var rule = CreateRule();
+        var alternative = rule.Content.Alternatives[0];
+        var context = new ParseContext([]);
+        var lookaheadKey = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
+        cache.TryAdd(lookaheadKey, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.ImmediateReject, null, null));
+        var attemptCount = 0;
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.RuleRoot,
+            cursorIndex: -1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        Assert.AreEqual(0, attemptCount);
+    }
+
+    [TestMethod]
+    public void Execute_DoesNotSkipRequiresParse()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache);
+        var rule = CreateRule();
+        var alternative = rule.Content.Alternatives[0];
+        var context = new ParseContext([]);
+        var lookaheadKey = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
+        cache.TryAdd(lookaheadKey, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, null, null));
+        var attemptCount = 0;
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.RuleRoot,
+            cursorIndex: -1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        Assert.AreEqual(1, attemptCount);
+    }
+
     private static Rule CreateRule()
     {
         return new Rule("root", 0, false, new Alternation([


### PR DESCRIPTION
### Motivation
- Replace the coarse boolean look-ahead observation with a structured, extensible probe model to enable richer future look-ahead work while preserving current behavior. 
- Keep the change conservative so it does not alter parser semantics, scheduling, diagnostics, or public APIs.

### Description
- Add `ParserLookaheadProbeKind` (`Unknown`, `ImmediateReject`, `RequiresParse`) and `ParserLookaheadProbeResult` as a structured probe representation stored in the look-ahead cache. 
- Replace `ParserLookaheadResult` usage with `ParserLookaheadProbeResult` in `ParserLookaheadCache` and `ScheduledAlternativeExecutor`, recording `ImmediateReject` for conservative non-consuming failures and `RequiresParse` for successful-start observations. 
- Update `ScheduledAlternativeExecutor` negative-shortcut check to only skip when the cached probe `Kind` equals `ImmediateReject`, preserving the existing negative shortcut scope and diagnostics behavior. 
- Update tests and README text: modify `ParserLookaheadCacheTests` and `ScheduledAlternativeExecutorTests` to assert probe kinds and added focused executor tests, and change README wording from the boolean "CanStart" phrasing to "structured look-ahead probe observations".

### Testing
- Updated and added unit tests in `UtilsTest/Parser`: `ParserLookaheadCacheTests` (store/retrieve probe kinds) and `ScheduledAlternativeExecutorTests` (added `Execute_UsesImmediateRejectShortcutOnly` and `Execute_DoesNotSkipRequiresParse`) and preserved existing parser tests. 
- Ran parser-focused test subset with `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~UtilsTest.Parser"` and observed all tests passed (`Passed: 358, Failed: 0`). 
- No behavioral or public API changes were observed during tests and diagnostics coverage remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc06f36cc0832691baca9908f014b1)