### PR TITLE
docs(parser): consolidate duplicated-work constraints and execution-sharing boundaries

### DIFF
--- a/Utils.Parser/Runtime/ActiveParseState.cs
+++ b/Utils.Parser/Runtime/ActiveParseState.cs
@@ -185,12 +185,35 @@ internal sealed record ActiveParseState
     /// The attached key is descriptive and never executable replay authority.
     /// </summary>
     public ActiveParseState WithContinuation(ContinuationKey continuation) => this with { Continuation = continuation };
+    /// <summary>
+    /// Advances local descriptive traversal state.
+    /// This update is orchestration metadata only and does not imply execution replay capability.
+    /// </summary>
     public ActiveParseState Advance(int currentInputPosition, RuleContentCursor cursor) => this with { CurrentInputPosition = currentInputPosition, Cursor = cursor };
+    /// <summary>
+    /// Attaches lineage metadata for deterministic runtime observability.
+    /// Lineage metadata is non-executable and does not represent resumable runtime frames.
+    /// </summary>
     public ActiveParseState WithLineage(ActiveParseStateKey? parentStateKey, int depth) => this with { ParentStateKey = parentStateKey, Depth = depth };
+    /// <summary>
+    /// Projects this descriptive state into parser visited-state identity.
+    /// </summary>
     public ParserStateKey ToParserStateKey(int minimumPrecedence) => new(Rule.Name, CurrentInputPosition, AlternativeIndex, Cursor.Index, minimumPrecedence);
+    /// <summary>
+    /// Projects this state into invocation-reuse identity.
+    /// Invocation reuse identity is not execution-replay identity.
+    /// </summary>
     public RuleInvocationKey ToRuleInvocationKey(int minimumPrecedence) => new(Rule.Name, OriginInputPosition, minimumPrecedence);
+    /// <summary>
+    /// Builds continuation transport metadata from the current descriptive state.
+    /// Returned key is metadata-only and not executable continuation state.
+    /// </summary>
     public ContinuationKey ToContinuationKey(int resumePosition, int minimumPrecedence) => new(Rule.Name, AlternativeIndex, Cursor.Index, resumePosition, minimumPrecedence);
 
+    /// <summary>
+    /// Rehydrates descriptive scheduling state from a branch snapshot.
+    /// This conversion does not reconstruct execution history.
+    /// </summary>
     public static ActiveParseState FromBranch(ParseBranch branch) => new()
     {
         Rule = branch.Rule,

--- a/Utils.Parser/Runtime/ParserStateRegistry.cs
+++ b/Utils.Parser/Runtime/ParserStateRegistry.cs
@@ -105,6 +105,7 @@ internal sealed class ParserStateRegistry
             return false;
         }
 
