### PR TITLE
tests + docs: consolidate deterministic runtime observability boundaries

### DIFF
--- a/Utils.Parser/Runtime/AlternativeSchedulingMetadata.cs
+++ b/Utils.Parser/Runtime/AlternativeSchedulingMetadata.cs
@@ -2,6 +2,8 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Holds informational metadata produced during alternative scheduling.
+/// This container is observable and testable, but non-authoritative:
+/// metadata here cannot override parse acceptance, parse-tree shape, or diagnostics authority.
 /// </summary>
 internal sealed class AlternativeSchedulingMetadata
 {

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutionResult.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutionResult.cs
@@ -3,6 +3,10 @@ namespace Utils.Parser.Runtime;
 /// <summary>
 /// Represents the result of one scheduled alternative execution attempt,
 /// including both parse state and shallow look-ahead observation metadata.
+/// <para>
+/// <see cref="State"/> is the only candidate for scheduler selection.
+/// <see cref="Probe"/> is observable orchestration metadata and does not authorize acceptance on its own.
+/// </para>
 /// </summary>
 internal readonly record struct ScheduledAlternativeExecutionResult(
     ActiveParseState? State,

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -170,6 +170,63 @@ public class AlternativeSchedulerTests
         Assert.AreEqual(withMetadata.SelectedState.AlternativeIndex, withoutMetadata.SelectedState.AlternativeIndex);
     }
 
+    [TestMethod]
+    public void Run_DeterministicSelection_UsesLengthThenPriorityThenAlternativeIndex()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = new Rule("r", 0, false, new Alternation([
+            new Alternative(4, Associativity.Left, new LiteralMatch("a"), "A"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "A"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "A")
+        ]));
+        var context = new ParseContext([]);
+
+        var result = scheduler.Run(
+            rule,
+            rule.Content.Alternatives,
+            originInputPosition: context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (alternative, index) => index switch
+            {
+                0 => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 10, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)),
+                1 => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 12, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)),
+                _ => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 12, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null))
+            });
+
+        Assert.IsNotNull(result.SelectedState);
+        Assert.AreEqual(12, result.SelectedState.CurrentInputPosition);
+        Assert.AreEqual(1, result.SelectedState.Alternative.Priority);
+        Assert.AreEqual(1, result.SelectedState.AlternativeIndex);
+    }
+
+    [TestMethod]
+    public void Run_PrunedStatesAssertions_AreMembershipBased_NotOrderBased()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = new Rule("r", 0, false, new Alternation([
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "X"),
+            new Alternative(2, Associativity.Left, new LiteralMatch("a"), "X"),
+            new Alternative(3, Associativity.Left, new LiteralMatch("a"), "Y")
+        ]));
+        var context = new ParseContext([]);
+
+        var result = scheduler.Run(
+            rule,
+            rule.Content.Alternatives,
+            originInputPosition: context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, context.Position, 8, index),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
+
+        Assert.AreEqual(1, result.PrunedStates.Count);
+        Assert.IsTrue(result.PrunedStates.All(static state => state.Status == ActiveParseStateStatus.Pruned));
+        Assert.IsTrue(result.CompletedStates.Any(static state => state.Alternative.Label == "X"));
+        Assert.IsTrue(result.CompletedStates.Any(static state => state.Alternative.Label == "Y"));
+    }
+
     private static (ParseContext Context, Rule Rule, IReadOnlyList<Alternative> Alternatives) CreateAlternatives()
     {
         var a = new Alternative(2, Associativity.Left, new LiteralMatch("a"), "A");
@@ -205,4 +262,3 @@ public class AlternativeSchedulerTests
         };
     }
 }
-

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -368,3 +368,53 @@ This document keeps only the limitations/non-authority angle:
 - metadata grouping does not grant branch-merge permission;
 - metadata remains discardable without changing parser correctness.
 
+## Deterministic runtime observability model (limitations view)
+
+This limitations-oriented view aligns with `RuntimeStateOwnership.md` and avoids introducing new runtime guarantees.
+
+### Authoritative runtime behavior (owned by parse authority)
+
+Authoritative/stable boundaries remain:
+
+- parse acceptance/rejection,
+- parse-tree outcome authority,
+- final diagnostics authority,
+- deterministic correctness from real parser execution,
+- documented invocation reuse behavior in `ParserStateRegistry`.
+
+### Observable orchestration behavior (testable, non-authoritative)
+
+Observable/runtime-analysis artifacts include:
+
+- scheduler metadata,
+- pruning metadata/diagnostics,
+- continuation/shared-prefix metadata,
+- lookahead probe observations,
+- branch grouping observations,
+- completed-state and related orchestration collections.
+
+Observable does not mean parse-authoritative.
+
+### Non-contractual implementation details
+
+Unless explicitly documented, the following are implementation details:
+
+- internal iteration/traversal details,
+- internal metadata grouping/storage shape,
+- local container/layout choices,
+- incidental ordering of internal collections.
+
+Tests should prefer structural equivalence and membership/group assertions over undocumented ordering assertions.
+
+### Explicit ordering semantics boundary
+
+Currently deterministic where documented:
+
+- alternative scheduling by priority,
+- local candidate comparison order (longest consumed input, then lower priority value, then lower alternative index).
+
+Not guaranteed:
+
+- incidental dictionary/set traversal order,
+- incidental internal metadata collection order,
+- undocumented internal grouping traversal order.

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -32,6 +32,48 @@ The parser runtime is authority-layered.
 - Supporting runtime components provide orchestration, probing, caching, and metadata.
 - Metadata components are descriptive and cannot decide parse outcomes on their own.
 
