### PR TITLE
Introduce parser action executor policy infrastructure

### DIFF
--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -69,6 +69,20 @@ public sealed class Antlr4GrammarConverter
         => new Runtime.CompiledGrammar(Parse(grammarText, diagnostics), semanticPredicateEvaluator, new DefaultParserActionExecutor());
 
     /// <summary>
+    /// Convenience factory: compiles <paramref name="grammarText"/> and configures
+    /// parser embedded action handling with <paramref name="parserActionExecutor"/>.
+    /// </summary>
+    /// <param name="grammarText">ANTLR4 grammar source (<c>.g4</c> content).</param>
+    /// <param name="parserActionExecutor">Parser embedded action execution policy.</param>
+    /// <param name="diagnostics">Optional diagnostics bag.</param>
+    /// <returns>A compiled grammar instance with injected action executor.</returns>
+    public static Runtime.CompiledGrammar Compile(
+        [StringSyntax("ANTLR4")] string grammarText,
+        IParserActionExecutor parserActionExecutor,
+        DiagnosticBag? diagnostics = null)
+        => new Runtime.CompiledGrammar(Parse(grammarText, diagnostics), new DefaultSemanticPredicateEvaluator(), parserActionExecutor);
+
+    /// <summary>
     /// Convenience factory: compiles <paramref name="grammarText"/> and configures explicit
     /// semantic predicate and parser action execution policies.
     /// </summary>

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -66,7 +66,23 @@ public sealed class Antlr4GrammarConverter
         [StringSyntax("ANTLR4")] string grammarText,
         ISemanticPredicateEvaluator semanticPredicateEvaluator,
         DiagnosticBag? diagnostics = null)
-        => new Runtime.CompiledGrammar(Parse(grammarText, diagnostics), semanticPredicateEvaluator);
+        => new Runtime.CompiledGrammar(Parse(grammarText, diagnostics), semanticPredicateEvaluator, new DefaultParserActionExecutor());
+
+    /// <summary>
+    /// Convenience factory: compiles <paramref name="grammarText"/> and configures explicit
+    /// semantic predicate and parser action execution policies.
+    /// </summary>
+    /// <param name="grammarText">ANTLR4 grammar source (<c>.g4</c> content).</param>
+    /// <param name="semanticPredicateEvaluator">Semantic predicate evaluator policy.</param>
+    /// <param name="parserActionExecutor">Parser embedded action execution policy.</param>
+    /// <param name="diagnostics">Optional diagnostics bag.</param>
+    /// <returns>A compiled grammar instance with injected runtime policies.</returns>
+    public static Runtime.CompiledGrammar Compile(
+        [StringSyntax("ANTLR4")] string grammarText,
+        ISemanticPredicateEvaluator semanticPredicateEvaluator,
+        IParserActionExecutor parserActionExecutor,
+        DiagnosticBag? diagnostics = null)
+        => new Runtime.CompiledGrammar(Parse(grammarText, diagnostics), semanticPredicateEvaluator, parserActionExecutor);
 
     /// <summary>
     /// Full pipeline: ANTLR4 grammar text → resolved <see cref="Utils.Parser.Model.ParserDefinition"/>.

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -419,7 +419,7 @@ The points below reflect the current implementation behavior.
 | `tokens { ... }` block | ⚠️ Parsed but not mapped | ❌ Not supported | Recognized but ignored in model conversion. |
 | `channels { ... }` block | ⚠️ Parsed but not mapped | ❌ Not supported | Recognized but ignored in model conversion. |
 | Top-level grammar actions (`@... { ... }`) | ⚠️ Parsed but not executed | ❌ Not supported | Stored metadata only. |
