### PR TITLE
Add explicit parser feature capability descriptors

### DIFF
--- a/Utils.Parser/Metadata/ParserFeature.cs
+++ b/Utils.Parser/Metadata/ParserFeature.cs
@@ -1,0 +1,38 @@
+namespace Utils.Parser.Metadata;
+
+/// <summary>
+/// Lists parser feature capabilities tracked by the parser capability model.
+/// </summary>
+public enum ParserFeature
+{
+    /// <summary>Right-associativity metadata via &lt;assoc=right&gt;.</summary>
+    AssocRight,
+    /// <summary>Grammar import declarations and project-level resolution.</summary>
+    GrammarImports,
+    /// <summary>Semantic predicate parsing and optional runtime evaluation policy.</summary>
+    SemanticPredicates,
+    /// <summary>Inline action parsing and optional runtime execution policy.</summary>
+    InlineActions,
+    /// <summary>Rule action blocks such as @init and @after.</summary>
+    RuleActions,
+    /// <summary>Rule parameter declaration metadata.</summary>
+    RuleParameters,
+    /// <summary>Rule returns declaration metadata.</summary>
+    RuleReturns,
+    /// <summary>Shared-prefix analysis metadata.</summary>
+    SharedPrefixMetadata,
+    /// <summary>Shared-prefix runtime execution optimization.</summary>
+    SharedPrefixExecution,
+    /// <summary>Continuation replay execution strategy.</summary>
+    ContinuationReplay,
+    /// <summary>Parser graph runtime execution strategy.</summary>
+    ParserGraphExecution,
+    /// <summary>Adaptive LL parsing strategy.</summary>
+    AdaptiveLl,
+    /// <summary>GLL parsing strategy.</summary>
+    Gll,
+    /// <summary>Asynchronous parsing execution.</summary>
+    AsyncParsing,
+    /// <summary>Parallel parsing execution.</summary>
+    ParallelParsing
+}

--- a/Utils.Parser/Metadata/ParserFeatureCapabilities.cs
+++ b/Utils.Parser/Metadata/ParserFeatureCapabilities.cs
@@ -37,6 +37,13 @@ public static class ParserFeatureCapabilities
         return capability;
     }
 
