### PR TITLE
Phase 4: clarify shared-prefix metadata authority, lifecycle, and invariants

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -243,6 +243,13 @@ Allowed work:
 - metadata validation,
 - documentation.
 
+Current clarification status:
+
+- shared-prefix metadata is explicitly documented as descriptive and non-authoritative,
+- metadata ownership and lifecycle boundaries are explicitly documented,
+- non-authority guarantees are explicit (no replay, no continuation execution, no branch merging, no semantic-equivalence guarantee),
+- future activation prerequisites are documented as boundaries only.
+
 Forbidden work:
 
 - shared-prefix execution,

--- a/Utils.Parser/Runtime/ActiveParseState.cs
+++ b/Utils.Parser/Runtime/ActiveParseState.cs
@@ -54,6 +54,8 @@ internal enum ActiveParseStateStatus
 /// It prepares explicit scheduling of parser work without changing current execution semantics.
 /// The model is descriptive scheduling/runtime-local state only: it is non-replayable,
 /// non-resumable, and not rollback-aware.
+/// Shared-prefix-related fields in this state are observational metadata boundaries only;
+/// they do not grant branch-selection authority, parse acceptance authority, or semantic equivalence guarantees.
 /// <para>
 /// <see cref="Continuation"/> is metadata that describes a potential continuation anchor.
 /// It is not executable runtime replay state and does not imply resume/rollback semantics.
@@ -100,9 +102,25 @@ internal sealed record ActiveParseState
         Cursor.Kind,
         Cursor.Index);
 
+    /// <summary>
+    /// Produces a new local completion state for scheduling transport.
+    /// This transformation is non-authoritative and does not finalize global parse outcomes.
+    /// </summary>
     public ActiveParseState Complete(int endPosition) => this with { Status = ActiveParseStateStatus.Completed, CurrentInputPosition = endPosition, EndPosition = endPosition };
+    /// <summary>
+    /// Produces a new local failure state for branch-level orchestration.
+    /// This does not assert global parse failure.
+    /// </summary>
     public ActiveParseState Fail() => this with { Status = ActiveParseStateStatus.Failed, EndPosition = null };
+    /// <summary>
+    /// Produces an orchestration-only pruned marker.
+    /// Pruning metadata is not a syntax-invalidity verdict.
+    /// </summary>
     public ActiveParseState Prune() => this with { Status = ActiveParseStateStatus.Pruned };
+    /// <summary>
+    /// Attaches continuation metadata to this state.
+    /// The attached key is descriptive and never executable replay authority.
+    /// </summary>
     public ActiveParseState WithContinuation(ContinuationKey continuation) => this with { Continuation = continuation };
     public ActiveParseState Advance(int currentInputPosition, RuleContentCursor cursor) => this with { CurrentInputPosition = currentInputPosition, Cursor = cursor };
     public ActiveParseState WithLineage(ActiveParseStateKey? parentStateKey, int depth) => this with { ParentStateKey = parentStateKey, Depth = depth };

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -10,6 +10,8 @@ namespace Utils.Parser.Runtime;
 /// It can mark states as pruned for local orchestration purposes only; pruning is not a syntax verdict.
 /// Parse acceptance remains decided by <see cref="ParserEngine"/>.
 /// Look-ahead observations transported by this scheduler remain advisory metadata and do not authorize branch acceptance.
