### PR TITLE
Phase 1: clarify alternative-selection contracts and harden invariants

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -139,6 +139,12 @@ Scope:
 - local outcome prioritization,
 - diagnostics around pruning and backtracking.
 
+Current clarification status:
+
+- local alternative comparison order is explicitly documented (longest match, then priority, then declaration order),
+- pruning is explicitly documented as orchestration-only and non-syntax-authoritative,
+- structural branch equivalence limits are explicitly documented as conservative and non-semantic-proof.
+
 Allowed work:
 
 - comments,

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -162,8 +162,8 @@ internal sealed class AlternativeScheduler
 
     /// <summary>
     /// Deduplicates locally completed states by structural scheduling identity.
-    /// Tie-breaking remains deterministic and conservative:
-    /// longest consumption first, then lower priority value, then lower declaration index.
+    /// Deduplication keeps the strongest state per identity using <see cref="IsBetterState"/>,
+    /// then returns states in deterministic traversal order.
     /// </summary>
     private static List<ActiveParseState> DeduplicateStates(IReadOnlyList<ActiveParseState> states, int minimumPrecedence)
     {
@@ -181,7 +181,7 @@ internal sealed class AlternativeScheduler
     }
 
     /// <summary>
-    /// Compares two local candidates using the current observable contract:
+    /// Compares two local candidates for best-candidate selection using the current observable contract:
     /// longer match wins; if tied, lower precedence priority value wins; if still tied,
     /// lower alternative index wins.
     /// </summary>

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -54,12 +54,16 @@ internal sealed class AlternativeScheduler
             return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(rule, ordered, lookaheadProbesByAlternative));
         }
 
+        // Deduplication keeps the strongest local completion for one structural state identity.
+        // This is not the final parse selection contract; it only reduces equivalent local candidates.
         var deduplicated = DeduplicateStates(completedStates, minimumPrecedence);
         // Pruning is an orchestration optimization only; it is not a syntax-validity verdict.
         var pruned = PruneEquivalentActiveStates(deduplicated, diagnostics);
         var prunedSet = new HashSet<ActiveParseState>(pruned);
         var prunedStates = deduplicated.Where(s => !prunedSet.Contains(s)).Select(static s => s.Prune()).ToList();
 
+        // The selected state is the scheduler's best local candidate after orchestration filters.
+        // ParserEngine still owns final parse acceptance (including trailing-token validation).
         ActiveParseState? winner = null;
         foreach (var state in pruned)
         {
@@ -156,6 +160,11 @@ internal sealed class AlternativeScheduler
         };
     }
 
+    /// <summary>
+    /// Deduplicates locally completed states by structural scheduling identity.
+    /// Tie-breaking remains deterministic and conservative:
+    /// longest consumption first, then lower priority value, then lower declaration index.
+    /// </summary>
     private static List<ActiveParseState> DeduplicateStates(IReadOnlyList<ActiveParseState> states, int minimumPrecedence)
     {
         var byIdentity = new Dictionary<ActiveParseStateKey, ActiveParseState>();
@@ -171,6 +180,11 @@ internal sealed class AlternativeScheduler
         return byIdentity.Values.OrderBy(static s => s.Alternative.Priority).ThenBy(static s => s.AlternativeIndex).ThenBy(static s => s.CurrentInputPosition).ToList();
     }
 
