### PR TITLE
Add centralized ParserRuntimeFeaturePolicy and normalize runtime wiring

### DIFF
--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -66,7 +66,9 @@ public sealed class Antlr4GrammarConverter
         [StringSyntax("ANTLR4")] string grammarText,
         ISemanticPredicateEvaluator semanticPredicateEvaluator,
         DiagnosticBag? diagnostics = null)
-        => new Runtime.CompiledGrammar(Parse(grammarText, diagnostics), semanticPredicateEvaluator, new DefaultParserActionExecutor());
+        => new Runtime.CompiledGrammar(
+            Parse(grammarText, diagnostics),
+            ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = semanticPredicateEvaluator });
 
     /// <summary>
     /// Convenience factory: compiles <paramref name="grammarText"/> and configures
@@ -80,7 +82,9 @@ public sealed class Antlr4GrammarConverter
         [StringSyntax("ANTLR4")] string grammarText,
         IParserActionExecutor parserActionExecutor,
         DiagnosticBag? diagnostics = null)
-        => new Runtime.CompiledGrammar(Parse(grammarText, diagnostics), new DefaultSemanticPredicateEvaluator(), parserActionExecutor);
+        => new Runtime.CompiledGrammar(
+            Parse(grammarText, diagnostics),
+            ParserRuntimeFeaturePolicy.Default with { ParserActionExecutor = parserActionExecutor });
 
     /// <summary>
     /// Convenience factory: compiles <paramref name="grammarText"/> and configures explicit

--- a/Utils.Parser/Runtime/CompiledGrammar.cs
+++ b/Utils.Parser/Runtime/CompiledGrammar.cs
@@ -26,7 +26,7 @@ public sealed class CompiledGrammar
     /// </summary>
     /// <param name="definition">A resolved grammar definition.</param>
     public CompiledGrammar(ParserDefinition definition)
-        : this(definition, new DefaultSemanticPredicateEvaluator(), new DefaultParserActionExecutor())
+        : this(definition, ParserRuntimeFeaturePolicy.Default)
     {
     }
 
@@ -39,7 +39,7 @@ public sealed class CompiledGrammar
     /// Evaluator used by the embedded <see cref="ParserEngine"/> for semantic predicates.
     /// </param>
     public CompiledGrammar(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator)
-        : this(definition, semanticPredicateEvaluator, new DefaultParserActionExecutor())
+        : this(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = semanticPredicateEvaluator })
     {
     }
 
@@ -50,7 +50,7 @@ public sealed class CompiledGrammar
     /// <param name="definition">A resolved grammar definition.</param>
     /// <param name="parserActionExecutor">Parser embedded action execution policy.</param>
     public CompiledGrammar(ParserDefinition definition, IParserActionExecutor parserActionExecutor)
-        : this(definition, new DefaultSemanticPredicateEvaluator(), parserActionExecutor)
+        : this(definition, ParserRuntimeFeaturePolicy.Default with { ParserActionExecutor = parserActionExecutor })
     {
     }
 
@@ -62,10 +62,27 @@ public sealed class CompiledGrammar
     /// <param name="semanticPredicateEvaluator">Semantic predicate evaluator policy.</param>
     /// <param name="parserActionExecutor">Parser embedded action execution policy.</param>
     public CompiledGrammar(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator, IParserActionExecutor parserActionExecutor)
+        : this(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                SemanticPredicateEvaluator = semanticPredicateEvaluator,
+                ParserActionExecutor = parserActionExecutor
+            })
+    {
+    }
+
+    /// <summary>
+    /// Initialises a <see cref="CompiledGrammar"/> from a fully resolved
+    /// <see cref="ParserDefinition"/> with an explicit runtime feature policy.
+    /// </summary>
+    /// <param name="definition">A resolved grammar definition.</param>
+    /// <param name="runtimeFeaturePolicy">Runtime feature policy applied to parser execution.</param>
+    public CompiledGrammar(ParserDefinition definition, ParserRuntimeFeaturePolicy runtimeFeaturePolicy)
     {
         Definition = definition;
         _lexer = new LexerEngine(definition);
-        _parser = new ParserEngine(definition, semanticPredicateEvaluator, parserActionExecutor);
+        _parser = new ParserEngine(definition, runtimeFeaturePolicy);
     }
 
     /// <summary>

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -39,6 +39,10 @@ public sealed class ParserEngine
     private readonly ISemanticPredicateEvaluator _semanticPredicateEvaluator;
     private readonly IParserActionExecutor _parserActionExecutor;
 
