### PR TITLE
ParserEngine: enrich shared-prefix metadata with boundaries and conservative continuation positions

### DIFF
--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -87,17 +87,39 @@ internal sealed class AlternativeScheduler
         for (var index = 0; index < orderedAlternatives.Count; index++)
         {
             var expectedTokenNames = lookaheadProbes[index].ExpectedTokenNames;
+            var sharedTokenName = ResolveSharedTokenName(candidates, index);
+            var sharedPrefixSequencePosition = sharedTokenName is null
+                ? 0
+                : _continuationFactory.ComputeSharedPrefixSequencePosition(orderedAlternatives[index], sharedTokenName);
             continuations.Add(_continuationFactory.Create(
                 rule,
                 orderedAlternatives[index],
                 index,
-                sequencePosition: 0,
+                sequencePosition: sharedPrefixSequencePosition,
                 expectedTokenNames,
                 candidateIndexes.Contains(index)));
         }
 
         var plans = _sharedPrefixPlanFactory.CreatePlans(candidates, continuations);
         return new AlternativeSchedulingMetadata { SharedPrefixPlans = plans };
+    }
+
+    /// <summary>
+    /// Resolves the first shared token candidate for an alternative while preserving detector ordering.
+    /// </summary>
+    private static string? ResolveSharedTokenName(
+        IReadOnlyList<ParserLookaheadSharedPrefixCandidate> candidates,
+        int alternativeIndex)
+    {
+        for (var index = 0; index < candidates.Count; index++)
+        {
+            if (candidates[index].AlternativeIndexes.Contains(alternativeIndex))
+            {
+                return candidates[index].TokenName;
+            }
+        }
+
+        return null;
     }
     private static ActiveParseState CreateInitialState(Rule rule, Alternative alternative, int originInputPosition, int alternativeIndex)
     {

--- a/Utils.Parser/Runtime/ParserContinuationFactory.cs
+++ b/Utils.Parser/Runtime/ParserContinuationFactory.cs
@@ -8,6 +8,32 @@ namespace Utils.Parser.Runtime;
 internal sealed class ParserContinuationFactory
 {
     /// <summary>
+    /// Computes a conservative sequence position for shared-token continuation metadata.
+    /// This shallow analysis is preparatory only and intentionally avoids deep parser semantics.
+    /// </summary>
+    /// <param name="alternative">Alternative containing the shared token.</param>
+    /// <param name="sharedTokenName">Shared token identifier from look-ahead metadata.</param>
+    /// <returns>Sequence position after the shared token, or zero when unsupported/ambiguous.</returns>
+    public int ComputeSharedPrefixSequencePosition(Alternative alternative, string sharedTokenName)
+    {
+        if (alternative.Content is not Sequence sequence)
+        {
+            return 0;
+        }
+
+        var meaningfulItems = sequence.Items
+            .Where(static item => item is not EmbeddedAction and not LexerCommand)
+            .ToArray();
+
+        if (meaningfulItems.Length == 0 || !IsSharedTokenMatch(meaningfulItems[0], sharedTokenName))
+        {
+            return 0;
+        }
+
+        return 1;
+    }
+
+    /// <summary>
     /// Creates a continuation descriptor from shallow rule/alternative location metadata.
     /// </summary>
     /// <param name="rule">Owning rule for the continuation point.</param>
@@ -66,5 +92,19 @@ internal sealed class ParserContinuationFactory
         }
 
         return meaningfulIndex;
+    }
+
+    /// <summary>
+    /// Determines whether a shallow sequence item matches a shared token name.
+    /// Only literal matches and direct rule references are supported.
+    /// </summary>
+    private static bool IsSharedTokenMatch(RuleContent content, string sharedTokenName)
+    {
+        return content switch
+        {
+            LiteralMatch literal => string.Equals(literal.Value, sharedTokenName, StringComparison.Ordinal),
+            RuleRef ruleRef => string.Equals(ruleRef.RuleName, sharedTokenName, StringComparison.Ordinal),
+            _ => false
+        };
     }
 }

