### PR TITLE
Add deterministic dry-run formatter for shared-prefix plans

### DIFF
--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanFormatter.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanFormatter.cs
@@ -1,0 +1,75 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Formats shared-prefix planning metadata into deterministic dry-run strings for tests and debugging.
+/// </summary>
+internal sealed class ParserSharedPrefixPlanFormatter
+{
+    /// <summary>
+    /// Formats a list of shared-prefix plans while preserving plan order.
+    /// </summary>
+    /// <param name="plans">Shared-prefix plans to format.</param>
+    /// <returns>A deterministic list of readable dry-run lines.</returns>
+    public IReadOnlyList<string> FormatPlans(IReadOnlyList<ParserSharedPrefixPlan> plans)
+    {
+        if (plans.Count == 0)
+        {
+            return [];
+        }
+
+        var lines = new string[plans.Count];
+        for (var index = 0; index < plans.Count; index++)
+        {
+            lines[index] = FormatPlan(plans[index]);
+        }
+
+        return lines;
+    }
+
+    /// <summary>
+    /// Formats one shared-prefix plan into a single deterministic dry-run line.
+    /// </summary>
+    /// <param name="plan">Shared-prefix plan metadata.</param>
+    /// <returns>A readable dry-run line with shared token, optional boundary, and continuation positions.</returns>
+    private static string FormatPlan(ParserSharedPrefixPlan plan)
+    {
+        var parts = new List<string>
+        {
+            $"shared token: {plan.SharedTokenName}"
+        };
+
+        if (ShouldRenderBoundary(plan))
+        {
+            parts.Add($"boundary: position {plan.Segment.Boundary.SequencePosition}");
+        }
+
+        for (var index = 0; index < plan.Continuations.Count; index++)
+        {
+            var continuation = plan.Continuations[index];
+            parts.Add($"alt {continuation.Key.AlternativeIndex} -> after position {continuation.Key.SequencePosition}");
+        }
+
+        return string.Join(" | ", parts);
+    }
+
+    /// <summary>
+    /// Determines whether the shared-prefix boundary should be rendered explicitly.
+    /// </summary>
+    /// <param name="plan">Plan to inspect.</param>
+    /// <returns>
+    /// <see langword="true"/> when at least one continuation position differs from the boundary position;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    private static bool ShouldRenderBoundary(ParserSharedPrefixPlan plan)
+    {
+        for (var index = 0; index < plan.Continuations.Count; index++)
+        {
+            if (plan.Continuations[index].Key.SequencePosition != plan.Segment.Boundary.SequencePosition)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs
@@ -104,6 +104,39 @@ public class AlternativeSchedulingMetadataTests
         Assert.AreEqual(1, result.Metadata.SharedPrefixPlans[0].Segment.Boundary.SequencePosition);
     }
 
+
+    [TestMethod]
+    public void Scheduler_Metadata_ProducesReadableSharedPrefixDryRunOutput()
+    {
+        var scheduler = new AlternativeScheduler();
+        var formatter = new ParserSharedPrefixPlanFormatter();
+        var alternatives = new[]
+        {
+            new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("+"), new RuleRef("expr")]), "a"),
+            new Alternative(1, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("-"), new RuleRef("expr")]), "b")
+        };
+        var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+
+        var result = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), Probe("ID")));
+
+        Assert.AreEqual(1, result.Metadata.SharedPrefixPlans.Count);
+        Assert.AreEqual("ID", result.Metadata.SharedPrefixPlans[0].SharedTokenName);
+        Assert.IsTrue(result.Metadata.SharedPrefixPlans[0].Continuations.All(static c => c.Key.SequencePosition == 1));
+
+        var lines = formatter.FormatPlans(result.Metadata.SharedPrefixPlans);
+
+        Assert.AreEqual(1, lines.Count);
+        StringAssert.Contains(lines[0], "shared token: ID");
+        StringAssert.Contains(lines[0], "alt 0 -> after position 1");
+        StringAssert.Contains(lines[0], "alt 1 -> after position 1");
+    }
+
     [TestMethod]
     public void Scheduler_Metadata_PreservesStableAlternativeIndexes()
     {

--- a/UtilsTest/Parser/ParserSharedPrefixPlanFormatterTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixPlanFormatterTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ParserSharedPrefixPlanFormatterTests
+{
+    [TestMethod]
+    public void FormatPlans_ReturnsEmpty_WhenNoPlans()
+    {
+        var formatter = new ParserSharedPrefixPlanFormatter();
+
+        var lines = formatter.FormatPlans([]);
+
+        Assert.AreEqual(0, lines.Count);
+    }
+
+    [TestMethod]
+    public void FormatPlans_FormatsSinglePlan()
+    {
+        var formatter = new ParserSharedPrefixPlanFormatter();
+        var plan = Plan("ID", 1, [Continuation(0, 1), Continuation(1, 1)]);
+
+        var lines = formatter.FormatPlans([plan]);
+
+        Assert.AreEqual(1, lines.Count);
+        Assert.AreEqual("shared token: ID | alt 0 -> after position 1 | alt 1 -> after position 1", lines[0]);
+    }
+
+    [TestMethod]
+    public void FormatPlans_FormatsMultiplePlansInStableOrder()
+    {
+        var formatter = new ParserSharedPrefixPlanFormatter();
+        var plans = new[]
+        {
+            Plan("ID", 1, [Continuation(0, 1), Continuation(1, 1)]),
+            Plan("NUMBER", 2, [Continuation(2, 2), Continuation(3, 2)])
+        };
+
+        var lines = formatter.FormatPlans(plans);
+
+        Assert.AreEqual(2, lines.Count);
+        Assert.AreEqual("shared token: ID | alt 0 -> after position 1 | alt 1 -> after position 1", lines[0]);
+        Assert.AreEqual("shared token: NUMBER | alt 2 -> after position 2 | alt 3 -> after position 2", lines[1]);
+    }
+
+    [TestMethod]
+    public void FormatPlans_IncludesBoundaryFallback_WhenContinuationPositionsDiverge()
+    {
+        var formatter = new ParserSharedPrefixPlanFormatter();
+        var plan = Plan("ID", 0, [Continuation(0, 1), Continuation(1, 2)]);
+
+        var lines = formatter.FormatPlans([plan]);
+
+        Assert.AreEqual(1, lines.Count);
+        Assert.AreEqual(
+            "shared token: ID | boundary: position 0 | alt 0 -> after position 1 | alt 1 -> after position 2",
+            lines[0]);
+    }
+
+    [TestMethod]
+    public void FormatPlans_UsesContinuationPositions()
+    {
+        var formatter = new ParserSharedPrefixPlanFormatter();
+        var plan = Plan("ID", 3, [Continuation(0, 3), Continuation(1, 3)]);
+
+        var lines = formatter.FormatPlans([plan]);
+
+        StringAssert.Contains(lines[0], "after position 3");
+    }
+
+    [TestMethod]
+    public void FormatPlans_DoesNotAlterSchedulingMetadata()
+    {
+        var formatter = new ParserSharedPrefixPlanFormatter();
+        var continuations = new[] { Continuation(0, 1), Continuation(1, 1) };
+        var plan = Plan("ID", 1, continuations);
+
+        _ = formatter.FormatPlans([plan]);
+
+        Assert.AreEqual(2, plan.Continuations.Count);
+        Assert.AreEqual(0, plan.Continuations[0].Key.AlternativeIndex);
+        Assert.AreEqual(1, plan.Continuations[0].Key.SequencePosition);
+        Assert.AreEqual(1, plan.Segment.Boundary.SequencePosition);
+    }
+
+    private static ParserSharedPrefixPlan Plan(
+        string tokenName,
+        int boundaryPosition,
+        IReadOnlyList<ParserContinuationDescriptor> continuations)
+    {
+        var alternativeIndexes = continuations.Select(static c => c.Key.AlternativeIndex).ToArray();
+        return new ParserSharedPrefixPlan(
+            tokenName,
+            alternativeIndexes,
+            continuations,
+            new ParserSharedPrefixSegment(tokenName, new ParserSharedPrefixBoundary(boundaryPosition, null)));
+    }
+
+    private static ParserContinuationDescriptor Continuation(int alternativeIndex, int sequencePosition)
+    {
+        return new ParserContinuationDescriptor(
+            new ParserContinuationKey("expr", alternativeIndex, sequencePosition),
+            ["ID"],
+            true);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a readable, deterministic dry-run/debug representation for existing shared-prefix planning metadata so plans can be inspected and audited without changing parser behavior.
- Keep the change conservative and metadata-only so it does not affect runtime parsing, diagnostics, or public APIs.

### Description
- Add an internal `ParserSharedPrefixPlanFormatter` that formats `ParserSharedPrefixPlan` (plus `ParserSharedPrefixSegment`/`ParserSharedPrefixBoundary`/`ParserContinuationDescriptor`) into stable, human-readable lines and renders an explicit boundary fallback when continuation positions diverge.
- Formatting uses continuation `SequencePosition` values and the plan `SharedTokenName` and remains deterministic and testable; the formatter is internal and not exposed on the public parser API.
- Added unit tests in `ParserSharedPrefixPlanFormatterTests.cs` and a small integration-style assertion in `AlternativeSchedulingMetadataTests.cs` to verify readable output for the `ID '+' expr | ID '-' expr` shape and to ensure the formatter does not mutate metadata.
- Modified/added files: `Utils.Parser/Runtime/ParserSharedPrefixPlanFormatter.cs`, `UtilsTest/Parser/ParserSharedPrefixPlanFormatterTests.cs`, and `UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs`.

### Testing
- Ran targeted tests with `dotnet test` for the parser metadata and scheduler suites including `ParserSharedPrefixPlanFormatterTests`, `AlternativeSchedulingMetadataTests`, `ParserContinuationFactoryTests`, `ParserSharedPrefixPlanFactoryTests`, and `AlternativeSchedulerTests`.
- Result: all targeted tests passed (`Passed: 42, Failed: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd67b82c8483268291af4ebdfdcc03)