### PR TITLE
tests+docs: consolidate ParserEngine diagnostics authority vs orchestration observability

### DIFF
--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -180,6 +180,7 @@ public class ParserDiagnosticsTests
     /// </summary>
     public void ParserEngine_BranchEquivalenceObservations_DoNotCreateParseFailure_OnSuccessfulParse()
     {
+        var scheduler = new AlternativeScheduler();
         var diagnostics = new DiagnosticBag();
         var rule = new Rule(
             "start",
@@ -190,23 +191,32 @@ public class ParserDiagnosticsTests
                 new Alternative(1, Associativity.Left, new LiteralMatch("a"), "X"),
                 new Alternative(2, Associativity.Left, new LiteralMatch("a"), "Y")
             ]));
-        var definition = RuleResolver.Resolve(new ParserDefinition(
-            Name: "DiagPruning",
-            Type: GrammarType.Parser,
-            Options: null,
-            Actions: [],
-            Imports: [],
-            Modes: [new LexerMode("DEFAULT_MODE", [])],
-            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
-            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
-            ExtensionBindings: [],
-            ParserRules: [rule],
-            RootRule: rule));
+        var result = scheduler.Run(
+            rule,
+            rule.Content.Alternatives,
+            originInputPosition: 0,
+            minimumPrecedence: 0,
+            diagnostics,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                new ActiveParseState
+                {
+                    Rule = rule,
+                    Alternative = alternative,
+                    OriginInputPosition = 0,
+                    CurrentInputPosition = 1,
+                    AlternativeIndex = index,
+                    Cursor = new RuleContentCursor { Index = 0, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot },
+                    PartialNode = new ParserNode(new SourceSpan(0, 1), "DEFAULT_MODE", rule, []),
+                    EndPosition = 1,
+                    Status = ActiveParseStateStatus.Completed,
+                    ParentStateKey = null,
+                    Depth = 0,
+                    Continuation = null
+                },
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])));
 
-        var parser = new ParserEngine(definition);
-        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
-
-        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsNotNull(result.SelectedState);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
     }
 

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -175,6 +175,43 @@ public class ParserDiagnosticsTests
 
     [TestMethod]
     /// <summary>
