### PR TITLE
Add conservative shared-prefix metadata validation

### DIFF
--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanValidator.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanValidator.cs
@@ -1,0 +1,121 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Defines severities produced by shared-prefix plan metadata validation.
+/// </summary>
+internal enum ParserSharedPrefixPlanValidationSeverity
+{
+    /// <summary>
+    /// Indicates informational metadata that does not invalidate a plan.
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Indicates suspicious metadata that should be reviewed.
+    /// </summary>
+    Warning
+}
+
+/// <summary>
+/// Represents one immutable validation issue produced for shared-prefix plan metadata.
+/// </summary>
+/// <param name="Severity">Severity assigned to this structural metadata issue.</param>
+/// <param name="Message">Deterministic issue message describing the detected condition.</param>
+internal readonly record struct ParserSharedPrefixPlanValidationIssue(
+    ParserSharedPrefixPlanValidationSeverity Severity,
+    string Message);
+
+/// <summary>
+/// Represents the immutable result of validating one shared-prefix plan.
+/// </summary>
+/// <param name="IsValid">
+/// <see langword="true"/> when no invalidating structural metadata was detected;
+/// otherwise, <see langword="false"/>.
+/// </param>
+/// <param name="Issues">Ordered structural metadata issues emitted during validation.</param>
+internal readonly record struct ParserSharedPrefixPlanValidationResult(
+    bool IsValid,
+    IReadOnlyList<ParserSharedPrefixPlanValidationIssue> Issues);
+
+/// <summary>
+/// Validates shared-prefix planning metadata conservatively without executing parser logic.
+/// </summary>
+internal sealed class ParserSharedPrefixPlanValidator
+{
+    /// <summary>
+    /// Validates one shared-prefix plan and returns deterministic structural metadata diagnostics.
+    /// </summary>
+    /// <param name="plan">Shared-prefix plan metadata to validate.</param>
+    /// <returns>An immutable validation result describing structural consistency and suspicious states.</returns>
+    public ParserSharedPrefixPlanValidationResult Validate(ParserSharedPrefixPlan plan)
+    {
+        var issues = new List<ParserSharedPrefixPlanValidationIssue>();
+        var isValid = true;
+
+        if (plan.Continuations.Count == 0)
+        {
+            issues.Add(new ParserSharedPrefixPlanValidationIssue(
+                ParserSharedPrefixPlanValidationSeverity.Warning,
+                "Shared-prefix plan has no continuations."));
+            isValid = false;
+        }
+
+        if (string.IsNullOrWhiteSpace(plan.Segment.SharedTokenName))
+        {
+            issues.Add(new ParserSharedPrefixPlanValidationIssue(
+                ParserSharedPrefixPlanValidationSeverity.Warning,
+                "Shared-prefix segment token name is empty."));
+            isValid = false;
+        }
+
+        if (plan.Segment.Boundary.SequencePosition < 0)
+        {
+            issues.Add(new ParserSharedPrefixPlanValidationIssue(
+                ParserSharedPrefixPlanValidationSeverity.Warning,
+                "Shared-prefix boundary position is negative."));
+            isValid = false;
+        }
+
+        var seenAlternativeIndexes = new HashSet<int>();
+        var hasDivergentContinuationPosition = false;
+        for (var index = 0; index < plan.Continuations.Count; index++)
+        {
+            var continuation = plan.Continuations[index];
+            if (continuation.Key.SequencePosition < 0)
+            {
+                issues.Add(new ParserSharedPrefixPlanValidationIssue(
+                    ParserSharedPrefixPlanValidationSeverity.Warning,
+                    "Shared-prefix continuation position is negative."));
+                isValid = false;
+            }
+
+            if (!seenAlternativeIndexes.Add(continuation.Key.AlternativeIndex))
+            {
+                issues.Add(new ParserSharedPrefixPlanValidationIssue(
+                    ParserSharedPrefixPlanValidationSeverity.Warning,
+                    $"Shared-prefix continuation alternative index {continuation.Key.AlternativeIndex} is duplicated."));
+            }
+
+            if (continuation.Key.SequencePosition != plan.Segment.Boundary.SequencePosition)
+            {
+                hasDivergentContinuationPosition = true;
+            }
+        }
+
+        if (hasDivergentContinuationPosition)
+        {
+            issues.Add(new ParserSharedPrefixPlanValidationIssue(
+                ParserSharedPrefixPlanValidationSeverity.Info,
+                "Shared-prefix boundary diverges from continuation positions; fallback metadata is expected."));
+
+            if (plan.Segment.Boundary.SequencePosition >= 0)
+            {
+                issues.Add(new ParserSharedPrefixPlanValidationIssue(
+                    ParserSharedPrefixPlanValidationSeverity.Warning,
+                    "Shared-prefix boundary position appears non-fallback while continuation positions diverge."));
+            }
+        }
+
+        return new ParserSharedPrefixPlanValidationResult(isValid, issues);
+    }
+}

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanValidator.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanValidator.cs
@@ -108,7 +108,7 @@ internal sealed class ParserSharedPrefixPlanValidator
                 ParserSharedPrefixPlanValidationSeverity.Info,
                 "Shared-prefix boundary diverges from continuation positions; fallback metadata is expected."));
 
