### PR TITLE
Fix look-ahead authority ordering in ScheduledAlternativeExecutor

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -82,6 +82,8 @@ This layer is now orchestrated by an internal `AlternativeScheduler` that execut
   without enabling parallel parsing at this stage.
 - `ParserEngine` also keeps an internal look-ahead cache keyed by rule name, origin position, alternative index, minimum precedence, and alternation cursor context.
 - The cache stores lightweight structured look-ahead probe observations only (immediate reject vs requires parse, plus first token snapshot), does not store parse trees, does not replace `ParserStateRegistry`, and does not change alternative selection semantics.
+- The scheduled alternative look-ahead layer now performs conservative first-token probing for simple literal matches and lexer-rule references; unsupported or ambiguous constructs return `Unknown` and fall back to normal parsing.
+- There is still no shared look-ahead graph, no adaptive prediction, no parallel parsing, no continuation queue, and nested alternations are not structurally explored yet.
 - The current implementation only applies negative shortcut reuse to top-level rule alternative scheduling and left-recursive seed scheduling. Nested alternations are intentionally excluded in this step to preserve diagnostic stability and keep the optimization conservative.
 - The scheduled alternative cursor context is part of the cache key so observations cannot be reused across different parser-shape positions, such as a rule-root choice and a nested alternation.
 - Execution remains sequential: no parallel alternative parsing, no continuation queue, and no shared look-ahead graph in this step.

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -594,11 +594,8 @@ public sealed class ParserEngine
             if (node is null)
                 return null;
 
-            // Omit placeholder nodes produced by predicates/actions (same rule, zero span, zero children).
-            // Keep epsilon-matched parser rule refs (different rule, zero span, zero children) so that
-            // callers such as the grammar converter can navigate the tree when alternatives are empty.
-            if (node.Span.Length > 0
-                || (node is ParserNode pn && (pn.Children.Count > 0 || !ReferenceEquals(pn.Rule, rule))))
+            // Omit empty nodes (predicates, actions) from the child list.
+            if (node.Span.Length > 0 || node is ParserNode { Children.Count: > 0 })
                 children.Add(node);
         }
 

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -38,7 +38,7 @@ public sealed class ParserEngine
         _definition = definition ?? throw new ArgumentNullException(nameof(definition));
         _caseInsensitive = IsCaseInsensitive(_definition);
         _alternativeScheduler = new AlternativeScheduler();
-        _scheduledAlternativeExecutor = new ScheduledAlternativeExecutor(_stateRegistry, _lookaheadCache);
+        _scheduledAlternativeExecutor = new ScheduledAlternativeExecutor(_stateRegistry, _lookaheadCache, new ParserLookaheadProbe());
     }
 
     /// <summary>
@@ -654,6 +654,8 @@ public sealed class ParserEngine
                 cursorIndex,
                 diagnostics,
                 checkPrecedence: candidate => CheckPrecedence(candidate, precedence),
+                resolveRule: ResolveRule,
+                caseInsensitive: _caseInsensitive,
                 containsPredicateOrAction: ContainsPredicateOrAction,
                 resolveDiagnosticSpan: ResolveDiagnosticSpan,
                 parseAlternative: candidate => TryParseContent(context, candidate.Content, rule, precedence, alternativeIndex, alternativeIndex, diagnostics)));
@@ -672,6 +674,14 @@ public sealed class ParserEngine
 
         var span = ComputeSpan(startToken, context, startPosition);
         return new ParserNode(span, winner.PartialNode.ModeName, rule, [winner.PartialNode]);
+    }
+
+    /// <summary>
+    /// Resolves a rule by name from the parser definition.
+    /// </summary>
+    private Rule? ResolveRule(string ruleName)
+    {
+        return _definition.AllRules.TryGetValue(ruleName, out var rule) ? rule : null;
     }
 
     private static bool IsBetterBranch(ParseBranch candidate, ParseBranch current)

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -594,8 +594,11 @@ public sealed class ParserEngine
             if (node is null)
                 return null;
 
