### PR TITLE
docs/tests: consolidate parser runtime identity boundaries and equivalence invariants

### DIFF
--- a/Utils.Parser/Runtime/ActiveParseState.cs
+++ b/Utils.Parser/Runtime/ActiveParseState.cs
@@ -12,6 +12,9 @@ internal readonly record struct ActiveParseStateKey(
     string CursorKind,
     int MinimumPrecedence,
     ContinuationKey? Continuation);
+// Scheduling identity only:
+// this key is intentionally richer than pruning identity because deduplication must preserve
+// local execution-shape differences (for example continuation metadata and precedence context).
 
 internal readonly record struct ActiveParseBranchEquivalenceKey(
     string RuleName,
@@ -19,6 +22,9 @@ internal readonly record struct ActiveParseBranchEquivalenceKey(
     int CurrentOrEndPosition,
     string CursorKind,
     int CursorIndex);
+// Pruning/orchestration grouping identity only:
+// this key intentionally excludes scheduler-local dimensions (for example alternative priority
+// and continuation metadata) and must not be interpreted as semantic equivalence evidence.
 
 internal enum ActiveParseStateStatus
 {

--- a/Utils.Parser/Runtime/ActiveParseState.cs
+++ b/Utils.Parser/Runtime/ActiveParseState.cs
@@ -7,6 +7,15 @@ namespace Utils.Parser.Runtime;
 /// This key is intentionally richer than pruning identity because scheduler deduplication
 /// must preserve local execution-shape differences (for example continuation metadata and precedence context).
 /// </summary>
+/// <param name="RuleName">Rule name associated with the local scheduled state.</param>
+/// <param name="OriginInputPosition">Input position where the rule invocation started.</param>
+/// <param name="CurrentInputPosition">Current input position reached by this local state.</param>
+/// <param name="AlternativeIndex">Alternative index in scheduler traversal order.</param>
+/// <param name="AlternativePriority">Alternative priority value used by deterministic ordering.</param>
+/// <param name="CursorIndex">Cursor index in the alternative content.</param>
+/// <param name="CursorKind">Cursor kind used to distinguish local traversal shape.</param>
+/// <param name="MinimumPrecedence">Minimum precedence context for this scheduled exploration.</param>
+/// <param name="Continuation">Optional continuation metadata key (transport metadata only).</param>
 internal readonly record struct ActiveParseStateKey(
     string RuleName,
     int OriginInputPosition,
@@ -23,6 +32,11 @@ internal readonly record struct ActiveParseStateKey(
 /// This key intentionally excludes scheduler-local dimensions (for example alternative priority
 /// and continuation metadata) and must not be interpreted as semantic equivalence evidence.
 /// </summary>
+/// <param name="RuleName">Rule name associated with the local branch state.</param>
+/// <param name="OriginInputPosition">Input position where the branch invocation started.</param>
+/// <param name="CurrentOrEndPosition">Current/end position used by structural branch grouping.</param>
+/// <param name="CursorKind">Cursor kind used by branch-equivalence grouping.</param>
+/// <param name="CursorIndex">Cursor index used by branch-equivalence grouping.</param>
 internal readonly record struct ActiveParseBranchEquivalenceKey(
     string RuleName,
     int OriginInputPosition,

--- a/Utils.Parser/Runtime/ActiveParseState.cs
+++ b/Utils.Parser/Runtime/ActiveParseState.cs
@@ -2,6 +2,11 @@ using Utils.Parser.Model;
 
 namespace Utils.Parser.Runtime;
 
+/// <summary>
+/// Scheduling identity only.
+/// This key is intentionally richer than pruning identity because scheduler deduplication
+/// must preserve local execution-shape differences (for example continuation metadata and precedence context).
+/// </summary>
 internal readonly record struct ActiveParseStateKey(
     string RuleName,
     int OriginInputPosition,
@@ -12,19 +17,18 @@ internal readonly record struct ActiveParseStateKey(
     string CursorKind,
     int MinimumPrecedence,
     ContinuationKey? Continuation);
-// Scheduling identity only:
-// this key is intentionally richer than pruning identity because deduplication must preserve
-// local execution-shape differences (for example continuation metadata and precedence context).
 
+/// <summary>
+/// Pruning/orchestration grouping identity only.
+/// This key intentionally excludes scheduler-local dimensions (for example alternative priority
+/// and continuation metadata) and must not be interpreted as semantic equivalence evidence.
+/// </summary>
 internal readonly record struct ActiveParseBranchEquivalenceKey(
     string RuleName,
     int OriginInputPosition,
     int CurrentOrEndPosition,
     string CursorKind,
     int CursorIndex);
-// Pruning/orchestration grouping identity only:
-// this key intentionally excludes scheduler-local dimensions (for example alternative priority
-// and continuation metadata) and must not be interpreted as semantic equivalence evidence.
 
 internal enum ActiveParseStateStatus
 {

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -57,7 +57,8 @@ internal sealed class AlternativeScheduler
             return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(rule, ordered, lookaheadProbesByAlternative));
         }
 
-        // Deduplication keeps the strongest local completion for one structural state identity.
+        // Deduplication uses scheduling identity (ActiveParseStateKey) and is intentionally
+        // separate from pruning equivalence (ActiveParseBranchEquivalenceKey).
         // This is not the final parse selection contract; it only reduces equivalent local candidates.
         var deduplicated = DeduplicateStates(completedStates, minimumPrecedence);
         // Pruning is an orchestration optimization only; it is not a syntax-validity verdict.
@@ -216,6 +217,7 @@ internal sealed class AlternativeScheduler
         // two branches are mergeable only when HasDistinctSemantics reports no potential semantic divergence.
         // This equivalence is structural/orchestration-oriented and intentionally conservative;
         // it does not claim semantic-runtime equivalence beyond current heuristics.
+        // Branch equivalence and invocation-result reuse are separate identity systems.
         // If distinct semantics are possible, both branches must be preserved.
         var groups = new Dictionary<ActiveParseBranchEquivalenceKey, List<ActiveParseState>>();
         foreach (var state in states)

--- a/Utils.Parser/Runtime/ParserStateRegistry.cs
+++ b/Utils.Parser/Runtime/ParserStateRegistry.cs
@@ -26,6 +26,10 @@ internal sealed class ParserStateRegistry
     }
 
     /// <summary>Marks a state as visited and returns <c>true</c> when it was not seen before.</summary>
+    /// <remarks>
+    /// <see cref="ParserStateKey"/> is visited-state tracking identity only.
+    /// It is intentionally independent from local scheduler identity and pruning equivalence identity.
+    /// </remarks>
     public bool TryEnterState(ParserStateKey key) => _visitedStates.Add(key);
 
     /// <summary>
@@ -46,6 +50,7 @@ internal sealed class ParserStateRegistry
     /// <summary>
     /// Adds a completed result for a shared rule invocation.
     /// Stored outcomes are invocation-local reuse artifacts and do not transfer global parse-authority ownership.
+    /// Reuse identity (<see cref="RuleInvocationKey"/>) is intentionally independent from pruning/scheduling identities.
     /// </summary>
     public bool AddCompletedResult(RuleInvocationKey invocation, ParserRuleResult result)
     {

--- a/UtilsTest/Parser/ActiveParseStateTests.cs
+++ b/UtilsTest/Parser/ActiveParseStateTests.cs
@@ -106,6 +106,17 @@ public class ActiveParseStateTests
     }
 
     [TestMethod]
+    public void ActiveParseState_ToBranchEquivalenceKey_DifferentCursorKindOrIndex_ProduceDifferentKeys()
+    {
+        var baseline = CreateActiveState(priority: 1, cursorIndex: 0, alternativeIndex: 0, currentPosition: 10).Complete(10);
+        var differentIndex = baseline with { Cursor = new RuleContentCursor { Kind = baseline.Cursor.Kind, Index = 1 } };
+        var differentKind = baseline with { Cursor = new RuleContentCursor { Kind = "rule-ref", Index = baseline.Cursor.Index } };
+
+        Assert.AreNotEqual(baseline.ToBranchEquivalenceKey(), differentIndex.ToBranchEquivalenceKey());
+        Assert.AreNotEqual(baseline.ToBranchEquivalenceKey(), differentKind.ToBranchEquivalenceKey());
+    }
+
+    [TestMethod]
     public void ActiveParseState_ToBranchEquivalenceKey_DifferentLabels_SameShapeKey_NotPruned()
     {
         // States with different labels must map to the same shape key so that

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -110,6 +110,33 @@ public class AlternativeSchedulerTests
         Assert.IsTrue(result.CompletedStates.All(s => s.ToStateKey(7).MinimumPrecedence == 7));
     }
 
+    [TestMethod]
+    public void Run_BranchEquivalence_IgnoresPriorityAndContinuationMetadata()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = new Rule("r", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "X"),
+            new Alternative(9, Associativity.Left, new LiteralMatch("a"), "X")
+        ]));
+        var context = new ParseContext([]);
+
+        var result = scheduler.Run(
+            rule,
+            rule.Content.Alternatives,
+            originInputPosition: context.Position,
+            minimumPrecedence: 2,
+            diagnostics: null,
+            parseAlternative: (alternative, index) =>
+            {
+                var state = CreateState(rule, alternative, context.Position, 4, index)
+                    .WithContinuation(new ContinuationKey(rule.Name, index, 0, 4 + index, 2));
+                return new ScheduledAlternativeExecutionResult(state, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"]));
+            });
+
+        Assert.AreEqual(1, result.CompletedStates.Count, "Equivalent pruning key should keep a single branch.");
+        Assert.AreEqual(1, result.PrunedStates.Count);
+    }
+
     private static (ParseContext Context, Rule Rule, IReadOnlyList<Alternative> Alternatives) CreateAlternatives()
     {
         var a = new Alternative(2, Associativity.Left, new LiteralMatch("a"), "A");
@@ -145,5 +172,4 @@ public class AlternativeSchedulerTests
         };
     }
 }
