### PR TITLE
Add execution eligibility details to shared-prefix dry-run formatter output

### DIFF
--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanFormatter.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanFormatter.cs
@@ -5,6 +5,8 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class ParserSharedPrefixPlanFormatter
 {
+    private readonly ParserSharedPrefixExecutionEligibilityAnalyzer eligibilityAnalyzer = new();
+
     /// <summary>
     /// Formats a list of shared-prefix plans while preserving plan and continuation order.
     /// </summary>
@@ -30,18 +32,36 @@ internal sealed class ParserSharedPrefixPlanFormatter
     /// Formats one shared-prefix plan into a deterministic multi-line dry-run block.
     /// </summary>
     /// <param name="plan">Shared-prefix plan metadata.</param>
-    /// <returns>A readable block with explicit shared segment, boundary, and continuations.</returns>
-    private static string FormatPlan(ParserSharedPrefixPlan plan)
+    /// <returns>
+    /// A readable block with explicit shared segment, boundary, eligibility status,
+    /// optional blockers, and continuations.
+    /// </returns>
+    private string FormatPlan(ParserSharedPrefixPlan plan)
     {
         var isFallbackBoundary = IsFallbackBoundary(plan);
+        var eligibility = this.eligibilityAnalyzer.Analyze(plan);
         var lines = new List<string>
         {
             $"shared segment: {plan.Segment.SharedTokenName}",
             isFallbackBoundary
                 ? $"boundary: position {plan.Segment.Boundary.SequencePosition} (fallback)"
                 : $"boundary: position {plan.Segment.Boundary.SequencePosition}",
-            "continuations:"
+            $"eligibility: {eligibility.Eligibility}",
         };
+
+        if (eligibility.Blockers.Count > 0)
+        {
+            lines.Add("blockers:");
+            for (var index = 0; index < eligibility.Blockers.Count; index++)
+            {
+                var blocker = eligibility.Blockers[index];
+                lines.Add($"  {blocker.Code}: {blocker.Message}");
+            }
+        }
+
+        lines.Add(
+            "continuations:"
+        );
 
         for (var index = 0; index < plan.Continuations.Count; index++)
         {

--- a/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
@@ -36,7 +36,7 @@ public class ParserSharedPrefixMetadataScenarioTests
 
         var formatted = new ParserSharedPrefixPlanFormatter().FormatPlans(plans);
         Assert.AreEqual(1, formatted.Count);
-        Assert.AreEqual("shared segment: ID\nboundary: position 1\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 1", formatted[0]);
+        Assert.AreEqual("shared segment: ID\nboundary: position 1\neligibility: Eligible\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 1", formatted[0]);
     }
 
     /// <summary>
@@ -115,7 +115,7 @@ public class ParserSharedPrefixMetadataScenarioTests
         Assert.IsTrue(validation.IsValid);
 
         var formatted = new ParserSharedPrefixPlanFormatter().FormatPlans(plans);
-        Assert.AreEqual("shared segment: ID\nboundary: position 1\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 1", formatted[0]);
+        Assert.AreEqual("shared segment: ID\nboundary: position 1\neligibility: Eligible\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 1", formatted[0]);
     }
 
     /// <summary>
@@ -133,7 +133,7 @@ public class ParserSharedPrefixMetadataScenarioTests
         Assert.IsFalse(validation.Issues.Any(static i => i.Message.Contains("non-fallback", StringComparison.Ordinal)));
 
         var formatted = new ParserSharedPrefixPlanFormatter().FormatPlans([plan]);
-        Assert.AreEqual("shared segment: ID\nboundary: position 0 (fallback)\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 2", formatted[0]);
+        Assert.AreEqual("shared segment: ID\nboundary: position 0 (fallback)\neligibility: RequiresFallback\nblockers:\n  SP002: Continuation positions diverge.\n  SP001: Fallback boundary prevents safe execution.\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 2", formatted[0]);
     }
 
     /// <summary>

--- a/UtilsTest/Parser/ParserSharedPrefixPlanFormatterTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixPlanFormatterTests.cs
@@ -26,8 +26,9 @@ public class ParserSharedPrefixPlanFormatterTests
 
         Assert.AreEqual(1, lines.Count);
         Assert.AreEqual(
-            "shared segment: ID\nboundary: position 1\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 1",
+            "shared segment: ID\nboundary: position 1\neligibility: Eligible\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 1",
             lines[0]);