-| Rule actions (`@init`, `@after`, inline `{...}`) | ⚠️ Partially supported | ⚠️ Parsed as raw blocks | Runtime stores actions and does not execute them. |
+| Rule actions (`@init`, `@after`, inline `{...}`) | ⚠️ Partially supported | ⚠️ Parsed as raw blocks | Runtime exposes an action executor abstraction; default policy stores actions and does not execute them. |
 | Semantic predicates (`{...}?`) | ⚠️ Parsed but not enforced | ⚠️ Parsed as raw blocks | Runtime accepts as empty successful matches. |
 | `returns [...]` | ⚠️ Partially supported | ❌ Not supported | Runtime stores raw return text. |
 | `locals`, `throws`, `catch`, `finally` | ⚠️ Parsed but ignored | ❌ Not supported | No runtime semantics yet. |
@@ -446,8 +446,7 @@ The points below reflect the current implementation behavior.
 
 ### Runtime semantics (`LexerEngine` / `ParserEngine`)
 
-- Embedded actions and semantic predicates are parsed and stored, but the parser engine does
-  not execute them; they are accepted as successful empty matches.
+- Embedded actions and semantic predicates are parsed and stored. Embedded actions are routed through a policy abstraction and default to not executed; semantic predicates are evaluator-driven.
 - Precedence is only enforced through recognized `precpred(_ctx, N)` patterns.
 - `precpred` extraction is regex-based; if the level cannot be parsed, precedence falls back
   to `0`.

--- a/Utils.Parser/Runtime/CompiledGrammar.cs
+++ b/Utils.Parser/Runtime/CompiledGrammar.cs
@@ -45,6 +45,17 @@ public sealed class CompiledGrammar
 
     /// <summary>
     /// Initialises a <see cref="CompiledGrammar"/> from a fully resolved
+    /// <see cref="ParserDefinition"/> and an explicit parser action execution policy.
+    /// </summary>
+    /// <param name="definition">A resolved grammar definition.</param>
+    /// <param name="parserActionExecutor">Parser embedded action execution policy.</param>
+    public CompiledGrammar(ParserDefinition definition, IParserActionExecutor parserActionExecutor)
+        : this(definition, new DefaultSemanticPredicateEvaluator(), parserActionExecutor)
+    {
+    }
+
+    /// <summary>
+    /// Initialises a <see cref="CompiledGrammar"/> from a fully resolved
     /// <see cref="ParserDefinition"/> with explicit predicate and action policies.
     /// </summary>
     /// <param name="definition">A resolved grammar definition.</param>

--- a/Utils.Parser/Runtime/CompiledGrammar.cs
+++ b/Utils.Parser/Runtime/CompiledGrammar.cs
@@ -26,7 +26,7 @@ public sealed class CompiledGrammar
     /// </summary>
     /// <param name="definition">A resolved grammar definition.</param>
     public CompiledGrammar(ParserDefinition definition)
-        : this(definition, new DefaultSemanticPredicateEvaluator())
+        : this(definition, new DefaultSemanticPredicateEvaluator(), new DefaultParserActionExecutor())
     {
     }
 
@@ -39,10 +39,22 @@ public sealed class CompiledGrammar
     /// Evaluator used by the embedded <see cref="ParserEngine"/> for semantic predicates.
     /// </param>
     public CompiledGrammar(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator)
+        : this(definition, semanticPredicateEvaluator, new DefaultParserActionExecutor())
+    {
+    }
+
+    /// <summary>
+    /// Initialises a <see cref="CompiledGrammar"/> from a fully resolved
+    /// <see cref="ParserDefinition"/> with explicit predicate and action policies.
+    /// </summary>
+    /// <param name="definition">A resolved grammar definition.</param>
+    /// <param name="semanticPredicateEvaluator">Semantic predicate evaluator policy.</param>
+    /// <param name="parserActionExecutor">Parser embedded action execution policy.</param>
+    public CompiledGrammar(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator, IParserActionExecutor parserActionExecutor)
     {
         Definition = definition;
         _lexer = new LexerEngine(definition);
-        _parser = new ParserEngine(definition, semanticPredicateEvaluator);
+        _parser = new ParserEngine(definition, semanticPredicateEvaluator, parserActionExecutor);
     }
 
     /// <summary>

