### PR TITLE
docs(parser): add ANTLR4 compatibility matrix

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -40,18 +40,6 @@ If a grammar relies on one of these areas, validate it with targeted tests befor
 
 For a detailed, implementation-aligned compatibility status (including diagnostics mapping and architectural limits), see [`docs/parser/Antlr4CompatibilityMatrix.md`](../docs/parser/Antlr4CompatibilityMatrix.md).
 
-### Current support matrix (high-level)
-
-| Area | Status | Notes |
-|---|---|---|
-| Runtime `.g4` parsing (`Antlr4GrammarConverter`) | Partial | Works for covered scenarios; full ANTLR4 parity is not claimed. |
-| Lexer commands `skip` / `more` / `type` / `channel` | Implemented | Core commands are supported by runtime lexer execution. |
-| Lexer modes (`pushMode`, `popMode`, `mode`) | Implemented | Mode stack behavior is available in runtime lexer. |
-| Declared `tokens { ... }` and `channels { ... }` metadata | Partial | Available in model/runtime, but must be validated against your grammar set. |
-| Runtime lexer extensions (`ILexerExtension`) | Implemented | Hooks are available (`TryReadTokens`, `OnAfterToken`, `OnEndOfInput`). |
-| Full ANTLR4 grammar compatibility | Not guaranteed | Advanced/edge constructs may differ from ANTLR4 behavior. |
-| Scheduled alternative look-ahead | Implemented (internal) | Lightweight cache records alternative-start observations to avoid repeated obviously impossible starts during deterministic sequential scheduling. |
-
 ## Key concepts
 
 | Class / Type | Role |

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -36,6 +36,10 @@ The items below are not guaranteed yet and should be considered missing or limit
 
 If a grammar relies on one of these areas, validate it with targeted tests before production rollout.
 
+### Detailed compatibility reference
+
+For a detailed, implementation-aligned compatibility status (including diagnostics mapping and architectural limits), see [`docs/parser/Antlr4CompatibilityMatrix.md`](../docs/parser/Antlr4CompatibilityMatrix.md).
+
 ### Current support matrix (high-level)
 
 | Area | Status | Notes |

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -42,7 +42,7 @@ The following constructs are parsed and stored, but runtime semantic execution i
 |---|---|---|
 | Semantic predicates (`{ condition }?`) | Parsed and represented in grammar model; runtime does not evaluate predicate semantics. | `SemanticPredicateNotEnforced` |
 | Inline actions (`{ code }`) | Parsed and stored; runtime does not execute target-language code blocks. | `InlineActionStoredNotExecuted` |
-| Rule actions (`@init`, `@after`) | Parsed as action metadata where present; no execution hook is active in runtime parsing. | `ActionIgnored` (pipeline-dependent) |
+| Rule actions (`@init`, `@after`) | Parsed as action metadata where present; no execution hook is active in runtime parsing. | `InlineActionStoredNotExecuted` when represented as runtime embedded actions; `ActionIgnored` may apply to top-level/pipeline actions. |
 
 Rationale: execution of user code and semantic predicates requires explicit policy boundaries and execution abstractions that are intentionally not part of the current deterministic runtime.
 

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -14,25 +14,25 @@ Support levels are intentionally explicit:
 
 This document describes the current implementation status only. It does not define roadmap commitments.
 
-## Fully supported
+## Supported in current runtime/project compiler
 
 The features below are operational in current runtime and project-compilation flows.
 
 | Feature | Status | Notes |
 |---|---|---|
-| Parser grammars (`parser grammar`) | Fully supported | Rule loading, resolution, and parsing are supported within current runtime constraints. |
-| Lexer grammars (`lexer grammar`) | Fully supported | Tokenization supports lexer rules, commands, and mode handling already implemented. |
-| Combined grammars (`grammar`) | Fully supported | Combined parser/lexer grammars are supported as an input form. |
-| Lexer modes (`mode`, `pushMode`, `popMode`) | Fully supported | Mode stack behavior is implemented by the lexer runtime. |
-| Token channels (`channels { ... }` and `-> channel(...)`) | Fully supported (runtime command), metadata support available | Channel command execution is supported; declared channel metadata is recognized by the grammar pipeline. |
-| Token vocabularies (`tokenVocab`) | Fully supported for dependency loading | Used by grammar loading and dependency resolution in project compilation workflows. |
-| Direct left recursion | Fully supported | Runtime includes direct-left-recursion handling with diagnostics and safeguards. |
+| Parser grammars (`parser grammar`) | Supported as grammar input form | Rule loading, resolution, and parsing are supported within current runtime constraints. |
+| Lexer grammars (`lexer grammar`) | Supported as grammar input form | Tokenization supports lexer rules, commands, and mode handling already implemented. |
+| Combined grammars (`grammar`) | Supported as grammar input form | Combined parser/lexer grammars are supported as an input form. |
+| Lexer modes (`mode`, `pushMode`, `popMode`) | Supported | Mode stack behavior is implemented by the lexer runtime. |
+| Token channels (`channels { ... }` and `-> channel(...)`) | Supported (runtime command), metadata support available | Channel command execution is supported; declared channel metadata is recognized by the grammar pipeline. |
+| Token vocabularies (`tokenVocab`) | Supported for project dependency loading | Used by grammar loading and dependency resolution in project compilation workflows. |
+| Direct left recursion | Supported with safeguards | Runtime includes direct-left-recursion handling with diagnostics and safeguards. |
 | Precedence handling | Supported with known limits | Left-recursive precedence exists, with explicit partial-parity diagnostic for complex ANTLR4 shapes. |