--- a/Utils.Parser/Runtime/ParserContinuationFactory.cs
+++ b/Utils.Parser/Runtime/ParserContinuationFactory.cs
@@ -13,7 +13,7 @@ internal sealed class ParserContinuationFactory
     /// </summary>
     /// <param name="alternative">Alternative containing the shared token.</param>
     /// <param name="sharedTokenName">Shared token identifier from look-ahead metadata.</param>
-    /// <returns>Sequence position after the shared token, or zero when unsupported/ambiguous.</returns>
+    /// <returns>Raw sequence-item index after the shared token, or zero when unsupported/ambiguous.</returns>
     public int ComputeSharedPrefixSequencePosition(Alternative alternative, string sharedTokenName)
     {
         if (alternative.Content is not Sequence sequence)
@@ -21,16 +21,24 @@ internal sealed class ParserContinuationFactory
             return 0;
         }
 
-        var meaningfulItems = sequence.Items
-            .Where(static item => item is not EmbeddedAction and not LexerCommand)
-            .ToArray();
+        var firstMeaningfulItemIndex = -1;
+        for (var index = 0; index < sequence.Items.Count; index++)
+        {
+            if (sequence.Items[index] is EmbeddedAction or LexerCommand)
+            {
+                continue;
+            }
 
-        if (meaningfulItems.Length == 0 || !IsSharedTokenMatchFromProbeMetadata(meaningfulItems[0], sharedTokenName))
+            firstMeaningfulItemIndex = index;
+            break;
+        }
+
+        if (firstMeaningfulItemIndex < 0 || !IsSharedTokenMatchFromProbeMetadata(sequence.Items[firstMeaningfulItemIndex], sharedTokenName))
         {
             return 0;
         }
 
-        return 1;
+        return firstMeaningfulItemIndex + 1;
     }
 
     /// <summary>

--- a/Utils.Parser/Runtime/ParserContinuationFactory.cs
+++ b/Utils.Parser/Runtime/ParserContinuationFactory.cs
@@ -25,7 +25,7 @@ internal sealed class ParserContinuationFactory
             .Where(static item => item is not EmbeddedAction and not LexerCommand)
             .ToArray();
 
-        if (meaningfulItems.Length == 0 || !IsSharedTokenMatch(meaningfulItems[0], sharedTokenName))
+        if (meaningfulItems.Length == 0 || !IsSharedTokenMatchFromProbeMetadata(meaningfulItems[0], sharedTokenName))
         {
             return 0;
         }
@@ -95,10 +95,12 @@ internal sealed class ParserContinuationFactory
     }
 
     /// <summary>
-    /// Determines whether a shallow sequence item matches a shared token name.
-    /// Only literal matches and direct rule references are supported.
+    /// Determines whether a shallow sequence item matches a shared token name
+    /// coming from look-ahead probe metadata.
+    /// This helper intentionally performs no rule-kind resolution and therefore
+    /// must only be used with probe metadata that already represents shallow token candidates.
     /// </summary>
