### PR TITLE
Consolidate parser branch outcome model contracts

### DIFF
--- a/Utils.Parser/Runtime/ActiveParseState.cs
+++ b/Utils.Parser/Runtime/ActiveParseState.cs
@@ -48,6 +48,8 @@ internal enum ActiveParseStateStatus
 
 /// <summary>
 /// Represents an active parser state/branch candidate during alternative exploration.
+/// The outcome model remains local: this type can describe branch success/failure/pruning,
+/// but it cannot determine global parse acceptance or final diagnostics.
 /// This data container is intentionally immutable and infrastructure-only.
 /// It prepares explicit scheduling of parser work without changing current execution semantics.
 /// The model is descriptive scheduling/runtime-local state only: it is non-replayable,

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -17,6 +17,8 @@ internal sealed class AlternativeScheduler
     private readonly ParserSharedPrefixPlanFactory _sharedPrefixPlanFactory = new();
     /// <summary>
     /// Drives alternative orchestration for a single alternation parse attempt.
+    /// Local outcomes here are descriptive scheduling artifacts:
+    /// completed/failed/pruned states do not decide global parse success or failure.
     /// </summary>
     public AlternativeSchedulingResult Run(
         Rule rule,
@@ -53,6 +55,7 @@ internal sealed class AlternativeScheduler
         }
 
         var deduplicated = DeduplicateStates(completedStates, minimumPrecedence);
+        // Pruning is an orchestration optimization only; it is not a syntax-validity verdict.
         var pruned = PruneEquivalentActiveStates(deduplicated, diagnostics);
         var prunedSet = new HashSet<ActiveParseState>(pruned);
         var prunedStates = deduplicated.Where(s => !prunedSet.Contains(s)).Select(static s => s.Prune()).ToList();

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -152,7 +152,9 @@ public sealed class ParserEngine
                 "Failed to parse from root rule", root);
         }
 
-        // Reject parses that leave trailing tokens unconsumed.
+        // A locally completed branch can still be globally rejected.
+        // Global success requires both a selected parse outcome and full input consumption.
+        // Trailing-token rejection is therefore a global-outcome gate owned by ParserEngine.
         if (!context.IsEnd)
         {
             var trailing = context.Peek()!;

--- a/Utils.Parser/Runtime/ParserStateRegistry.cs
+++ b/Utils.Parser/Runtime/ParserStateRegistry.cs
@@ -2,6 +2,8 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Stores parser-state tracking, shared rule invocation completions, and continuation metadata.
+/// Reusable results in this registry are invocation-local transport artifacts; they do not
+/// independently decide final parse acceptance, rejection, or final diagnostic selection.
 /// Runtime-authoritative state in this registry is limited to visited states, invocation completion tracking,
 /// and reusable parse outcomes keyed by invocation identity.
 /// Continuation descriptors and shared-prefix scheduling metadata are non-authoritative descriptive data.

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
@@ -31,6 +31,7 @@ internal sealed class ScheduledAlternativeExecutor
 
     /// <summary>
     /// Executes one alternative from the scheduler and returns a completed parse state when successful.
+    /// Returned completion/failure is local branch outcome transport, not global parse authority.
     /// Embedded parser actions may run during this attempt even when the branch is later rejected.
     /// The runtime does not provide rollback, exactly-once, or transactional isolation guarantees for external side effects.
     /// </summary>

--- a/UtilsTest/Parser/ParserBranchOutcomeModelTests.cs
+++ b/UtilsTest/Parser/ParserBranchOutcomeModelTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Model;
+using Utils.Parser.Resolution;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Locks branch outcome model invariants without changing runtime behavior.
+/// </summary>
+[TestClass]
+public class ParserBranchOutcomeModelTests
+{
+    [TestMethod]
+    public void LocalSuccess_DoesNotImplyGlobalSuccess_WhenTrailingTokensRemain()
+    {
+        var startRule = new Rule("start", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"))
+        ]));
+        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
+            Name: "Outcome",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [startRule],
+            RootRule: startRule)));
+
+        var diagnostics = new DiagnosticBag();
+        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a"), new Token(new SourceSpan(1, 1), "B", "DEFAULT_MODE", "DEFAULT_CHANNEL", "b")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ErrorNode>(result);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
+    }
+
+    [TestMethod]
+    public void LocalFailure_DoesNotImplyGlobalFailure_WhenAnotherAlternativeSucceeds()
+    {
+        var startRule = new Rule("start", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("b")]), "Long"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Short")
+        ]));
+        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
+            Name: "Outcome",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [startRule],
+            RootRule: startRule)));
+
+        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+    }
+
+    [TestMethod]
+    public void Pruning_DoesNotImplySyntaxInvalidity_WhenParseGloballySucceeds()
+    {
+        var root = new Rule("root", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "One"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Two")
+        ]));
+        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
+            Name: "Amb",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [root],
+            RootRule: root)));
+        var diagnostics = new DiagnosticBag();
+
+        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+                Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+    }
+
+    [TestMethod]
+    public void LocalDiagnostics_DoNotAutomaticallyBecomeGlobalDiagnostics()
+    {
+        var startRule = new Rule("start", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("b")]), "Long"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Short")
+        ]));
+        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
+            Name: "Outcome",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [startRule],
+            RootRule: startRule)));
+        var diagnostics = new DiagnosticBag();
+
+        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
+    }
+
+    [TestMethod]
+    public void CompletedBranch_DoesNotImplyFinalSelection_AlternativeSelectionRemainsDeterministic()
+    {
+        var root = new Rule("root", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("b")]), "Long"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Short")
+        ]));
+        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
+            Name: "Alt",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [root],
+            RootRule: root)));
+
+        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a"), new Token(new SourceSpan(1, 1), "B", "DEFAULT_MODE", "DEFAULT_CHANNEL", "b")]);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+    }
+}