+## Deterministic runtime observability model
+
+This section clarifies what is intentionally contractual versus what remains implementation-internal.
+
+### A) Authoritative runtime behavior (stable contract)
+
+The following are runtime-authoritative and intentionally stable:
+
+- parse acceptance/rejection ownership (`ParserEngine`),
+- parse-tree result ownership and shape authority (`ParserEngine`),
+- final diagnostics authority and emission ownership (`ParserEngine`),
+- deterministic correctness behavior from real parser execution,
+- invocation reuse semantics documented for `ParserStateRegistry.TryGetReusableResult`,
+- metadata-only boundaries (metadata remains non-execution authority).
+
+These are intended runtime guarantees.
+
+### B) Observable orchestration behavior (non-authoritative but testable)
+
+The following are observable and can be tested as runtime-analysis artifacts:
+
+- scheduler metadata and selected local candidate transport,
+- pruning observations and pruning diagnostics,
+- continuation metadata and shared-prefix plan metadata,
+- lookahead probe observations,
+- branch grouping observations,
+- completed/failed/pruned state collections.
+
+These are intentionally observable for deterministic auditing, but remain non-authoritative.
+
+### C) Non-contractual implementation details (must not be frozen by tests)
+
+The following are intentionally non-contractual unless explicitly documented otherwise:
+
+- internal collection traversal details,
+- internal grouping container layout,
+- metadata storage shape/internal representation,
+- local orchestration implementation structure,
+- incidental ordering not explicitly listed as deterministic.
+
+Tests should avoid relying on these details.
+
 ## Parsing authority
 
 `ParserEngine` remains the authoritative parser execution component.
@@ -333,6 +375,22 @@ Current local comparison uses the following stable ordering:
 3. lower `AlternativeIndex`.
 
 This ordering is used in scheduler deduplication and best-candidate selection, and is intentionally deterministic.
+
+### Ordering semantics: guaranteed vs not guaranteed
+
+Guaranteed deterministic ordering in current runtime:
+
+- alternative scheduling input ordering by `Alternative.Priority` (ascending),
+- local candidate comparison order: longest consumed input, then lower priority value, then lower alternative index,
+- deterministic selected-state resolution from the above comparison.
+
+Not guaranteed as ordered contracts:
+
+- dictionary/hash-set iteration order used internally for grouping and metadata transport,
+- incidental traversal order of observational collections unless documented by a specific contract,
+- internal layout/order of metadata group storage.
+
+Collections without explicit ordering guarantees should be tested as membership/grouping sets.
 
 ### Branch equivalence and pruning eligibility
 


### PR DESCRIPTION
### Motivation

- Reduce test coupling to implementation internals by making deterministic observability boundaries explicit.  
- Clarify which runtime artifacts are authoritative (parser-owned) versus observable orchestration metadata (non-authoritative) without changing runtime behavior.  
- Add focused invariants to document and guard existing deterministic scheduling contracts so future tests remain audit-friendly and conservative.

### Description

- Added a dedicated "Deterministic runtime observability model" and explicit ordering-semantics clarifications to `docs/parser/RuntimeStateOwnership.md` and aligned limitations text in `docs/parser/ParserMetadataAndRuntimeLimitations.md`.  
- Reinforced metadata/non-authority guidance with concise source comments in `Utils.Parser/Runtime/ScheduledAlternativeExecutionResult.cs` and `Utils.Parser/Runtime/AlternativeSchedulingMetadata.cs`.  
- Extended `UtilsTest/Parser/AlternativeSchedulerTests.cs` with focused invariant tests that assert the documented deterministic tie-break (`length -> priority -> alternative index`) and membership-based assertions for pruned/completed groups to avoid over-constraining incidental ordering.  
- No runtime logic, public API, parse-tree shape, diagnostics content, or roadmap direction was changed.

### Testing

- Ran targeted parser-runtime tests using `dotnet test` for scheduler/registry/state areas (`AlternativeSchedulerTests`, `ParserStateRegistryTests`, `ActiveParseStateTests`, `AlternativeSchedulingMetadataTests`, `ScheduledAlternativeExecutorTests`).  
- All targeted tests passed: `Passed: 63, Failed: 0` with the restoration/build completing successfully.  
- Validation shows documentation and test additions only and confirms no runtime behavior changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1d293cc88326a9caa3626a715fcf)