-    private static bool IsSharedTokenMatch(RuleContent content, string sharedTokenName)
+    private static bool IsSharedTokenMatchFromProbeMetadata(RuleContent content, string sharedTokenName)
     {
         return content switch
         {

--- a/Utils.Parser/Runtime/ParserSharedPrefixBoundary.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixBoundary.cs
@@ -1,0 +1,11 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Represents a structural continuation boundary for shared-prefix planning metadata.
+/// This boundary is informational only and does not capture runtime parser state.
+/// </summary>
+/// <param name="SequencePosition">Conservative resumption position within meaningful sequence items.</param>
+/// <param name="ExpectedTokenNames">Optional shallow expected-token names observed at the boundary.</param>
+internal readonly record struct ParserSharedPrefixBoundary(
+    int SequencePosition,
+    IReadOnlyList<string>? ExpectedTokenNames);

--- a/Utils.Parser/Runtime/ParserSharedPrefixBoundary.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixBoundary.cs
@@ -5,7 +5,10 @@ namespace Utils.Parser.Runtime;
 /// This boundary is informational only and does not capture runtime parser state.
 /// </summary>
 /// <param name="SequencePosition">Conservative resumption position within meaningful sequence items.</param>
-/// <param name="ExpectedTokenNames">Optional shallow expected-token names observed at the boundary.</param>
+/// <param name="ExpectedTokenNames">
+/// Optional shallow expected-token snapshot at this structural boundary.
+/// This value is intentionally <see langword="null"/> for now to avoid implying FOLLOW/restart semantics.
+/// </param>
 internal readonly record struct ParserSharedPrefixBoundary(
     int SequencePosition,
     IReadOnlyList<string>? ExpectedTokenNames);

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlan.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlan.cs
@@ -7,7 +7,9 @@ namespace Utils.Parser.Runtime;
 /// <param name="SharedTokenName">Shallow shared token identifier observed during look-ahead.</param>
 /// <param name="AlternativeIndexes">Stable alternative indexes participating in this plan.</param>
 /// <param name="Continuations">Continuation descriptors associated with participating alternatives.</param>
+/// <param name="Segment">Explicit shared-prefix segment and conservative boundary metadata.</param>
 internal readonly record struct ParserSharedPrefixPlan(
     string SharedTokenName,
     IReadOnlyList<int> AlternativeIndexes,
-    IReadOnlyList<ParserContinuationDescriptor> Continuations);
+    IReadOnlyList<ParserContinuationDescriptor> Continuations,
+    ParserSharedPrefixSegment Segment);

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
@@ -33,7 +33,7 @@ internal sealed class ParserSharedPrefixPlanFactory
             }
 
             var alternativeIndexes = matchingContinuations.Select(static continuation => continuation.Key.AlternativeIndex).ToArray();
-            var boundary = BuildBoundary(matchingContinuations, candidate.TokenName);
+            var boundary = BuildBoundary(matchingContinuations);
             var segment = new ParserSharedPrefixSegment(candidate.TokenName, boundary);
             plans.Add(new ParserSharedPrefixPlan(candidate.TokenName, alternativeIndexes, matchingContinuations, segment));
         }
@@ -107,14 +107,15 @@ internal sealed class ParserSharedPrefixPlanFactory
     /// <summary>
     /// Builds a conservative shared-prefix boundary from matching continuations.
     /// Falls back to sequence position zero when continuations disagree.
+    /// Expected-token names remain <see langword="null"/> to avoid suggesting
+    /// runtime FOLLOW-token or continuation-restart semantics.
     /// </summary>
     private static ParserSharedPrefixBoundary BuildBoundary(
-        IReadOnlyList<ParserContinuationDescriptor> continuations,
-        string sharedTokenName)
+        IReadOnlyList<ParserContinuationDescriptor> continuations)
     {
         if (continuations.Count == 0)
         {
-            return new ParserSharedPrefixBoundary(0, [sharedTokenName]);
+            return new ParserSharedPrefixBoundary(0, null);
         }
 
         var expectedPosition = continuations[0].Key.SequencePosition;
@@ -122,10 +123,10 @@ internal sealed class ParserSharedPrefixPlanFactory
         {
             if (continuations[index].Key.SequencePosition != expectedPosition)
             {
-                return new ParserSharedPrefixBoundary(0, [sharedTokenName]);
+                return new ParserSharedPrefixBoundary(0, null);
             }
         }
 
-        return new ParserSharedPrefixBoundary(expectedPosition, [sharedTokenName]);
+        return new ParserSharedPrefixBoundary(expectedPosition, null);
     }
 }

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
@@ -33,7 +33,9 @@ internal sealed class ParserSharedPrefixPlanFactory
             }
 
             var alternativeIndexes = matchingContinuations.Select(static continuation => continuation.Key.AlternativeIndex).ToArray();
