### PR TITLE
parser: consolidate metadata lifecycle & observability (docs + invariant tests)

### DIFF
--- a/Utils.Parser/Runtime/ParserLookaheadProbeResult.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbeResult.cs
@@ -2,6 +2,8 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Stores a lightweight structured look-ahead probe observation for a scheduled alternative start attempt.
+/// Probe results are transport metadata: they are observable and scheduler-usable, but non-authoritative
+/// and discardable without changing parse-tree authority or final parse acceptance rules.
 /// </summary>
 internal readonly record struct ParserLookaheadProbeResult(
     ParserLookaheadProbeKind Kind,

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlan.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlan.cs
@@ -3,6 +3,8 @@ namespace Utils.Parser.Runtime;
 /// <summary>
 /// Represents structural shared-prefix planning metadata that associates a shallow shared token
 /// with the participating alternatives and their continuation descriptors.
+/// This plan is observable orchestration metadata only: it can guide diagnostics/audit workflows,
+/// but it cannot authorize parse acceptance, diagnostics authority, replay, or branch merging.
 /// </summary>
 /// <param name="SharedTokenName">Shallow shared token identifier observed during look-ahead.</param>
 /// <param name="AlternativeIndexes">Stable alternative indexes participating in this plan.</param>

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -137,6 +137,39 @@ public class AlternativeSchedulerTests
         Assert.AreEqual(1, result.PrunedStates.Count);
     }
 
+
+    [TestMethod]
+    public void Run_MetadataProbeDifferences_DoNotChangeSelectedState()
+    {
+        var scheduler = new AlternativeScheduler();
+        var (context, rule, alternatives) = CreateAlternatives();
+
+        var withMetadata = scheduler.Run(
+            rule,
+            alternatives,
+            context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, context.Position, 5 + index, index),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
+
+        var withoutMetadata = scheduler.Run(
+            rule,
+            alternatives,
+            context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, context.Position, 5 + index, index),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
+
+        Assert.IsNotNull(withMetadata.SelectedState);
+        Assert.IsNotNull(withoutMetadata.SelectedState);
+        Assert.AreEqual(withMetadata.SelectedState.CurrentInputPosition, withoutMetadata.SelectedState.CurrentInputPosition);
+        Assert.AreEqual(withMetadata.SelectedState.AlternativeIndex, withoutMetadata.SelectedState.AlternativeIndex);
+    }
+
     private static (ParseContext Context, Rule Rule, IReadOnlyList<Alternative> Alternatives) CreateAlternatives()
     {
         var a = new Alternative(2, Associativity.Left, new LiteralMatch("a"), "A");

--- a/UtilsTest/Parser/ParserStateRegistryTests.cs
+++ b/UtilsTest/Parser/ParserStateRegistryTests.cs
@@ -237,6 +237,28 @@ public class ParserStateRegistryTests
         Assert.AreEqual(2, registry.GetCompletedResults(invocation).Count);
     }
 
+
+    [TestMethod]
+    public void Registry_RemovingContinuationMetadata_DoesNotChangeReusableCompletedResult()
+    {
+        var registry = new ParserStateRegistry();
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+        var node = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "result");
+        var continuation = new ContinuationKey("expr", 0, 1, 3, 0);
+
+        registry.AddContinuation(invocation, continuation);
+        registry.AddCompletedResult(invocation, new ParserRuleResult(node, 3, false));
+        Assert.IsTrue(registry.TryGetReusableResult(invocation, out var withMetadata));
+
+        registry.Clear();
+        registry.AddCompletedResult(invocation, new ParserRuleResult(node, 3, false));
+        Assert.IsTrue(registry.TryGetReusableResult(invocation, out var withoutMetadata));
+
+        Assert.AreEqual(withMetadata.EndPosition, withoutMetadata.EndPosition);
+        Assert.AreEqual(withMetadata.IsFailure, withoutMetadata.IsFailure);
+        Assert.AreSame(withMetadata.Node, withoutMetadata.Node);
+    }
+
     /// <summary>
     /// Ensures failure-only invocations return reusable failures.
     /// </summary>

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -350,3 +350,52 @@ The default policy remains conservative and unchanged:
 - inline parser actions use `DefaultParserActionExecutor` and are reported as not executed.
 
 Existing constructors that accept `ISemanticPredicateEvaluator` and/or `IParserActionExecutor` are still supported and internally normalized to the runtime policy object.