--- a/Utils.Parser/Runtime/DefaultParserActionExecutor.cs
+++ b/Utils.Parser/Runtime/DefaultParserActionExecutor.cs
@@ -1,0 +1,16 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Conservative default action executor that does not run embedded action code.
+/// </summary>
+internal sealed class DefaultParserActionExecutor : IParserActionExecutor
+{
+    /// <summary>
+    /// Returns <see cref="ParserActionExecutionResult.NotExecuted"/> for every action.
+    /// </summary>
+    /// <param name="context">Action context.</param>
+    /// <returns>Always <see cref="ParserActionExecutionResult.NotExecuted"/>.</returns>
+    public ParserActionExecutionResult Execute(ParserActionExecutionContext context)
+        => ParserActionExecutionResult.NotExecuted;
+}
+

--- a/Utils.Parser/Runtime/IParserActionExecutor.cs
+++ b/Utils.Parser/Runtime/IParserActionExecutor.cs
@@ -1,0 +1,17 @@
+using Utils.Parser.Model;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Defines policy-driven embedded action handling for <see cref="ParserEngine"/>.
+/// </summary>
+public interface IParserActionExecutor
+{
+    /// <summary>
+    /// Executes or ignores a parser action according to the runtime policy.
+    /// </summary>
+    /// <param name="context">Immutable action execution context.</param>
+    /// <returns>Execution decision for the action.</returns>
+    ParserActionExecutionResult Execute(ParserActionExecutionContext context);
+}
+

--- a/Utils.Parser/Runtime/ParserActionExecutionContext.cs
+++ b/Utils.Parser/Runtime/ParserActionExecutionContext.cs
@@ -1,0 +1,21 @@
+using Utils.Parser.Model;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Immutable action execution data passed to <see cref="IParserActionExecutor"/>.
+/// </summary>
+/// <param name="Rule">Current parser rule.</param>
+/// <param name="Action">Action model node.</param>
+/// <param name="ActionCode">Raw action code.</param>
+/// <param name="InputPosition">Current parser input position.</param>
+/// <param name="AlternativeIndex">Current alternative index.</param>
+/// <param name="ElementIndex">Current element index within the alternative.</param>
+public sealed record ParserActionExecutionContext(
+    Rule Rule,
+    RuleContent Action,
+    string ActionCode,
+    int InputPosition,
+    int AlternativeIndex,
+    int ElementIndex);
+

--- a/Utils.Parser/Runtime/ParserActionExecutionResult.cs
+++ b/Utils.Parser/Runtime/ParserActionExecutionResult.cs
@@ -1,0 +1,14 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Outcome returned by <see cref="IParserActionExecutor"/>.
+/// </summary>
+public enum ParserActionExecutionResult
+{
+    /// <summary>Action was executed by the configured runtime policy.</summary>
+    Executed,
+
+    /// <summary>Action was intentionally not executed and parsing must continue.</summary>
+    NotExecuted
+}
+

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -57,6 +57,16 @@ public sealed class ParserEngine
     }
 
     /// <summary>
+    /// Initializes a parser engine with an explicit parser action execution policy.
+    /// </summary>
+    /// <param name="definition">Resolved parser definition.</param>
+    /// <param name="parserActionExecutor">Policy used to handle parser embedded actions.</param>
+    public ParserEngine(ParserDefinition definition, IParserActionExecutor parserActionExecutor)
+        : this(definition, new DefaultSemanticPredicateEvaluator(), parserActionExecutor)
+    {
+    }
+
+    /// <summary>
     /// Initializes a parser engine with explicit semantic predicate and action execution policies.
     /// </summary>
     /// <param name="definition">Resolved parser definition.</param>

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -37,9 +37,10 @@ public sealed class ParserEngine
     private readonly ParserLookaheadCache _lookaheadCache = new();
     private readonly ScheduledAlternativeExecutor _scheduledAlternativeExecutor;
     private readonly ISemanticPredicateEvaluator _semanticPredicateEvaluator;
