### PR TITLE
Consolidate parser runtime ownership invariants and boundaries

### DIFF
--- a/Utils.Parser/Runtime/ActiveParseState.cs
+++ b/Utils.Parser/Runtime/ActiveParseState.cs
@@ -32,9 +32,15 @@ internal enum ActiveParseStateStatus
 /// Represents an active parser state/branch candidate during alternative exploration.
 /// This data container is intentionally immutable and infrastructure-only.
 /// It prepares explicit scheduling of parser work without changing current execution semantics.
+/// The model is descriptive scheduling/runtime-local state only: it is non-replayable,
+/// non-resumable, and not rollback-aware.
 /// <para>
 /// <see cref="Continuation"/> is metadata that describes a potential continuation anchor.
 /// It is not executable runtime replay state and does not imply resume/rollback semantics.
+/// </para>
+/// <para>
+/// <see cref="ParentStateKey"/> models lineage for scheduling metadata and is not an execution stack.
+/// <see cref="Depth"/> is structural lineage depth, not semantic invocation-frame depth.
 /// </para>
 /// </summary>
 internal sealed record ActiveParseState

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -5,6 +5,9 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Runs deterministic sequential scheduling for parser alternatives represented as <see cref="ActiveParseState"/>.
+/// This component is orchestration-only: it does not own semantic evaluation, diagnostics authority,
+/// parser-graph execution, replay, or speculative execution.
+/// Parse acceptance remains decided by <see cref="ParserEngine"/>.
 /// </summary>
 internal sealed class AlternativeScheduler
 {

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -6,6 +6,8 @@ namespace Utils.Parser.Runtime;
 /// <summary>
 /// Builds a parse tree from a flat token list using the rules in a
 /// <see cref="ParserDefinition"/>.
+/// This engine is the runtime authority for token consumption, diagnostics, parse-tree
+/// construction, and final parse outcomes.
 /// <para>
 /// The engine is a recursive-descent parser with full backtracking.
 /// It tries each alternative in priority order and rolls back the token position on
@@ -26,6 +28,11 @@ namespace Utils.Parser.Runtime;
 /// and parser actions return <see cref="ParserActionExecutionResult.NotExecuted"/>.
 /// Custom injected policies may reject alternatives and may execute action handlers,
 /// which can influence parse outcomes.
+/// </para>
+/// <para>
+/// Scheduling and metadata components do not own parse decisions:
+/// continuation descriptors are descriptive only, shared-prefix plans are informational only,
+/// and neither metadata pipeline executes runtime continuations.
 /// </para>
 /// </summary>
 /// <remarks>

--- a/Utils.Parser/Runtime/ParserLookaheadCache.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadCache.cs
@@ -2,6 +2,8 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Caches lightweight scheduled-alternative look-ahead observations for the current parse execution.
+/// Entries are syntax-oriented probe metadata only and are independent from semantic runtime state,
+/// parser action side effects, replay frames, and rollback mechanisms.
 /// </summary>
 internal sealed class ParserLookaheadCache
 {

--- a/Utils.Parser/Runtime/ParserLookaheadProbe.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbe.cs
@@ -6,6 +6,8 @@ namespace Utils.Parser.Runtime;
 /// Performs conservative first-token look-ahead probing for a scheduled alternative.
 /// The probe is intentionally shallow: it must not evaluate semantic predicates, execute parser actions,
 /// or consult external semantic runtime state.
+/// It is syntax-oriented only and does not execute parser rules speculatively,
+/// traverse parser graphs semantically, or run continuation metadata.
 /// </summary>
 internal sealed class ParserLookaheadProbe
 {

--- a/Utils.Parser/Runtime/ParserStateRegistry.cs
+++ b/Utils.Parser/Runtime/ParserStateRegistry.cs
@@ -2,9 +2,10 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Stores parser-state tracking, shared rule invocation completions, and continuation metadata.
-/// This registry is currently authoritative for completed invocation tracking and safe reuse lookup.
-/// It is preparatory for future path scheduling work, but it is not yet a full branch scheduler.
-/// Continuations are descriptive metadata only; they are not replay-ready runtime frames.
+/// Runtime-authoritative state in this registry is limited to visited states, invocation completion tracking,
+/// and reusable parse outcomes keyed by invocation identity.
+/// Continuation descriptors and shared-prefix scheduling metadata are non-authoritative descriptive data.
+/// This registry does not contain replay frames, semantic runtime frames, rollback state, or executable continuations.
 /// </summary>
 internal sealed class ParserStateRegistry
 {

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
@@ -6,6 +6,10 @@ namespace Utils.Parser.Runtime;
 /// <summary>
 /// Executes a single scheduled alternative attempt while keeping parser semantics
 /// in runtime components owned by <see cref="ParserEngine"/>.
+/// This executor is local and non-authoritative: it does not provide global parse authority,
+/// rollback safety, transactional isolation, or replay semantics.
+/// Its role is bounded coordination between <see cref="AlternativeScheduler"/>,
+/// <see cref="ParserStateRegistry"/>, and engine-owned parsing callbacks.
 /// </summary>
 internal sealed class ScheduledAlternativeExecutor
 {

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -167,6 +167,84 @@ public class ParserRuntimeInvariantTests
         Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
     }
 
+    [TestMethod]
+    public void SharedPrefixMetadata_RemainsNonAuthoritative_ForParseOutcome()
+    {
+        var startRule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new Sequence([
+                    new RuleRef("A"),
+                    new RuleRef("B")
+                ])),
+                new Alternative(1, Associativity.Left, new Sequence([
+                    new RuleRef("A"),
+                    new RuleRef("C")
+                ]))
+            ]));
+        var definition = CreateDefinition(startRule, LexerRule("A", "a"), LexerRule("B", "b"), LexerRule("C", "c"));
+        var parser = new ParserEngine(definition);
+
+        var result = parser.Parse([Token("A", "a"), Token("B", "b")]);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.AreEqual("start", result.Rule?.Name);
+    }
+
+    [TestMethod]
+    public void LookaheadProbe_RemainsConservative_ForParserRuleReference()
+    {
+        var parserRule = new Rule(
+            "expr",
+            1,
+            false,
+            new Alternation([new Alternative(0, Associativity.Left, new RuleRef("A"))]));
+        var startRule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([new Alternative(0, Associativity.Left, new RuleRef("expr"))]));
+        var definition = CreateDefinition(startRule, [parserRule], LexerRule("A", "a"));
+        var probe = new ParserLookaheadProbe();
+
+        var result = probe.Probe(
+            new Alternative(0, Associativity.Left, new RuleRef("expr")),
+            Token("A", "a"),
+            name => definition.ParserRules.FirstOrDefault(rule => string.Equals(rule.Name, name, StringComparison.Ordinal)),
+            false);
+
+        Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
+    }
+
+    [TestMethod]
+    public void ActiveParseState_ContinuationMetadata_IsDescriptiveOnly()
+    {
+        var state = new ActiveParseState
+        {
+            Rule = new Rule("expr", 0, false, new Alternation([])),
+            Alternative = new Alternative(0, Associativity.Left, new LiteralMatch("x")),
+            OriginInputPosition = 0,
+            CurrentInputPosition = 0,
+            AlternativeIndex = 0,
+            Cursor = new RuleContentCursor { Index = 0, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot },
+            PartialNode = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "metadata", null),
+            EndPosition = null,
+            Status = ActiveParseStateStatus.Active,
+            ParentStateKey = null,
+            Depth = 0,
+            Continuation = new ContinuationKey("expr", 0, 0, 0, 0)
+        };
+
+        var advanced = state.Advance(1, new RuleContentCursor { Index = 1, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot });
+
+        Assert.AreEqual(0, state.CurrentInputPosition);
+        Assert.AreEqual(1, advanced.CurrentInputPosition);
+        Assert.AreEqual(0, state.Continuation?.ResumePosition);
+        Assert.AreEqual(0, advanced.Continuation?.ResumePosition);
+    }
+
     private static ParserDefinition CreateDefinition(Rule startRule, Rule[] parserRules, params Rule[] lexerRules)
     {
         return RuleResolver.Resolve(new ParserDefinition(

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -168,7 +168,7 @@ public class ParserRuntimeInvariantTests
     }
 
     [TestMethod]
-    public void SharedPrefixMetadata_RemainsNonAuthoritative_ForParseOutcome()
+    public void ParserEngine_RuntimeParseOutcome_RemainsAuthoritative_WhenAlternativesSharePrefix()
     {
         var startRule = new Rule(
             "start",
@@ -191,6 +191,7 @@ public class ParserRuntimeInvariantTests
 
         Assert.IsInstanceOfType<ParserNode>(result);
         Assert.AreEqual("start", result.Rule?.Name);
+        Assert.IsFalse(result is ErrorNode);
     }
 
     [TestMethod]

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -1,0 +1,105 @@
+# Runtime State Ownership
+
+This document consolidates runtime-state ownership and authority boundaries for `Utils.Parser`.
+It is intentionally conservative and describes current behavior only.
+
+## Runtime authority model
+
+The parser runtime is authority-layered.
+
+- `ParserEngine` is the final runtime authority for:
+  - token consumption,
+  - parse-tree construction,
+  - diagnostic production,
+  - final parse outcomes.
+- Supporting runtime components provide orchestration, probing, caching, and metadata.
+- Metadata components are descriptive and cannot decide parse outcomes on their own.
+
+## Parsing authority
+
+`ParserEngine` remains the authoritative parser execution component.
+
+- It owns recursive rule parsing decisions.
+- It owns branch acceptance/rejection outcomes.
+- It owns final success/failure and trailing-token validation.
+- It owns parse result materialization.
+
+Non-engine components may assist the engine but do not replace these decisions.
+
+## Scheduling authority
+
+`AlternativeScheduler` is an orchestrator, not an autonomous parser executor.
+
+- It orders and coordinates alternative attempts.
+- It aggregates descriptive metadata for shared-prefix scenarios.
+- It does not own semantic predicate truth.
+- It does not own diagnostics authority.
+- It does not implement replay, rollback, speculative execution, or parser-graph traversal.
+
+`ScheduledAlternativeExecutor` performs local alternative attempts.
+
+- It is bounded to one alternative attempt at one invocation origin.
+- It does not provide global parse authority.
+- It does not provide transactional isolation.
+- It does not provide rollback or replay.
+
+## State ownership
+
+The runtime separates state by authority.
+
+### Reusable runtime state (authoritative)
+
+Owned by `ParserStateRegistry` for invocation-keyed reuse safety:
+
+- visited parser state tracking,
+- completed invocation outcomes,
+- reusable success/failure outcomes.
+
+### Metadata state (non-authoritative)
+
+Stored or computed as descriptive structures only:
+
+- continuation descriptors,
+- shared-prefix plans,
+- shared-prefix candidates,
+- scheduling annotations.
+
+### Preparatory state (non-authoritative)
+
+Used to coordinate execution attempts:
+
+- scheduler candidate sets,
+- lookahead probe outcomes,
+- lookahead cache entries.
+
+### Descriptive state (non-authoritative)
+
+`ActiveParseState` and related keys are structural runtime descriptors.
+
+- `Continuation` is descriptive metadata only.
+- `ParentStateKey` is lineage metadata, not an execution stack.
+- `Depth` is descriptive lineage depth, not semantic frame depth.
+
+## Metadata-only boundaries
+
+The following remain metadata-only and non-executable:
+
+- continuation descriptors,
+- shared-prefix plans,
+- lookahead metadata,
+- scheduling metadata.
+
+These structures cannot execute parsing, resume execution, or replay previous runtime steps.
+
+## Explicit non-goals
+
+The current runtime does **not** implement:
+
+- replay,
+- rollback,
+- semantic runtime frames,
+- parser graph execution,
+- speculative execution,
+- semantic-state-aware memoization.
+
+The runtime remains deterministic, conservative, syntax-oriented, and execution-conservative.


### PR DESCRIPTION
### Motivation

- Make runtime responsibilities and state ownership explicit and audit-friendly to avoid future architectural ambiguities while keeping behavior unchanged. 
- Lock down metadata/runtime boundaries (what is authoritative vs. descriptive) so scheduling/continuations/lookahead remain clearly non-executive and non-replayable.

### Description

- Added precise, conservative authority comments to key runtime components to document responsibilities without changing semantics or public APIs (`ParserEngine`, `AlternativeScheduler`, `ScheduledAlternativeExecutor`, `ParserStateRegistry`, `ActiveParseState`, `ParserLookaheadProbe`, `ParserLookaheadCache`).
- Added a new reference document `docs/parser/RuntimeStateOwnership.md` that consolidates the runtime authority model, parsing/scheduling authority, state ownership categories, metadata-only boundaries, and explicit non-goals (replay/rollback/speculation/etc.).
- Added light structural invariant tests in `UtilsTest/Parser/ParserRuntimeInvariantTests.cs` that assert shared-prefix metadata remains non-authoritative, lookahead remains conservative for parser-rule references, and `ActiveParseState` continuation metadata is descriptive-only.
- Changes are documentation and test additions / small clarifying comments only; there are no changes to parsing logic, memoization, public APIs, parse trees, diagnostics, scheduling semantics, or runtime behavior.

### Testing

- Ran `dotnet test UtilsTest/UtilsTest.csproj --no-restore --filter ParserRuntimeInvariantTests` to exercise the added invariants, and the run completed with all tests passing (`Passed: 9, Failed: 0`).
- No other automated test suites were changed; the modifications are intentionally conservative and validated by the focused invariant tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b9efc9dc83268c80d074d17ed562)