### PR TITLE
test+docs: consolidate ParserStateRegistry ownership and memoization invariants

### DIFF
--- a/UtilsTest/Parser/ParserStateRegistryTests.cs
+++ b/UtilsTest/Parser/ParserStateRegistryTests.cs
@@ -157,14 +157,16 @@ public class ParserStateRegistryTests
     {
         var registry = new ParserStateRegistry();
         var invocation = new RuleInvocationKey("expr", 0, 0);
-        var successNode = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "success");
+        var firstSuccessNode = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "success-1");
+        var secondSuccessNode = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "success-2");
 
         registry.AddCompletedResult(invocation, new ParserRuleResult(null, 0, true));
-        registry.AddCompletedResult(invocation, new ParserRuleResult(successNode, 5, false));
+        registry.AddCompletedResult(invocation, new ParserRuleResult(firstSuccessNode, 5, false));
+        registry.AddCompletedResult(invocation, new ParserRuleResult(secondSuccessNode, 6, false));
 
         Assert.IsTrue(registry.TryGetReusableResult(invocation, out var reusable));
         Assert.IsFalse(reusable.IsFailure);
-        Assert.AreSame(successNode, reusable.Node);
+        Assert.AreSame(firstSuccessNode, reusable.Node);
         Assert.AreEqual(5, reusable.EndPosition);
     }
 
@@ -198,6 +200,9 @@ public class ParserStateRegistryTests
 
         Assert.IsTrue(registry.AddCompletedResult(invocation, result));
         Assert.IsFalse(registry.AddCompletedResult(invocation, result));
+
+        var reconstructedDuplicate = new ParserRuleResult(node, 2, false);
+        Assert.IsFalse(registry.AddCompletedResult(invocation, reconstructedDuplicate));
         Assert.AreEqual(1, registry.GetCompletedResults(invocation).Count);
     }
 

--- a/UtilsTest/Parser/ParserStateRegistryTests.cs
+++ b/UtilsTest/Parser/ParserStateRegistryTests.cs
@@ -36,6 +36,100 @@ public class ParserStateRegistryTests
     }
 
     /// <summary>
+    /// Ensures clearing removes visited states, continuations, and completed results.
+    /// </summary>
+    [TestMethod]
+    public void Clear_RemovesVisitedStatesContinuationsAndCompletedResults()
+    {
+        var registry = new ParserStateRegistry();
+        var parserState = new ParserStateKey("expr", 2, 0, 0, 0);
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+        var continuation = new ContinuationKey("root", 0, 1, 2, 0);
+
+        registry.TryEnterState(parserState);
+        registry.AddContinuation(invocation, continuation);
+        registry.AddCompletedResult(invocation, new ParserRuleResult(null, 0, true));
+
+        registry.Clear();
+
+        Assert.IsTrue(registry.TryEnterState(parserState));
+        Assert.AreEqual(0, registry.GetContinuations(invocation).Count);
+        Assert.AreEqual(0, registry.GetCompletedResults(invocation).Count);
+        Assert.IsFalse(registry.TryGetReusableResult(invocation, out _));
+    }
+
+    /// <summary>
+    /// Ensures continuation metadata does not create reusable completed results.
+    /// </summary>
+    [TestMethod]
+    public void Registry_ContinuationMetadata_DoesNotCreateReusableResult()
+    {
+        var registry = new ParserStateRegistry();
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+
+        registry.AddContinuation(invocation, new ContinuationKey("root", 0, 1, 2, 0));
+
+        Assert.IsFalse(registry.TryGetReusableResult(invocation, out _));
+        Assert.AreEqual(0, registry.GetCompletedResults(invocation).Count);
+    }
+
+    /// <summary>
+    /// Ensures completed results do not create continuation metadata.
+    /// </summary>
+    [TestMethod]
+    public void Registry_CompletedResult_DoesNotCreateContinuationMetadata()
+    {
+        var registry = new ParserStateRegistry();
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+
+        registry.AddCompletedResult(invocation, new ParserRuleResult(null, 0, true));
+
+        Assert.AreEqual(0, registry.GetContinuations(invocation).Count);
+    }
+
+    /// <summary>
+    /// Ensures continuations are grouped by invocation key.
+    /// </summary>
+    [TestMethod]
+    public void Registry_ContinuationMetadata_IsGroupedByInvocationKey()
+    {
+        var registry = new ParserStateRegistry();
+        var invocationOne = new RuleInvocationKey("expr", 0, 0);
+        var invocationTwo = new RuleInvocationKey("expr", 1, 0);
+        var continuationOne = new ContinuationKey("root", 0, 1, 2, 0);
+        var continuationTwo = new ContinuationKey("root", 1, 0, 3, 0);
+
+        registry.AddContinuation(invocationOne, continuationOne);
+        registry.AddContinuation(invocationTwo, continuationTwo);
+
+        CollectionAssert.Contains(registry.GetContinuations(invocationOne).ToArray(), continuationOne);
+        CollectionAssert.DoesNotContain(registry.GetContinuations(invocationOne).ToArray(), continuationTwo);
+        CollectionAssert.Contains(registry.GetContinuations(invocationTwo).ToArray(), continuationTwo);
+    }
+
+    /// <summary>
+    /// Ensures completed results are grouped by invocation key.
+    /// </summary>
+    [TestMethod]
+    public void Registry_CompletedResults_AreGroupedByInvocationKey()
+    {
+        var registry = new ParserStateRegistry();
+        var invocationOne = new RuleInvocationKey("expr", 0, 0);
+        var invocationTwo = new RuleInvocationKey("expr", 1, 0);
+        var nodeOne = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "one");
+        var nodeTwo = new ErrorNode(new SourceSpan(1, 0), "DEFAULT_MODE", "two");
+        var resultOne = new ParserRuleResult(nodeOne, 1, false);
+        var resultTwo = new ParserRuleResult(nodeTwo, 2, false);
+
+        registry.AddCompletedResult(invocationOne, resultOne);
+        registry.AddCompletedResult(invocationTwo, resultTwo);
+
+        CollectionAssert.Contains(registry.GetCompletedResults(invocationOne).ToArray(), resultOne);
+        CollectionAssert.DoesNotContain(registry.GetCompletedResults(invocationOne).ToArray(), resultTwo);
+        CollectionAssert.Contains(registry.GetCompletedResults(invocationTwo).ToArray(), resultTwo);
+    }
+
+    /// <summary>
     /// Ensures successful completed results are reusable for the same invocation key.
     /// </summary>
     [TestMethod]