+/// Shared-prefix plans produced here remain descriptive lifecycle artifacts:
+/// they can be produced, transported, observed, reused for analysis, or discarded without changing parse authority.
 /// </summary>
 internal sealed class AlternativeScheduler
 {
@@ -81,15 +83,17 @@ internal sealed class AlternativeScheduler
 
     /// <summary>
     /// Builds informational scheduling metadata from shallow look-ahead observations.
+    /// Produced metadata remains non-authoritative and does not change branch execution requirements.
     /// </summary>
     private AlternativeSchedulingMetadata BuildMetadata(
         Rule rule,
         IReadOnlyList<Alternative> orderedAlternatives,
         IReadOnlyList<ParserLookaheadProbeResult> lookaheadProbes)
     {
-        // Metadata generation intentionally includes shallow observations from attempted
-        // alternatives even when parsing fails. Shared-prefix planning metadata is
-        // structural and observational only.
+        // Metadata lifecycle boundary:
+        // observations are produced from attempted alternatives, transported through scheduling,
+        // and exposed for diagnostics/audit tooling. This metadata remains structural-only,
+        // independent from parse acceptance, and discardable without semantic changes.
         var candidates = _sharedPrefixDetector.Detect(lookaheadProbes);
         var candidateIndexes = candidates
             .SelectMany(static candidate => candidate.AlternativeIndexes)

--- a/Utils.Parser/Runtime/ParserStateRegistry.cs
+++ b/Utils.Parser/Runtime/ParserStateRegistry.cs
@@ -7,6 +7,8 @@ namespace Utils.Parser.Runtime;
 /// Runtime-authoritative state in this registry is limited to visited states, invocation completion tracking,
 /// and reusable parse outcomes keyed by invocation identity.
 /// Continuation descriptors and shared-prefix scheduling metadata are non-authoritative descriptive data.
+/// Shared-prefix metadata in this registry is descriptive-only and does not authorize replay,
+/// continuation execution, branch merging, semantic equivalence, or rollback safety assumptions.
 /// This registry does not contain replay frames, semantic runtime frames, rollback state, or executable continuations.
 /// </summary>
 internal sealed class ParserStateRegistry
@@ -26,7 +28,10 @@ internal sealed class ParserStateRegistry
     /// <summary>Marks a state as visited and returns <c>true</c> when it was not seen before.</summary>
     public bool TryEnterState(ParserStateKey key) => _visitedStates.Add(key);
 
-    /// <summary>Adds a continuation for a shared rule invocation.</summary>
+    /// <summary>
+    /// Adds continuation metadata for a shared rule invocation.
+    /// The recorded continuation key is observational transport data only and is not executable resume authority.
+    /// </summary>
     public bool AddContinuation(RuleInvocationKey invocation, ContinuationKey continuation)
     {
         if (!_continuations.TryGetValue(invocation, out var set))
@@ -38,7 +43,10 @@ internal sealed class ParserStateRegistry
         return set.Add(continuation);
     }
 
-    /// <summary>Adds a completed result for a shared rule invocation.</summary>
+    /// <summary>
+    /// Adds a completed result for a shared rule invocation.
+    /// Stored outcomes are invocation-local reuse artifacts and do not transfer global parse-authority ownership.
+    /// </summary>
     public bool AddCompletedResult(RuleInvocationKey invocation, ParserRuleResult result)
     {
         if (!_completedResults.TryGetValue(invocation, out var list))
@@ -58,13 +66,19 @@ internal sealed class ParserStateRegistry
         return true;
     }
 
-    /// <summary>Gets continuations previously registered for an invocation.</summary>
+    /// <summary>
+    /// Gets continuations previously registered for an invocation.
+    /// Returned values are metadata snapshots and remain discardable from an execution-authority perspective.
+    /// </summary>
     public IReadOnlyList<ContinuationKey> GetContinuations(RuleInvocationKey invocation)
     {
         return _continuations.TryGetValue(invocation, out var set) ? [.. set] : [];
     }
 
-    /// <summary>Gets completed results previously registered for an invocation.</summary>
+    /// <summary>
+    /// Gets completed results previously registered for an invocation.
+    /// Retrieved values are reusable local outcomes and not final parse acceptance decisions.
+    /// </summary>
     public IReadOnlyList<ParserRuleResult> GetCompletedResults(RuleInvocationKey invocation)
     {
         return _completedResults.TryGetValue(invocation, out var list) ? list : [];

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
@@ -14,6 +14,8 @@ namespace Utils.Parser.Runtime;
 /// remains in <see cref="ParserEngine"/>.
 /// Its role is bounded coordination between <see cref="AlternativeScheduler"/>,
 /// <see cref="ParserStateRegistry"/>, and engine-owned parsing callbacks.
+/// Shared-prefix metadata observed during execution is non-authoritative and never enables replay,
+/// continuation resume, shared-frame execution, or branch merging.
 /// </summary>
 internal sealed class ScheduledAlternativeExecutor
 {

--- a/UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs
@@ -213,6 +213,107 @@ public class AlternativeSchedulingMetadataTests
         Assert.AreEqual(1, result.CompletedStates.Count);
         Assert.AreEqual(1, result.FailedStates.Count);
     }
+
+    [TestMethod]
+    public void Scheduler_MetadataPresence_DoesNotChangeParseAcceptanceSelection()
+    {
+        var withSharedMetadata = Run(new[] { new[] { "ID" }, new[] { "ID" } });
+        var withoutSharedMetadata = Run(new[] { new[] { "ID" }, new[] { "NUMBER" } });
+
+        Assert.IsNotNull(withSharedMetadata.SelectedState);
+        Assert.IsNotNull(withoutSharedMetadata.SelectedState);
+        Assert.AreEqual(withSharedMetadata.SelectedState.AlternativeIndex, withoutSharedMetadata.SelectedState.AlternativeIndex);
+        Assert.AreEqual(withSharedMetadata.SelectedState.CurrentInputPosition, withoutSharedMetadata.SelectedState.CurrentInputPosition);
+    }
+
+    [TestMethod]
+    public void Scheduler_MetadataPresence_DoesNotSuppressPruningDiagnostics()
+    {
+        var scheduler = new AlternativeScheduler();
+        var diagnostics = new DiagnosticBag();
+        var rule = new Rule("r", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "X"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "X")
+        ]));
+
+        _ = scheduler.Run(
+            rule,
+            rule.Content.Alternatives,
+            0,
+            0,
+            diagnostics,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")));
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
+    }
+
+    [TestMethod]
+    public void Scheduler_Metadata_DoesNotImplySemanticEquivalenceAcrossDistinctAlternatives()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = new Rule("r", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "X"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Y")
+        ]));
+
+        var result = scheduler.Run(
+            rule,
+            rule.Content.Alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")));
+
+        Assert.AreEqual(2, result.CompletedStates.Count);
+        Assert.AreEqual(0, result.PrunedStates.Count);
+    }
+
+    [TestMethod]
+    public void Scheduler_Metadata_DoesNotOwnBranchSelection()
+    {
+        var scheduler = new AlternativeScheduler();
+        var alternatives = new[]
+        {
+            new Alternative(0, Associativity.Left, new RuleRef("ID"), "a"),
+            new Alternative(1, Associativity.Left, new RuleRef("ID"), "b")
+        };
+        var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+
+        var result = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, index == 0 ? 1 : 3), Probe("ID")));
+
+        Assert.IsNotNull(result.SelectedState);
+        Assert.AreEqual(1, result.SelectedState.AlternativeIndex);
+    }
+
+    [TestMethod]
+    public void Scheduler_Metadata_CanExistWhenNoBranchIsAuthoritativelyAccepted()
+    {
+        var scheduler = new AlternativeScheduler();
+        var alternatives = new[]
+        {
+            new Alternative(0, Associativity.Left, new RuleRef("ID"), "a"),
+            new Alternative(1, Associativity.Left, new RuleRef("ID"), "b")
+        };
+        var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+
+        var result = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(null, Probe("ID")));
+
+        Assert.IsNull(result.SelectedState);
+        Assert.AreEqual(0, result.CompletedStates.Count);
+        Assert.AreEqual(1, result.Metadata.SharedPrefixPlans.Count);
+    }
     private static AlternativeSchedulingResult Run(IReadOnlyList<IReadOnlyList<string>> expected)
     {
         var scheduler = new AlternativeScheduler();

--- a/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
+++ b/UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs
@@ -384,6 +384,60 @@ public class ScheduledAlternativeExecutorTests
         Assert.AreEqual(1, attemptCount);
     }
 