--- a/UtilsTest/Parser/ParserBranchOutcomeModelTests.cs
+++ b/UtilsTest/Parser/ParserBranchOutcomeModelTests.cs
@@ -15,24 +15,13 @@ public class ParserBranchOutcomeModelTests
     [TestMethod]
     public void LocalSuccess_DoesNotImplyGlobalSuccess_WhenTrailingTokensRemain()
     {
-        var startRule = new Rule("start", 0, false, new Alternation([
+        var rule = new Rule("start", 0, false, new Alternation([
             new Alternative(0, Associativity.Left, new LiteralMatch("a"))
         ]));
-        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
-            Name: "Outcome",
-            Type: GrammarType.Parser,
-            Options: null,
-            Actions: [],
-            Imports: [],
-            Modes: [new LexerMode("DEFAULT_MODE", [])],
-            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
-            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
-            ExtensionBindings: [],
-            ParserRules: [startRule],
-            RootRule: startRule)));
-
+        var parser = CreateParser(rule, "OutcomeLocalSuccess");
         var diagnostics = new DiagnosticBag();
-        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a"), new Token(new SourceSpan(1, 1), "B", "DEFAULT_MODE", "DEFAULT_CHANNEL", "b")], diagnostics: diagnostics);
+
+        var result = parser.Parse([CreateToken(0, "A", "a"), CreateToken(1, "B", "b")], diagnostics: diagnostics);
 
         Assert.IsInstanceOfType<ErrorNode>(result);
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
@@ -41,24 +30,13 @@ public class ParserBranchOutcomeModelTests
     [TestMethod]
     public void LocalFailure_DoesNotImplyGlobalFailure_WhenAnotherAlternativeSucceeds()
     {
-        var startRule = new Rule("start", 0, false, new Alternation([
+        var rule = new Rule("start", 0, false, new Alternation([
             new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("b")]), "Long"),
             new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Short")
         ]));
-        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
-            Name: "Outcome",
-            Type: GrammarType.Parser,
-            Options: null,
-            Actions: [],
-            Imports: [],
-            Modes: [new LexerMode("DEFAULT_MODE", [])],
-            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
-            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
-            ExtensionBindings: [],
-            ParserRules: [startRule],
-            RootRule: startRule)));
+        var parser = CreateParser(rule, "OutcomeLocalFailure");
 
-        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
+        var result = parser.Parse([CreateToken(0, "A", "a")]);
 
         Assert.IsInstanceOfType<ParserNode>(result);
     }
@@ -66,54 +44,63 @@ public class ParserBranchOutcomeModelTests
     [TestMethod]
     public void Pruning_DoesNotImplySyntaxInvalidity_WhenParseGloballySucceeds()
     {
-        var root = new Rule("root", 0, false, new Alternation([
-            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "One"),
-            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Two")
+        var rule = new Rule("root", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "Same"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Same")
         ]));
-        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
-            Name: "Amb",
-            Type: GrammarType.Parser,
-            Options: null,
-            Actions: [],
-            Imports: [],
-            Modes: [new LexerMode("DEFAULT_MODE", [])],
-            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
-            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
-            ExtensionBindings: [],
-            ParserRules: [root],
-            RootRule: root)));
-        var diagnostics = new DiagnosticBag();
 