+    /// <summary>
+    /// Initializes a parser engine with the conservative default runtime feature policy.
+    /// </summary>
+    /// <param name="definition">Resolved parser definition.</param>
     public ParserEngine(ParserDefinition definition)
         : this(definition, ParserRuntimeFeaturePolicy.Default)
     {

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -40,7 +40,7 @@ public sealed class ParserEngine
     private readonly IParserActionExecutor _parserActionExecutor;
 
     public ParserEngine(ParserDefinition definition)
-        : this(definition, new DefaultSemanticPredicateEvaluator(), new DefaultParserActionExecutor())
+        : this(definition, ParserRuntimeFeaturePolicy.Default)
     {
     }
 
@@ -52,7 +52,9 @@ public sealed class ParserEngine
     /// Strategy used to evaluate semantic predicates without executing arbitrary source code.
     /// </param>
     public ParserEngine(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator)
-        : this(definition, semanticPredicateEvaluator, new DefaultParserActionExecutor())
+        : this(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = semanticPredicateEvaluator })
     {
     }
 
@@ -62,7 +64,9 @@ public sealed class ParserEngine
     /// <param name="definition">Resolved parser definition.</param>
     /// <param name="parserActionExecutor">Policy used to handle parser embedded actions.</param>
     public ParserEngine(ParserDefinition definition, IParserActionExecutor parserActionExecutor)
-        : this(definition, new DefaultSemanticPredicateEvaluator(), parserActionExecutor)
+        : this(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with { ParserActionExecutor = parserActionExecutor })
     {
     }
 
@@ -73,10 +77,27 @@ public sealed class ParserEngine
     /// <param name="semanticPredicateEvaluator">Policy used to evaluate semantic predicates.</param>
     /// <param name="parserActionExecutor">Policy used to handle parser embedded actions.</param>
     public ParserEngine(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator, IParserActionExecutor parserActionExecutor)