+    /// <summary>
+    /// Compares two local candidates using the current observable contract:
+    /// longer match wins; if tied, lower precedence priority value wins; if still tied,
+    /// lower alternative index wins.
+    /// </summary>
     private static bool IsBetterState(ActiveParseState candidate, ActiveParseState current)
     {
         if (candidate.CurrentInputPosition != current.CurrentInputPosition)
@@ -195,6 +209,8 @@ internal sealed class AlternativeScheduler
     {
         // Pruning safety invariant:
         // two branches are mergeable only when HasDistinctSemantics reports no potential semantic divergence.
+        // This equivalence is structural/orchestration-oriented and intentionally conservative;
+        // it does not claim semantic-runtime equivalence beyond current heuristics.
         // If distinct semantics are possible, both branches must be preserved.
         var groups = new Dictionary<ActiveParseBranchEquivalenceKey, List<ActiveParseState>>();
         foreach (var state in states)

--- a/Utils.Parser/Runtime/ParserStateRegistry.cs
+++ b/Utils.Parser/Runtime/ParserStateRegistry.cs
@@ -72,6 +72,8 @@ internal sealed class ParserStateRegistry
 
     /// <summary>
     /// Determines whether an invocation has any reusable completion result (success or failure).
+    /// Current deterministic preference is: first reusable success, otherwise first reusable failure.
+    /// This is invocation-local completion reuse, not final branch-selection authority.
     /// Reuse currently assumes deterministic evaluator/executor behavior for the same invocation key
     /// and does not model external semantic/action state.
     /// </summary>

--- a/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
+++ b/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
@@ -29,6 +29,7 @@ public class ParserEngineAlternativeSelectionTests
 
         Assert.IsNotInstanceOfType<ErrorNode>(tree);
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
+        Assert.IsTrue(CollectTokenTexts(tree).Contains("b"));
     }
 
     [TestMethod]
@@ -118,16 +119,41 @@ public class ParserEngineAlternativeSelectionTests
     [TestMethod]
     public void Parser_Alternatives_EquivalentBranchesCanBePrunedWithoutParseFailure()
     {
-        var root = new Rule("root", 0, false, new Alternation([
-            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "Same"),
-            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Same")
-        ]));
-        var parser = CreateParser(root, "AltPrune");
+        var scheduler = new AlternativeScheduler();
         var diagnostics = new DiagnosticBag();
+        var rule = new Rule("root", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "Same"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Same"),
+            new Alternative(2, Associativity.Left, new LiteralMatch("a"), "Different")
+        ]));
 
-        var tree = parser.Parse([Token(0, 1, "A", "a")], diagnostics: diagnostics);
+        var result = scheduler.Run(
+            rule,
+            rule.Content.Alternatives,
+            originInputPosition: 0,
+            minimumPrecedence: 0,
+            diagnostics,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                new ActiveParseState
+                {
+                    Rule = rule,
+                    Alternative = alternative,
+                    OriginInputPosition = 0,
+                    CurrentInputPosition = 1,
+                    AlternativeIndex = index,
+                    Cursor = new RuleContentCursor { Index = 0, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot },
+                    PartialNode = new ParserNode(new SourceSpan(0, 1), "DEFAULT_MODE", rule, []),
+                    EndPosition = 1,
+                    Status = ActiveParseStateStatus.Completed,
+                    ParentStateKey = null,
+                    Depth = 0,
+                    Continuation = null
+                },
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])));
 
-        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.IsNotNull(result.SelectedState);
+        Assert.IsTrue(result.PrunedStates.Count > 0);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
     }
 
@@ -146,6 +172,32 @@ public class ParserEngineAlternativeSelectionTests
         Assert.IsNotInstanceOfType<ErrorNode>(tree);
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.BacktrackingUsed.Code));
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+    }
+
+    private static List<string> CollectTokenTexts(ParseNode node)
+    {
+        var texts = new List<string>();
+        CollectTokenTextsCore(node, texts);
+        return texts;
+    }
+
+    private static void CollectTokenTextsCore(ParseNode node, List<string> texts)
+    {
+        switch (node)
+        {
+            case LexerNode lexerNode:
+                texts.Add(lexerNode.Token.Text);
+                return;
+            case ParserNode parserNode:
+                foreach (var child in parserNode.Children)
+                {
+                    CollectTokenTextsCore(child, texts);
+                }
+
+                return;
+            default:
+                return;
+        }
     }
 
     private static ParserEngine CreateParser(Rule root, string grammarName)