+        Assert.IsFalse(lines[0].Contains("\nblockers:\n", StringComparison.Ordinal));
     }
 
     [TestMethod]
@@ -57,8 +58,10 @@ public class ParserSharedPrefixPlanFormatterTests
 
         Assert.AreEqual(1, lines.Count);
         Assert.AreEqual(
-            "shared segment: ID\nboundary: position 0 (fallback)\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 2",
+            "shared segment: ID\nboundary: position 0 (fallback)\neligibility: RequiresFallback\nblockers:\n  SP002: Continuation positions diverge.\n  SP001: Fallback boundary prevents safe execution.\ncontinuations:\n  alt 0 -> position 1\n  alt 1 -> position 2",
             lines[0]);
+        StringAssert.Contains(lines[0], "SP001");
+        StringAssert.Contains(lines[0], "SP002");
     }
 
     [TestMethod]
@@ -71,8 +74,35 @@ public class ParserSharedPrefixPlanFormatterTests
 
         Assert.AreEqual(1, lines.Count);
         Assert.AreEqual(
-            "shared segment: ID\nboundary: position 1\ncontinuations:\n  alt 2 -> position 1\n  alt 0 -> position 1\n  alt 1 -> position 1",
+            "shared segment: ID\nboundary: position 1\neligibility: Eligible\ncontinuations:\n  alt 2 -> position 1\n  alt 0 -> position 1\n  alt 1 -> position 1",
             lines[0]);
+    }
+
+    [TestMethod]
+    public void FormatPlans_FormatsUnsafeEligibilityAndBlockers()
+    {
+        var formatter = new ParserSharedPrefixPlanFormatter();
+        var plan = Plan("ID", -1, [Continuation(0, -1), Continuation(1, -1)]);
+
+        var lines = formatter.FormatPlans([plan]);
+
+        Assert.AreEqual(1, lines.Count);
+        StringAssert.Contains(lines[0], "eligibility: Unsafe");
+        StringAssert.Contains(lines[0], "SP004");
+        StringAssert.Contains(lines[0], "SP008");
+    }
+
+    [TestMethod]
+    public void FormatPlans_FormatsNotEligibleEligibility()
+    {
+        var formatter = new ParserSharedPrefixPlanFormatter();
+        var plan = Plan(" ", 1, [Continuation(0, 1), Continuation(1, 1)]);
+
+        var lines = formatter.FormatPlans([plan]);
+
+        Assert.AreEqual(1, lines.Count);
+        StringAssert.Contains(lines[0], "eligibility: NotEligible");
+        StringAssert.Contains(lines[0], "SP005");
     }
 
     [TestMethod]


### PR DESCRIPTION
### Motivation
- Improve dry-run/debug visibility by surfacing shared-prefix execution eligibility and deterministic blockers alongside existing plan metadata without changing runtime behavior.
- Make it easier for reviewers to reason about whether a shared-prefix plan is theoretically safe to execute by including analyzer results in formatted output.

### Description
- Added an internal `ParserSharedPrefixExecutionEligibilityAnalyzer` instance to `ParserSharedPrefixPlanFormatter` and updated `FormatPlan` to include an `eligibility: <Status>` line for each plan. 
- When the analyzer returns blockers, the formatter renders a deterministic `blockers:` section (preserving blocker order) before the existing `continuations:` block.
- Kept formatter behavior deterministic and side-effect free, preserving plan and continuation ordering and not changing any parser/scheduling/execution logic.
- Updated unit tests to reflect the new informational output in `ParserSharedPrefixPlanFormatterTests` and `ParserSharedPrefixMetadataScenarioTests`, and added tests covering Eligible/RequiresFallback/Unsafe/NotEligible shapes.

### Testing
- Ran the updated unit tests for the parser metadata and formatter: `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ParserSharedPrefixPlanFormatterTests|FullyQualifiedName~ParserSharedPrefixMetadataScenarioTests|FullyQualifiedName~AlternativeSchedulingMetadataTests"`, and the selected tests passed (Passed: 26, Failed: 0).
- An initial test run revealed a missing MSTest helper (`StringAssert.DoesNotContain`), which was replaced with a portable assertion and re-run; the fixes were validated by the successful test run above.
- Existing analyzer/validator tests were not modified and remain unaffected by this informational-only formatter change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01831868e88326928d62f6d9530698)