### PR TITLE
Phase 2: Clarify diagnostics ownership/lifecycle and add invariant tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -183,6 +183,13 @@ Forbidden work:
 - changing diagnostic format,
 - changing observable diagnostic behavior without an explicit bug-fix PR.
 
+Current clarification status:
+
+- diagnostics ownership and authority boundaries are explicitly documented,
+- local vs global diagnostics lifecycle is explicitly documented,
+- orchestration diagnostics (pruning/backtracking) are explicitly separated from engine-authoritative parse diagnostics,
+- compatibility diagnostics are explicitly documented as independent from parse success/failure.
+
 ### Phase 3 — Lookahead contract consolidation
 
 Goal: keep lookahead shallow, conservative, and syntax-oriented while clarifying future options.

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -137,6 +137,10 @@ public class ParserDiagnosticsTests
     }
 
     [TestMethod]
+    /// <summary>
+    /// Verifies that backtracking diagnostics remain orchestration-oriented and do not
+    /// escalate to parse-failure diagnostics when the final parse succeeds.
+    /// </summary>
     public void ParserEngine_BacktrackingDiagnostic_RemainsOrchestrationOnly_OnSuccessfulParse()
     {
         var diagnostics = new DiagnosticBag();
@@ -170,6 +174,10 @@ public class ParserDiagnosticsTests
     }
 
     [TestMethod]
+    /// <summary>
+    /// Verifies that unsupported-feature compatibility diagnostics remain observable
+    /// independently of final parse success.
+    /// </summary>
     public void UnsupportedFeatureDiagnostic_SurvivesIndependently_FromRuntimeParseOutcome()
     {
         var diagnostics = new DiagnosticBag();

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -137,6 +137,56 @@ public class ParserDiagnosticsTests
     }
 
     [TestMethod]
