### PR TITLE
fix(parser): correct medium and low severity audit findings

### DIFF
--- a/Utils.Parser/Bootstrap/SyntaxColorisationGrammar.cs
+++ b/Utils.Parser/Bootstrap/SyntaxColorisationGrammar.cs
@@ -380,7 +380,8 @@ public static class SyntaxColorisationGrammar
     internal static int ComputeTokenLimit(string source)
     {
         int sourceLength = source?.Length ?? 0;
-        return Math.Max(256, (sourceLength + 1) * 4);
+        long computed = ((long)sourceLength + 1) * 4;
+        return (int)Math.Max(256, Math.Min(computed, int.MaxValue));
     }
 
     /// <summary>

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -40,7 +40,7 @@ internal sealed class AlternativeScheduler
                 continue;
             }
 
-            completedStates.Add(EnsureInitialized(parsed, initial));
+            completedStates.Add(EnsureInitialized(parsed));
         }
 
         if (completedStates.Count == 0)
@@ -130,7 +130,7 @@ internal sealed class AlternativeScheduler
             OriginInputPosition = originInputPosition,
             CurrentInputPosition = originInputPosition,
             AlternativeIndex = alternativeIndex,
-            Cursor = new RuleContentCursor { Index = 0, Kind = "alternative-root" },
+            Cursor = new RuleContentCursor { Index = 0, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot },
             PartialNode = new ErrorNode(new SourceSpan(originInputPosition, 0), "DEFAULT_MODE", "Alternative not evaluated", rule),
             EndPosition = null,
             Status = ActiveParseStateStatus.Active,
@@ -140,21 +140,12 @@ internal sealed class AlternativeScheduler
         };
     }
 
-    private static ActiveParseState EnsureInitialized(ActiveParseState state, ActiveParseState fallback)
+    private static ActiveParseState EnsureInitialized(ActiveParseState state)
     {
         return state with
         {
-            Rule = state.Rule,
-            Alternative = state.Alternative,
-            OriginInputPosition = state.OriginInputPosition,
-            AlternativeIndex = state.AlternativeIndex,
-            Cursor = state.Cursor,
-            PartialNode = state.PartialNode,
             Status = state.Status == ActiveParseStateStatus.Active ? ActiveParseStateStatus.Completed : state.Status,
-            EndPosition = state.EndPosition ?? state.CurrentInputPosition,
-            ParentStateKey = state.ParentStateKey,
-            Depth = state.Depth,
-            Continuation = state.Continuation
+            EndPosition = state.EndPosition ?? state.CurrentInputPosition
         };
     }
 