-        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
+        var scheduler = new AlternativeScheduler();
+        var schedulerDiagnostics = new DiagnosticBag();
+        var state = new ActiveParseState
+        {
+            Rule = rule,
+            Alternative = rule.Content.Alternatives[0],
+            OriginInputPosition = 0,
+            CurrentInputPosition = 1,
+            AlternativeIndex = 0,
+            Cursor = new RuleContentCursor { Index = 0, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot },
+            PartialNode = new ParserNode(new SourceSpan(0, 1), "DEFAULT_MODE", rule, []),
+            EndPosition = 1,
+            Status = ActiveParseStateStatus.Completed,
+            ParentStateKey = null,
+            Depth = 0,
+            Continuation = null
+        };
+
+        _ = scheduler.Run(rule, rule.Content.Alternatives, 0, 0, schedulerDiagnostics, (_, index) =>
+            new ScheduledAlternativeExecutionResult(
+                state with { Alternative = rule.Content.Alternatives[index], AlternativeIndex = index },
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])));
+
+        Assert.IsTrue(schedulerDiagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
+
+        var parser = CreateParser(rule, "OutcomePruning");
+        var parserDiagnostics = new DiagnosticBag();
+        var result = parser.Parse([CreateToken(0, "A", "a")], diagnostics: parserDiagnostics);
 
         Assert.IsInstanceOfType<ParserNode>(result);
-                Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+        Assert.IsFalse(parserDiagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+        Assert.IsFalse(parserDiagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
     }
 
     [TestMethod]
     public void LocalDiagnostics_DoNotAutomaticallyBecomeGlobalDiagnostics()
     {
-        var startRule = new Rule("start", 0, false, new Alternation([
-            new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("b")]), "Long"),
-            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Short")
+        var rule = new Rule("start", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([
+                new LiteralMatch("a"),
+                new LiteralMatch("b"),
+                new LiteralMatch("c")
+            ]), "Long"),
+            new Alternative(1, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("b")]), "Short")
         ]));
-        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
-            Name: "Outcome",
-            Type: GrammarType.Parser,
-            Options: null,
-            Actions: [],
-            Imports: [],
-            Modes: [new LexerMode("DEFAULT_MODE", [])],
-            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
-            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
-            ExtensionBindings: [],
-            ParserRules: [startRule],
-            RootRule: startRule)));
+        var parser = CreateParser(rule, "OutcomeDiagnostics");
         var diagnostics = new DiagnosticBag();
 
-        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
+        var result = parser.Parse([CreateToken(0, "A", "a"), CreateToken(1, "B", "b")], diagnostics: diagnostics);
 
         Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.BacktrackingUsed.Code));
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
     }
@@ -121,12 +108,22 @@ public class ParserBranchOutcomeModelTests
     [TestMethod]
     public void CompletedBranch_DoesNotImplyFinalSelection_AlternativeSelectionRemainsDeterministic()
     {
-        var root = new Rule("root", 0, false, new Alternation([
+        var rule = new Rule("root", 0, false, new Alternation([
             new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("b")]), "Long"),
             new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Short")
         ]));
-        var parser = new ParserEngine(RuleResolver.Resolve(new ParserDefinition(
-            Name: "Alt",
+        var parser = CreateParser(rule, "OutcomeSelection");
+
+        var result = parser.Parse([CreateToken(0, "A", "a"), CreateToken(1, "B", "b")]);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsTrue(ContainsLexerTokenText(result, "b"));
+    }
+
+    private static ParserEngine CreateParser(Rule rootRule, string grammarName)
+    {
+        var definition = new ParserDefinition(
+            Name: grammarName,
             Type: GrammarType.Parser,
             Options: null,
             Actions: [],
@@ -135,11 +132,20 @@ public class ParserBranchOutcomeModelTests
             DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
             DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
             ExtensionBindings: [],
-            ParserRules: [root],
-            RootRule: root)));
+            ParserRules: [rootRule],
+            RootRule: rootRule);
 
-        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a"), new Token(new SourceSpan(1, 1), "B", "DEFAULT_MODE", "DEFAULT_CHANNEL", "b")]);
+        return new ParserEngine(RuleResolver.Resolve(definition));
+    }
 
