### PR TITLE
docs(parser): clarify runtime policy boundaries and memoization assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Updated the `omy.Utils` NuGet description to a concise consumer-facing summary aligned with the package README and discoverability goals.
 
 ### Added
+- Clarified parser runtime documentation for policy-controlled semantic predicates/actions, conservative defaults, memoization assumptions, and related diagnostics semantics.
 - Corrected package casing reference from `omy.Utils.Xml` to `omy.Utils.XML` in the base package README to match the published NuGet package identifier.
 - Refined consumer documentation: updated root README and getting-started guide with complete package inventory, install-first flow, and explicit consumer vs contributor requirements.
 - Clarified getting-started and release documentation with csproj-derived TFM guidance, source-generator install example, and explicit CI workflow mapping.

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -489,3 +489,17 @@ The points below reflect the current implementation behavior.
 ## License
 
 Apache 2.0 — see the repository root for details.
+
+
+## Runtime policy defaults and safety boundaries
+
+`ParserEngine` routes semantic predicates and embedded parser actions through `ParserRuntimeFeaturePolicy`.
+By default, behavior remains conservative:
+
+- predicates -> `NotEvaluated`;
+- actions -> `NotExecuted`.
+
+Custom `ISemanticPredicateEvaluator` and `IParserActionExecutor` implementations may influence branch acceptance and may execute action logic.
+Memoization currently reuses rule results by `(rule, input position, precedence)` and does not model external semantic/action state, so custom runtime policies should remain deterministic for equivalent invocations.
+
+Current runtime still does not provide invocation frames, rollback-safe mutable semantic state, speculative action replay, continuation replay, or shared-prefix execution.

--- a/Utils.Parser/Runtime/DefaultParserActionExecutor.cs
+++ b/Utils.Parser/Runtime/DefaultParserActionExecutor.cs
@@ -1,7 +1,8 @@
 namespace Utils.Parser.Runtime;
 
 /// <summary>