-
 

--- a/UtilsTest/Parser/ParserStateRegistryTests.cs
+++ b/UtilsTest/Parser/ParserStateRegistryTests.cs
@@ -264,4 +264,24 @@ public class ParserStateRegistryTests
 
         Assert.IsFalse(registry.TryGetReusableResult(invocation, out _));
     }
+
+    /// <summary>
+    /// Ensures continuation metadata does not influence reusable result selection order.
+    /// </summary>
+    [TestMethod]
+    public void Registry_Memoization_ContinuationMetadata_DoesNotInfluenceReusableSelection()
+    {
+        var registry = new ParserStateRegistry();
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+        var expectedNode = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "expected");
+
+        registry.AddContinuation(invocation, new ContinuationKey("expr", 0, 1, 2, 0));
+        registry.AddContinuation(invocation, new ContinuationKey("expr", 1, 3, 4, 0));
+        registry.AddCompletedResult(invocation, new ParserRuleResult(expectedNode, 5, false));
+
+        Assert.IsTrue(registry.TryGetReusableResult(invocation, out var reusable));
+        Assert.IsFalse(reusable.IsFailure);
+        Assert.AreEqual(5, reusable.EndPosition);
+        Assert.AreSame(expectedNode, reusable.Node);
+    }
 }

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -139,22 +139,45 @@ Lifecycle (current behavior only):
 
 Continuations are therefore independent from parse authority and independent from diagnostics authority.
 
