### PR TITLE
Improve ANTLR4 argument/returns block capture scaffolding

### DIFF
--- a/Utils.Parser/Bootstrap/Antlr4Grammar.cs
+++ b/Utils.Parser/Bootstrap/Antlr4Grammar.cs
@@ -182,7 +182,9 @@ public static class Antlr4Grammar
                     Alt(1, NegCharSet("'\r\n\\"))))))));
 
         var beginArgument = new Rule("BEGIN_ARGUMENT", order++, false,
-            Alts(Alt(0, Lit("["))));
+            Alts(Alt(0, Seq(
+                Lit("["),
+                new Model.LexerCommand(LexerCommandType.PushMode, "Argument")))));
 
         var action = new Rule("ACTION", order++, false,
             Alts(Alt(0, Ref("NESTED_ACTION"))));
@@ -489,11 +491,20 @@ public static class Antlr4Grammar
         var pActionBlock = new Rule("actionBlock", pOrder++, false,
             Alts(Alt(0, Ref("ACTION"))));
 
-        // argActionBlock : BEGIN_ARGUMENT ARGUMENT_CONTENT*? END_ARGUMENT
+        // argumentElement : ARGUMENT_CONTENT | ARGUMENT_ESCAPE | ARGUMENT_STRING_LITERAL | ARGUMENT_CHAR_LITERAL | NESTED_ARGUMENT
+        var pArgumentElement = new Rule("argumentElement", pOrder++, false,
+            Alts(
+                Alt(0, Ref("ARGUMENT_CONTENT")),
+                Alt(1, Ref("ARGUMENT_ESCAPE")),
+                Alt(2, Ref("ARGUMENT_STRING_LITERAL")),
+                Alt(3, Ref("ARGUMENT_CHAR_LITERAL")),
+                Alt(4, Ref("NESTED_ARGUMENT"))));
+
+        // argActionBlock : BEGIN_ARGUMENT argumentElement*? END_ARGUMENT
         var pArgActionBlock = new Rule("argActionBlock", pOrder++, false,
             Alts(Alt(0, Seq(
                 Ref("BEGIN_ARGUMENT"),
-                Star(Ref("ARGUMENT_CONTENT"), greedy: false),
+                Star(Ref("argumentElement"), greedy: false),
                 Ref("END_ARGUMENT")))));
 
         // elementOption : qualifiedIdentifier | identifier ASSIGN (qualifiedIdentifier | STRING_LITERAL | INT)
@@ -965,7 +976,7 @@ public static class Antlr4Grammar
             pPrequelConstruct, pOptionsSpec, pOption, pOptionValue,
             pDelegateGrammars, pDelegateGrammar,
             pTokensSpec, pChannelsSpec, pIdList,
-            pAction, pActionScopeName, pActionBlock, pArgActionBlock,
+            pAction, pActionScopeName, pActionBlock, pArgumentElement, pArgActionBlock,
             pModeSpec, pRules, pRuleSpec,
             pParserRuleSpec, pExceptionGroup, pExceptionHandler, pFinallyClause,
             pRulePrequel, pRuleReturns, pThrowsSpec, pLocalsSpec,

--- a/Utils.Parser/Bootstrap/Antlr4Grammar.cs
+++ b/Utils.Parser/Bootstrap/Antlr4Grammar.cs
@@ -500,11 +500,13 @@ public static class Antlr4Grammar
                 Alt(3, Ref("ARGUMENT_CHAR_LITERAL")),
                 Alt(4, Ref("NESTED_ARGUMENT"))));
 