-            plans.Add(new ParserSharedPrefixPlan(candidate.TokenName, alternativeIndexes, matchingContinuations));
+            var boundary = BuildBoundary(matchingContinuations, candidate.TokenName);
+            var segment = new ParserSharedPrefixSegment(candidate.TokenName, boundary);
+            plans.Add(new ParserSharedPrefixPlan(candidate.TokenName, alternativeIndexes, matchingContinuations, segment));
         }
 
         return plans;
@@ -100,5 +102,30 @@ internal sealed class ParserSharedPrefixPlanFactory
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Builds a conservative shared-prefix boundary from matching continuations.
+    /// Falls back to sequence position zero when continuations disagree.
+    /// </summary>
+    private static ParserSharedPrefixBoundary BuildBoundary(
+        IReadOnlyList<ParserContinuationDescriptor> continuations,
+        string sharedTokenName)
+    {
+        if (continuations.Count == 0)
+        {
+            return new ParserSharedPrefixBoundary(0, [sharedTokenName]);
+        }
+
+        var expectedPosition = continuations[0].Key.SequencePosition;
+        for (var index = 1; index < continuations.Count; index++)
+        {
+            if (continuations[index].Key.SequencePosition != expectedPosition)
+            {
+                return new ParserSharedPrefixBoundary(0, [sharedTokenName]);
+            }
+        }
+
+        return new ParserSharedPrefixBoundary(expectedPosition, [sharedTokenName]);
     }
 }

--- a/Utils.Parser/Runtime/ParserSharedPrefixSegment.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixSegment.cs
@@ -1,0 +1,11 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Represents a shallow shared-prefix segment and its conservative structural boundary.
+/// This metadata is preparatory only and is not executable.
+/// </summary>
+/// <param name="SharedTokenName">Shared shallow token identifier.</param>
+/// <param name="Boundary">Conservative boundary used for future continuation resumption planning.</param>
+internal readonly record struct ParserSharedPrefixSegment(
+    string SharedTokenName,
+    ParserSharedPrefixBoundary Boundary);

--- a/UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs
@@ -84,10 +84,24 @@ public class AlternativeSchedulingMetadataTests
     [TestMethod]
     public void Scheduler_Metadata_CreatesContinuationDescriptors()
     {
-        var result = Run(new[] { new[] { "ID" }, new[] { "ID" } });
+        var scheduler = new AlternativeScheduler();
+        var alternatives = new[]
+        {
+            new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("+"), new RuleRef("expr")]), "a"),
+            new Alternative(1, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("-"), new RuleRef("expr")]), "b")
+        };
+        var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+        var result = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), Probe("ID")));
         var continuations = result.Metadata.SharedPrefixPlans[0].Continuations;
         Assert.AreEqual(2, continuations.Count);
-        Assert.IsTrue(continuations.All(static c => c.Key.SequencePosition == 0));
+        Assert.IsTrue(continuations.All(static c => c.Key.SequencePosition == 1));
+        Assert.AreEqual(1, result.Metadata.SharedPrefixPlans[0].Segment.Boundary.SequencePosition);
     }
 
     [TestMethod]

--- a/UtilsTest/Parser/ParserContinuationFactoryTests.cs
+++ b/UtilsTest/Parser/ParserContinuationFactoryTests.cs
@@ -106,4 +106,42 @@ public class ParserContinuationFactoryTests
         Assert.IsNull(descriptorType.GetProperty("TokenStream"));
         Assert.AreEqual(0, descriptorType.GetProperties().Count(static p => typeof(Delegate).IsAssignableFrom(p.PropertyType)));
     }