+    private readonly IParserActionExecutor _parserActionExecutor;
 
     public ParserEngine(ParserDefinition definition)
-        : this(definition, new DefaultSemanticPredicateEvaluator())
+        : this(definition, new DefaultSemanticPredicateEvaluator(), new DefaultParserActionExecutor())
     {
     }
 
@@ -51,9 +52,21 @@ public sealed class ParserEngine
     /// Strategy used to evaluate semantic predicates without executing arbitrary source code.
     /// </param>
     public ParserEngine(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator)
+        : this(definition, semanticPredicateEvaluator, new DefaultParserActionExecutor())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a parser engine with explicit semantic predicate and action execution policies.
+    /// </summary>
+    /// <param name="definition">Resolved parser definition.</param>
+    /// <param name="semanticPredicateEvaluator">Policy used to evaluate semantic predicates.</param>
+    /// <param name="parserActionExecutor">Policy used to handle parser embedded actions.</param>
+    public ParserEngine(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator, IParserActionExecutor parserActionExecutor)
     {
         _definition = definition ?? throw new ArgumentNullException(nameof(definition));
         _semanticPredicateEvaluator = semanticPredicateEvaluator ?? throw new ArgumentNullException(nameof(semanticPredicateEvaluator));
+        _parserActionExecutor = parserActionExecutor ?? throw new ArgumentNullException(nameof(parserActionExecutor));
         _caseInsensitive = IsCaseInsensitive(_definition);
         _alternativeScheduler = new AlternativeScheduler();
         _scheduledAlternativeExecutor = new ScheduledAlternativeExecutor(_stateRegistry, _lookaheadCache, new ParserLookaheadProbe());
@@ -492,14 +505,41 @@ public sealed class ParserEngine
                 // Already handled in CheckPrecedence.
                 return CreateEmptyNode(context, rule);
 
-            case EmbeddedAction:
-                // Embedded actions: never executed, always succeed.
-                diagnostics?.AddWithContext(ParserDiagnostics.InlineActionStoredNotExecuted, null, null, rule.Name, null);
-                return CreateEmptyNode(context, rule);
+            case EmbeddedAction embeddedAction:
+                return HandleEmbeddedAction(context, rule, embeddedAction, alternativeIndex, elementIndex, diagnostics);
 
             default:
                 return null;
         }
+    }
+
+
+    /// <summary>
+    /// Handles embedded parser actions using the configured executor policy.
+    /// </summary>
+    private ParseNode HandleEmbeddedAction(
+        ParseContext context,
+        Rule rule,
+        EmbeddedAction action,
+        int alternativeIndex,
+        int elementIndex,
+        DiagnosticBag? diagnostics)
+    {
+        var executionContext = new ParserActionExecutionContext(
+            rule,
+            action,
+            action.RawCode,
+            context.Position,
+            alternativeIndex,
+            elementIndex);
+
+        var executionResult = _parserActionExecutor.Execute(executionContext);
+        if (executionResult == ParserActionExecutionResult.NotExecuted)
+        {
+            diagnostics?.AddWithContext(ParserDiagnostics.InlineActionStoredNotExecuted, null, null, rule.Name, null);
+        }
+
+        return CreateEmptyNode(context, rule);
     }
 
     /// <summary>