+
+
+## Metadata lifecycle and observability model
+
+The current runtime uses a strict metadata lifecycle with four phases:
+
+1. **Production**: metadata is produced by runtime components while parsing is orchestrated (scheduler observations, lookahead probes, continuation descriptors, shared-prefix plans, pruning annotations).
+2. **Transport**: metadata is transported through runtime containers (`ActiveParseState`, scheduler results, and `ParserStateRegistry`) to keep orchestration deterministic and auditable.
+3. **Observation**: metadata is inspectable by tests, diagnostics plumbing, and formatting/analysis helpers.
+4. **Discard**: metadata can be ignored or removed without changing parser correctness.
+
+Ownership boundaries in this lifecycle are explicit:
+
+- `ParserEngine` is parse-authoritative (acceptance, parse-tree result, final diagnostics authority).
+- `AlternativeScheduler` owns deterministic orchestration and orchestration-local metadata aggregation.
+- `ParserStateRegistry` owns invocation-local reuse tracking plus metadata transport storage (continuations and related descriptors).
+- `ActiveParseState` owns branch-local descriptive state transport.
+- Continuation metadata, shared-prefix metadata, and lookahead metadata are descriptive artifacts only.
+
+Observability contract:
+
+- Observable metadata includes scheduler metadata, pruning metadata, continuation metadata, lookahead probe metadata, and shared-prefix metadata.
+- Observable does **not** mean authoritative: metadata can be inspected, tested, and used to guide orchestration, but it cannot override parse-authoritative execution.
+
+Non-authority guarantees:
+
+- metadata is descriptive, not parse-authoritative;
+- metadata may influence orchestration ordering/visibility only;
+- metadata must not independently finalize parse acceptance;
+- metadata must not independently finalize diagnostics authority;
+- metadata must not imply semantic equivalence;
+- metadata transport is not execution ownership.
+
+Discardability invariants:
+
+Removing metadata must not change:
+
+- parse-tree shape,
+- syntax validity,
+- parse acceptance,
+- diagnostics authority ownership,
+- semantic behavior.
+
+Additional clarifications that must remain true:
+
+- metadata reuse != semantic equivalence;
+- metadata presence != replay capability;
+- metadata presence != resumability or rollback support;
+- metadata grouping != branch merge permission.

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -351,51 +351,20 @@ The default policy remains conservative and unchanged:
 
 Existing constructors that accept `ISemanticPredicateEvaluator` and/or `IParserActionExecutor` are still supported and internally normalized to the runtime policy object.
 
-
 ## Metadata lifecycle and observability model
 
-The current runtime uses a strict metadata lifecycle with four phases:
+For the detailed lifecycle contract (production, transport, observation, discard) and
+component-by-component ownership boundaries, see:
 
