### PR TITLE
Resolve ANTLR4 imports during project compilation

### DIFF
--- a/Utils.Parser/ProjectCompilation/Antlr4GrammarProjectCompiler.cs
+++ b/Utils.Parser/ProjectCompilation/Antlr4GrammarProjectCompiler.cs
@@ -368,7 +368,7 @@ public static class Antlr4GrammarProjectCompiler
             }
 
             _stack.Add(grammarName);
-            var definition = Antlr4GrammarConverter.ParseUnresolved(source.Text, _diagnostics);
+            var definition = ParseUnresolvedForProjectCompilation(source.Text);
             _definitionsByName[definition.Name] = new LoadedGrammarDefinition(
                 definition,
                 resolutionMode == DependencyResolutionMode.FullImport);
@@ -400,6 +400,29 @@ public static class Antlr4GrammarProjectCompiler
             return definition.Options?.Values.TryGetValue("tokenVocab", out var tokenVocab) == true
                 ? tokenVocab
                 : null;
+        }
+
+        /// <summary>
+        /// Parses an unresolved grammar and suppresses converter-level unresolved-import diagnostics.
+        /// </summary>
+        /// <param name="grammarText">Grammar source text.</param>
+        /// <returns>Unresolved parser definition.</returns>
+        private ParserDefinition ParseUnresolvedForProjectCompilation(string grammarText)
+        {
+            var converterDiagnostics = new DiagnosticBag();
+            var definition = Antlr4GrammarConverter.ParseUnresolved(grammarText, converterDiagnostics);
+
+            foreach (var diagnostic in converterDiagnostics)
+            {
+                if (diagnostic.Code == ParserDiagnostics.ImportParsedButNotResolved.Code)
+                {
+                    continue;
+                }
+
+                _diagnostics?.Add(diagnostic);
+            }
+
+            return definition;
         }
     }
 

--- a/Utils.Parser/ProjectCompilation/Antlr4GrammarProjectCompiler.cs
+++ b/Utils.Parser/ProjectCompilation/Antlr4GrammarProjectCompiler.cs
@@ -410,19 +410,22 @@ public static class Antlr4GrammarProjectCompiler
         private ParserDefinition ParseUnresolvedForProjectCompilation(string grammarText)
         {
             var converterDiagnostics = new DiagnosticBag();
-            var definition = Antlr4GrammarConverter.ParseUnresolved(grammarText, converterDiagnostics);
-
-            foreach (var diagnostic in converterDiagnostics)
+            try
             {
-                if (diagnostic.Code == ParserDiagnostics.ImportParsedButNotResolved.Code)
-                {
-                    continue;
-                }
-
-                _diagnostics?.Add(diagnostic);
+                return Antlr4GrammarConverter.ParseUnresolved(grammarText, converterDiagnostics);
             }
+            finally
+            {
+                foreach (var diagnostic in converterDiagnostics)
+                {
+                    if (diagnostic.Code == ParserDiagnostics.ImportParsedButNotResolved.Code)
+                    {
+                        continue;
+                    }
 
-            return definition;
+                    _diagnostics?.Add(diagnostic);
+                }
+            }
         }
     }
 

--- a/UtilsTest/Parser/Antlr4GrammarProjectCompilerTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarProjectCompilerTests.cs
@@ -46,6 +46,24 @@ public class Antlr4GrammarProjectCompilerTests
     }
 
     /// <summary>
+    /// Verifies that direct imports provide lexer rules to the entry grammar and allow parsing.
+    /// </summary>
+    [TestMethod]
+    public void ImportResolution_ImportsLexerRulesIntoMainGrammar()
+    {
+        var resolver = CreateResolver(
+            ("Base", "grammar Base; ID : ('a'..'z')+ ; WS : (' ' | '\\t' | '\\r' | '\\n')+ -> skip ;"),
+            ("Main", "grammar Main; import Base; start : ID ;"));
+
+        var definition = Antlr4GrammarProjectCompiler.Parse("Main", resolver);
+        var compiled = Antlr4GrammarProjectCompiler.Compile("Main", resolver);
+        var parseTree = compiled.Parse("abc");
+
+        Assert.IsTrue(definition.AllRules.ContainsKey("ID"));
+        Assert.IsNotNull(parseTree);
+    }
+
+    /// <summary>
     /// Verifies that entry grammar rules override imported rules with identical names.
     /// </summary>
     [TestMethod]
@@ -61,6 +79,26 @@ public class Antlr4GrammarProjectCompilerTests
         Assert.AreEqual("start", definition.RootRule?.Name);
         Assert.AreEqual(1, definition.ParserRules.Count(static rule => rule.Name == "start"));
         Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.ImportedRuleIgnoredBecauseAlreadyDefined.Code));
+    }
+
+    /// <summary>
+    /// Verifies that entry parser rules override imported parser rules with the same name.
+    /// </summary>
+    [TestMethod]
+    public void ImportResolution_ImporterRuleOverridesImportedRule()
+    {
+        var diagnostics = new DiagnosticBag();
+        var resolver = CreateResolver(
+            ("Base", "grammar Base; item : 'base' ;"),
+            ("Main", "grammar Main; import Base; item : 'main' ; start : item ;"));
+
+        var definition = Antlr4GrammarProjectCompiler.Parse("Main", resolver, diagnostics);
+        var compiled = Antlr4GrammarProjectCompiler.Compile("Main", resolver);
+        var parseMain = compiled.Parse("main");
+
+        Assert.AreEqual(1, definition.ParserRules.Count(rule => rule.Name == "item"));
+        Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.ImportedRuleIgnoredBecauseAlreadyDefined.Code));
+        Assert.IsNotNull(parseMain);
     }
 
     /// <summary>