@@ -53,6 +147,89 @@ public class ParserStateRegistryTests
         Assert.AreEqual(4, reusable.EndPosition);
         Assert.AreSame(node, reusable.Node);
         Assert.IsFalse(reusable.IsFailure);
+    }
+
+    /// <summary>
+    /// Ensures first reusable success wins before reusable failures.
+    /// </summary>
+    [TestMethod]
+    public void Registry_Memoization_FirstReusableSuccessWinsBeforeFailure()
+    {
+        var registry = new ParserStateRegistry();
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+        var successNode = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "success");
+
+        registry.AddCompletedResult(invocation, new ParserRuleResult(null, 0, true));
+        registry.AddCompletedResult(invocation, new ParserRuleResult(successNode, 5, false));
+
+        Assert.IsTrue(registry.TryGetReusableResult(invocation, out var reusable));
+        Assert.IsFalse(reusable.IsFailure);
+        Assert.AreSame(successNode, reusable.Node);
+        Assert.AreEqual(5, reusable.EndPosition);
+    }
+
+    /// <summary>
+    /// Ensures first reusable failure wins when no reusable success exists.
+    /// </summary>
+    [TestMethod]
+    public void Registry_Memoization_FirstReusableFailureWinsWhenNoSuccessExists()
+    {
+        var registry = new ParserStateRegistry();
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+
+        registry.AddCompletedResult(invocation, new ParserRuleResult(null, 1, true));
+        registry.AddCompletedResult(invocation, new ParserRuleResult(null, 3, true));
+
+        Assert.IsTrue(registry.TryGetReusableResult(invocation, out var reusable));
+        Assert.IsTrue(reusable.IsFailure);
+        Assert.AreEqual(1, reusable.EndPosition);
+    }
+
+    /// <summary>
+    /// Ensures duplicate completed results are rejected.
+    /// </summary>
+    [TestMethod]
+    public void Registry_Memoization_DuplicateCompletedResult_IsRejected()
+    {
+        var registry = new ParserStateRegistry();
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+        var node = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "same");
+        var result = new ParserRuleResult(node, 2, false);
+
+        Assert.IsTrue(registry.AddCompletedResult(invocation, result));
+        Assert.IsFalse(registry.AddCompletedResult(invocation, result));
+        Assert.AreEqual(1, registry.GetCompletedResults(invocation).Count);
+    }
+
+    /// <summary>
+    /// Ensures completed results with different end positions are distinct.
+    /// </summary>
+    [TestMethod]
+    public void Registry_Memoization_DifferentEndPosition_IsDistinctCompletion()
+    {
+        var registry = new ParserStateRegistry();
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+        var node = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "same-node");
+
+        Assert.IsTrue(registry.AddCompletedResult(invocation, new ParserRuleResult(node, 2, false)));
+        Assert.IsTrue(registry.AddCompletedResult(invocation, new ParserRuleResult(node, 3, false)));
+        Assert.AreEqual(2, registry.GetCompletedResults(invocation).Count);
+    }
+
+    /// <summary>
+    /// Ensures completed results with different parse-node references are distinct.
+    /// </summary>
+    [TestMethod]
+    public void Registry_Memoization_DifferentNodeReference_IsDistinctCompletion()
+    {
+        var registry = new ParserStateRegistry();
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+        var nodeOne = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "node-1");
+        var nodeTwo = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "node-1");
+
+        Assert.IsTrue(registry.AddCompletedResult(invocation, new ParserRuleResult(nodeOne, 2, false)));
+        Assert.IsTrue(registry.AddCompletedResult(invocation, new ParserRuleResult(nodeTwo, 2, false)));
+        Assert.AreEqual(2, registry.GetCompletedResults(invocation).Count);
     }
 
     /// <summary>

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -139,6 +139,23 @@ Lifecycle (current behavior only):
 
 Continuations are therefore independent from parse authority and independent from diagnostics authority.
 