-            if (plan.Segment.Boundary.SequencePosition >= 0)
+            if (plan.Segment.Boundary.SequencePosition != 0)
             {
                 issues.Add(new ParserSharedPrefixPlanValidationIssue(
                     ParserSharedPrefixPlanValidationSeverity.Warning,

--- a/UtilsTest/Parser/ParserSharedPrefixPlanValidatorTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixPlanValidatorTests.cs
@@ -31,10 +31,23 @@ public class ParserSharedPrefixPlanValidatorTests
     }
 
     [TestMethod]
-    public void Validate_ReturnsValidWithInfoAndWarning_WhenBoundaryDiverges()
+    public void Validate_ReturnsValidWithInfoWithoutNonFallbackWarning_WhenBoundaryIsFallbackAndDiverges()
     {
         var validator = new ParserSharedPrefixPlanValidator();
         var plan = Plan("ID", 0, [Continuation(0, 1), Continuation(1, 2)]);
+
+        var result = validator.Validate(plan);
+
+        Assert.IsTrue(result.IsValid);
+        Assert.IsTrue(result.Issues.Any(static issue => issue.Severity == ParserSharedPrefixPlanValidationSeverity.Info));
+        Assert.IsFalse(result.Issues.Any(static issue => issue.Message.Contains("non-fallback", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void Validate_ReturnsValidWithInfoAndNonFallbackWarning_WhenBoundaryIsNonFallbackAndDiverges()
+    {
+        var validator = new ParserSharedPrefixPlanValidator();
+        var plan = Plan("ID", 1, [Continuation(0, 2), Continuation(1, 3)]);
 
         var result = validator.Validate(plan);
 

--- a/UtilsTest/Parser/ParserSharedPrefixPlanValidatorTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixPlanValidatorTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ParserSharedPrefixPlanValidatorTests
+{
+    [TestMethod]
+    public void Validate_ReturnsValidWithoutIssues_ForNormalSharedPrefixPlan()
+    {
+        var validator = new ParserSharedPrefixPlanValidator();
+        var plan = Plan("ID", 1, [Continuation(0, 1), Continuation(1, 1)]);
+
+        var result = validator.Validate(plan);
+
+        Assert.IsTrue(result.IsValid);
+        Assert.AreEqual(0, result.Issues.Count);
+    }
+
+    [TestMethod]
+    public void Validate_ReturnsInvalid_WhenContinuationsAreMissing()
+    {
+        var validator = new ParserSharedPrefixPlanValidator();
+        var plan = Plan("ID", 1, []);
+
+        var result = validator.Validate(plan);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.IsTrue(result.Issues.Any(static issue => issue.Message.Contains("no continuations", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void Validate_ReturnsValidWithInfoAndWarning_WhenBoundaryDiverges()
+    {
+        var validator = new ParserSharedPrefixPlanValidator();
+        var plan = Plan("ID", 0, [Continuation(0, 1), Continuation(1, 2)]);
+
+        var result = validator.Validate(plan);
+
+        Assert.IsTrue(result.IsValid);
+        Assert.IsTrue(result.Issues.Any(static issue => issue.Severity == ParserSharedPrefixPlanValidationSeverity.Info));
+        Assert.IsTrue(result.Issues.Any(static issue => issue.Message.Contains("non-fallback", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void Validate_ReturnsWarning_WhenAlternativeIndexesAreDuplicated()
+    {
+        var validator = new ParserSharedPrefixPlanValidator();
+        var plan = Plan("ID", 1, [Continuation(0, 1), Continuation(0, 1)]);
+
+        var result = validator.Validate(plan);
+
+        Assert.IsTrue(result.IsValid);
+        Assert.IsTrue(result.Issues.Any(static issue => issue.Message.Contains("duplicated", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void Validate_ReturnsInvalid_WhenNegativePositionsArePresent()
+    {
+        var validator = new ParserSharedPrefixPlanValidator();
+        var plan = Plan("ID", -1, [Continuation(0, -1), Continuation(1, 2)]);
+
+        var result = validator.Validate(plan);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.IsTrue(result.Issues.Count >= 2);
+    }
+
+    [TestMethod]
+    public void Validate_ReturnsInvalid_WhenSharedTokenNameIsEmpty()
+    {
+        var validator = new ParserSharedPrefixPlanValidator();
+        var plan = Plan("   ", 1, [Continuation(0, 1), Continuation(1, 1)]);
+
+        var result = validator.Validate(plan);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.IsTrue(result.Issues.Any(static issue => issue.Message.Contains("token name is empty", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void Validate_IsDeterministicAcrossInvocations()
+    {
+        var validator = new ParserSharedPrefixPlanValidator();
+        var plan = Plan("ID", 0, [Continuation(0, 1), Continuation(1, 2)]);
+
+        var first = validator.Validate(plan);
+        var second = validator.Validate(plan);
+
+        Assert.AreEqual(first.IsValid, second.IsValid);
+        CollectionAssert.AreEqual(first.Issues.ToArray(), second.Issues.ToArray());
+    }
+
+    private static ParserSharedPrefixPlan Plan(
+        string tokenName,
+        int boundaryPosition,
+        IReadOnlyList<ParserContinuationDescriptor> continuations)
+    {
+        var alternativeIndexes = continuations.Select(static c => c.Key.AlternativeIndex).ToArray();
+        return new ParserSharedPrefixPlan(
+            tokenName,
+            alternativeIndexes,
+            continuations,
+            new ParserSharedPrefixSegment(tokenName, new ParserSharedPrefixBoundary(boundaryPosition, null)));
+    }
+
+    private static ParserContinuationDescriptor Continuation(int alternativeIndex, int sequencePosition)
+    {
+        return new ParserContinuationDescriptor(
+            new ParserContinuationKey("expr", alternativeIndex, sequencePosition),
+            ["ID"],
+            true);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a shallow, deterministic, metadata-only validator for shared-prefix plans to surface suspicious structural states and improve auditability for future shared-prefix execution work.
- Keep the change conservative and behavior-preserving by avoiding any parser execution, scheduling, pruning, diagnostics, or graph traversal changes.

### Description
- Add internal immutable validation models: `ParserSharedPrefixPlanValidationSeverity`, `ParserSharedPrefixPlanValidationIssue`, and `ParserSharedPrefixPlanValidationResult`.
- Add `ParserSharedPrefixPlanValidator` with a `Validate(ParserSharedPrefixPlan)` method that performs only structural metadata checks including missing continuations, empty shared token name, negative positions, duplicate alternative indexes, boundary/continuation divergence (fallback detection), and non-fallback/divergence warnings.
- Add focused unit tests in `ParserSharedPrefixPlanValidatorTests.cs` that exercise normal/valid plans, missing continuations, fallback divergence, duplicate alternatives, negative positions, empty token name, and deterministic results.
- The change is metadata-only and does not modify formatting behavior, parser execution, scheduling, diagnostics, or public APIs.

### Testing
- Ran the new focused unit tests (`ParserSharedPrefixPlanValidatorTests`) along with targeted parser non-regression tests: `ParserContinuationFactoryTests`, `ParserSharedPrefixPlanFactoryTests`, `ParserSharedPrefixPlanFormatterTests`, `AlternativeSchedulingMetadataTests`, and `AlternativeSchedulerTests`.
- All selected tests passed (Passed: 50, Failed: 0) when running `dotnet test` with the focused filter.
- The validator tests assert deterministic, repeatable validation results across invocations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b31cef8083269496746d780ce4ee)