-        Assert.IsInstanceOfType<ParserNode>(result);
+    private static Token CreateToken(int position, string ruleName, string text)
+        => new(new SourceSpan(position, 1), ruleName, "DEFAULT_MODE", "DEFAULT_CHANNEL", text);
+
+    private static bool ContainsLexerTokenText(ParseNode root, string tokenText)
+    {
+        return new ParseTreeNavigator(root)
+            .Descendants()
+            .Prepend(new ParseTreeNavigator(root))
+            .Any(node => node.IsLexer && node.Node is LexerNode lexer && string.Equals(lexer.Token.Text, tokenText, StringComparison.Ordinal));
     }
 }

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -136,3 +136,48 @@ The runtime remains deterministic, conservative, syntax-oriented, and execution-
 - Partial nodes inside `ActiveParseState` are local scheduling/runtime artifacts.
 - They support branch-local selection and metadata flow only.
 - Final parse-tree authority remains in `ParserEngine` parse outcomes.
+
+## Branch outcome model
+
+Branch outcomes are intentionally split between **local** exploration and **global** parse authority.
+
+- **Local success**
+  - Means one branch completed for one invocation context.
+  - Does **not** imply global parse acceptance.
+  - Does **not** guarantee trailing-token consumption.
+  - Does **not** guarantee final branch selection.
+- **Global success**
+  - Decided only by `ParserEngine`.
+  - Requires an accepted final outcome and full-input consumption.
+- **Local failure**
+  - Means one branch attempt failed in current exploration.
+  - Does **not** imply global parse failure.
+  - May still contribute local diagnostic context.
+  - May be stored as reusable invocation-local outcome.
+- **Global failure**
+  - Decided only by `ParserEngine`.
+  - Occurs when no acceptable final outcome remains, or when trailing-token validation rejects the parse.
+- **Pruned outcome**
+  - Pruning is an orchestration optimization in scheduling.
+  - Pruning is **not** syntax invalidity.
+  - Pruning is **not** final parse failure.
+  - Pruning diagnostics (when emitted) are separate from syntax-failure diagnostics.
+
+### Diagnostic propagation model
+
+Diagnostics can be observed at multiple runtime layers, but final authority remains centralized.
+
+- **Local diagnostics** are exploratory descriptions generated during branch attempts.
+- **Transported diagnostics** may flow through local result containers without ownership transfer.
+- **Pruning diagnostics** describe orchestration decisions, not syntax invalidity.
+- **Global diagnostics** are the emitted parse diagnostics selected by `ParserEngine` for the final outcome.
+
+### Partial parse outcomes
+
+Partial outcomes are descriptive runtime artifacts:
+
+- partial nodes in local branch states,
+- completed local branch outcomes,
+- rejected local branch outcomes.
+
+They support deterministic orchestration and reuse, but they are not authoritative parse acceptance decisions.


### PR DESCRIPTION
### Motivation
- Reduce ambiguity in the parser runtime by making the distinction between local (branch) outcomes and global (engine) outcomes explicit and documented. 
- Centralize and clarify authority boundaries for outcome, pruning, diagnostics propagation, and partial parse artifacts without changing runtime algorithms or public APIs. 

### Description
- Added explicit documentation/comments clarifying outcome authority and invariants in runtime components by updating `ParserEngine`, `AlternativeScheduler`, `ScheduledAlternativeExecutor`, `ActiveParseState`, and `ParserStateRegistry`. 
- Expanded `docs/parser/RuntimeStateOwnership.md` with a new `Branch outcome model` section that defines local success/failure, global success/failure, pruning semantics, diagnostic propagation, and partial parse outcomes. 
- Added a focused, non-invasive test file `UtilsTest/Parser/ParserBranchOutcomeModelTests.cs` that encodes the requested outcome invariants (local success vs global success, local failure vs global failure, pruning semantics, diagnostics scoping, completed branch vs final selection). 
- No public API or runtime behavioral changes were introduced; changes are documentation and test additions plus inline clarifying comments only. 

### Testing
- Ran the new invariant tests with `dotnet test UtilsTest/UtilsTest.csproj --filter ParserBranchOutcomeModelTests --nologo` and all tests passed (`5/5`).
- No other automated tests were modified; the change set is designed to be audit-friendly and observable-only for reviewers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06db8aa2c48326b5c0b6469f58400d)