### PR TITLE
Parser: consolidate continuation lifecycle and shared-prefix observability invariants

### DIFF
--- a/Utils.Parser/Runtime/ActiveParseState.cs
+++ b/Utils.Parser/Runtime/ActiveParseState.cs
@@ -106,6 +106,11 @@ internal sealed record ActiveParseState
     public ActiveParseStateStatus Status { get; init; }
     public ActiveParseStateKey? ParentStateKey { get; init; }
     public int Depth { get; init; }
+    /// <summary>
+    /// Optional continuation transport metadata.
+    /// This value is observable but non-authoritative and remains discardable
+    /// without changing parse-authoritative correctness.
+    /// </summary>
     public ContinuationKey? Continuation { get; init; }
 
     public ActiveParseStateKey ToStateKey(int minimumPrecedence) => new(

--- a/Utils.Parser/Runtime/ActiveParseState.cs
+++ b/Utils.Parser/Runtime/ActiveParseState.cs
@@ -91,20 +91,54 @@ internal enum ActiveParseStateStatus
 /// </summary>
 internal sealed record ActiveParseState
 {
+    /// <summary>
+    /// Parser rule associated with this local scheduling state.
+    /// </summary>
     public required Rule Rule { get; init; }
+    /// <summary>
+    /// Alternative associated with this local scheduling state.
+    /// </summary>
     public required Alternative Alternative { get; init; }
+    /// <summary>
+    /// Input position where this rule invocation started.
+    /// </summary>
     public required int OriginInputPosition { get; init; }
+    /// <summary>
+    /// Current input position reached by this local state.
+    /// </summary>
     public required int CurrentInputPosition { get; init; }
+    /// <summary>
+    /// Stable scheduler-local index of the explored alternative.
+    /// </summary>
     public required int AlternativeIndex { get; init; }
+    /// <summary>
+    /// Local traversal cursor describing where exploration currently is in the alternative content.
+    /// </summary>
     public required RuleContentCursor Cursor { get; init; }
     /// <summary>
     /// Local partial parse node for branch-level scheduling.
     /// It is descriptive only and does not grant parse-tree authority.
     /// </summary>
     public required ParseNode PartialNode { get; init; }
+    /// <summary>
+    /// Optional local end position for completed/failed states.
+    /// When null, the state is still represented by its current input position.
+    /// </summary>
     public int? EndPosition { get; init; }
+    /// <summary>
+    /// Local branch status used by scheduling orchestration.
+    /// This status is descriptive and not parse-authoritative.
+    /// </summary>
     public ActiveParseStateStatus Status { get; init; }
+    /// <summary>
+    /// Optional lineage key for parent scheduling state metadata.
+    /// This is not an executable runtime stack frame reference.
+    /// </summary>
     public ActiveParseStateKey? ParentStateKey { get; init; }
+    /// <summary>
+    /// Structural lineage depth for scheduling metadata.
+    /// This value is descriptive and does not model semantic invocation depth.
+    /// </summary>
     public int Depth { get; init; }
     /// <summary>
     /// Optional continuation transport metadata.

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -117,6 +117,9 @@ internal sealed class AlternativeScheduler
                 candidateIndexes.Contains(index)));
         }
 
+        // Shared-prefix plans remain observational scheduler metadata:
+        // they expose deterministic grouping information, but never grant
+        // replay/resume/merge authority and never replace real parser execution.
         var plans = _sharedPrefixPlanFactory.CreatePlans(candidates, continuations);
         return new AlternativeSchedulingMetadata { SharedPrefixPlans = plans };
     }

