### PR TITLE
Introduce epsilon-aware look-ahead probe classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ builder.QueryString["key"].Add("value");
 Console.WriteLine(builder.ToString());
 ```
 
+## Parser look-ahead note
+
+The look-ahead probe layer can now conservatively classify structurally epsilon-capable alternatives such as optional or zero-or-more quantifiers. This classification remains informational and does not bypass normal parsing.
+
+Still intentionally out of scope: adaptive prediction, recursive FIRST-set analysis, shared look-ahead graphs, continuation queues, and parallel parsing.
+
 ## Recent expression updates
 
 - `ExpressionCompilerContext` is now the shared runtime context for expression compilers.

--- a/Utils.Parser/Runtime/ParserLookaheadProbe.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbe.cs
@@ -33,6 +33,7 @@ internal sealed class ParserLookaheadProbe
             LiteralMatch literal => ProbeLiteralMatch(literal, token, caseInsensitive),
             RuleRef ruleRef => ProbeRuleReference(ruleRef, token, resolveRule),
             Sequence sequence => ProbeSequence(sequence, token, resolveRule, caseInsensitive),
+            Quantifier quantifier => ProbeQuantifier(quantifier, token),
             _ => Unknown(token)
         };
     }
@@ -79,7 +80,7 @@ internal sealed class ParserLookaheadProbe
     }
 
     /// <summary>
-    /// Probes the first meaningful sequence item while skipping non-semantic runtime directives.
+    /// Probes sequence items while skipping non-semantic runtime directives.
     /// </summary>
     private static ParserLookaheadProbeResult ProbeSequence(
         Sequence sequence,
@@ -94,10 +95,32 @@ internal sealed class ParserLookaheadProbe
                 continue;
             }
 
-            return ProbeContent(item, token, resolveRule, caseInsensitive);
+            var itemProbe = ProbeContent(item, token, resolveRule, caseInsensitive);
+            switch (itemProbe.Kind)
+            {
+                case ParserLookaheadProbeKind.ImmediateReject:
+                    return itemProbe;
+                case ParserLookaheadProbeKind.RequiresParse:
+                    return itemProbe;
+                case ParserLookaheadProbeKind.EpsilonPossible:
+                    continue;
+                case ParserLookaheadProbeKind.Unknown:
+                default:
+                    return itemProbe;
+            }
         }
 
-        return Unknown(token);
+        return EpsilonPossible(token);
+    }
+
+    /// <summary>
+    /// Probes quantifiers conservatively for local epsilon capability only.
+    /// </summary>
+    private static ParserLookaheadProbeResult ProbeQuantifier(Quantifier quantifier, Token? token)
+    {
+        return quantifier.Min == 0
+            ? EpsilonPossible(token)
+            : Unknown(token);
     }
 
     private static ParserLookaheadProbeResult Unknown(Token? token) =>
@@ -108,4 +131,9 @@ internal sealed class ParserLookaheadProbe
 
     private static ParserLookaheadProbeResult RequiresParse(Token? token) =>
         new(ParserLookaheadProbeKind.RequiresParse, token?.RuleName, token?.Text);
+
+    private static ParserLookaheadProbeResult EpsilonPossible(Token? token) =>
+        new(ParserLookaheadProbeKind.EpsilonPossible, token?.RuleName, token?.Text);
 }
+
+

--- a/Utils.Parser/Runtime/ParserLookaheadProbe.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbe.cs
@@ -88,21 +88,27 @@ internal sealed class ParserLookaheadProbe
         Func<string, Rule?> resolveRule,
         bool caseInsensitive)
     {
-        foreach (var item in sequence.Items)
-        {
-            if (item is EmbeddedAction or LexerCommand)
-            {
-                continue;
-            }
+        var meaningfulItems = sequence.Items
+            .Where(static item => item is not EmbeddedAction and not LexerCommand)
+            .ToArray();
 
-            var itemProbe = ProbeContent(item, token, resolveRule, caseInsensitive);
+        if (meaningfulItems.Length == 0)
+        {
+            return EpsilonPossible(token);
+        }
+
+        var encounteredEpsilonPossible = false;
+
+        for (var i = 0; i < meaningfulItems.Length; i++)
+        {
+            var itemProbe = ProbeContent(meaningfulItems[i], token, resolveRule, caseInsensitive);
             switch (itemProbe.Kind)
             {
                 case ParserLookaheadProbeKind.ImmediateReject:
-                    return itemProbe;
                 case ParserLookaheadProbeKind.RequiresParse:
-                    return itemProbe;
+                    return encounteredEpsilonPossible ? Unknown(token) : itemProbe;
                 case ParserLookaheadProbeKind.EpsilonPossible:
+                    encounteredEpsilonPossible = true;
                     continue;
                 case ParserLookaheadProbeKind.Unknown:
                 default:

--- a/Utils.Parser/Runtime/ParserLookaheadProbeKind.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbeKind.cs
@@ -18,5 +18,11 @@ internal enum ParserLookaheadProbeKind
     /// <summary>
     /// The alternative may start and requires an actual parse attempt.
     /// </summary>
-    RequiresParse
+    RequiresParse,
+
+    /// <summary>
+    /// The alternative may succeed without consuming input.
+    /// Parsing must still execute normally.
+    /// </summary>
+    EpsilonPossible
 }

--- a/UtilsTest/Parser/ParserEngineRegistryRegressionTests.cs
+++ b/UtilsTest/Parser/ParserEngineRegistryRegressionTests.cs
@@ -206,6 +206,28 @@ public class ParserEngineRegistryRegressionTests
         Assert.IsFalse(diagnosticsY.Any(d => d.Code == ParserDiagnostics.ParserStateCycleDetected.Code));
     }
 
+
+    /// <summary>
+    /// Ensures epsilon-capable look-ahead classification does not skip a valid parse path
+    /// when an optional prefix can consume the current token.
+    /// </summary>
+    [TestMethod]
+    public void OptionalPrefixFollowedByLiteral_DoesNotRegressViaNegativeShortcut()
+    {
+        const string grammar = """
+            grammar G;
+            root : 'x'? 'y' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+
+        var diagnostics = new DiagnosticBag();
+        var tree = ParseWithDiagnostics(grammar, "x y", diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.AreEqual(1, CountTokenText(tree, "x"));
+        Assert.AreEqual(1, CountTokenText(tree, "y"));
+    }
+
     /// <summary>
     /// Ensures deterministic failures are memoized per invocation key and not re-evaluated for each backtracked alternative.
     /// </summary>

--- a/UtilsTest/Parser/ParserLookaheadProbeTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadProbeTests.cs
@@ -89,6 +89,64 @@ public class ParserLookaheadProbeTests
         Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
     }
 
+
+    [TestMethod]
+    public void Probe_OptionalQuantifier_ReturnsEpsilonPossible()
+    {
+        var quantifier = new Quantifier(new LiteralMatch("x"), 0, 1);
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(quantifier), TokenWithText("y"), static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.EpsilonPossible, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_StarQuantifier_ReturnsEpsilonPossible()
+    {
+        var quantifier = new Quantifier(new LiteralMatch("x"), 0, null);
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(quantifier), TokenWithText("y"), static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.EpsilonPossible, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_EmptySequence_ReturnsEpsilonPossible()
+    {
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(new Sequence([])), TokenWithText("x"), static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.EpsilonPossible, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_Sequence_ContinuesPastEpsilonPossible()
+    {
+        var sequence = new Sequence([
+            new Quantifier(new LiteralMatch("x"), 0, 1),
+            new LiteralMatch("go")
+        ]);
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(sequence), TokenWithText("stop"), static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_Sequence_AllOptional_ReturnsEpsilonPossible()
+    {
+        var sequence = new Sequence([
+            new Quantifier(new LiteralMatch("x"), 0, 1),
+            new Quantifier(new LiteralMatch("y"), 0, null)
+        ]);
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(sequence), TokenWithText("z"), static _ => null, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.EpsilonPossible, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_Sequence_UnknownStopsAnalysis()
+    {
+        Rule? Resolve(string name) => name == "expr" ? new Rule("expr", 0, false, new Alternation([])) { Kind = RuleKind.Parser } : null;
+        var sequence = new Sequence([
+            new RuleRef("expr"),
+            new LiteralMatch("go")
+        ]);
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(sequence), TokenWithText("go"), Resolve, false);
+        Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
+    }
+
     [TestMethod]
     public void Probe_NestedAlternation_ReturnsUnknown()
     {

--- a/UtilsTest/Parser/ParserLookaheadProbeTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadProbeTests.cs
@@ -114,14 +114,14 @@ public class ParserLookaheadProbeTests
     }
 
     [TestMethod]
-    public void Probe_Sequence_ContinuesPastEpsilonPossible()
+    public void Probe_Sequence_EpsilonPossibleBeforeLiteral_ReturnsUnknown()
     {
         var sequence = new Sequence([
             new Quantifier(new LiteralMatch("x"), 0, 1),
             new LiteralMatch("go")
         ]);
         var result = new ParserLookaheadProbe().Probe(CreateAlternative(sequence), TokenWithText("stop"), static _ => null, false);
-        Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
+        Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
     }
 
     [TestMethod]

--- a/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
+++ b/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
@@ -345,6 +345,45 @@ public class ScheduledAlternativeExecutorTests
         Assert.AreEqual(0, probeCallCount, "Probe must not run when the cache already holds an authoritative result.");
     }
 
+
+
+    [TestMethod]
+    public void Execute_EpsilonPossible_DoesNotTriggerShortcut()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
+        var rule = CreateRule();
+        var alternative = rule.Content.Alternatives[0];
+        var context = new ParseContext([new Token(new SourceSpan(0, 1), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
+        var lookaheadKey = new ParserLookaheadKey("root", 0, 0, 0, ScheduledAlternativeCursorKinds.RuleRoot, -1);
+        cache.TryAdd(lookaheadKey, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.EpsilonPossible, null, null));
+        var attemptCount = 0;
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.RuleRoot,
+            cursorIndex: -1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: _ =>
+            {
+                attemptCount++;
+                return null;
+            });
+
+        Assert.AreEqual(1, attemptCount);
+    }
+
     private static Rule CreateRule()
     {
         return new Rule("root", 0, false, new Alternation([


### PR DESCRIPTION
### Motivation
- The lightweight look-ahead probe could not represent alternatives that may succeed without consuming input (nullable/epsilon-capable), causing overly conservative `Unknown` outcomes for obviously optional constructs.
- Add a shallow, local classification to let runtime components observe epsilon-capable structures (optional / `*`) while preserving all existing parsing semantics and scheduling behavior.

### Description
- Added a new probe kind `ParserLookaheadProbeKind.EpsilonPossible` to represent alternatives that may succeed without consuming input and kept it informational-only. (`Utils.Parser/Runtime/ParserLookaheadProbeKind.cs`)
- Extended `ParserLookaheadProbe` to conservatively detect local epsilon cases: added `EpsilonPossible` helper and `ProbeQuantifier` handling for `Quantifier.Min == 0`, and updated `ProbeSequence` to walk sequence items while skipping actions/lexer commands and continuing past `EpsilonPossible` items. (`Utils.Parser/Runtime/ParserLookaheadProbe.cs`)
- Kept rule references conservative (parser `RuleRef` still returns `Unknown`) and did not introduce recursive FIRST/FOLLOW or any adaptive prediction; only structurally obvious local cases are handled.
- Added unit tests covering optional/star quantifiers, empty sequences, sequence continuation across epsilon-capable items, all-optional sequences, and unknown short-circuiting, and an executor test ensuring `EpsilonPossible` does not trigger the negative shortcut. (`UtilsTest/Parser/ParserLookaheadProbeTests.cs`, `UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs`)
- Added a short README note documenting the conservative, informational nature and explicit non-goals. (`README.md`)

### Testing
- Ran `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~UtilsTest.Parser"`; the run completed with build warnings and produced `Failed: 1, Passed: 380` where the single failure is an unrelated test `UtilsTest.Parser.Antlr4GrammarConverterTests.ParseLexerRule_Fragment` (external to the probe changes).
- The new/modified tests for the probe and executor (the tests added in `ParserLookaheadProbeTests` and `ScheduledAlternativeExecutorTests`) passed during the run.
- No changes were made to public APIs or scheduling logic, and the implementation is intentionally conservative to preserve existing runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4998ffec83269c233fc282596ec4)