-| `<assoc=right>` | Fully supported | Right-associative alternative metadata is parsed and applied in current precedence behavior. |
-| Project-level grammar imports | Fully supported in project compilation | Multi-file import resolution is supported in `Antlr4GrammarProjectCompiler`. |
-| Transitive imports | Fully supported in project compilation | Imported dependencies are resolved recursively at project-compilation level. |
-| Import cycle detection | Fully supported in project compilation | Cycles are detected and surfaced with dedicated diagnostics. |
-| Deterministic conflict resolution | Fully supported | Entry grammar definitions win deterministically over imported duplicates, with diagnostic traceability. |
+| `<assoc=right>` | Supported | Right-associative alternative metadata is parsed and applied in current precedence behavior. |
+| Project-level grammar imports | Supported in project compilation | Multi-file import resolution is supported in `Antlr4GrammarProjectCompiler`. |
+| Transitive imports | Supported in project compilation | Imported dependencies are resolved recursively at project-compilation level. |
+| Import cycle detection | Supported in project compilation | Cycles are detected and surfaced with dedicated diagnostics. |
+| Deterministic conflict resolution | Supported | Entry grammar definitions win deterministically over imported duplicates, with diagnostic traceability. |
 
 ## Parsed but not executed
 

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -1,0 +1,106 @@
+# ANTLR4 Compatibility Matrix
+
+## Introduction
+
+`Utils.Parser` supports ANTLR4 grammar ingestion progressively, with a conservative runtime execution model.
+
+Support levels are intentionally explicit:
+
+- **supported**: parsed, resolved, and executed by the current runtime;
+- **parsed but not executed**: syntax is recognized and represented, but execution semantics are intentionally disabled;
+- **parsed but not fully resolved**: syntax is recognized, but runtime/value resolution is incomplete;
+- **partially supported**: available in constrained scope with documented limits;
+- **unsupported**: intentionally outside the current runtime model.
+
+This document describes the current implementation status only. It does not define roadmap commitments.
+
+## Fully supported
+
+The features below are operational in current runtime and project-compilation flows.
+
+| Feature | Status | Notes |
+|---|---|---|
+| Parser grammars (`parser grammar`) | Fully supported | Rule loading, resolution, and parsing are supported within current runtime constraints. |
+| Lexer grammars (`lexer grammar`) | Fully supported | Tokenization supports lexer rules, commands, and mode handling already implemented. |
+| Combined grammars (`grammar`) | Fully supported | Combined parser/lexer grammars are supported as an input form. |
+| Lexer modes (`mode`, `pushMode`, `popMode`) | Fully supported | Mode stack behavior is implemented by the lexer runtime. |
+| Token channels (`channels { ... }` and `-> channel(...)`) | Fully supported (runtime command), metadata support available | Channel command execution is supported; declared channel metadata is recognized by the grammar pipeline. |
+| Token vocabularies (`tokenVocab`) | Fully supported for dependency loading | Used by grammar loading and dependency resolution in project compilation workflows. |
+| Direct left recursion | Fully supported | Runtime includes direct-left-recursion handling with diagnostics and safeguards. |
+| Precedence handling | Supported with known limits | Left-recursive precedence exists, with explicit partial-parity diagnostic for complex ANTLR4 shapes. |
+| `<assoc=right>` | Fully supported | Right-associative alternative metadata is parsed and applied in current precedence behavior. |
+| Project-level grammar imports | Fully supported in project compilation | Multi-file import resolution is supported in `Antlr4GrammarProjectCompiler`. |
+| Transitive imports | Fully supported in project compilation | Imported dependencies are resolved recursively at project-compilation level. |
+| Import cycle detection | Fully supported in project compilation | Cycles are detected and surfaced with dedicated diagnostics. |
+| Deterministic conflict resolution | Fully supported | Entry grammar definitions win deterministically over imported duplicates, with diagnostic traceability. |
+
+## Parsed but not executed
+
+The following constructs are parsed and stored, but runtime semantic execution is intentionally disabled.
+
+| Construct | Current behavior | Diagnostics |
+|---|---|---|
+| Semantic predicates (`{ condition }?`) | Parsed and represented in grammar model; runtime does not evaluate predicate semantics. | `SemanticPredicateNotEnforced` |
+| Inline actions (`{ code }`) | Parsed and stored; runtime does not execute target-language code blocks. | `InlineActionStoredNotExecuted` |
+| Rule actions (`@init`, `@after`) | Parsed as action metadata where present; no execution hook is active in runtime parsing. | `ActionIgnored` (pipeline-dependent) |
+
+Rationale: execution of user code and semantic predicates requires explicit policy boundaries and execution abstractions that are intentionally not part of the current deterministic runtime.
+
+## Parsed but not fully resolved
+
+The following constructs are recognized but not fully resolved into executable runtime semantics.
+
+| Construct | Current behavior | Limitations |
+|---|---|---|
+| Rule parameters (`rule[int x]`) | Bracketed parameter syntax is partially recognized by bootstrap parsing. | No runtime invocation-frame/value binding model is implemented. |
+| Rule returns (`returns [int value]`) | Returns metadata can be parsed and preserved as raw text. | No runtime value propagation/extraction contract exists for parser execution. |
+
+These constructs are treated as syntax/metadata compatibility points, not as fully executable semantics.
+
+## Partially supported
+
+| Area | Current support boundary |
+|---|---|
+| `import` usage | Fully resolved when grammars are compiled as a project input set; isolated single-file compilation may emit `ImportParsedButNotResolved` when no resolver context is provided. |
+| `tokenVocab` | Dependency loading is supported; effective behavior depends on available resolver inputs and vocabulary source availability in the compilation context. |
+| Left-recursive precedence parity | Implemented for current runtime model, but not equivalent to all ANTLR4 precedence scenarios; the runtime can emit `LeftRecursivePrecedencePartiallySupported` where applicable. |
+
+## Unsupported
+
+The following capabilities are currently unsupported by design:
+
+- adaptive LL prediction;
+- GLL parsing;
+- speculative parsing and continuation replay;
+- parser graph execution;
+- parse-forest generation;
+- parallel parsing;
+- async parsing;
+- semantic action execution engines;
+- contextual lexer dispatch beyond current deterministic lexer/mode behavior.
+
+These are intentionally outside the current runtime envelope.
+
+## Architectural notes
+
+Current parser architecture includes explicit metadata infrastructure for future-safe analysis, while preserving deterministic execution boundaries.
+
+- Shared-prefix infrastructure is **metadata-only**.
+- Continuation descriptors are structural metadata, not runtime replay state.
+- No shared-prefix execution pipeline is active.
+- `AlternativeScheduler` provides explicit deterministic orchestration.
+- `ParserStateRegistry` centralizes parser state guards.
+- `ActiveParseState` provides explicit state normalization for branch handling.
+
+The above architecture supports auditability and controlled evolution without changing current parser semantics.
+
+## Design philosophy
+
+`Utils.Parser` follows conservative compatibility evolution:
+
+- deterministic runtime behavior first;
+- explicit diagnostics when semantics are parsed but not executed;
+- compatibility through explicit modeling before execution support;
+- audit-friendly boundaries between metadata, resolution, and runtime execution.
+
+This policy avoids speculative runtime complexity while still enabling progressive ANTLR4 syntax coverage.


### PR DESCRIPTION
### Motivation

- Provide a single, implementation-aligned reference describing which ANTLR4 constructs `Utils.Parser` currently supports, parses-but-does-not-execute, parses-but-does-not-fully-resolve, partially supports, or intentionally does not support. 

### Description

- Add `docs/parser/Antlr4CompatibilityMatrix.md` documenting support levels, mapping key diagnostics (for example `SemanticPredicateNotEnforced`, `InlineActionStoredNotExecuted`, `ImportParsedButNotResolved`, `LeftRecursivePrecedencePartiallySupported`) to their runtime meaning, and summarizing architectural boundaries (metadata-only shared-prefix infra, deterministic scheduler ownership, no continuation replay). 
- The document contains clear sections for Fully supported, Parsed but not executed, Parsed but not fully resolved, Partially supported, Unsupported, Architectural notes, and Design philosophy, and makes no code or API changes. 

### Testing

- No automated tests were run because this is a documentation-only change and repository guidelines exempt metadata/docs changes from requiring tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d91c4ab88326b26df60c2ce773f0)