--- a/Utils.Parser/Runtime/ParserLookaheadSharedPrefixCandidate.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadSharedPrefixCandidate.cs
@@ -2,6 +2,8 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Represents a shallow shared first-token candidate observed across multiple alternatives.
+/// This candidate is observational grouping metadata only:
+/// it does not authorize execution sharing, replay, or branch merging.
 /// </summary>
 internal readonly record struct ParserLookaheadSharedPrefixCandidate(
     string TokenName,

--- a/Utils.Parser/Runtime/ParserStateRegistry.cs
+++ b/Utils.Parser/Runtime/ParserStateRegistry.cs
@@ -74,6 +74,7 @@ internal sealed class ParserStateRegistry
     /// <summary>
     /// Gets continuations previously registered for an invocation.
     /// Returned values are metadata snapshots and remain discardable from an execution-authority perspective.
+    /// Retrieval does not provide replay/resume capability and does not imply executable parser frames.
     /// </summary>
     public IReadOnlyList<ContinuationKey> GetContinuations(RuleInvocationKey invocation)
     {

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -334,6 +334,10 @@ public class ParserRuntimeInvariantTests
         Assert.AreEqual(continuation, continuations[0]);
     }
 
+    /// <summary>
+    /// Ensures continuation metadata can be present or absent without changing
+    /// invocation-level reusable result selection semantics.
+    /// </summary>
     [TestMethod]
     public void ContinuationMetadata_Discardability_DoesNotChangeReusableResultSelection()
     {
@@ -391,6 +395,10 @@ public class ParserRuntimeInvariantTests
         Assert.AreEqual(0, advanced.Continuation?.ResumePosition);
     }
 
+    /// <summary>
+    /// Verifies shared-prefix metadata remains observational and does not authorize
+    /// semantic branch merge across alternatives with distinct labels.
+    /// </summary>
     [TestMethod]
     public void SharedPrefixMetadata_Observation_DoesNotAuthorizeBranchMergeAcrossDistinctSemantics()
     {
@@ -416,6 +424,10 @@ public class ParserRuntimeInvariantTests
         Assert.AreEqual(0, result.PrunedStates.Count);
     }
 
+    /// <summary>
+    /// Creates a deterministic completed <see cref="ActiveParseState"/> for scheduler-focused
+    /// metadata invariant tests without introducing parser-authoritative behavior changes.
+    /// </summary>
     private static ActiveParseState CreateState(Rule rule, Alternative alternative, int index, int endPosition)
     {
         return new ActiveParseState

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -335,6 +335,25 @@ public class ParserRuntimeInvariantTests
     }
 
     [TestMethod]
+    public void ContinuationMetadata_Discardability_DoesNotChangeReusableResultSelection()
+    {
+        var invocation = new RuleInvocationKey("expr", 0, 0);
+        var successNode = new ParserNode(new SourceSpan(0, 1), "DEFAULT_MODE", null, []);
+        var reusableSuccess = new ParserRuleResult(successNode, 1, false);
+        var registryWithContinuation = new ParserStateRegistry();
+        var registryWithoutContinuation = new ParserStateRegistry();
+
+        Assert.IsTrue(registryWithContinuation.AddCompletedResult(invocation, reusableSuccess));
+        Assert.IsTrue(registryWithoutContinuation.AddCompletedResult(invocation, reusableSuccess));
+        Assert.IsTrue(registryWithContinuation.AddContinuation(invocation, new ContinuationKey("expr", 0, 0, 1, 0)));
+
+        Assert.IsTrue(registryWithContinuation.TryGetReusableResult(invocation, out var withContinuation));
+        Assert.IsTrue(registryWithoutContinuation.TryGetReusableResult(invocation, out var withoutContinuation));
+        Assert.AreEqual(withoutContinuation.EndPosition, withContinuation.EndPosition);
+        Assert.AreEqual(withoutContinuation.IsFailure, withContinuation.IsFailure);
+    }
+
+    [TestMethod]
     public void ContinuationIdentity_DoesNotImplySemanticRuntimeEquivalence()
     {
         var continuation = new ContinuationKey("expr", 0, 1, 4, 0);
@@ -370,6 +389,50 @@ public class ParserRuntimeInvariantTests
         Assert.AreEqual(1, advanced.CurrentInputPosition);
         Assert.AreEqual(0, state.Continuation?.ResumePosition);
         Assert.AreEqual(0, advanced.Continuation?.ResumePosition);
+    }
+
+    [TestMethod]
+    public void SharedPrefixMetadata_Observation_DoesNotAuthorizeBranchMergeAcrossDistinctSemantics()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = new Rule("expr", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new RuleRef("ID"), "label-a"),
+            new Alternative(1, Associativity.Left, new RuleRef("ID"), "label-b")
+        ]));
+
+        var result = scheduler.Run(
+            rule,
+            rule.Content.Alternatives,
+            0,
+            0,
+            diagnostics: null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, index, 1),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
+
+        Assert.AreEqual(1, result.Metadata.SharedPrefixPlans.Count);
+        CollectionAssert.AreEquivalent(new[] { 0, 1 }, result.Metadata.SharedPrefixPlans[0].AlternativeIndexes.ToArray());
+        Assert.AreEqual(2, result.CompletedStates.Count);
+        Assert.AreEqual(0, result.PrunedStates.Count);
+    }
+
+    private static ActiveParseState CreateState(Rule rule, Alternative alternative, int index, int endPosition)
+    {
+        return new ActiveParseState
+        {
+            Rule = rule,
+            Alternative = alternative,
+            OriginInputPosition = 0,
+            CurrentInputPosition = endPosition,
+            AlternativeIndex = index,
+            Cursor = new RuleContentCursor { Index = 0, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot },
+            PartialNode = new ParserNode(new SourceSpan(0, endPosition), "DEFAULT_MODE", rule, []),
+            EndPosition = endPosition,
+            Status = ActiveParseStateStatus.Completed,
+            ParentStateKey = null,
+            Depth = 0,
+            Continuation = null
+        };
     }
 
     private static ParserDefinition CreateDefinition(Rule startRule, Rule[] parserRules, params Rule[] lexerRules)

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -161,6 +161,23 @@ Current structural limitations:
 
 These are current runtime facts, not temporary promises.
 