-/// Conservative default action executor that does not run embedded action code.
+/// Conservative default action executor that does not run embedded action code and returns
+/// <see cref="ParserActionExecutionResult.NotExecuted"/> for every embedded action.
 /// </summary>
 internal sealed class DefaultParserActionExecutor : IParserActionExecutor
 {

--- a/Utils.Parser/Runtime/DefaultSemanticPredicateEvaluator.cs
+++ b/Utils.Parser/Runtime/DefaultSemanticPredicateEvaluator.cs
@@ -1,8 +1,8 @@
 namespace Utils.Parser.Runtime;
 
 /// <summary>
-/// Default evaluator that preserves legacy parser behavior by not evaluating
-/// semantic predicate source code.
+/// Default evaluator that preserves conservative legacy behavior by not evaluating
+/// semantic predicate source code and returning <see cref="SemanticPredicateEvaluationResult.NotEvaluated"/>.
 /// </summary>
 internal sealed class DefaultSemanticPredicateEvaluator : ISemanticPredicateEvaluator
 {

--- a/Utils.Parser/Runtime/IParserActionExecutor.cs
+++ b/Utils.Parser/Runtime/IParserActionExecutor.cs
@@ -4,6 +4,7 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Defines policy-driven embedded action handling for <see cref="ParserEngine"/>.
+/// Implementations may execute side effects and can therefore influence observable runtime behavior.
 /// </summary>
 public interface IParserActionExecutor
 {
@@ -11,7 +12,8 @@ public interface IParserActionExecutor
     /// Executes or ignores a parser action according to the runtime policy.
     /// </summary>
     /// <param name="context">Immutable action execution context.</param>
-    /// <returns>Execution decision for the action.</returns>
+    /// <returns>Execution decision for the action.
+    /// For memoization safety, implementations should avoid invocation-count-dependent mutable external state.</returns>
     ParserActionExecutionResult Execute(ParserActionExecutionContext context);
 }
 

--- a/Utils.Parser/Runtime/ISemanticPredicateEvaluator.cs
+++ b/Utils.Parser/Runtime/ISemanticPredicateEvaluator.cs
@@ -2,6 +2,7 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Defines policy-driven semantic predicate handling for <see cref="ParserEngine"/>.
+/// Implementations can influence branch acceptance and therefore parse outcomes.
 /// </summary>
 public interface ISemanticPredicateEvaluator
 {
@@ -9,6 +10,7 @@ public interface ISemanticPredicateEvaluator
     /// Evaluates the semantic predicate described by <paramref name="context"/>.
     /// </summary>
     /// <param name="context">Predicate metadata and parser location.</param>
-    /// <returns>Evaluation outcome controlling branch acceptance.</returns>
+    /// <returns>Evaluation outcome controlling branch acceptance.
+    /// Implementations are expected to remain deterministic for identical invocation context when memoization is enabled.</returns>
     SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context);
 }

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -19,8 +19,13 @@ namespace Utils.Parser.Runtime;
 /// </para>
 /// <para>
 /// Semantic predicates (<see cref="ValidatingPredicate"/>, <see cref="GatingPredicate"/>)
-/// and embedded actions (<see cref="EmbeddedAction"/>) are silently accepted without
-/// execution; they have no effect on the parse tree shape.
+/// and embedded actions (<see cref="EmbeddedAction"/>) are controlled by the configured
+/// <see cref="ParserRuntimeFeaturePolicy"/>.
+/// The default policy preserves conservative behavior:
+/// semantic predicates return <see cref="SemanticPredicateEvaluationResult.NotEvaluated"/>
+/// and parser actions return <see cref="ParserActionExecutionResult.NotExecuted"/>.
+/// Custom injected policies may reject alternatives and may execute action handlers,
+/// which can influence parse outcomes.
 /// </para>
 /// </summary>
 /// <remarks>
@@ -177,8 +182,12 @@ public sealed class ParserEngine
         // this supersedes the previous local parse-memo dictionary and keeps reuse decisions centralized.
         // Safety currently depends on RuleInvocationKey identity:
         //   (rule name, input position, minimum precedence).
-        // This is sufficient for current parser semantics because semantic predicates/actions are not executed.
-        // TODO: revisit key shape when semantic state, mode-sensitive parser state, or predicate execution is enabled.
+        // Runtime reuse currently assumes predicate/action policies are deterministic for a given invocation key.
+        // The memoization key does not currently include runtime policy state, evaluator external state,
+        // or side-effect state. Custom policies should therefore avoid invocation-count-dependent behavior
+        // and externally observable mutable semantic state.
+        // Future runtime work may require a wider key shape when semantic runtime state or rollback-aware
+        // action semantics are modeled explicitly.
         var invocationKey = new RuleInvocationKey(rule.Name, initialPosition, precedence);
         if (_stateRegistry.TryGetReusableResult(invocationKey, out var reusableResult))
         {
@@ -493,7 +502,9 @@ public sealed class ParserEngine
     /// <summary>
     /// Dispatches to the appropriate handler based on the concrete type of
     /// <paramref name="content"/>.
-    /// Predicates and embedded actions are silently treated as empty successful matches.
+    /// Predicates and embedded actions are delegated to the configured runtime policy.
+    /// Default policy keeps conservative behavior by returning empty successful matches when
+    /// predicates are not evaluated and actions are not executed.
     /// </summary>
     /// <param name="context">Mutable token-stream cursor.</param>
     /// <param name="content">Grammar element to match.</param>

--- a/Utils.Parser/Runtime/ParserRuntimeFeaturePolicy.cs
+++ b/Utils.Parser/Runtime/ParserRuntimeFeaturePolicy.cs
@@ -3,6 +3,7 @@ namespace Utils.Parser.Runtime;
 /// <summary>
 /// Immutable runtime feature policy used by parser components to centralize optional
 /// runtime strategies such as semantic predicate evaluation and parser action execution.
+/// The policy can affect branch acceptance and action execution, but does not change parser scheduling mechanics.
 /// </summary>
 public sealed record ParserRuntimeFeaturePolicy
 {

--- a/Utils.Parser/Runtime/ParserStateRegistry.cs
+++ b/Utils.Parser/Runtime/ParserStateRegistry.cs
@@ -66,7 +66,11 @@ internal sealed class ParserStateRegistry
         return _completedResults.TryGetValue(invocation, out var list) ? list : [];
     }
 
-    /// <summary>Determines whether an invocation has any reusable deterministic completion result (success or failure).</summary>
+    /// <summary>
+    /// Determines whether an invocation has any reusable completion result (success or failure).
+    /// Reuse currently assumes deterministic evaluator/executor behavior for the same invocation key
+    /// and does not model external semantic/action state.
+    /// </summary>
     public bool TryGetReusableResult(RuleInvocationKey invocation, out ParserRuleResult result)
     {
         result = default;

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -44,7 +44,7 @@ The following constructs are parsed and stored, but runtime semantic execution i
 | Inline actions (`{ code }`) | Parsed and stored; runtime does not execute target-language code blocks. | `InlineActionStoredNotExecuted` |
 | Rule actions (`@init`, `@after`) | Parsed as action metadata where present; no execution hook is active in runtime parsing. | `InlineActionStoredNotExecuted` when represented as runtime embedded actions; `ActionIgnored` may apply to top-level/pipeline actions. |
 
-Rationale: execution of user code and semantic predicates requires explicit policy boundaries and execution abstractions that are intentionally not part of the current deterministic runtime.
+Rationale: execution of user code and semantic predicates is policy-controlled. The default runtime keeps deterministic conservative behavior (not evaluated / not executed), while custom policies may alter branch acceptance and action handling within the documented runtime boundaries.
 
 ## Parsed but not fully resolved
 
@@ -112,3 +112,10 @@ This policy avoids speculative runtime complexity while still enabling progressi
 The repository now also exposes a code-facing capability descriptor model (`ParserFeatureCapabilities`) that centralizes feature support levels (Supported, SupportedWithLimits, RuntimeOptional, MetadataOnly, ParsedOnly, Unsupported).
 
 This model is **descriptive only** and does not change parser behavior, diagnostics emission, parse-tree shape, or runtime execution policies.
+
+
+## Memoization and policy assumptions
+
+Parser invocation reuse is currently keyed by rule, input position, and precedence.
+This model currently assumes policy handlers are deterministic for equivalent invocations and does not include evaluator/executor external state in the memoization key.
+Custom policies should therefore avoid invocation-count-dependent decisions and externally observable mutable semantic state.

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document consolidates parser documentation that explains what is currently implemented as metadata, what is intentionally not executed at runtime, and which architectural constraints protect deterministic parser behavior.
+This document consolidates parser documentation that explains what is currently implemented as metadata, what is policy-controlled at runtime, and which architectural constraints protect deterministic parser behavior.
 
 It is factual and conservative. It does not define a roadmap commitment.
 
@@ -14,6 +14,41 @@ This document intentionally consolidates previous shared-prefix architecture doc
 - `SharedPrefixMetadataPipeline.md`
 
 It also replaces narrower invocation-frame-only wording with a broader metadata/runtime limitations scope.
+
+
+## Runtime policy boundaries (semantic predicates and actions)
+
+`ParserEngine` delegates semantic predicates and embedded actions to `ParserRuntimeFeaturePolicy`:
+
+- Default policy is conservative:
+  - semantic predicates return `NotEvaluated`;
+  - parser actions return `NotExecuted`.
+- Custom policies may:
+  - reject branches (`SemanticPredicateEvaluationResult.Rejected`);
+  - accept branches (`Satisfied`);
+  - execute parser actions (`ParserActionExecutionResult.Executed`).
+
+This means runtime behavior can depend on injected evaluators/executors, even though default behavior preserves legacy conservative semantics.
+
+## Memoization assumptions and limits
+
+Invocation reuse currently keys completed results by `(rule, input position, precedence)`.
+The memoization layer does **not** currently model:
+
+- runtime feature policy state;
+- semantic evaluator external state;
+- parser action side-effect state;
+- rollback-safe mutable semantic frames.
+
+As a result, custom policies are expected to remain deterministic for equivalent invocations, avoid invocation-count-dependent behavior, and avoid externally observable mutable semantic state.
+Future runtime work may require broader memoization keys and rollback-aware semantic-state modeling.
+
+## Diagnostics meaning for policy-controlled features
+
+- `SemanticPredicateNotEnforced` is emitted when a predicate is encountered and the active evaluator returns `NotEvaluated`.
+- `InlineActionStoredNotExecuted` is emitted when an embedded action is encountered and the active executor returns `NotExecuted`.
+
+With custom policies, these diagnostics may be reduced or suppressed when predicates/actions are actively handled.
 
 ## 1) Parameters and `returns`: parsed and preserved as metadata
 


### PR DESCRIPTION
### Motivation

- Recent runtime additions (`ISemanticPredicateEvaluator`, `IParserActionExecutor`, `ParserRuntimeFeaturePolicy`) changed an architectural assumption about predicates/actions and memoization, but some code comments still described the old "always ignored" behavior.  
- Update documentation and inline comments to reflect that semantic predicates and embedded actions are policy-driven and that memoization keys do not model runtime policy/external state.  
- Make explicit the conservative defaults and the safety expectations for custom policies so consumers understand nondeterminism and memoization limits.

### Description

- Revised `ParserEngine` XML summary and inline comments to document that predicates/actions are delegated to `ParserRuntimeFeaturePolicy`, that the default policy is conservative (`NotEvaluated` / `NotExecuted`), and that custom policies may influence branch acceptance and action execution.  
- Clarified memoization safety near `RuleInvocationKey` usage to state that reuse is keyed by `(rule, input position, precedence)` and currently does not include runtime policy or external evaluator/executor state, and that custom policies should remain deterministic for equivalent invocations.  
- Updated runtime contract documentation for `ISemanticPredicateEvaluator`, `IParserActionExecutor`, and `ParserRuntimeFeaturePolicy` to call out determinism expectations and side-effect considerations.  
- Updated default implementations (`DefaultSemanticPredicateEvaluator`, `DefaultParserActionExecutor`) documentation to explicitly state conservative return values.  
- Added reuse-safety wording to `ParserStateRegistry` comments.  
- Extended and clarified user-facing docs: `docs/parser/ParserMetadataAndRuntimeLimitations.md`, `docs/parser/Antlr4CompatibilityMatrix.md`, and `Utils.Parser/README.md` with runtime policy boundaries, memoization assumptions, and diagnostics semantics (e.g. `SemanticPredicateNotEnforced`, `InlineActionStoredNotExecuted`).  
- Added a short changelog entry describing this documentation/safety clarification pass.

All changes are documentation and comment-only; no runtime logic, scheduling, diagnostics behavior, memoization mechanics, or public APIs were modified.

### Testing

- No automated tests were run because this PR contains only documentation and comment changes.  
- Change validation performed via repository diffs and review of modified files: `Utils.Parser/Runtime/ParserEngine.cs`, `Utils.Parser/Runtime/ISemanticPredicateEvaluator.cs`, `Utils.Parser/Runtime/IParserActionExecutor.cs`, `Utils.Parser/Runtime/ParserRuntimeFeaturePolicy.cs`, `Utils.Parser/Runtime/DefaultSemanticPredicateEvaluator.cs`, `Utils.Parser/Runtime/DefaultParserActionExecutor.cs`, `Utils.Parser/Runtime/ParserStateRegistry.cs`, `docs/parser/ParserMetadataAndRuntimeLimitations.md`, `docs/parser/Antlr4CompatibilityMatrix.md`, `Utils.Parser/README.md`, and `CHANGELOG.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037e17a4008326a5db018a432b6f24)