### PR TITLE
Add metadata-only shared-prefix execution eligibility analyzer

### DIFF
--- a/Utils.Parser/Runtime/ParserSharedPrefixExecutionEligibilityAnalyzer.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixExecutionEligibilityAnalyzer.cs
@@ -64,7 +64,7 @@ internal sealed class ParserSharedPrefixExecutionEligibilityAnalyzer
         var boundaryPosition = plan.Segment.Boundary.SequencePosition;
         if (boundaryPosition < 0)
         {
-            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP004", "Negative continuation position detected."));
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP004", "Negative shared-prefix position detected."));
         }
 
         if (string.IsNullOrWhiteSpace(plan.Segment.SharedTokenName))
@@ -108,7 +108,7 @@ internal sealed class ParserSharedPrefixExecutionEligibilityAnalyzer
 
         if (hasNegativeContinuationPosition)
         {
-            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP004", "Negative continuation position detected."));
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP004", "Negative shared-prefix position detected."));
         }
 
         if (hasDivergentContinuationPosition)

--- a/Utils.Parser/Runtime/ParserSharedPrefixExecutionEligibilityAnalyzer.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixExecutionEligibilityAnalyzer.cs
@@ -1,0 +1,159 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Represents conservative execution eligibility classifications for shared-prefix plan metadata.
+/// </summary>
+internal enum ParserSharedPrefixExecutionEligibility
+{
+    /// <summary>
+    /// Indicates that the metadata shape is conservatively safe for future shared-prefix execution experiments.
+    /// </summary>
+    Eligible,
+
+    /// <summary>
+    /// Indicates that fallback-only execution should be required if execution is ever introduced.
+    /// </summary>
+    RequiresFallback,
+
+    /// <summary>
+    /// Indicates that the metadata shape is currently unsupported for execution.
+    /// </summary>
+    NotEligible,
+
+    /// <summary>
+    /// Indicates contradictory or corrupted metadata that should be treated as unsafe.
+    /// </summary>
+    Unsafe
+}
+
+/// <summary>
+/// Represents one deterministic blocker emitted by shared-prefix execution eligibility analysis.
+/// </summary>
+/// <param name="Code">Stable blocker code.</param>
+/// <param name="Message">Deterministic blocker message.</param>
+internal readonly record struct ParserSharedPrefixExecutionBlocker(
+    string Code,
+    string Message);
+
+/// <summary>
+/// Represents the immutable result of analyzing one shared-prefix plan for execution eligibility.
+/// </summary>
+/// <param name="Eligibility">Conservative execution eligibility classification.</param>
+/// <param name="Blockers">Deterministic blockers explaining why the plan is not fully eligible.</param>
+internal readonly record struct ParserSharedPrefixExecutionEligibilityResult(
+    ParserSharedPrefixExecutionEligibility Eligibility,
+    IReadOnlyList<ParserSharedPrefixExecutionBlocker> Blockers);
+
+/// <summary>
+/// Analyzes shared-prefix plan metadata conservatively without executing parser logic.
+/// </summary>
+internal sealed class ParserSharedPrefixExecutionEligibilityAnalyzer
+{
+    private readonly ParserSharedPrefixPlanValidator validator = new();
+
+    /// <summary>
+    /// Analyzes one shared-prefix plan and classifies conservative execution eligibility.
+    /// </summary>
+    /// <param name="plan">Shared-prefix plan metadata to classify.</param>
+    /// <returns>Immutable classification and deterministic blockers.</returns>
+    public ParserSharedPrefixExecutionEligibilityResult Analyze(ParserSharedPrefixPlan plan)
+    {
+        var blockers = new List<ParserSharedPrefixExecutionBlocker>();
+        var validation = this.validator.Validate(plan);
+
+        var boundaryPosition = plan.Segment.Boundary.SequencePosition;
+        if (boundaryPosition < 0)
+        {
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP004", "Negative continuation position detected."));
+        }
+
+        if (string.IsNullOrWhiteSpace(plan.Segment.SharedTokenName))
+        {
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP005", "Shared segment token is empty."));
+        }
+
+        if (plan.Continuations.Count == 0)
+        {
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP006", "Shared-prefix plan has no continuations."));
+        }
+
+        var seenAlternativeIndexes = new HashSet<int>();
+        var hasDuplicateAlternativeIndex = false;
+        var hasNegativeContinuationPosition = false;
+        var hasDivergentContinuationPosition = false;
+
+        for (var index = 0; index < plan.Continuations.Count; index++)
+        {
+            var continuation = plan.Continuations[index];
+            if (!seenAlternativeIndexes.Add(continuation.Key.AlternativeIndex))
+            {
+                hasDuplicateAlternativeIndex = true;
+            }
+
+            if (continuation.Key.SequencePosition < 0)
+            {
+                hasNegativeContinuationPosition = true;
+            }
+
+            if (continuation.Key.SequencePosition != boundaryPosition)
+            {
+                hasDivergentContinuationPosition = true;
+            }
+        }
+
+        if (hasDuplicateAlternativeIndex)
+        {
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP003", "Duplicate alternative indexes detected."));
+        }
+
+        if (hasNegativeContinuationPosition)
+        {
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP004", "Negative continuation position detected."));
+        }
+
+        if (hasDivergentContinuationPosition)
+        {
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP002", "Continuation positions diverge."));
+        }
+
+        if (boundaryPosition == 0)
+        {
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP001", "Fallback boundary prevents safe execution."));
+        }
+
+        if (!validation.IsValid)
+        {
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP007", "Plan validation failed."));
+        }
+
+        var hasNonFallbackDivergenceWarning = validation.Issues.Any(static issue =>
+            issue.Severity == ParserSharedPrefixPlanValidationSeverity.Warning
+            && issue.Message.Contains("non-fallback", StringComparison.Ordinal));
+
+        if (hasNonFallbackDivergenceWarning)
+        {
+            return new ParserSharedPrefixExecutionEligibilityResult(ParserSharedPrefixExecutionEligibility.Unsafe, blockers);
+        }
+
+        if (boundaryPosition < 0 || hasNegativeContinuationPosition)
+        {
+            return new ParserSharedPrefixExecutionEligibilityResult(ParserSharedPrefixExecutionEligibility.Unsafe, blockers);
+        }
+
+        if (hasDivergentContinuationPosition && boundaryPosition == 0)
+        {
+            return new ParserSharedPrefixExecutionEligibilityResult(ParserSharedPrefixExecutionEligibility.RequiresFallback, blockers);
+        }
+
+        if (validation.IsValid
+            && blockers.Count == 0
+            && boundaryPosition > 0
+            && !hasDivergentContinuationPosition
+            && !hasDuplicateAlternativeIndex)
+        {
+            return new ParserSharedPrefixExecutionEligibilityResult(ParserSharedPrefixExecutionEligibility.Eligible, blockers);
+        }
+
+        return new ParserSharedPrefixExecutionEligibilityResult(ParserSharedPrefixExecutionEligibility.NotEligible, blockers);
+    }
+}