--- a/Utils.Parser/Runtime/KeywordLookup.cs
+++ b/Utils.Parser/Runtime/KeywordLookup.cs
@@ -89,7 +89,7 @@ internal sealed class KeywordLookup
         {
             int peeked = stream.Peek(offset);
             if (peeked < 0) break;                                // end of stream
-            char c = (char)peeked;
+            char c = (char)peeked;                                // safe: buffer stores char (UTF-16 units)
 
             char key = Normalize(c);
             if (!nodes.TryGetValue(key, out var node)) break;   // no further trie path

--- a/Utils.Parser/Runtime/LexerEngine.cs
+++ b/Utils.Parser/Runtime/LexerEngine.cs
@@ -9,6 +9,10 @@ namespace Utils.Parser.Runtime;
 /// Converts a <see cref="TextReader"/> into a sequence of <see cref="Token"/> values
 /// using the lexer rules in a <see cref="ParserDefinition"/>.
 /// </summary>
+/// <remarks>
+/// This class is not thread-safe. Each concurrent tokenization must use a separate
+/// <see cref="LexerEngine"/> instance.
+/// </remarks>
 public sealed class LexerEngine(ParserDefinition definition)
 {
     private const string DefaultChannel = "DEFAULT_CHANNEL";

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -23,6 +23,10 @@ namespace Utils.Parser.Runtime;
 /// execution; they have no effect on the parse tree shape.
 /// </para>
 /// </summary>
+/// <remarks>
+/// This class is not thread-safe. Each concurrent parse must use a separate
+/// <see cref="ParserEngine"/> instance.
+/// </remarks>
 public sealed class ParserEngine
 {
     private readonly ParserDefinition _definition;

--- a/Utils.Parser/Runtime/ParserSharedPrefixExecutionEligibilityAnalyzer.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixExecutionEligibilityAnalyzer.cs
@@ -108,7 +108,7 @@ internal sealed class ParserSharedPrefixExecutionEligibilityAnalyzer
 
         if (hasNegativeContinuationPosition)
         {
-            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP004", "Negative shared-prefix position detected."));
+            blockers.Add(new ParserSharedPrefixExecutionBlocker("SP008", "Negative continuation sequence position detected."));
         }
 
         if (hasDivergentContinuationPosition)
@@ -145,11 +145,7 @@ internal sealed class ParserSharedPrefixExecutionEligibilityAnalyzer
             return new ParserSharedPrefixExecutionEligibilityResult(ParserSharedPrefixExecutionEligibility.RequiresFallback, blockers);
         }
 
-        if (validation.IsValid
-            && blockers.Count == 0
-            && boundaryPosition > 0
-            && !hasDivergentContinuationPosition
-            && !hasDuplicateAlternativeIndex)
+        if (validation.IsValid && blockers.Count == 0)
         {
             return new ParserSharedPrefixExecutionEligibilityResult(ParserSharedPrefixExecutionEligibility.Eligible, blockers);
         }

--- a/Utils.Parser/Runtime/ScheduledAlternativeCursorKinds.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeCursorKinds.cs
@@ -11,6 +11,8 @@ internal static class ScheduledAlternativeCursorKinds
 
     public const string Alternation = "alternation";
 
+    public const string AlternativeRoot = "alternative-root";
+
     /// <summary>
     /// Returns <c>true</c> when the cursor kind supports conservative negative look-ahead shortcut reuse.
     /// </summary>

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
@@ -116,7 +116,7 @@ internal sealed class ScheduledAlternativeExecutor
             OriginInputPosition = startPosition,
             CurrentInputPosition = context.Position,
             AlternativeIndex = alternativeIndex,
-            Cursor = new RuleContentCursor { Index = 0, Kind = "alternative-root" },
+            Cursor = new RuleContentCursor { Index = 0, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot },
             PartialNode = result,
             EndPosition = context.Position,
             Status = ActiveParseStateStatus.Completed,

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -53,6 +53,45 @@ public class AlternativeSchedulerTests
     }
 
     [TestMethod]
+    public void Run_ReturnsNoSelectedState_WhenAlternativesIsEmpty()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = new Rule("r", 0, false, new Alternation([]));
+        var context = new ParseContext([]);
+
+        var result = scheduler.Run(
+            rule,
+            [],
+            originInputPosition: 0,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
+
+        Assert.IsNull(result.SelectedState);
+        Assert.AreEqual(0, result.CompletedStates.Count);
+        Assert.AreEqual(0, result.FailedStates.Count);
+    }
+
+    [TestMethod]
+    public void Run_AllAlternativesFail_ReturnsNullSelectedStateAndAllFailed()
+    {
+        var scheduler = new AlternativeScheduler();
+        var (context, rule, alternatives) = CreateAlternatives();
+
+        var result = scheduler.Run(
+            rule,
+            alternatives,
+            originInputPosition: context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
+
+        Assert.IsNull(result.SelectedState);
+        Assert.AreEqual(0, result.CompletedStates.Count);
+        Assert.AreEqual(alternatives.Count, result.FailedStates.Count);
+    }
+
+    [TestMethod]
     public void Run_UsesMinimumPrecedenceInIdentity()
     {
         var scheduler = new AlternativeScheduler();

--- a/UtilsTest/Parser/ParserSharedPrefixExecutionEligibilityAnalyzerTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixExecutionEligibilityAnalyzerTests.cs
@@ -68,15 +68,27 @@ public class ParserSharedPrefixExecutionEligibilityAnalyzerTests
     }
 
     [TestMethod]
-    public void Analyze_ReturnsUnsafe_ForNegativePositions()
+    public void Analyze_ReturnsUnsafe_ForNegativeBoundaryPosition()
     {
         var analyzer = new ParserSharedPrefixExecutionEligibilityAnalyzer();
-        var plan = Plan("ID", -1, [Continuation(0, -1), Continuation(1, 1)]);
+        var plan = Plan("ID", -1, [Continuation(0, 1), Continuation(1, 1)]);
 
         var result = analyzer.Analyze(plan);
 
         Assert.AreEqual(ParserSharedPrefixExecutionEligibility.Unsafe, result.Eligibility);
         Assert.IsTrue(result.Blockers.Any(static blocker => blocker.Code == "SP004"));
+    }
+
+    [TestMethod]
+    public void Analyze_ReturnsUnsafe_ForNegativeContinuationPosition()
+    {
+        var analyzer = new ParserSharedPrefixExecutionEligibilityAnalyzer();
+        var plan = Plan("ID", 1, [Continuation(0, -1), Continuation(1, 1)]);
+
+        var result = analyzer.Analyze(plan);
+
+        Assert.AreEqual(ParserSharedPrefixExecutionEligibility.Unsafe, result.Eligibility);
+        Assert.IsTrue(result.Blockers.Any(static blocker => blocker.Code == "SP008"));
     }
 
     private static ParserSharedPrefixPlan Plan(


### PR DESCRIPTION
## Summary

- Fix overflow risk in `ComputeTokenLimit`: cast to `long` before multiplication, then clamp to `int.MaxValue`
- Replace magic string `"alternative-root"` with `ScheduledAlternativeCursorKinds.AlternativeRoot` constant (x2)
- Simplify `EnsureInitialized` to only set the two fields that actually change
- Rename SP004 blocker for negative continuation position to SP008 to avoid collision with the existing SP004 boundary check
- Simplify the `Eligible` guard condition: redundant checks already covered by `blockers.Count == 0`
- Add thread-safety remarks to `LexerEngine` and `ParserEngine` doc comments
- Add inline comment clarifying safe `(char)` cast in `KeywordLookup`

## Test plan

- [ ] New `AlternativeSchedulerTests`: empty-alternatives and all-fail scenarios
- [ ] New `ParserSharedPrefixExecutionEligibilityAnalyzerTests`: separate tests for negative boundary (SP004) and negative continuation (SP008)
- [ ] Run full test suite (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)