--- a/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
+++ b/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
@@ -12,6 +12,9 @@ namespace UtilsTest.Parser;
 [TestClass]
 public class ParserEngineAlternativeSelectionTests
 {
+    /// <summary>
+    /// Verifies that when both alternatives can start, the branch that consumes more input is selected.
+    /// </summary>
     [TestMethod]
     public void Parser_Alternatives_LongerSuccessfulBranchIsSelected()
     {
@@ -116,6 +119,9 @@ public class ParserEngineAlternativeSelectionTests
         Assert.IsNotInstanceOfType<ErrorNode>(tree);
     }
 
+    /// <summary>
+    /// Verifies orchestration pruning for equivalent branches without escalating to parse-failure diagnostics.
+    /// </summary>
     [TestMethod]
     public void Parser_Alternatives_EquivalentBranchesCanBePrunedWithoutParseFailure()
     {
@@ -157,6 +163,9 @@ public class ParserEngineAlternativeSelectionTests
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
     }
 
+    /// <summary>
+    /// Verifies that backtracking diagnostics remain scoped and do not become parse-failure diagnostics on success.
+    /// </summary>
     [TestMethod]
     public void Parser_Alternatives_BacktrackingDiagnosticDoesNotBecomeParseFailureDiagnostic()
     {
@@ -174,6 +183,9 @@ public class ParserEngineAlternativeSelectionTests
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
     }
 
+    /// <summary>
+    /// Collects lexer token texts from the parse tree in traversal order.
+    /// </summary>
     private static List<string> CollectTokenTexts(ParseNode node)
     {
         var texts = new List<string>();
@@ -181,6 +193,9 @@ public class ParserEngineAlternativeSelectionTests
         return texts;
     }
 
+    /// <summary>
+    /// Recursively traverses parse nodes and appends lexer token texts to <paramref name="texts"/>.
+    /// </summary>
     private static void CollectTokenTextsCore(ParseNode node, List<string> texts)
     {
         switch (node)
@@ -200,6 +215,9 @@ public class ParserEngineAlternativeSelectionTests
         }
     }
 
+    /// <summary>
+    /// Creates a parser engine for tests using a single root parser rule and default channels/mode.
+    /// </summary>
     private static ParserEngine CreateParser(Rule root, string grammarName)
     {
         return new ParserEngine(Utils.Parser.Resolution.RuleResolver.Resolve(new ParserDefinition(

--- a/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
+++ b/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Diagnostics;
 using Utils.Parser.Model;
 using Utils.Parser.Runtime;
 using static UtilsTest.Parser.TestInfrastructure.ParserEngineTestHelpers;
@@ -11,6 +12,25 @@ namespace UtilsTest.Parser;
 [TestClass]
 public class ParserEngineAlternativeSelectionTests
 {
+    [TestMethod]
+    public void Parser_Alternatives_LongerSuccessfulBranchIsSelected()
+    {
+        var root = new Rule("root", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("b")]), "Long"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Short")
+        ]));
+
+        var parser = CreateParser(root, "AltLongest");
+        var diagnostics = new DiagnosticBag();
+        var tree = parser.Parse([
+            Token(0, 1, "A", "a"),
+            Token(1, 1, "B", "b")
+        ], diagnostics: diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
+    }
+
     [TestMethod]
     public void Parser_Alternatives_SimpleAndFailedThenSuccess_Preserved()
     {
@@ -93,5 +113,54 @@ public class ParserEngineAlternativeSelectionTests
 
         var tree = parser.Parse(tokens);
         Assert.IsNotInstanceOfType<ErrorNode>(tree);
+    }
+
+    [TestMethod]
+    public void Parser_Alternatives_EquivalentBranchesCanBePrunedWithoutParseFailure()
+    {
+        var root = new Rule("root", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "Same"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Same")
+        ]));
+        var parser = CreateParser(root, "AltPrune");
+        var diagnostics = new DiagnosticBag();
+
+        var tree = parser.Parse([Token(0, 1, "A", "a")], diagnostics: diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+    }
+
+    [TestMethod]
+    public void Parser_Alternatives_BacktrackingDiagnosticDoesNotBecomeParseFailureDiagnostic()
+    {
+        var root = new Rule("root", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("c")]), "FirstFails"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "SecondSucceeds")
+        ]));
+        var parser = CreateParser(root, "AltBacktracking");
+        var diagnostics = new DiagnosticBag();
+
+        var tree = parser.Parse([Token(0, 1, "A", "a")], diagnostics: diagnostics);
+
+        Assert.IsNotInstanceOfType<ErrorNode>(tree);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.BacktrackingUsed.Code));
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+    }
+
+    private static ParserEngine CreateParser(Rule root, string grammarName)
+    {
+        return new ParserEngine(Utils.Parser.Resolution.RuleResolver.Resolve(new ParserDefinition(
+            Name: grammarName,
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [root],
+            RootRule: root)));
     }
 }

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -181,3 +181,49 @@ Partial outcomes are descriptive runtime artifacts:
 - rejected local branch outcomes.
 
 They support deterministic orchestration and reuse, but they are not authoritative parse acceptance decisions.