+        // Reuse chooses an invocation-completion artifact only; it does not recreate branch execution history.
         var success = list.FirstOrDefault(static item => !item.IsFailure && item.Node is not null);
         if (success.Node is not null)
         {

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -483,3 +483,59 @@ Not guaranteed:
 - incidental dictionary/set traversal order,
 - incidental internal metadata collection order,
 - undocumented internal grouping traversal order.
+
+
+## Duplicated-work-reduction constraint model (limitations view)
+
+Current metadata-rich infrastructure is intentionally preparation-oriented and non-executable.
+It supports deterministic auditability and future analysis only.
+
+### Reusable metadata (non-authoritative)
+
+Reusable metadata currently includes:
+
+- lookahead observations,
+- shared-prefix grouping metadata,
+- continuation transport metadata,
+- invocation completion metadata,
+- orchestration/runtime observations.
+
+These do not imply replay, resumability, semantic equivalence, or execution authority transfer.
+
+### Non-shareable runtime state
+
+Current runtime does not permit sharing or reconstruction of:
+
+- active execution state,
+- semantic parser context,
+- mutable branch-local state,
+- diagnostics-authoritative execution state,
+- parse-tree-authoritative execution ownership.
+
+No runtime contract currently establishes safe replay, rollback, or branch-merge semantics.
+
+## Execution-sharing safety boundaries (limitations view)
+
+The following equivalence assumptions are explicitly invalid in current runtime:
+
+- metadata grouping != execution sharing,
+- reusable completion != branch replay,
+- invocation reuse != execution reuse,
+- continuation transport != resumable execution,
+- shared-prefix grouping != merge permission,
+- deterministic observability != semantic equivalence,
+- structural similarity != safe state sharing.
+
+### Future activation preconditions
+
+Any future duplicated-work reduction execution work would require explicit modeling and validation of:
+
+- semantic-state ownership,
+- replay safety,
+- rollback guarantees,
+- merge semantics,
+- diagnostics ownership resolution,
+- parse-tree authority preservation,
+- dedicated runtime invariants and tests.
+
+These are prerequisite boundaries only, not active capabilities.

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -580,3 +580,64 @@ Additional clarifications that must remain true:
 - metadata presence != replay capability;
 - metadata presence != resumability or rollback support;
 - metadata grouping != branch merge permission.
+
+
+## Duplicated-work-reduction constraint model
+
+The current runtime exposes metadata that can support **future analysis** of duplicated work, but not execution sharing.
+
+### Reusable metadata (non-authoritative)
+
+The following are reusable as observational metadata only:
+
+- lookahead observations,
+- shared-prefix grouping metadata,
+- continuation transport metadata,
+- invocation completion metadata,
+- orchestration/runtime observations.
+
+These metadata forms:
+
+- may support future duplicated-work analysis,
+- do not authorize replay,
+- do not authorize resumability,
+- do not prove semantic equivalence,
+- do not transfer parse or diagnostics authority.
+
+### Non-shareable runtime state (authoritative or semantically coupled)
+
+The following remain isolated and non-shareable in current runtime contracts:
+
+- active parser execution state,
+- semantic parser context,
+- mutable branch-local state,
+- diagnostics-authoritative execution state,
+- parse-tree-authoritative execution ownership.
+
+No current contract establishes safe sharing, replay, rollback, or merge of these states.
+
+## Execution-sharing safety boundaries
+
+Explicit non-feature boundaries that must remain true:
+
+- metadata grouping != execution sharing,
+- reusable completion != branch replay,
+- invocation reuse != execution reuse,
+- continuation transport != resumable execution,
+- shared-prefix grouping != merge permission,
+- deterministic observability != semantic equivalence,
+- structural similarity != safe state sharing.
+
+### Future activation preconditions (boundary-only)
+
+Any future duplicated-work reduction activation would require all of the following to be explicitly modeled and validated first:
+
+- semantic-state ownership,
+- replay safety guarantees,
+- rollback guarantees,
+- merge semantics,
+- diagnostics ownership resolution,
+- parse-tree authority preservation,
+- dedicated runtime invariants and tests.
+
+This document intentionally records constraints only; it does not define an implementation design.


### PR DESCRIPTION
### Motivation

- Clarify and centralize the constraints that separate metadata reuse from executable/runtime authority to avoid future misinterpretation that metadata implies safe execution sharing.  
- Reinforce anti-replay/anti-merge and non-shareable-state guarantees so future duplicated-work-reduction research has explicit preconditions to meet.  
- Add compact source-level guardrails so maintainers reading runtime types cannot mistake descriptive metadata for executable state.

### Description

- Added a focused `Duplicated-work-reduction constraint model` section and `Execution-sharing safety boundaries` language to `docs/parser/RuntimeStateOwnership.md` to record what metadata is reusable and what runtime state must remain isolated.  
- Added a mirrored `Duplicated-work-reduction constraint model (limitations view)` section to `docs/parser/ParserMetadataAndRuntimeLimitations.md` to keep terminology aligned and emphasize preconditions for any future activation work.  
- Inserted concise XML docs/comments in `Utils.Parser/Runtime/ActiveParseState.cs` on methods such as `Advance`, `WithLineage`, `ToParserStateKey`, `ToRuleInvocationKey`, and `ToContinuationKey` to explicitly state these operations produce metadata-only, non-executable artifacts.  
- Added a short inline comment in `Utils.Parser/Runtime/ParserStateRegistry.cs`'s `TryGetReusableResult` clarifying that reuse returns invocation-completion artifacts and does not recreate branch execution history; these changes are documentation/comments only and do not change public API or runtime behavior.

### Testing

- Ran the targeted parser tests using `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ParserRuntimeInvariantTests|FullyQualifiedName~AlternativeSchedulerTests|FullyQualifiedName~ParserStateRegistryTests"`.  
- The filtered run executed the targeted parser tests (43 tests matched) and completed with `Passed: 43, Failed: 0`.  
- No runtime behavior or parse-tree changes were introduced by these edits and the test results confirm deterministic invariants remain intact.  
- `ROADMAP.md` was reviewed and remains accurate for this PR because the work is documentation/comments-only and introduces no runtime or roadmap-direction changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b02b2c0a48326905d857d09b0e9c9)