### PR TITLE
ci: run dotnetcore workflow only on pull_request to avoid duplicate runs

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,9 +1,6 @@
 name: Utils
 
 on:
-    push:
-        branches:
-            - '**'
     pull_request:
         branches:
             - '**'


### PR DESCRIPTION
### Motivation
- Avoid duplicate CI executions (push + pull_request) that cause the same tests to run twice for PR branches.

### Description
- Removed the `push` trigger from `.github/workflows/dotnetcore.yml` so the workflow now triggers only on `pull_request`; the build/test/scan/artifact steps remain unchanged.

### Testing
- No automated tests were executed because this change only updates CI trigger configuration and does not modify runtime code; CI will run on pull requests to validate the workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08aec784908326aa664819fac6b501)