@@ -614,7 +654,13 @@ public sealed class ParserEngine
         for (int itemIndex = 0; itemIndex < seq.Items.Count; itemIndex++)
         {
             var item = seq.Items[itemIndex];
-            if (item is EmbeddedAction or Model.LexerCommand)
+            if (item is EmbeddedAction embeddedAction)
+            {
+                _ = HandleEmbeddedAction(context, rule, embeddedAction, alternativeIndex, itemIndex, diagnostics);
+                continue;
+            }
+
+            if (item is Model.LexerCommand)
                 continue;
 
             var itemStartPosition = context.Position;

--- a/UtilsTest/Parser/ParserEngineActionExecutorTests.cs
+++ b/UtilsTest/Parser/ParserEngineActionExecutorTests.cs
@@ -1,0 +1,148 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Model;
+using Utils.Parser.Resolution;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Verifies parser behavior with injected parser action executors.
+/// </summary>
+[TestClass]
+public class ParserEngineActionExecutorTests
+{
+    [TestMethod]
+    public void InlineAction_DefaultExecutor_PreservesCurrentBehavior()
+    {
+        var startRule = CreateStartRuleWithInlineAction("doSomething();");
+        var tokenRuleA = CreateTokenRuleA();
+        var definition = CreateDefinition(startRule, tokenRuleA);
+        var parser = new ParserEngine(definition);
+        var diagnostics = new DiagnosticBag();
+
+        var result = parser.Parse([new Token(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.InlineActionStoredNotExecuted.Code));
+    }
+
+    [TestMethod]
+    public void InlineAction_CustomExecutor_IsInvoked()
+    {
+        var startRule = CreateStartRuleWithInlineAction("log();");
+        var tokenRuleA = CreateTokenRuleA();
+        var definition = CreateDefinition(startRule, tokenRuleA);
+        var observer = new ObservingParserActionExecutor(ParserActionExecutionResult.NotExecuted);
+        var parser = new ParserEngine(definition, new DefaultSemanticPredicateEvaluator(), observer);
+
+        var result = parser.Parse([new Token(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.AreEqual("log();", observer.LastContext?.ActionCode);
+        Assert.AreEqual("start", observer.LastContext?.Rule.Name);
+        Assert.AreEqual(0, observer.LastContext?.AlternativeIndex);
+        Assert.AreEqual(0, observer.LastContext?.ElementIndex);
+    }
+
+    [TestMethod]
+    public void InlineAction_CustomExecutor_DoesNotAlterParseBehavior()
+    {
+        var startRule = CreateStartRuleWithInlineAction("run();");
+        var tokenRuleA = CreateTokenRuleA();
+        var definition = CreateDefinition(startRule, tokenRuleA);
+        var parser = new ParserEngine(definition, new DefaultSemanticPredicateEvaluator(), new ObservingParserActionExecutor(ParserActionExecutionResult.Executed));
+
+        var result = parser.Parse([new Token(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+    }
+
+    [TestMethod]
+    public void CompileAndParse_FromAntlrText_UsesInjectedActionExecutor()
+    {
+        var observer = new ObservingParserActionExecutor(ParserActionExecutionResult.NotExecuted);
+        var grammar = Antlr4GrammarConverter.Compile(
+            """
+            grammar P;
+            start : { log(); } A ;
+            A : 'a' ;
+            """,
+            new DefaultSemanticPredicateEvaluator(),
+            observer);
+
+        var result = grammar.Parse("a");
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsNotNull(observer.LastContext);
+        Assert.AreEqual("log();", observer.LastContext.ActionCode.Trim());
+    }
+
+    private static Rule CreateTokenRuleA()
+    {
+        return new Rule("A", 0, true, new Alternation([new Alternative(0, Associativity.Left, new LiteralMatch("a"))]));
+    }
+
+    private static Rule CreateStartRuleWithInlineAction(string code)
+    {
+        return new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([
+                new Alternative(
+                    0,
+                    Associativity.Left,
+                    new Sequence([
+                        new EmbeddedAction(code, ActionContext.Alternative, ActionPosition.Inline, []),
+                        new RuleRef("A")
+                    ]))
+            ]));
+    }
+
+    private static ParserDefinition CreateDefinition(Rule startRule, Rule tokenRuleA)
+    {
+        return RuleResolver.Resolve(new ParserDefinition(
+            Name: "G",
+            Type: GrammarType.Combined,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [tokenRuleA])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [startRule],
+            RootRule: startRule));
+    }
+
+    /// <summary>
+    /// Test executor that captures the latest action context for assertions.
+    /// </summary>
+    private sealed class ObservingParserActionExecutor : IParserActionExecutor
+    {
+        private readonly ParserActionExecutionResult _result;
+
+        /// <summary>
+        /// Initializes the executor.
+        /// </summary>
+        /// <param name="result">Result returned by <see cref="Execute"/>.</param>
+        public ObservingParserActionExecutor(ParserActionExecutionResult result)
+        {
+            _result = result;
+        }
+
+        /// <summary>
+        /// Gets the last context passed to <see cref="Execute"/>.
+        /// </summary>
+        public ParserActionExecutionContext? LastContext { get; private set; }
+
+        /// <inheritdoc />
+        public ParserActionExecutionResult Execute(ParserActionExecutionContext context)
+        {
+            LastContext = context;
+            return _result;
+        }
+    }
+}

--- a/UtilsTest/Parser/ParserEngineActionExecutorTests.cs
+++ b/UtilsTest/Parser/ParserEngineActionExecutorTests.cs
@@ -59,6 +59,25 @@ public class ParserEngineActionExecutorTests
         Assert.IsInstanceOfType<ParserNode>(result);
     }
 
+
+    [TestMethod]
+    public void CompileAndParse_FromAntlrText_ActionOnlyOverload_UsesInjectedActionExecutor()
+    {
+        var observer = new ObservingParserActionExecutor(ParserActionExecutionResult.NotExecuted);
+        var grammar = Antlr4GrammarConverter.Compile(
+            """
+            grammar P;
+            start : { log(); } A ;
+            A : 'a' ;
+            """,
+            observer);
+
+        var result = grammar.Parse("a");
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsNotNull(observer.LastContext);
+    }
+
     [TestMethod]
     public void CompileAndParse_FromAntlrText_UsesInjectedActionExecutor()
     {


### PR DESCRIPTION
### Motivation

- Introduce an explicit, injectable parser action execution abstraction to make action handling policy-driven and auditable while avoiding any runtime execution of arbitrary code. 
- Preserve existing deterministic parser semantics and diagnostics (`InlineActionStoredNotExecuted`), and provide a future-safe DI point for controlled custom executors. 

### Description

- Added the policy API surface: `IParserActionExecutor`, immutable `ParserActionExecutionContext`, `ParserActionExecutionResult`, and a conservative `DefaultParserActionExecutor` that always returns `NotExecuted`. 
- Wired executor injection through runtime construction paths by extending `ParserEngine` constructors and by adding corresponding overloads to `CompiledGrammar` and `Antlr4GrammarConverter.Compile(...)`, defaulting to the no-op executor. 
- Replaced the implicit inline-action ignore path with an explicit `HandleEmbeddedAction(...)` call so `EmbeddedAction` nodes are presented to the executor deterministically while preserving parse-tree shape and emitting the existing diagnostic when actions are not executed. 
- Files changed/added: `Utils.Parser/Runtime/IParserActionExecutor.cs`, `ParserActionExecutionContext.cs`, `ParserActionExecutionResult.cs`, `DefaultParserActionExecutor.cs`, modified `Utils.Parser/Runtime/ParserEngine.cs`, `Utils.Parser/Runtime/CompiledGrammar.cs`, `Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs`, and added tests in `UtilsTest/Parser/ParserEngineActionExecutorTests.cs`. 

### Testing

- Executed the new focused test group with `dotnet test UtilsTest/UtilsTest.csproj --filter ParserEngineActionExecutorTests` and the suite passed (4 tests passed). 
- An earlier automated run surfaced a missing sequence-level action invocation which was corrected and the tests re-run to green status.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f850c9348326b1f5b17ca17b451e)