--- a/UtilsTest/Parser/ParserSharedPrefixExecutionEligibilityAnalyzerTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixExecutionEligibilityAnalyzerTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ParserSharedPrefixExecutionEligibilityAnalyzerTests
+{
+    [TestMethod]
+    public void Analyze_ReturnsEligible_ForSimpleOperatorShape()
+    {
+        var analyzer = new ParserSharedPrefixExecutionEligibilityAnalyzer();
+        var plan = Plan("ID", 1, [Continuation(0, 1), Continuation(1, 1)]);
+
+        var result = analyzer.Analyze(plan);
+
+        Assert.AreEqual(ParserSharedPrefixExecutionEligibility.Eligible, result.Eligibility);
+        Assert.AreEqual(0, result.Blockers.Count);
+    }
+
+    [TestMethod]
+    public void Analyze_ReturnsRequiresFallback_WithSp001AndSp002_ForFallbackDivergence()
+    {
+        var analyzer = new ParserSharedPrefixExecutionEligibilityAnalyzer();
+        var plan = Plan("ID", 0, [Continuation(0, 1), Continuation(1, 2)]);
+
+        var result = analyzer.Analyze(plan);
+
+        Assert.AreEqual(ParserSharedPrefixExecutionEligibility.RequiresFallback, result.Eligibility);
+        Assert.IsTrue(result.Blockers.Any(static blocker => blocker.Code == "SP001"));
+        Assert.IsTrue(result.Blockers.Any(static blocker => blocker.Code == "SP002"));
+    }
+
+    [TestMethod]
+    public void Analyze_ReturnsNotEligible_ForInvalidMetadata()
+    {
+        var analyzer = new ParserSharedPrefixExecutionEligibilityAnalyzer();
+        var plan = Plan(" ", 1, []);
+
+        var result = analyzer.Analyze(plan);
+
+        Assert.AreEqual(ParserSharedPrefixExecutionEligibility.NotEligible, result.Eligibility);
+        Assert.IsTrue(result.Blockers.Count > 0);
+    }
+
+    [TestMethod]
+    public void Analyze_ReturnsUnsafe_ForContradictoryMetadata()
+    {
+        var analyzer = new ParserSharedPrefixExecutionEligibilityAnalyzer();
+        var plan = Plan("ID", 1, [Continuation(0, 2), Continuation(1, 3)]);
+
+        var result = analyzer.Analyze(plan);
+
+        Assert.AreEqual(ParserSharedPrefixExecutionEligibility.Unsafe, result.Eligibility);
+        Assert.IsTrue(result.Blockers.Any(static blocker => blocker.Code == "SP002"));
+    }
+
+    [TestMethod]
+    public void Analyze_ReturnsNotEligible_ForDuplicateAlternatives()
+    {
+        var analyzer = new ParserSharedPrefixExecutionEligibilityAnalyzer();
+        var plan = Plan("ID", 1, [Continuation(0, 1), Continuation(0, 1)]);
+
+        var result = analyzer.Analyze(plan);
+
+        Assert.AreEqual(ParserSharedPrefixExecutionEligibility.NotEligible, result.Eligibility);
+        Assert.IsTrue(result.Blockers.Any(static blocker => blocker.Code == "SP003"));
+    }
+
+    [TestMethod]
+    public void Analyze_ReturnsUnsafe_ForNegativePositions()
+    {
+        var analyzer = new ParserSharedPrefixExecutionEligibilityAnalyzer();
+        var plan = Plan("ID", -1, [Continuation(0, -1), Continuation(1, 1)]);
+
+        var result = analyzer.Analyze(plan);
+
+        Assert.AreEqual(ParserSharedPrefixExecutionEligibility.Unsafe, result.Eligibility);
+        Assert.IsTrue(result.Blockers.Any(static blocker => blocker.Code == "SP004"));
+    }
+
+    private static ParserSharedPrefixPlan Plan(
+        string tokenName,
+        int boundaryPosition,
+        IReadOnlyList<ParserContinuationDescriptor> continuations)
+    {
+        var alternativeIndexes = continuations.Select(static continuation => continuation.Key.AlternativeIndex).ToArray();
+        return new ParserSharedPrefixPlan(
+            tokenName,
+            alternativeIndexes,
+            continuations,
+            new ParserSharedPrefixSegment(tokenName, new ParserSharedPrefixBoundary(boundaryPosition, null)));
+    }
+
+    private static ParserContinuationDescriptor Continuation(int alternativeIndex, int sequencePosition)
+    {
+        return new ParserContinuationDescriptor(
+            new ParserContinuationKey("expr", alternativeIndex, sequencePosition),
+            ["ID"],
+            true);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a conservative, metadata-only analyzer that can deterministically answer whether a `ParserSharedPrefixPlan` could be considered for future shared-prefix execution without executing any parser logic.
- Surface explicit, stable blockers for unsafe or unsupported plan shapes to aid code review and future experiments while preserving runtime behavior.
- Keep the subsystem internal, immutable, deterministic, and strictly read-only to avoid introducing execution, scheduling, or runtime changes.

### Description
- Added `Utils.Parser/Runtime/ParserSharedPrefixExecutionEligibilityAnalyzer.cs` introducing internal immutable types: `ParserSharedPrefixExecutionEligibility`, `ParserSharedPrefixExecutionBlocker`, and `ParserSharedPrefixExecutionEligibilityResult`, and the `ParserSharedPrefixExecutionEligibilityAnalyzer` with `Analyze(ParserSharedPrefixPlan)` logic.
- Analyzer reuses `ParserSharedPrefixPlanValidator` for structural validation, emits deterministic blocker codes/messages (`SP001`..`SP007`), and implements conservative classification into `Eligible`, `RequiresFallback`, `NotEligible`, or `Unsafe` without mutating plans or altering runtime behavior.
- Added focused unit tests in `UtilsTest/Parser/ParserSharedPrefixExecutionEligibilityAnalyzerTests.cs` that cover: a simple eligible operator case, requires-fallback fallback divergence, invalid metadata, contradictory metadata (unsafe), duplicate alternatives, and negative positions.

### Testing
- Executed the targeted non-regression parser metadata/scheduling test set with: `dotnet test UtilsTest/UtilsTest.csproj --filter "ParserSharedPrefixExecutionEligibilityAnalyzerTests|ParserSharedPrefixPlanValidatorTests|ParserSharedPrefixPlanFormatterTests|ParserSharedPrefixMetadataScenarioTests|AlternativeSchedulingMetadataTests|AlternativeSchedulerTests"` and the run passed (no failures).
- The newly added `ParserSharedPrefixExecutionEligibilityAnalyzerTests` passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d7ab7a0883268768f1fccf8e67ea)