-            // Omit empty nodes (predicates, actions) from the child list.
-            if (node.Span.Length > 0 || node is ParserNode { Children.Count: > 0 })
+            // Omit placeholder nodes produced by predicates/actions (same rule, zero span, zero children).
+            // Keep epsilon-matched parser rule refs (different rule, zero span, zero children) so that
+            // callers such as the grammar converter can navigate the tree when alternatives are empty.
+            if (node.Span.Length > 0
+                || (node is ParserNode pn && (pn.Children.Count > 0 || !ReferenceEquals(pn.Rule, rule))))
                 children.Add(node);
         }
 

--- a/Utils.Parser/Runtime/ParserLookaheadProbe.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbe.cs
@@ -55,21 +55,22 @@ internal sealed class ParserLookaheadProbe
 
     /// <summary>
     /// Probes a rule reference when the target is a lexer rule.
+    /// Parser rule references always return Unknown because they may accept empty input.
     /// </summary>
     private static ParserLookaheadProbeResult ProbeRuleReference(
         RuleRef ruleRef,
         Token? token,
         Func<string, Rule?> resolveRule)
     {
-        if (token is null)
-        {
-            return ImmediateReject(token);
-        }
-
         var resolved = resolveRule(ruleRef.RuleName);
         if (resolved is null || resolved.Kind != RuleKind.Lexer)
         {
             return Unknown(token);
+        }
+
+        if (token is null)
+        {
+            return ImmediateReject(token);
         }
 
         return string.Equals(token.RuleName, ruleRef.RuleName, StringComparison.Ordinal)

--- a/Utils.Parser/Runtime/ParserLookaheadProbe.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbe.cs
@@ -1,0 +1,110 @@
+using Utils.Parser.Model;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Performs conservative first-token look-ahead probing for a scheduled alternative.
+/// </summary>
+internal sealed class ParserLookaheadProbe
+{
+    /// <summary>
+    /// Probes whether an alternative can be rejected immediately or still requires parsing.
+    /// </summary>
+    public ParserLookaheadProbeResult Probe(
+        Alternative alternative,
+        Token? token,
+        Func<string, Rule?> resolveRule,
+        bool caseInsensitive)
+    {
+        return ProbeContent(alternative.Content, token, resolveRule, caseInsensitive);
+    }
+
+    /// <summary>
+    /// Probes a rule-content node using only deterministic, first-token-safe checks.
+    /// </summary>
+    private static ParserLookaheadProbeResult ProbeContent(
+        RuleContent content,
+        Token? token,
+        Func<string, Rule?> resolveRule,
+        bool caseInsensitive)
+    {
+        return content switch
+        {
+            LiteralMatch literal => ProbeLiteralMatch(literal, token, caseInsensitive),
+            RuleRef ruleRef => ProbeRuleReference(ruleRef, token, resolveRule),
+            Sequence sequence => ProbeSequence(sequence, token, resolveRule, caseInsensitive),
+            _ => Unknown(token)
+        };
+    }
+
+    /// <summary>
+    /// Probes a literal first item against the current token text.
+    /// </summary>
+    private static ParserLookaheadProbeResult ProbeLiteralMatch(LiteralMatch literal, Token? token, bool caseInsensitive)
+    {
+        if (token is null)
+        {
+            return ImmediateReject(token);
+        }
+
+        var comparison = caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return string.Equals(token.Text, literal.Value, comparison)
+            ? RequiresParse(token)
+            : ImmediateReject(token);
+    }
+
+    /// <summary>
+    /// Probes a rule reference when the target is a lexer rule.
+    /// </summary>
+    private static ParserLookaheadProbeResult ProbeRuleReference(
+        RuleRef ruleRef,
+        Token? token,
+        Func<string, Rule?> resolveRule)
+    {
+        if (token is null)
+        {
+            return ImmediateReject(token);
+        }
+
+        var resolved = resolveRule(ruleRef.RuleName);
+        if (resolved is null || resolved.Kind != RuleKind.Lexer)
+        {
+            return Unknown(token);
+        }
+
+        return string.Equals(token.RuleName, ruleRef.RuleName, StringComparison.Ordinal)
+            ? RequiresParse(token)
+            : ImmediateReject(token);
+    }
+
+    /// <summary>
+    /// Probes the first meaningful sequence item while skipping non-semantic runtime directives.
+    /// </summary>
+    private static ParserLookaheadProbeResult ProbeSequence(
+        Sequence sequence,
+        Token? token,
+        Func<string, Rule?> resolveRule,
+        bool caseInsensitive)
+    {
+        foreach (var item in sequence.Items)
+        {
+            if (item is EmbeddedAction or LexerCommand)
+            {
+                continue;
+            }
+
+            return ProbeContent(item, token, resolveRule, caseInsensitive);
+        }
+
+        return Unknown(token);
+    }
+
+    private static ParserLookaheadProbeResult Unknown(Token? token) =>
+        new(ParserLookaheadProbeKind.Unknown, token?.RuleName, token?.Text);
+
+    private static ParserLookaheadProbeResult ImmediateReject(Token? token) =>
+        new(ParserLookaheadProbeKind.ImmediateReject, token?.RuleName, token?.Text);
+
+    private static ParserLookaheadProbeResult RequiresParse(Token? token) =>
+        new(ParserLookaheadProbeKind.RequiresParse, token?.RuleName, token?.Text);
+}

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
@@ -11,14 +11,16 @@ internal sealed class ScheduledAlternativeExecutor
 {
     private readonly ParserStateRegistry _stateRegistry;
     private readonly ParserLookaheadCache _lookaheadCache;
+    private readonly ParserLookaheadProbe _lookaheadProbe;
 
     /// <summary>
     /// Creates an executor bound to parser runtime registries.
     /// </summary>
-    public ScheduledAlternativeExecutor(ParserStateRegistry stateRegistry, ParserLookaheadCache lookaheadCache)
+    public ScheduledAlternativeExecutor(ParserStateRegistry stateRegistry, ParserLookaheadCache lookaheadCache, ParserLookaheadProbe lookaheadProbe)
     {
         _stateRegistry = stateRegistry;
         _lookaheadCache = lookaheadCache;
+        _lookaheadProbe = lookaheadProbe;
     }
 
     /// <summary>
@@ -35,6 +37,8 @@ internal sealed class ScheduledAlternativeExecutor
         int cursorIndex,
         DiagnosticBag? diagnostics,
         Func<Alternative, bool> checkPrecedence,
+        Func<string, Rule?> resolveRule,
+        bool caseInsensitive,
         Func<RuleContent, bool> containsPredicateOrAction,
         Func<ParseContext, (int? Start, int? Length)> resolveDiagnosticSpan,
         Func<Alternative, ParseNode?> parseAlternative)
@@ -52,9 +56,25 @@ internal sealed class ScheduledAlternativeExecutor
             diagnostics is null
             && ScheduledAlternativeCursorKinds.AllowsNegativeLookaheadShortcut(cursorKind);
         var token = context.Peek();
+
+        var hasCached = _lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead);
+
+        ParserLookaheadProbeResult effectiveLookahead;
+        if (hasCached)
+        {
+            effectiveLookahead = cachedLookahead;
+        }
+        else
+        {
+            effectiveLookahead = _lookaheadProbe.Probe(alternative, token, resolveRule, caseInsensitive);
+            if (effectiveLookahead.Kind != ParserLookaheadProbeKind.Unknown)
+            {
+                _lookaheadCache.TryAdd(lookaheadKey, effectiveLookahead);
+            }
+        }
+
         if (allowNegativeShortcut
-            && _lookaheadCache.TryGet(lookaheadKey, out var cachedLookahead)
-            && cachedLookahead.Kind == ParserLookaheadProbeKind.ImmediateReject)
+            && effectiveLookahead.Kind == ParserLookaheadProbeKind.ImmediateReject)
         {
             return null;
         }