+### Continuation lifecycle model (limitations view)
+
+Continuation metadata lifecycle remains strictly descriptive:
+
+1. produced from deterministic parser context,
+2. attached/transported as metadata,
+3. observed for auditing/tests/formatting,
+4. discarded without changing parse-authoritative behavior.
+
+Interpretation boundaries that must remain explicit:
+
+- continuation metadata != replay capability;
+- continuation metadata != resumability;
+- continuation transport != execution authority;
+- continuation metadata != branch merge permission;
+- continuation metadata != semantic-equivalence proof.
+
 ## 1) Parameters and `returns`: parsed and preserved as metadata
 
 The grammar ingestion pipeline supports ANTLR4-style rule signatures such as:
@@ -231,6 +248,23 @@ Lifecycle clarifications:
 - observability: metadata is observable for audit/documentation purposes only.
 
 Metadata lifecycle remains independent from parse authority and diagnostics authority.
+
+### Shared-prefix observability model (limitations view)
+
+Shared-prefix metadata remains observational/grouping-only metadata:
+
+- it exists for deterministic runtime visibility,
+- it does not authorize execution sharing,
+- it does not authorize branch merge,
+- it does not establish semantic equivalence,
+- it does not change parse-authoritative selection or diagnostics authority.
+
+Shared-prefix lifecycle remains:
+
+1. production (lookahead + scheduler context),
+2. transport (metadata containers),
+3. observation (auditability/debugging/tests),
+4. discardability (no parser-correctness impact).
 
 ## Conservative preconditions before any future activation work
 

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -212,6 +212,29 @@ Lifecycle (current behavior only):
 
 Continuations are therefore independent from parse authority and independent from diagnostics authority.
 