+    /// <summary>
+    /// Builds the canonical capability descriptors used by this catalog.
+    /// </summary>
+    /// <remarks>
+    /// This method is intentionally descriptive only and must not introduce runtime behavior changes.
+    /// </remarks>
+    /// <returns>An array containing one descriptor per <see cref="ParserFeature"/>.</returns>
     private static ParserFeatureCapability[] BuildCapabilities()
     {
         return

--- a/Utils.Parser/Metadata/ParserFeatureCapabilities.cs
+++ b/Utils.Parser/Metadata/ParserFeatureCapabilities.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Utils.Parser.Diagnostics;
+
+namespace Utils.Parser.Metadata;
+
+/// <summary>
+/// Provides an immutable catalog of parser feature capabilities.
+/// </summary>
+public static class ParserFeatureCapabilities
+{
+    private static readonly IReadOnlyDictionary<ParserFeature, ParserFeatureCapability> CapabilityByFeature =
+        new ReadOnlyDictionary<ParserFeature, ParserFeatureCapability>(
+            BuildCapabilities().ToDictionary(static capability => capability.Feature));
+
+    /// <summary>
+    /// Gets all declared parser feature capabilities.
+    /// </summary>
+    public static IReadOnlyList<ParserFeatureCapability> All { get; } =
+        new ReadOnlyCollection<ParserFeatureCapability>(CapabilityByFeature.Values.OrderBy(static entry => entry.Feature).ToArray());
+
+    /// <summary>
+    /// Gets the capability descriptor for a feature.
+    /// </summary>
+    /// <param name="feature">Feature to resolve.</param>
+    /// <returns>The immutable capability descriptor.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the feature value is unknown.</exception>
+    public static ParserFeatureCapability Get(ParserFeature feature)
+    {
+        if (!CapabilityByFeature.TryGetValue(feature, out ParserFeatureCapability? capability))
+        {
+            throw new ArgumentOutOfRangeException(nameof(feature), feature, "Unknown parser feature.");
+        }
+
+        return capability;
+    }
+
+    private static ParserFeatureCapability[] BuildCapabilities()
+    {
+        return
+        [
+            new(ParserFeature.AssocRight, ParserFeatureSupportLevel.Supported, "<assoc=right> precedence annotations are applied.", null, null),
+            new(ParserFeature.GrammarImports, ParserFeatureSupportLevel.SupportedWithLimits, "Grammar imports are resolved during project compilation.", "Resolution scope is project-compilation level.", null),
+            new(ParserFeature.SemanticPredicates, ParserFeatureSupportLevel.RuntimeOptional, "Semantic predicates are recognized and can be evaluated via injected policy.", "Default policy does not enforce predicates semantically.", ParserDiagnostics.SemanticPredicateNotEnforced.Code),
+            new(ParserFeature.InlineActions, ParserFeatureSupportLevel.RuntimeOptional, "Inline actions are captured and can be executed via injected policy.", "Default policy stores actions without executing them.", ParserDiagnostics.InlineActionStoredNotExecuted.Code),
+            new(ParserFeature.RuleActions, ParserFeatureSupportLevel.ParsedOnly, "Rule actions (@init/@after) are parsed.", "No runtime execution hook is currently available.", ParserDiagnostics.ActionIgnored.Code),
+            new(ParserFeature.RuleParameters, ParserFeatureSupportLevel.MetadataOnly, "Rule parameters are preserved as raw metadata.", "No invocation-frame parameter semantics are implemented.", null),
+            new(ParserFeature.RuleReturns, ParserFeatureSupportLevel.MetadataOnly, "Rule returns are preserved as raw metadata.", "No runtime return propagation is implemented.", null),
+            new(ParserFeature.SharedPrefixMetadata, ParserFeatureSupportLevel.MetadataOnly, "Shared-prefix analysis metadata is available.", "Metadata is descriptive and does not imply runtime execution.", null),
+            new(ParserFeature.SharedPrefixExecution, ParserFeatureSupportLevel.Unsupported, "Shared-prefix execution is not implemented.", null, null),
+            new(ParserFeature.ContinuationReplay, ParserFeatureSupportLevel.Unsupported, "Continuation replay is not implemented.", null, null),
+            new(ParserFeature.ParserGraphExecution, ParserFeatureSupportLevel.Unsupported, "Parser graph execution is not implemented.", null, null),
+            new(ParserFeature.AdaptiveLl, ParserFeatureSupportLevel.Unsupported, "Adaptive LL strategy is not implemented.", null, null),
+            new(ParserFeature.Gll, ParserFeatureSupportLevel.Unsupported, "GLL strategy is not implemented.", null, null),
+            new(ParserFeature.AsyncParsing, ParserFeatureSupportLevel.Unsupported, "Asynchronous parser execution is not implemented.", null, null),
+            new(ParserFeature.ParallelParsing, ParserFeatureSupportLevel.Unsupported, "Parallel parser execution is not implemented.", null, null)
+        ];
+    }
+}

--- a/Utils.Parser/Metadata/ParserFeatureCapability.cs
+++ b/Utils.Parser/Metadata/ParserFeatureCapability.cs
@@ -1,0 +1,16 @@
+namespace Utils.Parser.Metadata;
+
+/// <summary>
+/// Describes the support status of one parser feature.
+/// </summary>
+/// <param name="Feature">Feature being described.</param>
+/// <param name="SupportLevel">Current support level.</param>
+/// <param name="Summary">Short support summary.</param>
+/// <param name="Limitation">Optional limitation details.</param>
+/// <param name="RelatedDiagnosticCode">Optional related diagnostic code.</param>
+public sealed record ParserFeatureCapability(
+    ParserFeature Feature,
+    ParserFeatureSupportLevel SupportLevel,
+    string Summary,
+    string? Limitation,
+    string? RelatedDiagnosticCode);

--- a/Utils.Parser/Metadata/ParserFeatureSupportLevel.cs
+++ b/Utils.Parser/Metadata/ParserFeatureSupportLevel.cs
@@ -1,0 +1,37 @@
+namespace Utils.Parser.Metadata;
+
+/// <summary>
+/// Indicates the current support level of a parser feature.
+/// </summary>
+public enum ParserFeatureSupportLevel
+{
+    /// <summary>
+    /// The feature is not supported.
+    /// </summary>
+    Unsupported,
+
+    /// <summary>
+    /// The feature is parsed but only retained structurally.
+    /// </summary>
+    ParsedOnly,
+
+    /// <summary>
+    /// The feature is parsed and preserved as metadata only.
+    /// </summary>
+    MetadataOnly,
+
+    /// <summary>
+    /// The feature can be enabled at runtime through an injected policy.
+    /// </summary>
+    RuntimeOptional,
+
+    /// <summary>
+    /// The feature is supported but has explicit limitations.
+    /// </summary>
+    SupportedWithLimits,
+
+    /// <summary>
+    /// The feature is fully supported.
+    /// </summary>
+    Supported
+}

--- a/UtilsTest/Parser/ParserFeatureCapabilitiesTests.cs
+++ b/UtilsTest/Parser/ParserFeatureCapabilitiesTests.cs
@@ -42,7 +42,7 @@ public class ParserFeatureCapabilitiesTests
 
         foreach (var capability in ParserFeatureCapabilities.All.Where(static item => !string.IsNullOrWhiteSpace(item.RelatedDiagnosticCode)))
         {
-            Assert.IsTrue(Utils.Parser.Diagnostics.ParserDiagnostics.TryGet(capability.RelatedDiagnosticCode!, out _), $"Unknown diagnostic code: {capability.RelatedDiagnosticCode}");
+            Assert.IsTrue(ParserDiagnostics.TryGet(capability.RelatedDiagnosticCode!, out _), $"Unknown diagnostic code: {capability.RelatedDiagnosticCode}");
         }
     }
 