-1. **Production**: metadata is produced by runtime components while parsing is orchestrated (scheduler observations, lookahead probes, continuation descriptors, shared-prefix plans, pruning annotations).
-2. **Transport**: metadata is transported through runtime containers (`ActiveParseState`, scheduler results, and `ParserStateRegistry`) to keep orchestration deterministic and auditable.
-3. **Observation**: metadata is inspectable by tests, diagnostics plumbing, and formatting/analysis helpers.
-4. **Discard**: metadata can be ignored or removed without changing parser correctness.
+- [`RuntimeStateOwnership.md`](./RuntimeStateOwnership.md#metadata-lifecycle-and-observability-model)
 
-Ownership boundaries in this lifecycle are explicit:
+This document keeps only the limitations/non-authority angle:
 
-- `ParserEngine` is parse-authoritative (acceptance, parse-tree result, final diagnostics authority).
-- `AlternativeScheduler` owns deterministic orchestration and orchestration-local metadata aggregation.
-- `ParserStateRegistry` owns invocation-local reuse tracking plus metadata transport storage (continuations and related descriptors).
-- `ActiveParseState` owns branch-local descriptive state transport.
-- Continuation metadata, shared-prefix metadata, and lookahead metadata are descriptive artifacts only.
+- metadata remains descriptive, not parse-authoritative;
+- metadata may inform orchestration visibility, but cannot finalize parse acceptance;
+- metadata cannot independently finalize diagnostics authority;
+- metadata reuse is not semantic equivalence evidence;
+- metadata presence does not imply replay, rollback, or resumability;
+- metadata grouping does not grant branch-merge permission;
+- metadata remains discardable without changing parser correctness.
 
-Observability contract:
-
-- Observable metadata includes scheduler metadata, pruning metadata, continuation metadata, lookahead probe metadata, and shared-prefix metadata.
-- Observable does **not** mean authoritative: metadata can be inspected, tested, and used to guide orchestration, but it cannot override parse-authoritative execution.
-
-Non-authority guarantees:
-
-- metadata is descriptive, not parse-authoritative;
-- metadata may influence orchestration ordering/visibility only;
-- metadata must not independently finalize parse acceptance;
-- metadata must not independently finalize diagnostics authority;
-- metadata must not imply semantic equivalence;
-- metadata transport is not execution ownership.
-
-Discardability invariants:
-
-Removing metadata must not change:
-
-- parse-tree shape,
-- syntax validity,
-- parse acceptance,
-- diagnostics authority ownership,
-- semantic behavior.
-
-Additional clarifications that must remain true:
-
-- metadata reuse != semantic equivalence;
-- metadata presence != replay capability;
-- metadata presence != resumability or rollback support;
-- metadata grouping != branch merge permission.

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -397,3 +397,52 @@ Before any future activation work (such as replay, shared execution, continuatio
 - continuation ownership and execution authority model.
 
 This section documents boundaries only. None of these systems are implemented by the current runtime.
+
+
+## Metadata lifecycle and observability model
+
+The current runtime uses a strict metadata lifecycle with four phases:
+
+1. **Production**: metadata is produced by runtime components while parsing is orchestrated (scheduler observations, lookahead probes, continuation descriptors, shared-prefix plans, pruning annotations).
+2. **Transport**: metadata is transported through runtime containers (`ActiveParseState`, scheduler results, and `ParserStateRegistry`) to keep orchestration deterministic and auditable.
+3. **Observation**: metadata is inspectable by tests, diagnostics plumbing, and formatting/analysis helpers.
+4. **Discard**: metadata can be ignored or removed without changing parser correctness.
+
+Ownership boundaries in this lifecycle are explicit:
+
+- `ParserEngine` is parse-authoritative (acceptance, parse-tree result, final diagnostics authority).
+- `AlternativeScheduler` owns deterministic orchestration and orchestration-local metadata aggregation.
+- `ParserStateRegistry` owns invocation-local reuse tracking plus metadata transport storage (continuations and related descriptors).
+- `ActiveParseState` owns branch-local descriptive state transport.
+- Continuation metadata, shared-prefix metadata, and lookahead metadata are descriptive artifacts only.
+
+Observability contract:
+
+- Observable metadata includes scheduler metadata, pruning metadata, continuation metadata, lookahead probe metadata, and shared-prefix metadata.
+- Observable does **not** mean authoritative: metadata can be inspected, tested, and used to guide orchestration, but it cannot override parse-authoritative execution.
+
+Non-authority guarantees:
+
+- metadata is descriptive, not parse-authoritative;
+- metadata may influence orchestration ordering/visibility only;
+- metadata must not independently finalize parse acceptance;
+- metadata must not independently finalize diagnostics authority;
+- metadata must not imply semantic equivalence;
+- metadata transport is not execution ownership.
+
+Discardability invariants:
+
+Removing metadata must not change:
+
+- parse-tree shape,
+- syntax validity,
+- parse acceptance,
+- diagnostics authority ownership,
+- semantic behavior.
+
+Additional clarifications that must remain true:
+
+- metadata reuse != semantic equivalence;
+- metadata presence != replay capability;
+- metadata presence != resumability or rollback support;
+- metadata grouping != branch merge permission.


### PR DESCRIPTION
### Motivation

- Clarify and centralize metadata lifecycle and observability contracts so future contributors cannot treat metadata as execution authority.  
- Make ownership and discardability invariants explicit for scheduler, registry, active state, continuation, shared-prefix, and lookahead metadata.  
- Lock those invariants with targeted tests while preserving all runtime behavior and public APIs.

### Description

- Added a focused "Metadata lifecycle and observability model" section to `docs/parser/RuntimeStateOwnership.md` and `docs/parser/ParserMetadataAndRuntimeLimitations.md` that explicitly describes the phases `production`, `transport`, `observation`, and `discard`, ownership boundaries (`ParserEngine`, `AlternativeScheduler`, `ParserStateRegistry`, `ActiveParseState`), observable vs non-authoritative metadata, and discardability invariants.  
- Strengthened source-level comments to reinforce non-authority semantics in metadata types by updating `Utils.Parser/Runtime/ParserSharedPrefixPlan.cs` and `Utils.Parser/Runtime/ParserLookaheadProbeResult.cs`.  
- Added focused invariant tests in `UtilsTest/Parser` to assert metadata-only semantics without changing execution: `Run_MetadataProbeDifferences_DoNotChangeSelectedState` (ensures different probe payloads do not change scheduler selection) and `Registry_RemovingContinuationMetadata_DoesNotChangeReusableCompletedResult` (ensures continuation metadata discardability vs registry memoization).  
- Files modified: `docs/parser/RuntimeStateOwnership.md`, `docs/parser/ParserMetadataAndRuntimeLimitations.md`, `Utils.Parser/Runtime/ParserSharedPrefixPlan.cs`, `Utils.Parser/Runtime/ParserLookaheadProbeResult.cs`, `UtilsTest/Parser/AlternativeSchedulerTests.cs`, `UtilsTest/Parser/ParserStateRegistryTests.cs`.

### Testing

- Ran targeted parser runtime tests with: `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~AlternativeSchedulerTests|FullyQualifiedName~ParserStateRegistryTests|FullyQualifiedName~ActiveParseStateTests|FullyQualifiedName~ParserLookahead"`.  
- Result: all targeted tests passed (Passed: 78, Failed: 0).  
- No runtime behavior, parse-tree shape, diagnostics output, or public API changes were introduced; the changes are documentation + tests only and preserve conservative semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a19b8072083268fd0b0d8009ed5ac)