+
+    [TestMethod]
+    public void ComputeSharedPrefixSequencePosition_SequenceWithSharedFirstToken_ReturnsOne()
+    {
+        var factory = new ParserContinuationFactory();
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("+"), new RuleRef("expr")]));
+
+        var result = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
+
+        Assert.AreEqual(1, result);
+    }
+
+    [TestMethod]
+    public void ComputeSharedPrefixSequencePosition_IgnoresEmbeddedActionAndLexerCommand()
+    {
+        var factory = new ParserContinuationFactory();
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([
+            new EmbeddedAction("x();", ActionContext.Alternative, ActionPosition.Inline, []),
+            new LexerCommand(LexerCommandType.Skip, null),
+            new RuleRef("ID"),
+            new LiteralMatch("-")
+        ]));
+
+        var result = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
+
+        Assert.AreEqual(1, result);
+    }
+
+    [TestMethod]
+    public void ComputeSharedPrefixSequencePosition_UnsupportedStructure_FallsBackToZero()
+    {
+        var factory = new ParserContinuationFactory();
+        var alternative = new Alternative(0, Associativity.Left, new RuleRef("expr"));
+
+        var result = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
+
+        Assert.AreEqual(0, result);
+    }
 }

--- a/UtilsTest/Parser/ParserContinuationFactoryTests.cs
+++ b/UtilsTest/Parser/ParserContinuationFactoryTests.cs
@@ -144,4 +144,15 @@ public class ParserContinuationFactoryTests
 
         Assert.AreEqual(0, result);
     }
+
+    [TestMethod]
+    public void ComputeSharedPrefixSequencePosition_RuleRefNameMismatch_FallsBackToZero()
+    {
+        var factory = new ParserContinuationFactory();
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("expr"), new RuleRef("tail")]));
+
+        var result = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
+
+        Assert.AreEqual(0, result);
+    }
 }

--- a/UtilsTest/Parser/ParserContinuationFactoryTests.cs
+++ b/UtilsTest/Parser/ParserContinuationFactoryTests.cs
@@ -131,7 +131,26 @@ public class ParserContinuationFactoryTests
 
         var result = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
 
-        Assert.AreEqual(1, result);
+        Assert.AreEqual(3, result);
+    }
+
+    [TestMethod]
+    public void Create_WithRawSharedPrefixSequencePosition_NormalizesMeaningfulBoundary()
+    {
+        var factory = new ParserContinuationFactory();
+        var rule = new Rule("expr", 0, false, new Alternation([]));
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([
+            new EmbeddedAction("x();", ActionContext.Alternative, ActionPosition.Inline, []),
+            new LexerCommand(LexerCommandType.Skip, null),
+            new RuleRef("ID"),
+            new RuleRef("expr")
+        ]));
+
+        var rawSequencePosition = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
+        var descriptor = factory.Create(rule, alternative, 0, rawSequencePosition, ["ID"], true);
+
+        Assert.AreEqual(3, rawSequencePosition);
+        Assert.AreEqual(1, descriptor.Key.SequencePosition);
     }
 
     [TestMethod]

--- a/UtilsTest/Parser/ParserSharedPrefixPlanFactoryTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixPlanFactoryTests.cs
@@ -39,6 +39,7 @@ public class ParserSharedPrefixPlanFactoryTests
         Assert.AreEqual("ID", result[0].SharedTokenName);
         CollectionAssert.AreEqual(new[] { 0, 1 }, result[0].AlternativeIndexes.ToArray());
         Assert.AreEqual(2, result[0].Continuations.Count);
+        Assert.AreEqual(0, result[0].Segment.Boundary.SequencePosition);
     }
 
     [TestMethod]
@@ -125,5 +126,17 @@ public class ParserSharedPrefixPlanFactoryTests
             new ParserContinuationKey("expr", alternativeIndex, 0),
             expectedTokenNames,
             true);