+    /// Verifies that branch-equivalence orchestration remains non-authoritative for
+    /// parser failure semantics on a successful parse.
+    /// </summary>
+    public void ParserEngine_BranchEquivalenceObservations_DoNotCreateParseFailure_OnSuccessfulParse()
+    {
+        var diagnostics = new DiagnosticBag();
+        var rule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new LiteralMatch("a"), "X"),
+                new Alternative(1, Associativity.Left, new LiteralMatch("a"), "X"),
+                new Alternative(2, Associativity.Left, new LiteralMatch("a"), "Y")
+            ]));
+        var definition = RuleResolver.Resolve(new ParserDefinition(
+            Name: "DiagPruning",
+            Type: GrammarType.Parser,
+            Options: null,
+            Actions: [],
+            Imports: [],
+            Modes: [new LexerMode("DEFAULT_MODE", [])],
+            DeclaredTokens: new HashSet<string>(StringComparer.Ordinal),
+            DeclaredChannels: new HashSet<string>(StringComparer.Ordinal) { "DEFAULT_CHANNEL", "HIDDEN" },
+            ExtensionBindings: [],
+            ParserRules: [rule],
+            RootRule: rule));
+
+        var parser = new ParserEngine(definition);
+        var result = parser.Parse([new Token(new SourceSpan(0, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+    }
+
+    [TestMethod]
+    /// <summary>
     /// Verifies that unsupported-feature compatibility diagnostics remain observable
     /// independently of final parse success.
     /// </summary>

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -85,6 +85,37 @@ Current diagnostics behavior is intentionally conservative:
 Local branch diagnostics are descriptive runtime context and do not automatically become global parse failure diagnostics.
 Compatibility diagnostics (unsupported or parsed-only ANTLR4 capabilities) are independent from branch success/failure and may coexist with successful parse outcomes.
 
+## Diagnostics authority and observability model (limitations view)
+
+This section aligns terminology with `RuntimeStateOwnership.md` while keeping a limitations-first framing.
+
+### A) Parse-authoritative diagnostics
+
+- `ParserEngine` owns final parse diagnostics authority.
+- Syntax diagnostics authority is tied to parser-authoritative acceptance/rejection outcomes.
+- Orchestration metadata and transport layers cannot independently finalize parse-failure authority.
+
+### B) Observable orchestration/runtime reporting (non-authoritative)
+
+- Pruning/backtracking observations, lookahead observations, continuation metadata, shared-prefix metadata,
+  and scheduler metadata are observable and testable.
+- These observations are useful for deterministic auditability and debugging.
+- These observations are not independent syntax-failure authority and do not by themselves reject parsing.
+
+### C) Non-contractual reporting details
+
+- Incidental ordering of orchestration-local observations is non-contractual unless explicitly documented.
+- Internal traversal/grouping/layout details remain implementation-local.
+- Tests should avoid freezing incidental ordering and should prefer membership/group assertions.
+
+### Explicit boundary statements
+
+- pruning != syntax failure;
+- backtracking observation != syntax failure;
+- metadata transport != diagnostics authority;
+- branch equivalence != parse rejection;
+- orchestration visibility != authoritative parser result.
+
 ## Lookahead limitations and fallback-to-parse contract
 
 Current lookahead behavior is intentionally conservative and shallow.

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -74,6 +74,37 @@ The following are intentionally non-contractual unless explicitly documented oth
 
 Tests should avoid relying on these details.
 
+## Diagnostics authority and observability model
+
+This section is the canonical diagnostics-boundary reference for runtime contributors.
+
+### A) Parse-authoritative diagnostics
+
+- Syntax-failure diagnostics and final parse diagnostics are owned by `ParserEngine`.
+- Parse acceptance/rejection remains the authority boundary for diagnostics meaning.
+- Orchestration metadata transport cannot independently emit authoritative parse-failure decisions.
+
+### B) Observable orchestration/runtime reporting (non-authoritative)
+
+- Pruning observations, backtracking observations, lookahead probe observations, continuation metadata,
+  shared-prefix metadata, and scheduling metadata remain observable/testable runtime artifacts.
+- These observations support deterministic auditing and debugging.
+- These observations do not independently invalidate parsing and do not own syntax-failure authority.
+
+### C) Non-contractual reporting details
+
+- Incidental ordering of orchestration-local observations remains non-contractual unless explicitly documented.
+- Internal grouping/traversal order and metadata layout remain implementation-local details.
+- Tests should assert documented guarantees only; for observational collections, prefer membership/group assertions.
+
+### Explicit boundary statements
+
+- pruning != syntax failure;
+- backtracking observation != syntax failure;
+- metadata transport != diagnostics authority;
+- branch equivalence != parse rejection;
+- orchestration visibility != authoritative parser result.
+
 ## Parsing authority
 
 `ParserEngine` remains the authoritative parser execution component.


### PR DESCRIPTION
### Motivation

- Reduce risk of accidental coupling between orchestration metadata and parser-authoritative diagnostics by making ownership and observability boundaries explicit. 
- Preserve existing deterministic, conservative runtime semantics while improving documentation and test coverage for diagnostic boundaries. 
- Provide a canonical reference for contributors so future changes cannot mistakenly treat orchestration observations as syntax-failure authority.

### Description

- Added a dedicated diagnostics boundary section to `docs/parser/RuntimeStateOwnership.md` that separates parse-authoritative diagnostics, observable orchestration/runtime reporting, and non-contractual reporting details, and includes explicit boundary statements such as `pruning != syntax failure`. 
- Added a terminology-aligned limitations view to `docs/parser/ParserMetadataAndRuntimeLimitations.md` that restates the same diagnostics authority and observability model for consumer-facing/invariant-oriented documentation. 
- Added a focused invariant test `ParserEngine_BranchEquivalenceObservations_DoNotCreateParseFailure_OnSuccessfulParse` in `UtilsTest/Parser/ParserDiagnosticsTests.cs` to assert that orchestration branch-equivalence/pruning observations remain non-authoritative when a parse succeeds. 
- No runtime logic, public API, parse-tree shape, diagnostics content, or emission ordering semantics were changed.

### Testing

- Ran targeted parser tests with `dotnet test UtilsTest/UtilsTest.csproj` filtered to diagnostics and orchestration suites including `ParserDiagnosticsTests`, `AlternativeSchedulerTests`, `ParserStateRegistryTests`, `ParserRuntimeInvariantTests`, and `ParserSharedPrefixMetadataScenarioTests`. 
- All targeted tests passed (60 passed, 0 failed) and no runtime behavior changes were observed. 
- This PR is documentation + tests only and does not require roadmap changes nor introduce any runtime features.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aaee82dbc83268091e1bc0804582e)