### PR TITLE
Phase 3: clarify current lookahead authority and fallback contracts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -216,6 +216,14 @@ Forbidden work:
 - evaluating predicates during lookahead,
 - executing actions during lookahead.
 
+Current clarification status:
+
+- lookahead ownership boundaries are explicit (`ParserLookaheadProbe` / `ParserLookaheadCache` / engine authority),
+- advisory vs authoritative lookahead outcomes are explicitly documented,
+- fallback-to-parse behavior is documented for `RequiresParse`, `Unknown`, and ambiguous/epsilon-sensitive outcomes,
+- cache semantics are explicit as metadata-only and non-authoritative,
+- invariant tests cover conservative behavior for parser-rule references, predicates/actions, and ambiguous shallow outcomes.
+
 ### Phase 4 — Shared-prefix metadata maturity
 
 Goal: improve shared-prefix metadata quality without activating execution.

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -9,6 +9,7 @@ namespace Utils.Parser.Runtime;
 /// parser-graph execution, replay, or speculative execution.
 /// It can mark states as pruned for local orchestration purposes only; pruning is not a syntax verdict.
 /// Parse acceptance remains decided by <see cref="ParserEngine"/>.
+/// Look-ahead observations transported by this scheduler remain advisory metadata and do not authorize branch acceptance.
 /// </summary>
 internal sealed class AlternativeScheduler
 {

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -46,6 +46,9 @@ public sealed class ParserEngine
     private readonly bool _caseInsensitive;
     private readonly ParserStateRegistry _stateRegistry = new();
     private readonly AlternativeScheduler _alternativeScheduler;
+    // Look-ahead cache ownership boundary:
+    // cache entries are advisory probe metadata scoped to one Parse invocation.
+    // They do not alter engine-owned parse authority or trailing-token final validation.
     private readonly ParserLookaheadCache _lookaheadCache = new();
     private readonly ScheduledAlternativeExecutor _scheduledAlternativeExecutor;
     private readonly ISemanticPredicateEvaluator _semanticPredicateEvaluator;

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -41,17 +41,48 @@ namespace Utils.Parser.Runtime;
 /// </remarks>
 public sealed class ParserEngine
 {
+    /// <summary>
+    /// Parser definition that provides grammar rules, root rule, and runtime metadata.
+    /// </summary>
     private readonly ParserDefinition _definition;
+
+    /// <summary>
+    /// Active recursion-guard frame set used to prevent re-entering the same rule at the same input position.
+    /// </summary>
     private readonly HashSet<ParserFrameKey> _activeRuleFrames = new();
+
+    /// <summary>
+    /// Indicates whether parser token/literal matching is performed using case-insensitive comparison.
+    /// </summary>
     private readonly bool _caseInsensitive;
+
+    /// <summary>
+    /// Registry for visited states and reusable per-invocation parse outcomes.
+    /// </summary>
     private readonly ParserStateRegistry _stateRegistry = new();
+
+    /// <summary>
+    /// Sequential alternative-orchestration component used for local branch scheduling.
+    /// </summary>
     private readonly AlternativeScheduler _alternativeScheduler;
     // Look-ahead cache ownership boundary:
     // cache entries are advisory probe metadata scoped to one Parse invocation.
     // They do not alter engine-owned parse authority or trailing-token final validation.
     private readonly ParserLookaheadCache _lookaheadCache = new();
+
+    /// <summary>
+    /// Local alternative-execution coordinator used by scheduling flow.
+    /// </summary>
     private readonly ScheduledAlternativeExecutor _scheduledAlternativeExecutor;
+
+    /// <summary>
+    /// Policy component used to evaluate semantic predicates under runtime feature constraints.
+    /// </summary>
     private readonly ISemanticPredicateEvaluator _semanticPredicateEvaluator;
+
+    /// <summary>
+    /// Policy component used to handle parser embedded actions under runtime feature constraints.
+    /// </summary>
     private readonly IParserActionExecutor _parserActionExecutor;
 
     /// <summary>

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -65,9 +65,11 @@ public sealed class ParserEngine
     /// Sequential alternative-orchestration component used for local branch scheduling.
     /// </summary>
     private readonly AlternativeScheduler _alternativeScheduler;
-    // Look-ahead cache ownership boundary:
-    // cache entries are advisory probe metadata scoped to one Parse invocation.
-    // They do not alter engine-owned parse authority or trailing-token final validation.
+    /// <summary>
+    /// Look-ahead cache scoped to a single parse execution.
+    /// Stored entries are advisory probe metadata and do not alter engine-owned parse authority
+    /// or trailing-token final validation.
+    /// </summary>
     private readonly ParserLookaheadCache _lookaheadCache = new();
 
     /// <summary>

--- a/Utils.Parser/Runtime/ParserLookaheadCache.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadCache.cs
@@ -4,6 +4,8 @@ namespace Utils.Parser.Runtime;
 /// Caches lightweight scheduled-alternative look-ahead observations for the current parse execution.
 /// Entries are syntax-oriented probe metadata only and are independent from semantic runtime state,
 /// parser action side effects, replay frames, and rollback mechanisms.
+/// Cached values are advisory: they may inform conservative shortcut rejection, but they never
+/// own parse acceptance and never replace authoritative parse execution in <see cref="ParserEngine"/>.
 /// </summary>
 internal sealed class ParserLookaheadCache
 {

--- a/Utils.Parser/Runtime/ParserLookaheadProbe.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbe.cs
@@ -8,6 +8,9 @@ namespace Utils.Parser.Runtime;
 /// or consult external semantic runtime state.
 /// It is syntax-oriented only and does not execute parser rules speculatively,
 /// traverse parser graphs semantically, or run continuation metadata.
+/// Probe results are advisory metadata consumed by orchestration components.
+/// This probe can only provide deterministic immediate-reject evidence; all non-reject outcomes
+/// remain parse-required and must be confirmed by authoritative parser execution.
 /// </summary>
 internal sealed class ParserLookaheadProbe
 {
@@ -65,7 +68,8 @@ internal sealed class ParserLookaheadProbe
 
     /// <summary>
     /// Probes a rule reference when the target is a lexer rule.
-    /// Parser rule references always return Unknown because they may accept empty input.
+    /// Parser-rule references always return Unknown to preserve conservative fallback-to-parse behavior:
+    /// parser rules may accept empty input and may depend on deeper structure that shallow probing cannot prove.
     /// </summary>
     private static ParserLookaheadProbeResult ProbeRuleReference(
         RuleRef ruleRef,

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
@@ -8,6 +8,8 @@ namespace Utils.Parser.Runtime;
 /// in runtime components owned by <see cref="ParserEngine"/>.
 /// This executor is local and non-authoritative: it does not provide global parse authority,
 /// rollback safety, transactional isolation, or replay semantics.
+/// Look-ahead data (live probe or cached result) is advisory orchestration metadata:
+/// it can only support conservative shortcut rejection paths and never directly accept a branch.
 /// It may propagate branch-local diagnostics through callback outputs, but final diagnostic authority
 /// remains in <see cref="ParserEngine"/>.
 /// Its role is bounded coordination between <see cref="AlternativeScheduler"/>,
@@ -82,6 +84,9 @@ internal sealed class ScheduledAlternativeExecutor
             }
         }
 
+        // Authoritative shortcut boundary:
+        // look-ahead can reject immediately when deterministic first-token mismatch is observed,
+        // but it cannot accept a branch. Any non-reject outcome requires real parsing.
         if (allowNegativeShortcut
             && effectiveLookahead.Kind == ParserLookaheadProbeKind.ImmediateReject)
         {

--- a/UtilsTest/Parser/ParserLookaheadProbeTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadProbeTests.cs
@@ -218,6 +218,32 @@ public class ParserLookaheadProbeTests
     }
 
     [TestMethod]
+    public void Probe_Sequence_WithPredicateThenLiteral_RemainsUnknown()
+    {
+        var sequence = new Sequence([
+            new GatingPredicate("isEnabled"),
+            new LiteralMatch("go")
+        ]);
+
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(sequence), TokenWithText("go"), static _ => null, false);
+
+        Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
+    }
+
+    [TestMethod]
+    public void Probe_Sequence_WithActionThenLiteral_RemainsRequiresParse()
+    {
+        var sequence = new Sequence([
+            new EmbeddedAction("mark", ActionContext.Alternative, ActionPosition.Inline, []),
+            new LiteralMatch("go")
+        ]);
+
+        var result = new ParserLookaheadProbe().Probe(CreateAlternative(sequence), TokenWithText("go"), static _ => null, false);
+
+        Assert.AreEqual(ParserLookaheadProbeKind.RequiresParse, result.Kind);
+    }
+
+    [TestMethod]
     public void Probe_NestedAlternation_ReturnsUnknown()
     {
         var nested = new Alternation([new Alternative(0, Associativity.Left, new LiteralMatch("x"), null)]);

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -74,6 +74,24 @@ Current diagnostics behavior is intentionally conservative:
 Local branch diagnostics are descriptive runtime context and do not automatically become global parse failure diagnostics.
 Compatibility diagnostics (unsupported or parsed-only ANTLR4 capabilities) are independent from branch success/failure and may coexist with successful parse outcomes.
 
+## Lookahead limitations and fallback-to-parse contract
+
+Current lookahead behavior is intentionally conservative and shallow.
+
+- Lookahead probing is first-token-oriented and does not perform deep parser-rule simulation.
+- Parser-rule references in lookahead remain advisory and may return `Unknown`.
+- Epsilon-sensitive shapes may produce `Unknown`/`EpsilonPossible` to avoid over-claiming acceptance.
+- Predicates are never evaluated by lookahead as parse-authoritative evidence.
+- Parser actions are never executed by lookahead as parse-authoritative evidence.
+- Lookahead is semantic-state-agnostic and does not model external mutable runtime state.
+
+Fallback semantics:
+
+- `ImmediateReject` can be used as deterministic local reject evidence in allowed scheduler/executor contexts.
+- `RequiresParse`, `Unknown`, and `EpsilonPossible` are parse-required outcomes.
+- Ambiguous or parser-rule-dependent outcomes must defer to real parsing.
+- Cached lookahead entries are reusable advisory metadata only and do not replace parse execution.
+
 ## 1) Parameters and `returns`: parsed and preserved as metadata
 
 The grammar ingestion pipeline supports ANTLR4-style rule signatures such as:

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -42,6 +42,26 @@ Non-engine components may assist the engine but do not replace these decisions.
 - It does not provide global parse authority.
 - It does not provide transactional isolation.
 - It does not provide rollback or replay.
+- It can use lookahead for conservative local shortcut rejection only.
+- It cannot accept alternatives based on lookahead-only outcomes.
+
+## Lookahead authority and ownership (current model)
+
+Lookahead is intentionally split across three components with explicit boundaries:
+
+- `ParserLookaheadProbe`
+  - Computes shallow, first-token-oriented observations only.
+  - Can authoritatively conclude `ImmediateReject` when deterministic mismatch is observed.
+  - Cannot authoritatively conclude parse success.
+- `ParserLookaheadCache`
+  - Stores probe observations as runtime metadata for reuse in the same parse execution.
+  - Does not own parse acceptance/rejection decisions.
+  - Does not imply semantic equivalence between branches.
+- `ParserEngine` (through scheduled execution)
+  - Owns final parse acceptance and all branch confirmation.
+  - Uses lookahead as advisory input only.
+
+Authoritative parse acceptance always requires real parsing in engine-owned execution paths.
 
 ## State ownership
 


### PR DESCRIPTION
### Motivation

- Make the CURRENT lookahead model explicit and easier to reason about by documenting authority, ownership, and conservative fallback semantics without changing runtime behavior. 
- Reduce implicit reasoning around shallow probes, parser-rule references, epsilon handling, predicates/actions, and cache semantics so future work can evolve safely. 
- Add focused, deterministic invariants so observable behavior around lookahead remains conservative and audit-friendly.

### Description

- Added authoritative/advisory clarifications to runtime code comments in `ParserLookaheadProbe`, `ParserLookaheadCache`, `ParserEngine`, `AlternativeScheduler`, and `ScheduledAlternativeExecutor` to state that lookahead is advisory, that only `ImmediateReject` is deterministic shortcut evidence, and that final acceptance remains owned by `ParserEngine`.
- Made `ParserLookaheadCache` semantics explicit in comments that cached probe results are metadata-only and do not replace authoritative parsing.
- Tightened `ScheduledAlternativeExecutor` and `AlternativeScheduler` comments to document when negative lookahead shortcuts may be used and to explicitly prohibit lookahead-only acceptance.
- Expanded parser documentation by updating `docs/parser/RuntimeStateOwnership.md` and `docs/parser/ParserMetadataAndRuntimeLimitations.md` with a new section describing lookahead ownership, limitations, and the fallback-to-parse contract, and updated `ROADMAP.md` Phase 3 status notes.
- Added/adjusted invariant tests in `UtilsTest/Parser/ParserLookaheadProbeTests.cs` to cover predicate/action handling and epsilon/ambiguity conservatism in shallow probes (kept observable-contract assertions only).

### Testing

- Ran targeted tests with `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ParserLookaheadProbeTests|FullyQualifiedName~ParserLookaheadCacheTests"` and observed one failing assertion relating to a newly-added predicate test; corrected the test to match the conservative current contract and re-ran tests.
- Final targeted test run `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ParserLookaheadProbeTests|FullyQualifiedName~ParserLookaheadCacheTests" --no-restore` passed (all targeted tests passed).
- No other automated test suites were modified or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088ae28ae483269fcb8210f827166c)