@@ -80,6 +118,23 @@ public class Antlr4GrammarProjectCompilerTests
     }
 
     /// <summary>
+    /// Verifies that transitive imports are available in the final merged grammar.
+    /// </summary>
+    [TestMethod]
+    public void ImportResolution_SupportsTransitiveImports()
+    {
+        var resolver = CreateResolver(
+            ("Tokens", "grammar Tokens; ID : ('a'..'z')+ ; WS : (' ' | '\\t' | '\\r' | '\\n')+ -> skip ;"),
+            ("Base", "grammar Base; import Tokens;"),
+            ("Main", "grammar Main; import Base; start : ID ;"));
+
+        var compiled = Antlr4GrammarProjectCompiler.Compile("Main", resolver);
+        var parseTree = compiled.Parse("abc");
+
+        Assert.IsNotNull(parseTree);
+    }
+
+    /// <summary>
     /// Verifies that cyclic imports are detected.
     /// </summary>
     [TestMethod]
@@ -93,6 +148,36 @@ public class Antlr4GrammarProjectCompilerTests
         var exception = Assert.ThrowsExactly<GrammarValidationException>(() => Antlr4GrammarProjectCompiler.Parse("A", resolver, diagnostics));
 
         StringAssert.Contains(exception.Message, "Import cycle");
+        Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.ImportCycleDetected.Code));
+    }
+
+    /// <summary>
+    /// Verifies that missing imports keep project compilation deterministic and diagnostic-driven.
+    /// </summary>
+    [TestMethod]
+    public void ImportResolution_ReportsMissingImport()
+    {
+        var diagnostics = new DiagnosticBag();
+        var resolver = CreateResolver(("Main", "grammar Main; import Missing; start : 'a' ;"));
+
+        Assert.ThrowsExactly<GrammarValidationException>(() => Antlr4GrammarProjectCompiler.Parse("Main", resolver, diagnostics));
+        Assert.IsTrue(diagnostics.Any(diagnostic =>
+            diagnostic.Code == ParserDiagnostics.ImportParsedButNotResolved.Code
+            || diagnostic.Code == ParserDiagnostics.ImportedGrammarNotFound.Code));
+    }
+
+    /// <summary>
+    /// Verifies that cyclic imports are detected without recursive overflow.
+    /// </summary>
+    [TestMethod]
+    public void ImportResolution_DetectsImportCycles()
+    {
+        var diagnostics = new DiagnosticBag();
+        var resolver = CreateResolver(
+            ("A", "grammar A; import B; start : 'a' ;"),
+            ("B", "grammar B; import A; b : 'b' ;"));
+
+        Assert.ThrowsExactly<GrammarValidationException>(() => Antlr4GrammarProjectCompiler.Parse("A", resolver, diagnostics));
         Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.ImportCycleDetected.Code));
     }
 

--- a/UtilsTest/Parser/Antlr4GrammarProjectCompilerTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarProjectCompilerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Bootstrap;
 using Utils.Parser.Diagnostics;
 using Utils.Parser.ProjectCompilation;
 using Utils.Parser.Resolution;
@@ -179,6 +180,21 @@ public class Antlr4GrammarProjectCompilerTests
 
         Assert.ThrowsExactly<GrammarValidationException>(() => Antlr4GrammarProjectCompiler.Parse("A", resolver, diagnostics));
         Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.ImportCycleDetected.Code));
+    }
+
+    /// <summary>
+    /// Verifies converter diagnostics are propagated when an imported grammar fails to parse.
+    /// </summary>
+    [TestMethod]
+    public void ImportResolution_InvalidImportedGrammar_PropagatesParseDiagnostics()
+    {
+        var diagnostics = new DiagnosticBag();
+        var resolver = CreateResolver(
+            ("Main", "grammar Main; import Broken; start : ID ;"),
+            ("Broken", "grammar Broken; $$$"));
+
+        Assert.ThrowsExactly<GrammarParseException>(() => Antlr4GrammarProjectCompiler.Parse("Main", resolver, diagnostics));
+        Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.ParseFailure.Code));
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- Project compilation must resolve ANTLR4 `import` declarations so imported lexer/parser rules, tokens, channels and modes are available to the importing grammar without changing runtime parsing behavior.  
- Converter-level diagnostics for parsed-but-unresolved imports produce noisy/stale diagnostics when project compilation can resolve them; those should be suppressed at converter-time and handled at project level.  
- Need deterministic, conservative semantics (importer wins on conflicts), transitive imports, and cycle/missing-import detection implemented at project-compilation scope only.

### Description
- Implemented project-level parsing helper `ParseUnresolvedForProjectCompilation` that invokes `Antlr4GrammarConverter.ParseUnresolved` into a local `DiagnosticBag` and forwards all converter diagnostics except `ImportParsedButNotResolved` to the project diagnostics.  
- Updated dependency loading `Visit(...)` to call `ParseUnresolvedForProjectCompilation` while building the grammar graph, keeping existing traversal, tokenVocab handling, transitive import loading, and cycle detection logic intact.  
- Added focused tests in `UtilsTest/Parser/Antlr4GrammarProjectCompilerTests.cs` exercising import resolution behaviors and expectations.  
- Modified files: `Utils.Parser/ProjectCompilation/Antlr4GrammarProjectCompiler.cs` and `UtilsTest/Parser/Antlr4GrammarProjectCompilerTests.cs`.

### Testing
- Ran the project-level test subset: `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~Antlr4GrammarProjectCompilerTests"`.  
- Result: all tests in `Antlr4GrammarProjectCompilerTests` passed (18 passed).  
- New/updated tests cover: lexer-rule import usable by consumer grammar, importer-rule override precedence, transitive imports, missing-import diagnostics, and cycle detection without stack overflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cea51fec83269205249a596f23ba)