+        : this(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                SemanticPredicateEvaluator = semanticPredicateEvaluator,
+                ParserActionExecutor = parserActionExecutor
+            })
+    {
+    }
+
+    /// <summary>
+    /// Initializes a parser engine with an explicit runtime feature policy.
+    /// </summary>
+    /// <param name="definition">Resolved parser definition.</param>
+    /// <param name="runtimeFeaturePolicy">Runtime feature policy for optional parser behavior.</param>
+    public ParserEngine(ParserDefinition definition, ParserRuntimeFeaturePolicy runtimeFeaturePolicy)
     {
         _definition = definition ?? throw new ArgumentNullException(nameof(definition));
-        _semanticPredicateEvaluator = semanticPredicateEvaluator ?? throw new ArgumentNullException(nameof(semanticPredicateEvaluator));
-        _parserActionExecutor = parserActionExecutor ?? throw new ArgumentNullException(nameof(parserActionExecutor));
+        var effectivePolicy = runtimeFeaturePolicy ?? throw new ArgumentNullException(nameof(runtimeFeaturePolicy));
+        _semanticPredicateEvaluator = effectivePolicy.SemanticPredicateEvaluator ?? throw new ArgumentNullException(nameof(runtimeFeaturePolicy));
+        _parserActionExecutor = effectivePolicy.ParserActionExecutor ?? throw new ArgumentNullException(nameof(runtimeFeaturePolicy));
         _caseInsensitive = IsCaseInsensitive(_definition);
         _alternativeScheduler = new AlternativeScheduler();
         _scheduledAlternativeExecutor = new ScheduledAlternativeExecutor(_stateRegistry, _lookaheadCache, new ParserLookaheadProbe());

--- a/Utils.Parser/Runtime/ParserRuntimeFeaturePolicy.cs
+++ b/Utils.Parser/Runtime/ParserRuntimeFeaturePolicy.cs
@@ -1,0 +1,28 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Immutable runtime feature policy used by parser components to centralize optional
+/// runtime strategies such as semantic predicate evaluation and parser action execution.
+/// </summary>
+public sealed record ParserRuntimeFeaturePolicy
+{
+    /// <summary>
+    /// Gets the conservative default runtime policy.
+    /// Semantic predicates are not evaluated and parser actions are not executed.
+    /// </summary>
+    public static ParserRuntimeFeaturePolicy Default { get; } = new()
+    {
+        SemanticPredicateEvaluator = new DefaultSemanticPredicateEvaluator(),
+        ParserActionExecutor = new DefaultParserActionExecutor()
+    };
+
+    /// <summary>
+    /// Gets the semantic predicate evaluation strategy.
+    /// </summary>
+    public required ISemanticPredicateEvaluator SemanticPredicateEvaluator { get; init; }
+
+    /// <summary>
+    /// Gets the parser action execution strategy.
+    /// </summary>
+    public required IParserActionExecutor ParserActionExecutor { get; init; }
+}

--- a/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
@@ -1,0 +1,147 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Model;
+using Utils.Parser.Resolution;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Verifies runtime feature policy defaults and policy propagation in parser runtime entry points.
+/// </summary>
+[TestClass]
+public class ParserRuntimeFeaturePolicyTests
+{
+    [TestMethod]
+    public void ParserRuntimeFeaturePolicy_DefaultPreservesCurrentBehavior()
+    {
+        Assert.IsInstanceOfType<DefaultSemanticPredicateEvaluator>(ParserRuntimeFeaturePolicy.Default.SemanticPredicateEvaluator);
+        Assert.IsInstanceOfType<DefaultParserActionExecutor>(ParserRuntimeFeaturePolicy.Default.ParserActionExecutor);
+    }
+
+    [TestMethod]
+    public void ParserEngine_ExistingOverloads_ProduceEquivalentPolicies()
+    {
+        var definition = CreateMinimalDefinition();
+        var evaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Satisfied);
+        var executor = new ConstantParserActionExecutor(ParserActionExecutionResult.Executed);
+
+        var evaluatorOnly = new ParserEngine(definition, evaluator);
+        var executorOnly = new ParserEngine(definition, executor);
+        var combined = new ParserEngine(definition, evaluator, executor);
+
+        Assert.AreSame(evaluator, GetSemanticPredicateEvaluator(evaluatorOnly));
+        Assert.IsInstanceOfType<DefaultParserActionExecutor>(GetParserActionExecutor(evaluatorOnly));
+
+        Assert.IsInstanceOfType<DefaultSemanticPredicateEvaluator>(GetSemanticPredicateEvaluator(executorOnly));
+        Assert.AreSame(executor, GetParserActionExecutor(executorOnly));
+
+        Assert.AreSame(evaluator, GetSemanticPredicateEvaluator(combined));
+        Assert.AreSame(executor, GetParserActionExecutor(combined));
+    }
+
+    [TestMethod]
+    public void ParserRuntimeFeaturePolicy_CustomStrategies_ArePropagated()
+    {
+        var definition = CreateMinimalDefinition();
+        var evaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Satisfied);
+        var executor = new ConstantParserActionExecutor(ParserActionExecutionResult.Executed);
+        var policy = ParserRuntimeFeaturePolicy.Default with
+        {
+            SemanticPredicateEvaluator = evaluator,
+            ParserActionExecutor = executor
+        };
+
+        var parser = new ParserEngine(definition, policy);
+
+        Assert.AreSame(evaluator, GetSemanticPredicateEvaluator(parser));
+        Assert.AreSame(executor, GetParserActionExecutor(parser));
+    }
+
+    [TestMethod]
+    public void RuntimePolicy_DoesNotAlterDefaultDiagnostics()
+    {
+        const string grammar = """
+            grammar P;
+            start : {canProceed}? A {notify();} ;
+            A : 'a' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+
+        var definition = Antlr4GrammarConverter.Parse(grammar);
+        var tokens = new CompiledGrammar(definition).Tokenize("a");
+
+        var diagnosticsWithDefaultConstructor = new DiagnosticBag();
+        var diagnosticsWithDefaultPolicy = new DiagnosticBag();
+
+        var parserWithDefaultConstructor = new ParserEngine(definition);
+        var parserWithDefaultPolicy = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default);
+
+        parserWithDefaultConstructor.Parse(tokens, diagnostics: diagnosticsWithDefaultConstructor);
+        parserWithDefaultPolicy.Parse(tokens, diagnostics: diagnosticsWithDefaultPolicy);
+
+        CollectionAssert.AreEqual(
+            diagnosticsWithDefaultConstructor.Select(static diagnostic => diagnostic.Code).ToArray(),
+            diagnosticsWithDefaultPolicy.Select(static diagnostic => diagnostic.Code).ToArray());
+    }
+
+    private static ISemanticPredicateEvaluator GetSemanticPredicateEvaluator(ParserEngine parser)
+    {
+        var field = typeof(ParserEngine).GetField("_semanticPredicateEvaluator", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (ISemanticPredicateEvaluator)field.GetValue(parser)!;
+    }
+
+    private static IParserActionExecutor GetParserActionExecutor(ParserEngine parser)
+    {
+        var field = typeof(ParserEngine).GetField("_parserActionExecutor", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (IParserActionExecutor)field.GetValue(parser)!;
+    }
+
+    private static ParserDefinition CreateMinimalDefinition()
+    {
+        var startRule = new Rule("start", 0, false, new Alternation([new Alternative(0, Associativity.Left, new Sequence([]))]));
+        return RuleResolver.Resolve(new ParserDefinition(
+            Name: "G",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [startRule],
+            RootRule: startRule));
+    }
+
+    private sealed class ConstantSemanticPredicateEvaluator : ISemanticPredicateEvaluator
+    {
+        private readonly SemanticPredicateEvaluationResult _result;
+
+        public ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult result)
+        {
+            _result = result;
+        }
+
+        public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+        {
+            return _result;
+        }
+    }
+
+    private sealed class ConstantParserActionExecutor : IParserActionExecutor
+    {
+        private readonly ParserActionExecutionResult _result;
+
+        public ConstantParserActionExecutor(ParserActionExecutionResult result)
+        {
+            _result = result;
+        }
+
+        public ParserActionExecutionResult Execute(ParserActionExecutionContext context)
+        {
+            return _result;
+        }
+    }
+}

--- a/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
@@ -13,6 +13,9 @@ namespace UtilsTest.Parser;
 [TestClass]
 public class ParserRuntimeFeaturePolicyTests
 {
+    /// <summary>
+    /// Verifies that the default runtime feature policy preserves the existing conservative strategies.
+    /// </summary>
     [TestMethod]
     public void ParserRuntimeFeaturePolicy_DefaultPreservesCurrentBehavior()
     {
@@ -20,6 +23,9 @@ public class ParserRuntimeFeaturePolicyTests
         Assert.IsInstanceOfType<DefaultParserActionExecutor>(ParserRuntimeFeaturePolicy.Default.ParserActionExecutor);
     }
 
+    /// <summary>
+    /// Verifies that existing constructor overloads map runtime strategies exactly as before.
+    /// </summary>
     [TestMethod]
     public void ParserEngine_ExistingOverloads_ProduceEquivalentPolicies()
     {
@@ -41,6 +47,9 @@ public class ParserRuntimeFeaturePolicyTests
         Assert.AreSame(executor, GetParserActionExecutor(combined));
     }
 
+    /// <summary>
+    /// Verifies that explicitly configured runtime strategy instances are propagated to the parser engine.
+    /// </summary>
     [TestMethod]
     public void ParserRuntimeFeaturePolicy_CustomStrategies_ArePropagated()
     {
@@ -59,6 +68,9 @@ public class ParserRuntimeFeaturePolicyTests
         Assert.AreSame(executor, GetParserActionExecutor(parser));
     }
 
+    /// <summary>
+    /// Verifies that using the explicit default runtime policy does not change emitted diagnostics.
+    /// </summary>
     [TestMethod]
     public void RuntimePolicy_DoesNotAlterDefaultDiagnostics()
     {
@@ -86,18 +98,32 @@ public class ParserRuntimeFeaturePolicyTests
             diagnosticsWithDefaultPolicy.Select(static diagnostic => diagnostic.Code).ToArray());
     }
 
+    /// <summary>
+    /// Gets the semantic predicate evaluator instance currently held by the parser engine.
+    /// </summary>
+    /// <param name="parser">Parser engine to inspect.</param>
+    /// <returns>Configured semantic predicate evaluator.</returns>
     private static ISemanticPredicateEvaluator GetSemanticPredicateEvaluator(ParserEngine parser)
     {
         var field = typeof(ParserEngine).GetField("_semanticPredicateEvaluator", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
         return (ISemanticPredicateEvaluator)field.GetValue(parser)!;
     }
 
+    /// <summary>
+    /// Gets the parser action executor instance currently held by the parser engine.
+    /// </summary>
+    /// <param name="parser">Parser engine to inspect.</param>
+    /// <returns>Configured parser action executor.</returns>
     private static IParserActionExecutor GetParserActionExecutor(ParserEngine parser)
     {
         var field = typeof(ParserEngine).GetField("_parserActionExecutor", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
         return (IParserActionExecutor)field.GetValue(parser)!;
     }
 
+    /// <summary>
+    /// Creates a minimal resolved parser definition suitable for constructor wiring tests.
+    /// </summary>
+    /// <returns>A resolved parser definition.</returns>
     private static ParserDefinition CreateMinimalDefinition()
     {
         var startRule = new Rule("start", 0, false, new Alternation([new Alternative(0, Associativity.Left, new Sequence([]))]));
@@ -115,30 +141,54 @@ public class ParserRuntimeFeaturePolicyTests
             RootRule: startRule));
     }
 
+    /// <summary>
+    /// Semantic predicate evaluator used by tests to return a deterministic result.
+    /// </summary>
     private sealed class ConstantSemanticPredicateEvaluator : ISemanticPredicateEvaluator
     {
         private readonly SemanticPredicateEvaluationResult _result;
 
+        /// <summary>
+        /// Initializes the evaluator with the configured evaluation result.
+        /// </summary>
+        /// <param name="result">Result returned for all predicate evaluations.</param>
         public ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult result)
         {
             _result = result;
         }
 
+        /// <summary>
+        /// Returns the configured semantic predicate evaluation result.
+        /// </summary>
+        /// <param name="context">Semantic predicate evaluation context.</param>
+        /// <returns>The configured result.</returns>
         public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
         {
             return _result;
         }
     }
 
+    /// <summary>
+    /// Parser action executor used by tests to return a deterministic result.
+    /// </summary>
     private sealed class ConstantParserActionExecutor : IParserActionExecutor
     {
         private readonly ParserActionExecutionResult _result;
 
+        /// <summary>
+        /// Initializes the executor with the configured action execution result.
+        /// </summary>
+        /// <param name="result">Result returned for all action executions.</param>
         public ConstantParserActionExecutor(ParserActionExecutionResult result)
         {
             _result = result;
         }
 
+        /// <summary>
+        /// Returns the configured parser action execution result.
+        /// </summary>
+        /// <param name="context">Parser action execution context.</param>
+        /// <returns>The configured result.</returns>
         public ParserActionExecutionResult Execute(ParserActionExecutionContext context)
         {
             return _result;

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -175,3 +175,13 @@ Without this evidence, execution-oriented changes should not be merged.
 A centralized parser capability descriptor model is available in code (`ParserFeatureCapabilities`) to make support status queryable and auditable.
 
 It is intentionally descriptive metadata and is **not** used to gate parsing, alter diagnostics, or introduce new runtime behavior.
+
+
+## Runtime feature policy
+
+Parser runtime optional behaviors are centralized through `ParserRuntimeFeaturePolicy` (`Utils.Parser.Runtime`).
+The default policy remains conservative and unchanged:
+- semantic predicates use `DefaultSemanticPredicateEvaluator` and are reported as not enforced;
+- inline parser actions use `DefaultParserActionExecutor` and are reported as not executed.
+
+Existing constructors that accept `ISemanticPredicateEvaluator` and/or `IParserActionExecutor` are still supported and internally normalized to the runtime policy object.


### PR DESCRIPTION
### Motivation
- Reduce fragmentation of optional runtime-injection points (semantic predicate evaluator and action executor) by introducing a single immutable runtime policy model.
- Stabilize future runtime configuration growth while preserving existing defaults and parser execution semantics exactly.
- Keep public compatibility by retaining existing constructor overloads and internally normalizing them to the new policy object.

### Description
- Add `ParserRuntimeFeaturePolicy` (immutable record) with an explicit `Default` instance that uses `DefaultSemanticPredicateEvaluator` and `DefaultParserActionExecutor` to preserve conservative behavior.
- Refactor `ParserEngine` constructors to normalize existing overloads to a single `ParserRuntimeFeaturePolicy` entry point while preserving the original overloads for compatibility.
- Update `CompiledGrammar` and `Antlr4GrammarConverter` to route evaluator/executor overloads through `ParserRuntimeFeaturePolicy` so runtime strategy wiring converges internally.
- Add unit tests (`UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs`) verifying default equivalence, overload-to-policy mapping, custom strategy propagation, and unchanged default diagnostics, and update runtime documentation (`docs/parser/ParserMetadataAndRuntimeLimitations.md`).

### Testing
- Ran the focused runtime policy test suite with `dotnet test UtilsTest/UtilsTest.csproj --filter ParserRuntimeFeaturePolicyTests --nologo`; result: 4 passed, 0 failed.
- The change compiles as part of the solution restore/build performed by the test run with no test failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034c1f21f483269ef9c8ba002a3d16)