-## Parser identity and registry reuse boundaries
+## Runtime identity and equivalence model
 
 Parser runtime identities are intentionally split by ownership purpose and must remain distinct.
 
-- `ParserStateKey` is for visited-state tracking and duplicate state-entry prevention.
-- `RuleInvocationKey` is for invocation-local completed-result reuse.
-- `ContinuationKey` is descriptive continuation metadata only.
-- `ActiveParseStateKey` is scheduling/local-state identity for branch-local transport.
-- `ActiveParseBranchEquivalenceKey` is pruning/orchestration identity for conservative branch grouping.
+- `ParserStateKey`:
+  - visited-state tracking identity only.
+- `RuleInvocationKey`:
+  - invocation-local reusable completion identity only.
+- `ContinuationKey`:
+  - metadata transport identity only.
+- `ActiveParseStateKey`:
+  - local scheduling/deduplication identity only.
+- `ActiveParseBranchEquivalenceKey`:
+  - pruning/orchestration grouping identity only.
 
-These identities must not be collapsed into one semantic identity.
+These identities are intentionally non-equivalent:
+
+- none imply semantic equivalence;
+- none imply replay safety;
+- none imply rollback safety;
+- none imply branch merge safety;
+- none imply semantic-state equivalence.
+
+Critical boundary comparisons:
+
+- scheduling deduplication identity (`ActiveParseStateKey`) **!=** pruning equivalence identity (`ActiveParseBranchEquivalenceKey`);
+- pruning equivalence **!=** reusable invocation result identity (`RuleInvocationKey`);
+- reusable invocation identity **!=** parse acceptance identity (`ParserEngine` authority).
+
+Why multiple identities exist:
+
+- each runtime layer owns different decisions (visited-state tracking, invocation reuse, local scheduling, local pruning);
+- collapsing identities would over-claim equivalence and could silently break conservative runtime guarantees.
 
 Additional invariants:
 