+### Continuation lifecycle model (consolidated)
+
+Continuation metadata follows a strict, metadata-only lifecycle:
+
+1. **Production**: continuation identities/descriptors are produced from deterministic parser context (rule, alternative, sequence/cursor, position).
+2. **Attachment/transport**: continuation keys may be attached to `ActiveParseState` and transported through `ParserStateRegistry`.
+3. **Observability**: continuation metadata can be inspected for auditing, formatting, diagnostics context, and invariant tests.
+4. **Discardability**: continuation metadata can be ignored or removed without changing parse correctness, parse-tree shape, diagnostics authority, or final acceptance ownership.
+
+Mandatory ownership boundary:
+
+- `ParserEngine` remains parse-authoritative.
+- Continuation metadata remains orchestration/runtime metadata only.
+- Continuation metadata never owns execution authority.
+
+Explicit non-feature boundaries:
+
+- continuation metadata != replay support;
+- continuation metadata != resumable execution frame;
+- continuation transport != execution ownership;
+- continuation metadata != branch-merge authorization;
+- continuation metadata != semantic equivalence guarantee.
+
 ## Runtime identity and equivalence model
 
 Parser runtime identities are intentionally split by ownership purpose and must remain distinct.
@@ -471,6 +494,28 @@ Explicit non-authority guarantees:
 - metadata does not establish semantic equivalence,
 - metadata does not imply rollback safety,
 - metadata does not override diagnostics ownership.
+
+### Shared-prefix observability model (consolidated)
+
+Shared-prefix metadata is deterministic observability/grouping metadata:
+
+- it exposes orchestration/runtime structure;
+- it does not execute shared prefixes;
+- it does not alter parse-authoritative behavior.
+
+Shared-prefix grouping boundaries:
+
+- grouping != execution sharing;
+- grouping != semantic equivalence;
+- grouping != branch-merge permission;
+- grouping remains non-authoritative.
+
+Shared-prefix lifecycle boundaries:
+
+1. **Production** from shallow lookahead and scheduler context.
+2. **Transport** through scheduling/registry metadata containers.
+3. **Observation** for deterministic auditing and diagnostics-adjacent visibility.
+4. **Discardability** without changing parser correctness or parse authority.
 
 ## Future activation preconditions (documentation boundary only)
 


### PR DESCRIPTION
### Motivation

- Clarify and harden continuation lifecycle ownership and shared-prefix observability so metadata remains descriptive only and cannot be misinterpreted as execution authority.  
- Prevent accidental broadening toward replay/resume/merge/execution-sharing by consolidating explicit non-goals and lifecycle boundaries in docs, source comments, and invariants tests.  

### Description

- Documentation: add consolidated lifecycle/observability sections to `docs/parser/RuntimeStateOwnership.md` and `docs/parser/ParserMetadataAndRuntimeLimitations.md` that describe continuation lifecycle phases and shared-prefix observability semantics and state explicit non-authority boundaries.  
- Source comments: add concise guardrail comments in `Utils.Parser/Runtime/AlternativeScheduler.cs`, `Utils.Parser/Runtime/ActiveParseState.cs`, `Utils.Parser/Runtime/ParserStateRegistry.cs`, and `Utils.Parser/Runtime/ParserLookaheadSharedPrefixCandidate.cs` to reinforce metadata-only semantics and discardability guarantees.  
- Tests: add focused invariant tests in `UtilsTest/Parser/ParserRuntimeInvariantTests.cs` to assert continuation discardability does not affect reusable-result selection and shared-prefix observation does not authorize branch merge; existing parser invariants preserved.  
- Modified files: `docs/parser/RuntimeStateOwnership.md`, `docs/parser/ParserMetadataAndRuntimeLimitations.md`, `Utils.Parser/Runtime/AlternativeScheduler.cs`, `Utils.Parser/Runtime/ActiveParseState.cs`, `Utils.Parser/Runtime/ParserStateRegistry.cs`, `Utils.Parser/Runtime/ParserLookaheadSharedPrefixCandidate.cs`, and `UtilsTest/Parser/ParserRuntimeInvariantTests.cs`.

### Testing

- Ran targeted parser tests with: `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ParserRuntimeInvariantTests|FullyQualifiedName~AlternativeSchedulerTests|FullyQualifiedName~ParserStateRegistryTests|FullyQualifiedName~AlternativeSchedulingMetadataTests"`.  
- Result: all targeted tests passed (Passed: 59, Failed: 0) and no runtime behavior changes were introduced.  
- Notes: build emitted pre-existing repository/package warnings unrelated to these changes; tests remain green and validate metadata-only invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad9f8de7883269153aef6935afdb7)