+    }
+
+    [TestMethod]
+    public void CreatePlans_ContainsExplicitSegmentBoundaryMetadata()
+    {
+        var factory = new ParserSharedPrefixPlanFactory();
+
+        var result = factory.CreatePlans([Candidate("ID", [0, 1])], [Continuation(0, ["ID"]), Continuation(1, ["ID"])]);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("ID", result[0].Segment.SharedTokenName);
+        CollectionAssert.AreEqual(new[] { "ID" }, result[0].Segment.Boundary.ExpectedTokenNames?.ToArray() ?? []);
     }
 }

--- a/UtilsTest/Parser/ParserSharedPrefixPlanFactoryTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixPlanFactoryTests.cs
@@ -137,6 +137,21 @@ public class ParserSharedPrefixPlanFactoryTests
 
         Assert.AreEqual(1, result.Count);
         Assert.AreEqual("ID", result[0].Segment.SharedTokenName);
-        CollectionAssert.AreEqual(new[] { "ID" }, result[0].Segment.Boundary.ExpectedTokenNames?.ToArray() ?? []);
+        Assert.IsNull(result[0].Segment.Boundary.ExpectedTokenNames);
+    }
+
+    [TestMethod]
+    public void CreatePlans_BoundaryFallsBackToZero_WhenContinuationPositionsDiverge()
+    {
+        var factory = new ParserSharedPrefixPlanFactory();
+        var result = factory.CreatePlans(
+            [Candidate("ID", [0, 1])],
+            [
+                new ParserContinuationDescriptor(new ParserContinuationKey("expr", 0, 1), ["ID"], true),
+                new ParserContinuationDescriptor(new ParserContinuationKey("expr", 1, 2), ["ID"], true)
+            ]);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual(0, result[0].Segment.Boundary.SequencePosition);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide explicit, immutable structural metadata for shared-prefix boundaries and segments to prepare the runtime for future shared-prefix/continuation features while keeping everything metadata-only and behavior-preserving.  
- Make continuation descriptors carry a shallow, conservative sequence position (not execution state) so future resumption logic can rely on deterministic, structural positions.  
- Ensure changes are conservative, deterministic, and do not alter scheduling, diagnostics, parse-tree shape, or public APIs.  

### Description
- Added two new immutable records: `ParserSharedPrefixBoundary` and `ParserSharedPrefixSegment` and extended `ParserSharedPrefixPlan` to include an explicit `Segment` property.  
- Updated `ParserSharedPrefixPlanFactory` to compute a conservative boundary from matched continuations and to attach a `ParserSharedPrefixSegment` to each created plan, with a deterministic fallback to sequence position `0` when positions diverge.  
- Extended `ParserContinuationFactory` with `ComputeSharedPrefixSequencePosition` and `IsSharedTokenMatch` to compute a shallow, conservative sequence position for simple shapes (`LiteralMatch` and `RuleRef`), ignoring `EmbeddedAction` and `LexerCommand`, and falling back to `0` for unsupported or ambiguous shapes.  
- Updated `AlternativeScheduler` metadata construction to resolve the first shared-token candidate per alternative and pass the computed shallow sequence position into continuation descriptors; existing scheduling/pruning/diagnostic logic remains unchanged and observational.  
- Tests updated/added to validate metadata behavior and conservative fallback: `ParserContinuationFactoryTests`, `ParserSharedPrefixPlanFactoryTests`, and `AlternativeSchedulingMetadataTests` (focused checks for boundary extraction, explicit segment metadata, continuation positions, and non-regression).  

### Testing
- Ran the focused parser runtime tests with: `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ParserContinuationFactoryTests|FullyQualifiedName~ParserSharedPrefixPlanFactoryTests|FullyQualifiedName~AlternativeSchedulingMetadataTests"`.  
- Result: Passed 29, Failed 0 (all filtered tests passed).  
- No change to runtime behavior, and existing scheduler-related tests that assert selection/pruning/diagnostics continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca06d326883268b45e73595e6c82f)