--- a/UtilsTest/Parser/ParserFeatureCapabilitiesTests.cs
+++ b/UtilsTest/Parser/ParserFeatureCapabilitiesTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using Utils.Parser.Metadata;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Tests for the parser capability descriptor model.
+/// </summary>
+[TestClass]
+public class ParserFeatureCapabilitiesTests
+{
+    [TestMethod]
+    public void ParserFeatureCapabilities_AllFeaturesHaveUniqueEntries()
+    {
+        var all = ParserFeatureCapabilities.All;
+
+        Assert.AreEqual(all.Count, all.Select(static capability => capability.Feature).Distinct().Count());
+        Assert.AreEqual(Enum.GetValues<ParserFeature>().Length, all.Count);
+    }
+
+    [TestMethod]
+    public void ParserFeatureCapabilities_KnownFeaturesHaveExpectedLevels()
+    {
+        Assert.AreEqual(ParserFeatureSupportLevel.RuntimeOptional, ParserFeatureCapabilities.Get(ParserFeature.SemanticPredicates).SupportLevel);
+        Assert.AreEqual(ParserFeatureSupportLevel.RuntimeOptional, ParserFeatureCapabilities.Get(ParserFeature.InlineActions).SupportLevel);
+        Assert.AreEqual(ParserFeatureSupportLevel.MetadataOnly, ParserFeatureCapabilities.Get(ParserFeature.RuleParameters).SupportLevel);
+        Assert.AreEqual(ParserFeatureSupportLevel.Unsupported, ParserFeatureCapabilities.Get(ParserFeature.SharedPrefixExecution).SupportLevel);
+        Assert.AreEqual(ParserFeatureSupportLevel.Supported, ParserFeatureCapabilities.Get(ParserFeature.AssocRight).SupportLevel);
+    }
+
+    [TestMethod]
+    public void ParserFeatureCapabilities_RelatedDiagnostics_AreAligned()
+    {
+        var semanticPredicates = ParserFeatureCapabilities.Get(ParserFeature.SemanticPredicates);
+        var inlineActions = ParserFeatureCapabilities.Get(ParserFeature.InlineActions);
+
+        Assert.AreEqual("UP1006", semanticPredicates.RelatedDiagnosticCode);
+        Assert.AreEqual("UP1005", inlineActions.RelatedDiagnosticCode);
+
+        foreach (var capability in ParserFeatureCapabilities.All.Where(static item => !string.IsNullOrWhiteSpace(item.RelatedDiagnosticCode)))
+        {
+            Assert.IsTrue(Utils.Parser.Diagnostics.ParserDiagnostics.TryGet(capability.RelatedDiagnosticCode!, out _), $"Unknown diagnostic code: {capability.RelatedDiagnosticCode}");
+        }
+    }
+
+    [TestMethod]
+    public void ParserFeatureCapabilities_GetThrowsClearlyForUnknown()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => ParserFeatureCapabilities.Get((ParserFeature)999));
+    }
+}