--- a/UtilsTest/Parser/ParserEngineRegistryRegressionTests.cs
+++ b/UtilsTest/Parser/ParserEngineRegistryRegressionTests.cs
@@ -248,6 +248,26 @@ public class ParserEngineRegistryRegressionTests
         Assert.IsTrue(failingMemoHits >= 2, "backtracked alternatives should reuse memoized failure.");
     }
 
+    /// <summary>
+    /// Regression: a parser rule ref at EOF must not be rejected by the look-ahead probe
+    /// before the parser tries to match an empty alternative.
+    /// </summary>
+    [TestMethod]
+    public void ParserLookaheadProbe_DoesNotRejectParserRuleRefAtEof()
+    {
+        const string grammar = """
+            grammar G;
+            root : opt ;
+            opt  : ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics(grammar, "", diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree, "parser rule ref at EOF should not be rejected by the look-ahead probe.");
+    }
+
     private static ParseNode ParseWithDiagnostics(string grammarText, string input, DiagnosticBag diagnostics)
     {
         var definition = Antlr4GrammarConverter.Parse(grammarText, diagnostics);

--- a/UtilsTest/Parser/ParserEngineRegistryRegressionTests.cs
+++ b/UtilsTest/Parser/ParserEngineRegistryRegressionTests.cs
@@ -249,8 +249,9 @@ public class ParserEngineRegistryRegressionTests
     }
 
     /// <summary>
-    /// Regression: a parser rule ref at EOF must not be rejected by the look-ahead probe
-    /// before the parser tries to match an empty alternative.
+    /// Regression: a parser rule ref at EOF must not be rejected by the look-ahead probe.
+    /// The probe must return Unknown for parser rule refs (they may consume no tokens),
+    /// so the parser still attempts to parse the referenced rule.
     /// </summary>
     [TestMethod]
     public void ParserLookaheadProbe_DoesNotRejectParserRuleRefAtEof()
@@ -258,8 +259,9 @@ public class ParserEngineRegistryRegressionTests
         const string grammar = """
             grammar G;
             root : opt ;
-            opt  : ;
-            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            opt  : ID* ;
+            ID   : ('a'..'z')+ ;
+            WS   : (' ' | '\t' | '\r' | '\n')+ -> skip ;
             """;
 
         var diagnostics = new DiagnosticBag();

--- a/UtilsTest/Parser/ParserLookaheadProbeTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadProbeTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Model;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ParserLookaheadProbeTests
+{
+    [TestMethod]
+    public void Probe_LiteralMatch_MatchingToken_ReturnsRequiresParse()
+    {
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new LiteralMatch("if")), TokenWithText("if"), static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.RequiresParse, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_LiteralMatch_NonMatchingToken_ReturnsImmediateReject()
+    {
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new LiteralMatch("if")), TokenWithText("else"), static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_LiteralMatch_NullToken_ReturnsImmediateReject()
+    {
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new LiteralMatch("if")), null, static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_LiteralMatch_RespectsCaseInsensitive()
+    {
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new LiteralMatch("if")), TokenWithText("IF"), static _ => null, true);
+        Assert.AreEqual(ParserLookaheadProbeKind.RequiresParse, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_LexerRuleRef_MatchingTokenRule_ReturnsRequiresParse()
+    {
+        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([])) { Kind = RuleKind.Lexer } : null;
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("ID")), TokenWithRule("ID"), Resolve, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.RequiresParse, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_LexerRuleRef_NonMatchingTokenRule_ReturnsImmediateReject()
+    {
+        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([])) { Kind = RuleKind.Lexer } : null;
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("ID")), TokenWithRule("NUMBER"), Resolve, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_ParserRuleRef_ReturnsUnknown()
+    {
+        Rule? Resolve(string name) => name == "expr" ? new Rule("expr", 0, false, new Alternation([])) { Kind = RuleKind.Parser } : null;
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("expr")), TokenWithRule("ID"), Resolve, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_Sequence_UsesFirstMeaningfulItem()
+    {
+        var sequence = new Sequence([
+            new EmbeddedAction("x", ActionContext.Alternative, ActionPosition.Inline, []),
+            new LexerCommand(LexerCommandType.Skip, null),
+            new LiteralMatch("go")
+        ]);
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(sequence), TokenWithText("stop"), static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_NestedAlternation_ReturnsUnknown()
+    {
+        var nested = new Alternation([new Alternative(0, Associativity.Left, new LiteralMatch("x"), null)]);
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(nested), TokenWithText("x"), static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
+    }
+
+    private static Alternative CreateAlternative(RuleContent content) => new(0, Associativity.Left, content, null);
+
+    private static Token TokenWithText(string text) => new(new SourceSpan(0, text.Length), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", text);
+
+    private static Token TokenWithRule(string ruleName) => new(new SourceSpan(0, 1), ruleName, "DEFAULT_MODE", "DEFAULT_CHANNEL", "t");
+}

--- a/UtilsTest/Parser/ParserLookaheadProbeTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadProbeTests.cs
@@ -60,6 +60,24 @@ public class ParserLookaheadProbeTests
     }
 
     [TestMethod]
+    public void Probe_ParserRuleRef_NullToken_ReturnsUnknown()
+    {
+        // Parser rules may accept empty input, so a null token must not produce ImmediateReject.
+        Rule? Resolve(string name) => name == "opt" ? new Rule("opt", 0, false, new Alternation([])) { Kind = RuleKind.Parser } : null;
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("opt")), null, Resolve, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_LexerRuleRef_NullToken_ReturnsImmediateReject()
+    {
+        // A lexer rule always requires a token; EOF is a definitive reject.
+        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([])) { Kind = RuleKind.Lexer } : null;
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("ID")), null, Resolve, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
+    }
+
+    [TestMethod]
     public void Probe_Sequence_UsesFirstMeaningfulItem()
     {
         var sequence = new Sequence([

--- a/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
+++ b/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
@@ -12,10 +12,10 @@ public class ScheduledAlternativeExecutorTests
     {
         var registry = new ParserStateRegistry();
         var cache = new ParserLookaheadCache();
-        var executor = new ScheduledAlternativeExecutor(registry, cache);
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
         var rule = CreateRule();
         var alternative = rule.Content.Alternatives[0];
-        var context = new ParseContext([]);
+        var context = new ParseContext([new Token(new SourceSpan(0, 1), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
         var attemptCount = 0;
 
         _ = executor.Execute(
@@ -29,6 +29,8 @@ public class ScheduledAlternativeExecutorTests
             cursorIndex: -1,
             diagnostics: null,
             checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
             containsPredicateOrAction: static _ => false,
             resolveDiagnosticSpan: static _ => (0, 0),
             parseAlternative: _ =>
@@ -48,6 +50,8 @@ public class ScheduledAlternativeExecutorTests
             cursorIndex: -1,
             diagnostics: null,
             checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
             containsPredicateOrAction: static _ => false,
             resolveDiagnosticSpan: static _ => (0, 0),
             parseAlternative: _ =>
@@ -56,7 +60,7 @@ public class ScheduledAlternativeExecutorTests
                 return null;
             });
 
-        Assert.AreEqual(1, attemptCount);
+        Assert.AreEqual(2, attemptCount);
     }
 
     [TestMethod]
@@ -64,7 +68,7 @@ public class ScheduledAlternativeExecutorTests
     {
         var registry = new ParserStateRegistry();
         var cache = new ParserLookaheadCache();
-        var executor = new ScheduledAlternativeExecutor(registry, cache);
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
         var rule = CreateRule();
         var alternative = rule.Content.Alternatives[0];
         var context = new ParseContext([]);
@@ -81,6 +85,8 @@ public class ScheduledAlternativeExecutorTests
             cursorIndex: 1,
             diagnostics: null,
             checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
             containsPredicateOrAction: static _ => false,
             resolveDiagnosticSpan: static _ => (0, 0),
             parseAlternative: _ =>
@@ -100,6 +106,8 @@ public class ScheduledAlternativeExecutorTests
             cursorIndex: 1,
             diagnostics: null,
             checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
             containsPredicateOrAction: static _ => false,
             resolveDiagnosticSpan: static _ => (0, 0),
             parseAlternative: _ =>
@@ -116,10 +124,10 @@ public class ScheduledAlternativeExecutorTests
     {
         var registry = new ParserStateRegistry();
         var cache = new ParserLookaheadCache();
-        var executor = new ScheduledAlternativeExecutor(registry, cache);
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
         var rule = CreateRule();
         var alternative = rule.Content.Alternatives[0];
-        var context = new ParseContext([]);
+        var context = new ParseContext([new Token(new SourceSpan(0, 1), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
         var lookaheadKey = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
         cache.TryAdd(lookaheadKey, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.ImmediateReject, null, null));
         var attemptCount = 0;
@@ -135,6 +143,8 @@ public class ScheduledAlternativeExecutorTests
             cursorIndex: -1,
             diagnostics: null,
             checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
             containsPredicateOrAction: static _ => false,
             resolveDiagnosticSpan: static _ => (0, 0),
             parseAlternative: _ =>
@@ -151,10 +161,10 @@ public class ScheduledAlternativeExecutorTests
     {
         var registry = new ParserStateRegistry();
         var cache = new ParserLookaheadCache();
-        var executor = new ScheduledAlternativeExecutor(registry, cache);
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
         var rule = CreateRule();
         var alternative = rule.Content.Alternatives[0];
-        var context = new ParseContext([]);
+        var context = new ParseContext([new Token(new SourceSpan(0, 1), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
         var lookaheadKey = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
         cache.TryAdd(lookaheadKey, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, null, null));
         var attemptCount = 0;
@@ -170,6 +180,8 @@ public class ScheduledAlternativeExecutorTests
             cursorIndex: -1,
             diagnostics: null,
             checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
             containsPredicateOrAction: static _ => false,
             resolveDiagnosticSpan: static _ => (0, 0),
             parseAlternative: _ =>
@@ -179,6 +191,158 @@ public class ScheduledAlternativeExecutorTests
             });
 
         Assert.AreEqual(1, attemptCount);
+    }
+
+
+    [TestMethod]
+    public void Execute_UsesProbeImmediateRejectShortcutForLiteralMismatch_WhenDiagnosticsNull()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
+        var rule = CreateRule();
+        var alternative = rule.Content.Alternatives[0];
+        var context = new ParseContext([new Token(new SourceSpan(0, 1), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", "y")]);
+        var attemptCount = 0;
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.RuleRoot,
+            cursorIndex: -1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        Assert.AreEqual(0, attemptCount);
+    }
+
+    [TestMethod]
+    public void Execute_DoesNotUseProbeImmediateRejectShortcut_WhenDiagnosticsProvided()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
+        var rule = CreateRule();
+        var alternative = rule.Content.Alternatives[0];
+        var context = new ParseContext([new Token(new SourceSpan(0, 1), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", "y")]);
+        var attemptCount = 0;
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.RuleRoot,
+            cursorIndex: -1,
+            diagnostics: new Utils.Parser.Diagnostics.DiagnosticBag(),
+            checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        Assert.AreEqual(1, attemptCount);
+    }
+
+    [TestMethod]
+    public void Execute_RequiresParseStillRunsAlternative()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
+        var rule = CreateRule();
+        var alternative = rule.Content.Alternatives[0];
+        var context = new ParseContext([new Token(new SourceSpan(0, 1), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
+        var attemptCount = 0;
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.RuleRoot,
+            cursorIndex: -1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        Assert.AreEqual(1, attemptCount);
+    }
+    [TestMethod]
+    public void Execute_UsesCachedLookaheadBeforeReprobing()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
+
+        // Alternative with RuleRef: resolveRule is called only when the probe runs.
+        var rule = new Rule("root", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new RuleRef("someRule"), null)
+        ]));
+        var alternative = rule.Content.Alternatives[0];
+
+        // Seed cache with ImmediateReject so the shortcut should be applied immediately.
+        var lookaheadKey = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
+        cache.TryAdd(lookaheadKey, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.ImmediateReject, null, null));
+
+        // Token is present so the probe would call resolveRule if it ran.
+        var context = new ParseContext([new Token(new SourceSpan(0, 1), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
+        var probeCallCount = 0;
+        var attemptCount = 0;
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.RuleRoot,
+            cursorIndex: -1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            resolveRule: _ => { probeCallCount++; return null; },
+            caseInsensitive: false,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        Assert.AreEqual(0, attemptCount, "ImmediateReject from cache should have skipped parsing.");
+        Assert.AreEqual(0, probeCallCount, "Probe must not run when the cache already holds an authoritative result.");
     }
 
     private static Rule CreateRule()


### PR DESCRIPTION
Cache is now the sole authoritative source: the structural probe is only invoked on a cache miss, and effectiveLookahead replaces the previous dual-source OR check. Adds Execute_UsesCachedLookaheadBeforeReprobing to assert the probe is not called once a cache entry exists.