### PR TITLE
Fix continuation sequence-position normalization after final sequence item

### DIFF
--- a/Utils.Parser/Runtime/ParserContinuationFactory.cs
+++ b/Utils.Parser/Runtime/ParserContinuationFactory.cs
@@ -85,8 +85,7 @@ internal sealed class ParserContinuationFactory
         }
 
         var meaningfulIndex = 0;
-        var maxIndex = sequence.Items.Count - 1;
-        var boundedPosition = sequencePosition > maxIndex ? maxIndex : sequencePosition;
+        var boundedPosition = sequencePosition > sequence.Items.Count ? sequence.Items.Count : sequencePosition;
 
         for (var index = 0; index < boundedPosition; index++)
         {

--- a/UtilsTest/Parser/ParserContinuationFactoryTests.cs
+++ b/UtilsTest/Parser/ParserContinuationFactoryTests.cs
@@ -154,6 +154,46 @@ public class ParserContinuationFactoryTests
     }
 
     [TestMethod]
+    public void Create_SequenceContinuationAfterFinalItem_PreservesMeaningfulPosition()
+    {
+        var factory = new ParserContinuationFactory();
+        var rule = new Rule("expr", 0, false, new Alternation([]));
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID")]));
+
+        var descriptor = factory.Create(rule, alternative, 0, 1, null, false);
+
+        Assert.AreEqual(1, descriptor.Key.SequencePosition);
+    }
+
+    [TestMethod]
+    public void Create_SequenceContinuationAfterMeaningfulItem_IgnoresEmbeddedActionAndLexerCommand()
+    {
+        var factory = new ParserContinuationFactory();
+        var rule = new Rule("expr", 0, false, new Alternation([]));
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([
+            new EmbeddedAction("x();", ActionContext.Alternative, ActionPosition.Inline, []),
+            new LexerCommand(LexerCommandType.Skip, null),
+            new RuleRef("ID")
+        ]));
+
+        var descriptor = factory.Create(rule, alternative, 0, 3, null, false);
+
+        Assert.AreEqual(1, descriptor.Key.SequencePosition);
+    }
+
+    [TestMethod]
+    public void Create_SequenceContinuationBeyondLength_ClampsToSequenceLength()
+    {
+        var factory = new ParserContinuationFactory();
+        var rule = new Rule("expr", 0, false, new Alternation([]));
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new RuleRef("expr")]));
+
+        var descriptor = factory.Create(rule, alternative, 0, 99, null, false);
+
+        Assert.AreEqual(2, descriptor.Key.SequencePosition);
+    }
+
+    [TestMethod]
     public void ComputeSharedPrefixSequencePosition_UnsupportedStructure_FallsBackToZero()
     {
         var factory = new ParserContinuationFactory();


### PR DESCRIPTION
### Motivation
- Fix an off-by-one clamp in continuation metadata normalization that under-counted positions located after the final sequence item while preserving all existing normalization semantics (ignored `EmbeddedAction`/`LexerCommand`, meaningful-item counting) and avoiding any runtime or API changes.

### Description
- Replace the upper-bound clamp in `ParserContinuationFactory.ComputeSequencePosition(...)` so raw positions are bounded to `sequence.Items.Count` instead of `sequence.Items.Count - 1`, allowing continuation positions after the last item to normalize correctly (`Utils.Parser/Runtime/ParserContinuationFactory.cs`).
- Add three unit tests validating the end-of-sequence behavior: final-item continuation normalization, ignoring `EmbeddedAction`/`LexerCommand` during normalization, and clamping of extreme positions beyond sequence length (`UtilsTest/Parser/ParserContinuationFactoryTests.cs`).
- Change is metadata-only, conservative, and keeps the original loop that counts meaningful items before the continuation position.

### Testing
- Ran the targeted non-regression test set using the test filter for parser metadata: `ParserContinuationFactoryTests`, `ParserSharedPrefixPlanFactoryTests`, `ParserSharedPrefixMetadataScenarioTests`, `ParserSharedPrefixExecutionEligibilityAnalyzerTests`, and `AlternativeSchedulingMetadataTests`.
- All targeted tests passed: `Passed: 49, Failed: 0` (no test regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a018107e5d08326af1dd922df261086)