-        // argActionBlock : BEGIN_ARGUMENT argumentElement*? END_ARGUMENT
+        // argActionBlock : BEGIN_ARGUMENT argumentElement* END_ARGUMENT
+        // Greedy star is correct: argumentElement never matches END_ARGUMENT (']'),
+        // so the star stops naturally when the closing bracket is reached.
         var pArgActionBlock = new Rule("argActionBlock", pOrder++, false,
             Alts(Alt(0, Seq(
                 Ref("BEGIN_ARGUMENT"),
-                Star(Ref("argumentElement"), greedy: false),
+                Star(Ref("argumentElement")),
                 Ref("END_ARGUMENT")))));
 
         // elementOption : qualifiedIdentifier | identifier ASSIGN (qualifiedIdentifier | STRING_LITERAL | INT)

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -623,6 +623,17 @@ public sealed class Antlr4GrammarConverter
     {
         var name = Require(FirstToken(node, "RULE_REF"), "Missing RULE_REF in parserRuleSpec").Text;
 
+        List<RuleParameter>? parameters = null;
+        var parameterBlock = First(node, "argActionBlock");
+        if (parameterBlock != null)
+        {
+            var raw = GetArgActionBlockText(parameterBlock);
+            if (raw.Length > 0)
+            {
+                parameters = [new RuleParameter(raw, raw)];
+            }
+        }
+
         List<RuleReturn>? returns = null;
         var returnsNode = First(node, "ruleReturns");
         if (returnsNode != null)
@@ -673,7 +684,7 @@ public sealed class Antlr4GrammarConverter
         var ruleAltList = Require(First(ruleBlock, "ruleAltList"), "Missing ruleAltList");
         var content = ConvertRuleAltList(ruleAltList);
 
-        return new Rule(name, _order++, false, content, null, null, returns, initAction, afterAction);
+        return new Rule(name, _order++, false, content, null, parameters, returns, initAction, afterAction);
     }
 
     // ─── ruleAltList / labeledAlt / alternative ───────────────────────────────
@@ -997,13 +1008,22 @@ public sealed class Antlr4GrammarConverter
         throw new GrammarParseException("Unknown lexerCommandExpr");
     }
 
-    /// <summary>Concatenates all <c>ARGUMENT_CONTENT</c> token texts inside an <c>argActionBlock</c> node.</summary>
-    private static string GetArgActionBlockText(ParserNode node) =>
-        string.Concat(FlatChildren(node)
+    /// <summary>
+    /// Concatenates all token text inside an <c>argActionBlock</c> node while excluding
+    /// the outer <c>[</c> and <c>]</c> delimiters.
+    /// </summary>
+    private static string GetArgActionBlockText(ParserNode node)
+    {
+        var tokens = FlatChildren(node)
             .OfType<LexerNode>()
-            .Where(n => n.Rule?.Name == "ARGUMENT_CONTENT")
-            .Select(n => n.Token.Text))
-        .Trim();
+            .Select(n => n.Token.Text)
+            .ToList();
+
+        if (tokens.Count >= 2 && tokens[0] == "[" && tokens[^1] == "]")
+            return string.Concat(tokens.Skip(1).Take(tokens.Count - 2));
+
+        return string.Concat(tokens);
+    }
 
     /// <summary>Extracts the string representation of an option value from an <c>optionValue</c> node.</summary>
     private static string GetOptionValueText(ParserNode node)

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -1011,18 +1011,34 @@ public sealed class Antlr4GrammarConverter
     /// <summary>
     /// Concatenates all token text inside an <c>argActionBlock</c> node while excluding
     /// the outer <c>[</c> and <c>]</c> delimiters.
+    /// Uses a deep leaf-token walk because <c>argumentElement</c> sub-nodes wrap the
+    /// individual <c>ARGUMENT_CONTENT</c> tokens and are not flattened by <see cref="FlatChildren"/>.
     /// </summary>
     private static string GetArgActionBlockText(ParserNode node)
     {
-        var tokens = FlatChildren(node)
-            .OfType<LexerNode>()
-            .Select(n => n.Token.Text)
-            .ToList();
+        var tokens = AllLeafTokens(node).ToList();
 
         if (tokens.Count >= 2 && tokens[0] == "[" && tokens[^1] == "]")
             return string.Concat(tokens.Skip(1).Take(tokens.Count - 2));
 
         return string.Concat(tokens);
+    }
+
+    /// <summary>Yields the text of every leaf <see cref="LexerNode"/> in depth-first order.</summary>
+    private static IEnumerable<string> AllLeafTokens(ParseNode node)
+    {
+        if (node is LexerNode lex)
+        {
+            yield return lex.Token.Text;
+            yield break;
+        }
+
+        if (node is ParserNode pn)
+        {
+            foreach (var child in pn.Children)
+                foreach (var tok in AllLeafTokens(child))
+                    yield return tok;
+        }
     }
 
     /// <summary>Extracts the string representation of an option value from an <c>optionValue</c> node.</summary>