+    public void ParserEngine_BacktrackingDiagnostic_RemainsOrchestrationOnly_OnSuccessfulParse()
+    {
+        var diagnostics = new DiagnosticBag();
+        var rule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("a"), new LiteralMatch("b")])),
+                new Alternative(1, Associativity.Left, new LiteralMatch("a"))
+            ]));
+        var definition = RuleResolver.Resolve(new ParserDefinition(
+            Name: "DiagBacktracking",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [rule],
+            RootRule: rule));
+
+        var parser = new ParserEngine(definition);
+        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.BacktrackingUsed.Code));
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+    }
+
+    [TestMethod]
+    public void UnsupportedFeatureDiagnostic_SurvivesIndependently_FromRuntimeParseOutcome()
+    {
+        var diagnostics = new DiagnosticBag();
+        var definition = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            options { language = Cpp; }
+            start : 'a' ;
+            """, diagnostics);
+
+        var parser = new ParserEngine(definition);
+        var node = parser.Parse([new Token(new SourceSpan(0, 1), "a", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(node);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.UnsupportedAntlrLanguageOptionIgnored.Code));
+    }
+
+    [TestMethod]
     public void ValidCase_EmitsNoErrorDiagnostics()
     {
         var diagnostics = new DiagnosticBag();

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -83,6 +83,14 @@ The following capabilities are currently unsupported by design:
 
 These are intentionally outside the current runtime envelope.
 
+## Diagnostics interpretation for compatibility
+
+Compatibility diagnostics are intended to document capability boundaries, not to redefine parse authority:
+
+- unsupported/ignored ANTLR4 feature diagnostics are compatibility-oriented and may appear even when parse succeeds;
+- orchestration diagnostics (such as pruning/backtracking) remain separate from compatibility diagnostics;
+- engine-authoritative parse diagnostics (parse failure, trailing tokens) remain owned by `ParserEngine`.
+
 ## Architectural notes
 
 Current parser architecture includes explicit metadata infrastructure for future-safe analysis, while preserving deterministic execution boundaries.

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -63,6 +63,17 @@ Custom runtime policies should therefore remain deterministic and conservative, 
 
 With custom policies, these diagnostics may be reduced or suppressed when predicates/actions are actively handled.
 
+## Diagnostics ownership and lifecycle boundaries
+
+Current diagnostics behavior is intentionally conservative:
+
+- `ParserEngine` owns final observable parse outcome diagnostics (including parse failure and trailing tokens).
+- `AlternativeScheduler` and `ScheduledAlternativeExecutor` may emit orchestration diagnostics (for example pruning/backtracking) but do not own final parse acceptance.
+- `ParserLookaheadProbe` and `ParserLookaheadCache` provide shallow transport/probing metadata and do not establish parse-authoritative diagnostics by themselves.
+
+Local branch diagnostics are descriptive runtime context and do not automatically become global parse failure diagnostics.
+Compatibility diagnostics (unsupported or parsed-only ANTLR4 capabilities) are independent from branch success/failure and may coexist with successful parse outcomes.
+
 ## 1) Parameters and `returns`: parsed and preserved as metadata
 
 The grammar ingestion pipeline supports ANTLR4-style rule signatures such as:

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -172,6 +172,35 @@ Diagnostics can be observed at multiple runtime layers, but final authority rema
 - **Pruning diagnostics** describe orchestration decisions, not syntax invalidity.
 - **Global diagnostics** are the emitted parse diagnostics selected by `ParserEngine` for the final outcome.
 
+### Observable diagnostics categories (current runtime)
+
+Current observable categories are implementation-aligned and intentionally flat:
+
+- **Syntax/parse-failure diagnostics**: parse failure when no acceptable root outcome exists.
+- **Trailing-token diagnostics**: engine-authoritative rejection when input remains after local success.
+- **Pruning diagnostics**: orchestration ambiguity/pruning information produced by scheduling flow.
+- **Backtracking diagnostics**: orchestration-only information about branch rewinds during exploration.
+- **Unsupported-feature diagnostics**: compatibility-oriented diagnostics for parsed-but-not-executed or unsupported ANTLR4 features.
+- **Informational diagnostics**: runtime traceability diagnostics such as entering/leaving rule and default behavior applied.
+
+These categories describe current behavior and ownership boundaries; they are not a new runtime hierarchy.
+
+### Diagnostics lifecycle (current behavior)
+
+Diagnostics follow a conservative lifecycle:
+
+1. **Creation** in the component currently executing logic (`ParserEngine`, scheduler/executor, resolver/converter pipelines).
+2. **Propagation** via shared `DiagnosticBag` references passed through runtime calls.
+3. **Transport** through local branch outcomes where needed for orchestration visibility.
+4. **Global visibility decision** through engine-owned final parse acceptance/rejection gates.
+
+Important lifecycle boundary:
+
+- branch-local diagnostics are descriptive and may be present even when that branch is later rejected;
+- successful global parse can still keep orchestration diagnostics (for example pruning/backtracking);
+- rejected local branch outcomes do not automatically become authoritative parse-failure diagnostics;
+- trailing-token diagnostics are emitted only by final engine acceptance checks.
+
 ### Partial parse outcomes
 
 Partial outcomes are descriptive runtime artifacts:


### PR DESCRIPTION
### Motivation

- Consolidate and clarify the current diagnostics model (ownership, authority, lifecycle, and categories) without changing runtime behavior or public APIs.
- Make orchestration vs engine-authoritative diagnostics boundaries explicit so future maintenance is safer and easier to reason about.
- Add focused, deterministic invariant tests that lock observable diagnostics behavior for the current runtime.

### Description

- Added explicit diagnostics ownership, categories, and lifecycle documentation to `docs/parser/RuntimeStateOwnership.md` including observable categories and a conservative lifecycle model. 
- Clarified diagnostics ownership and lifecycle boundaries in `docs/parser/ParserMetadataAndRuntimeLimitations.md` and added compatibility-interpretation notes to `docs/parser/Antlr4CompatibilityMatrix.md`.
- Updated `ROADMAP.md` Phase 2 to record the current clarification status for diagnostics consolidation.
- Added focused invariant tests in `UtilsTest/Parser/ParserDiagnosticsTests.cs` asserting that backtracking/pruning diagnostics remain orchestration-oriented and that unsupported-feature compatibility diagnostics can coexist with successful parses.
- No public API changes, no runtime behavior changes, and no new diagnostics framework or buffering/replay semantics introduced.

### Testing

- Ran the targeted parser test selection with `dotnet test UtilsTest/UtilsTest.csproj --filter "ParserDiagnosticsTests|ParserBranchOutcomeModelTests|ParserRuntimeInvariantTests|AlternativeSchedulerTests|ParserEngineTrailingTokenTests"` and all selected tests passed (Passed: 36, Failed: 0). 
- The newly added `ParserDiagnosticsTests` assertions passed as part of the run, confirming the documented invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083ffde9fc832693f82a45f4e14ffc)