+## Parser identity and registry reuse boundaries
+
+Parser runtime identities are intentionally split by ownership purpose and must remain distinct.
+
+- `ParserStateKey` is for visited-state tracking and duplicate state-entry prevention.
+- `RuleInvocationKey` is for invocation-local completed-result reuse.
+- `ContinuationKey` is descriptive continuation metadata only.
+- `ActiveParseStateKey` is scheduling/local-state identity for branch-local transport.
+- `ActiveParseBranchEquivalenceKey` is pruning/orchestration identity for conservative branch grouping.
+
+These identities must not be collapsed into one semantic identity.
+
+Additional invariants:
+
+- Continuation metadata must not affect reusable parse-result selection.
+- Reusable parse results are invocation-local reuse artifacts and are not final parse acceptance authority.
+
 ## Metadata-only boundaries
 
 The following remain metadata-only and non-executable:


### PR DESCRIPTION
### Motivation

- Strengthen and lock existing runtime invariants around `ParserStateRegistry` ownership, parser-state identity, and memoization without changing runtime behavior.
- Make continuation metadata, invocation-local reuse, and scheduling/pruning identities explicit and auditable to prevent accidental collapsing of distinct identities.
- Keep the change conservative and review-friendly (tests + docs only) to preserve parse determinism and observable behavior.

### Description

- Added focused invariant tests in `UtilsTest/Parser/ParserStateRegistryTests.cs` covering clear semantics, continuation-vs-result separation, grouping by `RuleInvocationKey`, memoization winner selection, duplicate rejection, and distinctness by end position/node reference.
- Added a concise subsection `Parser identity and registry reuse boundaries` to `docs/parser/RuntimeStateOwnership.md` clarifying the roles of `ParserStateKey`, `RuleInvocationKey`, `ContinuationKey`, `ActiveParseStateKey`, and `ActiveParseBranchEquivalenceKey`, and reinforcing metadata-only and non-authority guarantees.
- Type: test + documentation consolidation; Runtime behavior impact: none; Parse-tree impact: none; Diagnostics impact: none; Public API impact: none; Metadata semantics impact: clarification only.
- No roadmap update required because this PR only locks and documents existing runtime invariants without changing roadmap direction or runtime behavior.

### Testing

- Ran targeted tests with `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ParserStateRegistryTests"` and all targeted tests passed (15 passed, 0 failed).
- The run included normal repository restore/build warnings only and did not introduce test regressions.
- Tests added specifically: `Clear_RemovesVisitedStatesContinuationsAndCompletedResults`, `Registry_ContinuationMetadata_DoesNotCreateReusableResult`, `Registry_CompletedResult_DoesNotCreateContinuationMetadata`, `Registry_ContinuationMetadata_IsGroupedByInvocationKey`, `Registry_CompletedResults_AreGroupedByInvocationKey`, `Registry_Memoization_FirstReusableSuccessWinsBeforeFailure`, `Registry_Memoization_FirstReusableFailureWinsWhenNoSuccessExists`, `Registry_Memoization_DuplicateCompletedResult_IsRejected`, `Registry_Memoization_DifferentEndPosition_IsDistinctCompletion`, and `Registry_Memoization_DifferentNodeReference_IsDistinctCompletion`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b0d86cdc8326ab61926d36c66a90)