--- a/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
@@ -261,21 +261,95 @@ public class Antlr4GrammarConverterTests
     // ─── 9. returns [...] ─────────────────────────────────────────────────────
 
     [TestMethod]
-    public void ParseParserRule_Returns_ParsesWithoutException()
+    public void RuleParameters_SimpleParameterBlock_IsPreserved()
     {
-        // The bootstrap grammar's argActionBlock handling has limitations with
-        // the [int v] syntax (Argument mode not triggered in DEFAULT_MODE).
-        // This test verifies the grammar parses without crashing, and that the
-        // rule itself is created (even if returns data is not captured).
-        // The grammar below avoids the argActionBlock limitation by omitting
-        // the actual argument content check.
         var def = Antlr4GrammarConverter.Parse("""
-            grammar A; 
-            r : 'x' ;
+            grammar G;
+            start[int x] : 'a' ;
             """);
 
-        // Even without returns, ensure rule is present
-        Assert.IsTrue(def.AllRules.ContainsKey("r"));
+        var rule = def.AllRules["start"];
+        Assert.IsNotNull(rule.Parameters);
+        Assert.AreEqual("int x", rule.Parameters![0].Type);
+    }
+
+    [TestMethod]
+    public void RuleParameters_GenericParameterBlock_IsPreserved()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start[List<int> items] : 'a' ;
+            """);
+
+        var rule = def.AllRules["start"];
+        Assert.IsNotNull(rule.Parameters);
+        Assert.AreEqual("List<int> items", rule.Parameters![0].Type);
+    }
+
+    [TestMethod]
+    public void RuleParameters_NestedGenericArguments_AreBalanced()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start[Dictionary<string, List<int>> map] : 'a' ;
+            """);
+
+        var rule = def.AllRules["start"];
+        Assert.AreEqual("Dictionary<string, List<int>> map", rule.Parameters![0].Type);
+    }
+
+    [TestMethod]
+    public void RuleReturns_Block_IsPreserved()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start returns [int value] : 'a' ;
+            """);
+
+        var rule = def.AllRules["start"];
+        Assert.IsNotNull(rule.Returns);
+        Assert.AreEqual("int value", rule.Returns![0].Type);
+    }
+
+    [TestMethod]
+    public void RuleParametersAndReturns_Both_AreCaptured()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start[int x] returns [int value] : 'a' ;
+            """);
+
+        var rule = def.AllRules["start"];
+        Assert.AreEqual("int x", rule.Parameters![0].Type);
+        Assert.AreEqual("int value", rule.Returns![0].Type);
+    }
+
+    [TestMethod]
+    public void RuleParameters_MultilineBlock_IsPreserved()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start[
+                int x,
+                string y
+            ]
+            : 'a'
+            ;
+            """);
+
+        var raw = def.AllRules["start"].Parameters![0].Type;
+        StringAssert.Contains(raw, "int x,");
+        StringAssert.Contains(raw, "string y");
+    }
+
+    [TestMethod]
+    public void RuleParameters_MalformedBlock_ProducesDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        Assert.ThrowsException<GrammarParseException>(() => Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start[List<int x : 'a' ;
+            """, diagnostics));
     }
 
     // ─── 10. Fragment rule ────────────────────────────────────────────────────

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -52,8 +52,8 @@ The following constructs are recognized but not fully resolved into executable r
 
 | Construct | Current behavior | Limitations |
 |---|---|---|
-| Rule parameters (`rule[int x]`) | Bracketed parameter syntax is partially recognized by bootstrap parsing. | No runtime invocation-frame/value binding model is implemented. |
-| Rule returns (`returns [int value]`) | Returns metadata can be parsed and preserved as raw text. | No runtime value propagation/extraction contract exists for parser execution. |
+| Rule parameters (`rule[int x]`) | Bracketed parameter blocks are parsed with balanced-text capture and preserved as raw metadata text (including multiline and nested generic-like syntax). | No runtime invocation-frame/value binding model is implemented. |
+| Rule returns (`returns [int value]`) | Returns blocks are parsed with the same balanced-text preservation strategy and stored as raw metadata text. | No runtime value propagation/extraction contract exists for parser execution. |
 
 These constructs are treated as syntax/metadata compatibility points, not as fully executable semantics.
 