+    [TestMethod]
+    public void Execute_MetadataDoesNotAuthorizeReplay_AlternativeBodyRunsPerAttempt()
+    {
+        var registry = new ParserStateRegistry();
+        var cache = new ParserLookaheadCache();
+        var executor = new ScheduledAlternativeExecutor(registry, cache, new ParserLookaheadProbe());
+        var rule = CreateRule();
+        var alternative = rule.Content.Alternatives[0];
+        var context = new ParseContext([new Token(new SourceSpan(0, 1), "ID", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
+        var parseCalls = 0;
+
+        ParseNode? Parse(Alternative _)
+        {
+            parseCalls++;
+            return null;
+        }
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.Alternation,
+            cursorIndex: 1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: Parse);
+
+        _ = executor.Execute(
+            context,
+            rule,
+            alternative,
+            alternativeIndex: 0,
+            startPosition: 0,
+            precedence: 0,
+            cursorKind: ScheduledAlternativeCursorKinds.Alternation,
+            cursorIndex: 1,
+            diagnostics: null,
+            checkPrecedence: static _ => true,
+            resolveRule: static _ => null,
+            caseInsensitive: false,
+            containsPredicateOrAction: static _ => false,
+            resolveDiagnosticSpan: static _ => (0, 0),
+            parseAlternative: Parse);
+
+        Assert.AreEqual(2, parseCalls);
+    }
+
     private static Rule CreateRule()
     {
         return new Rule("root", 0, false, new Alternation([

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -128,6 +128,56 @@ No parameter evaluation and no return extraction occurs at runtime.
 
 ## 2) Shared-prefix infrastructure: metadata-only
 
+
+## Shared-prefix metadata authority, limitations, and lifecycle
+
+Current shared-prefix infrastructure is descriptive-only.
+
+Authority clarifications:
+
+- Shared-prefix metadata does not own parse acceptance or rejection.
+- Shared-prefix metadata does not own branch selection.
+- Shared-prefix metadata does not authorize replay, continuation execution, or branch merging.
+- Shared-prefix metadata does not establish semantic equivalence between alternatives.
+- Shared-prefix metadata does not imply rollback safety, side-effect isolation, or speculative safety.
+
+Current structural limitations (explicit):
+
+- no shared execution frames,
+- no continuation replay,
+- no parser-graph execution,
+- no action replay safety model,
+- no semantic-runtime-aware equivalence model,
+- no rollback guarantees,
+- no side-effect isolation model,
+- no shared semantic state,
+- no speculative execution.
+
+Lifecycle clarifications:
+
+- production: metadata is produced from shallow lookahead and scheduling context,
+- transport: metadata is carried through scheduler output and registry-attached structures,
+- reuse: metadata is reused for validation/formatting/analysis,
+- discardability: metadata can be discarded without changing parse-authoritative outcomes,
+- observability: metadata is observable for audit/documentation purposes only.
+
+Metadata lifecycle remains independent from parse authority and diagnostics authority.
+
+## Conservative preconditions before any future activation work
+
+Any future work that attempts replay/shared execution/continuation resume must first define and validate, at minimum:
+
+- explicit rollback semantics,
+- semantic-state ownership and isolation,
+- deterministic replay rules,
+- diagnostics replay/ownership rules,
+- parse-tree compatibility/equivalence proofs,
+- branch identity and merge-safety contracts,
+- continuation ownership and execution authority contracts.
+
+These are prerequisite boundaries, not current capabilities.
+
+
 The shared-prefix pipeline exists for analysis, validation, and auditability. It does not execute shared prefixes.
 
 Active metadata production path:

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -2,6 +2,17 @@
 
 ## Purpose
 
+This file is the **conceptual overview** for metadata scope and runtime limitations.
+
+Use this document when the question is: *"what is metadata-only today, and what structural limits/preconditions exist?"*
+
+Companion roles:
+
+- `docs/parser/RuntimeStateOwnership.md`: authoritative ownership and parse-authority reference.
+- Runtime source comments (`Utils.Parser/Runtime/*`): implementation-local reminders and invariants near code.
+
+To reduce repetition, this document avoids redefining detailed ownership tables when already covered in `RuntimeStateOwnership.md`.
+
 This document consolidates parser documentation that explains what is currently implemented as metadata, what is policy-controlled at runtime, and which architectural constraints protect deterministic parser behavior.
 
 It is factual and conservative. It does not define a roadmap commitment.

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -276,3 +276,45 @@ This ordering is used in scheduler deduplication and best-candidate selection, a
 - Multiple local completions may coexist.
 - Only one deterministic local winner is selected by scheduling.
 - Final parse acceptance still depends on engine-level gates (including full-input consumption).
+
+
+## Shared-prefix metadata ownership and lifecycle (current runtime)
+
+Shared-prefix structures are intentionally metadata-only.
+
+- Production: metadata is produced from shallow lookahead observations and scheduler orchestration context.
+- Transport: metadata is transported through runtime result containers for visibility and auditability.
+- Reuse: metadata may be reused for formatting/validation/analysis in the same conservative execution model.
+- Discardability: metadata may be dropped without changing parse acceptance, branch selection, parse-tree shape, or diagnostics authority.
+- Observability: metadata is observable as runtime information, not executable state.
+
+Ownership boundaries:
+
+- `ParserEngine` owns parse acceptance/rejection and final diagnostics.
+- `AlternativeScheduler` owns deterministic orchestration and metadata aggregation.
+- `ParserStateRegistry` owns invocation-local reusable tracking and metadata transport storage.
+- Metadata structures (`ParserSharedPrefixPlan`, continuation descriptors, shared-prefix candidates) do not own execution authority.
+
+Explicit non-authority guarantees:
+
+- metadata does not authorize replay,
+- metadata does not authorize continuation execution,
+- metadata does not authorize branch merging,
+- metadata does not establish semantic equivalence,
+- metadata does not imply rollback safety,
+- metadata does not override diagnostics ownership.
+
+## Future activation preconditions (documentation boundary only)
+
+Before any future activation work (such as replay, shared execution, continuation resume, or duplicated-work elimination), minimum architectural preconditions would need explicit designs and tests, including:
+
+- explicit rollback model,
+- semantic-state ownership model,
+- side-effect safety model,
+- deterministic replay semantics,
+- diagnostics replay and ownership rules,
+- parse-tree compatibility guarantees,
+- branch identity guarantees,
+- continuation ownership and execution authority model.
+
+This section documents boundaries only. None of these systems are implemented by the current runtime.

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -3,6 +3,23 @@
 This document consolidates runtime-state ownership and authority boundaries for `Utils.Parser`.
 It is intentionally conservative and describes current behavior only.
 
+## Document role in parser documentation set
+
+This file is the **authoritative ownership reference** for current runtime authority boundaries.
+
+Use this document when the question is: *"which component owns which decision?"*
+
+Companion roles:
+
+- `docs/parser/ParserMetadataAndRuntimeLimitations.md`: conceptual limitations and preconditions overview.
+- Runtime source comments (`Utils.Parser/Runtime/*`): implementation-local guardrails for maintainers.
+
+To limit drift and repetition:
+
+- keep ownership and authority contracts canonical here,
+- keep conceptual narrative and limitations in the metadata/limitations document,
+- keep source comments short and implementation-aligned, and refer to this document for canonical authority rules.
+
 ## Runtime authority model
 
 The parser runtime is authority-layered.


### PR DESCRIPTION
### Motivation

- Make the CURRENT shared-prefix metadata model explicit, conservative, and easier to reason about without changing runtime behavior or public APIs.
- Reduce implicit reasoning by documenting ownership, limitations, and lifecycle of metadata-only structures used during scheduling and lookahead.
- Add focused, deterministic invariants to ensure metadata remains descriptive-only and cannot be mistaken for execution authority.

### Description

- Clarified non-authoritative semantics in runtime types by adding precise comments to `ParserStateRegistry`, `ActiveParseState`, `AlternativeScheduler`, and `ScheduledAlternativeExecutor`, explicitly stating that shared-prefix metadata is descriptive-only and does not authorize replay, continuation execution, branch merging, semantic-equivalence guarantees, or rollback safety (changes in `Utils.Parser/Runtime/*`).
- Hardened documentation with new/expanded sections that explain shared-prefix metadata ownership, lifecycle (production, transport, reuse, discardability, observability), explicit structural limitations, and conservative preconditions required before any future activation work in `docs/parser/RuntimeStateOwnership.md` and `docs/parser/ParserMetadataAndRuntimeLimitations.md`.
- Synced roadmap Phase 4 status to reflect that metadata maturity work is descriptive-only in `ROADMAP.md`.
- Added focused invariant tests that are observable and deterministic (no fragile internal assertions) to demonstrate metadata-only contracts and boundaries; tests added/updated in `UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs` and `UtilsTest/Parser/ScheduledAlternativeExecutorTests.cs` to cover metadata non-authority for acceptance/selection, diagnostics non-suppression, no implicit semantic equivalence, metadata independence from authoritative acceptance, and that metadata does not enable replay.
- No runtime behavior changes, no public API changes, and no activation of shared-prefix execution, replay, continuation resume, branch merging, or rollback systems were introduced.

### Testing

- Ran targeted parser tests: `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~UtilsTest.Parser.AlternativeSchedulingMetadataTests|FullyQualifiedName~UtilsTest.Parser.ScheduledAlternativeExecutorTests"` and verified they passed (`Passed: 26/26`).
- The changes are documentation- and test-focused; existing test-suite compatibility was preserved and the modified tests are deterministic and audit-friendly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089230e74083269ff70dd06a3dd1c7)