-- Continuation metadata must not affect reusable parse-result selection.
-- Reusable parse results are invocation-local reuse artifacts and are not final parse acceptance authority.
+- continuation metadata must not affect pruning grouping;
+- continuation metadata must not affect reusable parse-result selection;
+- reusable parse results are invocation-local reuse artifacts and are not final parse acceptance authority.
 
 ## Metadata-only boundaries
 


### PR DESCRIPTION
### Motivation
- Type: tests + documentation consolidation to harden parser runtime identity ownership and equivalence semantics without changing behavior. 
- Preserve conservative, deterministic runtime invariants and prevent accidental collapsing of distinct identity systems used by scheduling, pruning, and memoization. 

### Description
- Added a focused "Runtime identity and equivalence model" section to `docs/parser/RuntimeStateOwnership.md` documenting the roles of `ParserStateKey`, `RuleInvocationKey`, `ContinuationKey`, `ActiveParseStateKey`, and `ActiveParseBranchEquivalenceKey` and explicitly stating they are non-equivalent and non-authoritative for semantic equivalence, replay, rollback, or branch merging. 
- Added concise source comments clarifying identity ownership and non-equivalence in `Utils.Parser/Runtime/ActiveParseState.cs`, `AlternativeScheduler.cs`, and `ParserStateRegistry.cs`. 
- Added focused invariant tests in `UtilsTest/Parser` to lock observable structural semantics only: `ActiveParseStateTests` (cursor/shape/equivalence boundaries), `AlternativeSchedulerTests` (pruning equivalence ignores priority/continuation metadata), and `ParserStateRegistryTests` (continuation metadata does not influence reusable result selection). 
- All changes are metadata/comments/tests only and do not alter runtime behavior, public APIs, diagnostics, or parse-tree shapes. 

### Testing
- Ran targeted test set for the impacted components with `dotnet test UtilsTest/UtilsTest.csproj --no-build --filter "FullyQualifiedName~ActiveParseStateTests|FullyQualifiedName~AlternativeSchedulerTests|FullyQualifiedName~ParserStateRegistryTests"`. 
- Result: all targeted tests passed (Passed: 33, Failed: 0). 
- No runtime behavior changes were observed during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a15417c388326898c3ff777270812)