### PR DESCRIPTION
### Motivation
- Improve bootstrap parsing fidelity for ANTLR4 rule parameter (`rule[...]`) and returns (`returns [...]`) blocks so their raw text is preserved for future metadata/runtime work.
- Use a conservative balanced-text approach (lexer mode + richer argument token acceptance) to survive nested generic-like syntax and multiline blocks without introducing runtime semantics.
- Keep runtime behavior unchanged: this is metadata-only bootstrap scaffolding and must not enable parameter passing or execution.

### Description

**`Utils.Parser/Bootstrap/Antlr4Grammar.cs`**
- `argActionBlock` now uses a plain greedy `Star(Ref("argumentElement"))` instead of `Star(..., greedy:false)`. The non-greedy form broke `TryParseQuantifier` (which exits as soon as `count >= min`, with no lookahead), consuming at most one token before requiring `END_ARGUMENT`. Since `argumentElement` never matches `]`, the greedy star stops naturally.
- Added `argumentElement` parser rule accepting `ARGUMENT_CONTENT`, `ARGUMENT_ESCAPE`, `ARGUMENT_STRING_LITERAL`, `ARGUMENT_CHAR_LITERAL`, and `NESTED_ARGUMENT` — covering escaped chars, quoted strings, and nested `[...]` blocks.

**`Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs`**
- Replaced `GetArgActionBlockText` with a version backed by `AllLeafTokens()`, a depth-first walk that collects every leaf `LexerNode` token. The previous implementation used `FlatChildren().OfType<LexerNode>()`, which only flattens nodes of the same rule name — `ARGUMENT_CONTENT` tokens wrapped inside `argumentElement` nodes (different rule name) were invisible, so the function returned an empty string even when parsing succeeded.
- `ConvertParserRuleSpec` captures the raw parameter block as `[new RuleParameter(raw, raw)]` and the returns block as `[new RuleReturn(raw, raw)]`. Both store the uninterpreted block text — no type splitting, no symbol table, no runtime semantics.

**`docs/parser/Antlr4CompatibilityMatrix.md`**
- Updated compatibility matrix: bracketed parameter/returns blocks are now preserved as raw balanced text; runtime parameter/return semantics remain unsupported.

### Testing

All 7 new tests pass (0 failed):

```
dotnet test UtilsTest/UtilsTest.csproj --filter "RuleParameters|RuleReturns"
Réussi! — échec : 0, réussite : 7, ignorée(s) : 0
```

| Test | Input | Assertion |
|------|-------|-----------|
| `RuleParameters_SimpleParameterBlock_IsPreserved` | `start[int x]` | `Parameters[0].Type == "int x"` |
| `RuleParameters_GenericParameterBlock_IsPreserved` | `start[List<int> items]` | contains `"List<int> items"` |
| `RuleParameters_NestedGenericArguments_AreBalanced` | `start[Dictionary<string, List<int>> map]` | full text preserved |
| `RuleReturns_Block_IsPreserved` | `start returns [int value]` | `Returns[0].Type == "int value"` |
| `RuleParametersAndReturns_Both_AreCaptured` | `start[int x] returns [int value]` | both captured |
| `RuleParameters_MultilineBlock_IsPreserved` | multiline `[int x, string y]` | contains both fields |
| `RuleParameters_MalformedBlock_ProducesDiagnostic` | `start[List<int x` (unterminated) | throws `GrammarParseException` |

Full suite: 1377 passed, 0 failed (1384 total with 7 ignored).

### Scope note

`parameters = [new RuleParameter(raw, raw)]` stores the entire bracket content as a single raw string. There is no semantic parsing of parameter names, types, or defaults. This is intentional: the goal of this PR is reliable text preservation only. Runtime parameter binding is explicitly out of scope.

---
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0303569d448326862967486872c4f9)
