### PR TITLE
docs(parser): add SharedPrefixExecutionPreconditions architecture document

### DIFF
--- a/docs/parser/SharedPrefixExecutionPreconditions.md
+++ b/docs/parser/SharedPrefixExecutionPreconditions.md
@@ -1,0 +1,117 @@
+# Shared Prefix Execution Preconditions (ParserEngine)
+
+## Scope and Intent
+
+This document defines the architectural preconditions that must be satisfied before any future shared-prefix *execution* experiments are allowed in `Utils.Parser` / `ParserEngine`.
+
+This document is intentionally conservative. It establishes constraints for safety and reviewability. It does not authorize execution changes by itself.
+
+## Current Runtime Status (Phase 0)
+
+The current shared-prefix components are **metadata-only** and **observational**:
+
+- `ParserLookaheadProbe`
+- `ParserLookaheadSharedPrefixDetector`
+- `ParserContinuationFactory`
+- `ParserSharedPrefixBoundary`
+- `ParserSharedPrefixSegment`
+- `ParserSharedPrefixPlan`
+- `ParserSharedPrefixPlanFormatter`
+- `ParserSharedPrefixPlanValidator`
+
+Current semantics:
+
+- Shared-prefix plans are descriptors only.
+- Continuations are structural descriptors only.
+- No continuation replay exists.
+- No resumable parser runtime exists.
+- No parser graph execution exists.
+- No shared-prefix parsing is executed.
+
+## Architectural Invariants (Must Always Hold)
+
+Any future work must preserve all current externally observable parser behavior, including:
+
+1. Parser determinism.
+2. Parse tree shape and node ordering.
+3. Diagnostics content, position, and ordering.
+4. Scheduling order semantics.
+5. Alternative ordering semantics.
+6. Runtime conservatism (correctness-first behavior under uncertainty).
+
+Invariants above are non-negotiable. Optimization opportunities must be rejected if they cannot preserve these properties.
+
+## Preconditions for Any Future Shared-Prefix Execution Experiment
+
+No shared-prefix execution experiment is permitted unless **all** conditions below are satisfied for the targeted scenario:
+
+1. **Non-fallback boundary**: the boundary is not marked fallback and cannot re-enter fallback paths.
+2. **Stable continuation positions**: continuation anchors are stable and reproducible for all alternatives.
+3. **Homogeneous continuation structure**: continuation descriptors are structurally compatible across alternatives.
+4. **Deterministic scheduling**: execution order is deterministic and equivalent to current behavior.
+5. **No observable side effects**: executing a shared prefix once does not suppress, duplicate, or reorder visible effects.
+6. **No semantic predicate influence**: semantic predicates do not alter alternative selection within the shared segment.
+7. **No unsafe embedded actions**: embedded actions in the shared segment are absent or proven behaviorally inert.
+8. **No diagnostics divergence**: diagnostics emitted by shared execution are exactly equivalent to baseline execution.
+9. **No parse tree divergence**: parse tree structure and token-to-node mapping remain equivalent to baseline execution.
+
+If any precondition is not proven, the runtime must keep baseline behavior (duplicated work per alternative).
+
+## Explicitly Unsupported Cases (Initially Rejected)
+
+Future shared-prefix execution work must initially reject the following cases:
+
+- Recursive shared-prefix replay.
+- Nested shared-prefix execution.
+- Fallback boundaries.
+- Divergent continuation layouts.
+- Parser graph execution.
+- Speculative replay.
+- Async continuations.
+- Parallel parsing.
+- Parse forests.
+- Generalized LL / GLL behavior.
+
+## Non-Goals (Current Project State)
+
+The project is **not** currently implementing:
+
+- Adaptive LL parsing.
+- GLL parsing.
+- Parser DAG/graph execution.
+- Coroutine-based parsing.
+- Parallel parsing.
+- Async parsing.
+- Parse forest generation.
+
+## Conservative Phased Roadmap (Intent Only)
+
+The roadmap below is architectural guidance only. It is not a commitment to deliver behavior changes.
+
+- **Phase 0 (current)**: metadata-only shared-prefix detection/planning and validation.
+- **Phase 1**: validation hardening and documentation stabilization.
+- **Phase 2**: extremely limited shared-token execution experiments under strict gating.
+- **Phase 3**: continuation replay experiments with explicit equivalence checks.
+- **Phase 4**: possible reduction of duplicated parsing work, only where safety is demonstrated.
+
+Later phases remain optional and may be postponed or cancelled if invariants cannot be preserved.
+
+## Safety Philosophy
+
+Parser correctness and auditability have priority over optimization:
+
+- Correctness must dominate throughput improvements.
+- Duplicated work is acceptable when equivalence cannot be proven.
+- Runtime stability is preferred over aggressive execution strategies.
+- Parser behavior must remain explainable, deterministic, and reviewable.
+
+## Review Gate for Future PRs
+
+Any future PR proposing shared-prefix execution must explicitly include:
+
+1. Which preconditions are satisfied and how they were demonstrated.
+2. Which unsupported cases remain rejected.
+3. Why parser determinism, diagnostics, scheduling, and parse tree behavior remain equivalent.
+4. A rollback path preserving baseline behavior.
+
+Without this evidence, execution-oriented changes must not be merged.


### PR DESCRIPTION
### Motivation
- Provide conservative architectural guardrails that explicitly delimit what is and is not allowed before any shared-prefix *execution* experiments are attempted in `Utils.Parser` / `ParserEngine`.
- Ensure future reviewers and contributors have a clear, auditable checklist that preserves parser determinism, parse-tree shape, diagnostics, scheduling, and observable behavior.

### Description
- Add a single documentation file at `docs/parser/SharedPrefixExecutionPreconditions.md` that records the current runtime status (metadata-only shared-prefix components) and states that no shared-prefix execution or continuation replay is performed today.
- Enumerate non-negotiable architectural invariants (parser determinism, parse tree shape, diagnostics, scheduling, alternative ordering, and runtime conservatism) and a strict set of preconditions that must all be satisfied before any shared-prefix execution may be considered.
- List explicitly unsupported cases (recursive/nested replay, fallback boundaries, parser graph execution, speculative/async/parallel parsing, parse forests, GLL/adaptive LL, etc.), present a conservative phased roadmap (Phase 0..4) as guidance only, and define a review gate checklist for future execution PRs.

### Testing
- No automated tests were run because this is a documentation-only change that does not modify runtime code, public APIs, or metadata semantics, and therefore does not require test changes under the project guidelines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d56bbb908326bb5dba9a5bde5c33)