+
+## Alternative selection and pruning contracts (current behavior)
+
+This section documents current observable behavior only. It is not a forward design proposal.
+
+- Final selected parse outcome is owned by `ParserEngine`.
+- `AlternativeScheduler` computes a best local candidate among locally completed states.
+- `ScheduledAlternativeExecutor` only transports local branch outcomes; it does not own final selection.
+
+### Local candidate eligibility
+
+- A branch is a local completion candidate only when an `ActiveParseState` is completed.
+- Failed local branches remain useful for diagnostics/backtracking context, but are not completion candidates.
+- Branches may complete locally and still be globally rejected later (for example, trailing tokens).
+
+### Deterministic local comparison order
+
+Current local comparison uses the following stable ordering:
+
+1. longest consumed input (`CurrentInputPosition`),
+2. lower `Alternative.Priority` value,
+3. lower `AlternativeIndex`.
+
+This ordering is used in scheduler deduplication and best-candidate selection, and is intentionally deterministic.
+
+### Branch equivalence and pruning eligibility
+
+- Equivalence keys are structural/runtime-orchestration keys (rule, origin, end/current position, cursor kind/index).
+- Pruning is allowed only when branch semantics are not considered distinct by the current runtime check.
+- Equivalence here is conservative and structural; it is **not** a complete semantic-equivalence proof.
+- Equivalent branches can still each have locally successful outcomes before pruning.
+
+### Pruning semantics and diagnostics
+
+- Pruning is orchestration-only elimination.
+- Pruning is not syntax invalidity.
+- Pruning is not parse failure.
+- Pruning does not own final parse acceptance.
+- Pruning diagnostics are ambiguity/orchestration diagnostics and remain separate from syntax-failure diagnostics.
+
+### Completed state versus final selected outcome
+
+- A completed local state means one branch reached a local completion point.
+- Multiple local completions may coexist.
+- Only one deterministic local winner is selected by scheduling.
+- Final parse acceptance still depends on engine-level gates (including full-input consumption).


### PR DESCRIPTION
### Motivation

- Make the current alternative-selection behavior explicit and easier to reason about by improving inline comments, runtime documentation, and adding invariant tests.  
- Lock conservative orchestration contracts (selection authority, pruning semantics, completed-state comparison) without altering runtime algorithms or public behavior.  
- Reduce implicit reasoning and surface deterministic, observable rules to support safe future evolution (Phase 1 of the roadmap).

### Description

- Clarified scheduler-local selection contracts and tie-breaking in `AlternativeScheduler` by adding documentation about deduplication intent, winner selection boundary, deterministic comparison order, and conservative equivalence assumptions; changes in `Utils.Parser/Runtime/AlternativeScheduler.cs`.  
- Made `ParserStateRegistry` reuse semantics explicit by documenting the current deterministic preference (first reusable success, otherwise first reusable failure) and noting reuse is invocation-local, in `Utils.Parser/Runtime/ParserStateRegistry.cs`.  
- Added an explicit section documenting current alternative-selection, pruning, equivalence, and completed-vs-final outcome contracts in `docs/parser/RuntimeStateOwnership.md`.  
- Updated `ROADMAP.md` Phase 1 status to record the clarified checkpoints (comparison order, pruning authority, structural-equivalence limits).  
- Added focused, deterministic tests in `UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs` covering: longest-match selection, pruning of equivalent branches without escalating to parse failure, and scoped backtracking diagnostics remaining separate from parse-failure diagnostics.

### Testing

- Ran the targeted parser invariant tests with: `dotnet test UtilsTest/UtilsTest.csproj --filter ParserEngineAlternativeSelectionTests --no-restore`.  
- Result: tests passed (6/6) after making the test assertions observable-behavior-oriented and non-fragile.  
- Note: only targeted parser invariant tests were run per change scope; no runtime-algorithm changes were introduced so full-suite runs were not required for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073d891dc8832687386be353cd4044)