--- a/UtilsTest/Parser/ParserFeatureCapabilitiesTests.cs
+++ b/UtilsTest/Parser/ParserFeatureCapabilitiesTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
+using Utils.Parser.Diagnostics;
 using Utils.Parser.Metadata;
 
 namespace UtilsTest.Parser;
@@ -36,8 +37,8 @@ public class ParserFeatureCapabilitiesTests
         var semanticPredicates = ParserFeatureCapabilities.Get(ParserFeature.SemanticPredicates);
         var inlineActions = ParserFeatureCapabilities.Get(ParserFeature.InlineActions);
 
-        Assert.AreEqual("UP1006", semanticPredicates.RelatedDiagnosticCode);
-        Assert.AreEqual("UP1005", inlineActions.RelatedDiagnosticCode);
+        Assert.AreEqual(ParserDiagnostics.SemanticPredicateNotEnforced.Code, semanticPredicates.RelatedDiagnosticCode);
+        Assert.AreEqual(ParserDiagnostics.InlineActionStoredNotExecuted.Code, inlineActions.RelatedDiagnosticCode);
 
         foreach (var capability in ParserFeatureCapabilities.All.Where(static item => !string.IsNullOrWhiteSpace(item.RelatedDiagnosticCode)))
         {

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -106,3 +106,9 @@ The above architecture supports auditability and controlled evolution without ch
 - audit-friendly boundaries between metadata, resolution, and runtime execution.
 
 This policy avoids speculative runtime complexity while still enabling progressive ANTLR4 syntax coverage.
+
+## Capability descriptor model (code-facing)
+
+The repository now also exposes a code-facing capability descriptor model (`ParserFeatureCapabilities`) that centralizes feature support levels (Supported, SupportedWithLimits, RuntimeOptional, MetadataOnly, ParsedOnly, Unsupported).
+
+This model is **descriptive only** and does not change parser behavior, diagnostics emission, parse-tree shape, or runtime execution policies.

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -169,3 +169,9 @@ Any future PR proposing execution changes would need to demonstrate, at minimum:
 4. a rollback path to baseline behavior.
 
 Without this evidence, execution-oriented changes should not be merged.
+
+## Capability model note
+
+A centralized parser capability descriptor model is available in code (`ParserFeatureCapabilities`) to make support status queryable and auditable.
+
+It is intentionally descriptive metadata and is **not** used to gate parsing, alter diagnostics, or introduce new runtime behavior.


### PR DESCRIPTION
### Motivation

- Centralize and make parser feature support queryable and auditable via a small, descriptive capability model without changing runtime behavior. 
- Capture conservative, deterministic mappings that reflect current generator/runtime limitations and diagnostics so support status is easy to inspect and reason about. 

### Description

- Added a new metadata model under `Utils.Parser.Metadata`: `ParserFeatureSupportLevel`, `ParserFeature`, `ParserFeatureCapability` (record), and `ParserFeatureCapabilities` provider exposing `All` and `Get` with an immutable catalog. 
- Populated the catalog with conservative, descriptive mappings (e.g. `SemanticPredicates` and `InlineActions` as `RuntimeOptional`, `RuleParameters`/`RuleReturns` as `MetadataOnly`, `SharedPrefixExecution` as `Unsupported`, `AssocRight` as `Supported`) and referenced existing diagnostics where appropriate. 
- Added focused unit tests `UtilsTest/Parser/ParserFeatureCapabilitiesTests.cs` validating completeness/uniqueness, representative support levels, related diagnostic codes, and `Get` failure behavior. 
- Updated parser docs (`docs/parser/Antlr4CompatibilityMatrix.md` and `docs/parser/ParserMetadataAndRuntimeLimitations.md`) to mention the new code-facing capability model and explicitly state it is descriptive only.

### Testing

- Ran the targeted test filter: `dotnet test UtilsTest/UtilsTest.csproj --filter ParserFeatureCapabilities` and the new test class executed successfully (Passed 4/4). 
- Unit tests added: `ParserFeatureCapabilities_AllFeaturesHaveUniqueEntries`, `ParserFeatureCapabilities_KnownFeaturesHaveExpectedLevels`, `ParserFeatureCapabilities_RelatedDiagnostics_AreAligned`, and `ParserFeatureCapabilities_GetThrowsClearlyForUnknown`, all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03448b29a4832683212ba09fce706b)