### PR TITLE
tests+docs: consolidate lookahead authority, fallback-to-parse guarantees, and probe observability

### DIFF
--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -297,6 +297,50 @@ public class ParserRuntimeInvariantTests
     }
 
     [TestMethod]
+    public void LookaheadProbe_InconclusiveOutcome_StillRequiresParserAuthoritativeValidation()
+    {
+        var startRule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new Sequence([
+                    new Quantifier(new LiteralMatch("x"), 0, 1),
+                    new RuleRef("A")
+                ]))
+            ]));
+        var parser = new ParserEngine(CreateDefinition(startRule, LexerRule("A", "a")));
+        var diagnostics = new DiagnosticBag();
+
+        // The optional prefix keeps lookahead conservative (Unknown/EpsilonPossible path),
+        // so parse-authoritative execution must still validate syntax.
+        var result = parser.Parse([Token("A", "a")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsFalse(result is ErrorNode);
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
+    }
+
+    [TestMethod]
+    public void LookaheadMetadataVariations_DoNotChangeParserAuthoritativeDiagnosticsOutcome()
+    {
+        var startRule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new RuleRef("A"))
+            ]));
+        var parser = new ParserEngine(CreateDefinition(startRule, LexerRule("A", "a"), LexerRule("B", "b")));
+        var diagnostics = new DiagnosticBag();
+
+        var result = parser.Parse([Token("A", "a"), Token("B", "b")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ErrorNode>(result);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
+    }
+
+    [TestMethod]
     public void ContinuationMetadata_StoredInRegistry_DoesNotCreateReusableParseOutcome()
     {
         var registry = new ParserStateRegistry();

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -299,6 +299,18 @@ public class ParserRuntimeInvariantTests
     [TestMethod]
     public void LookaheadProbe_InconclusiveOutcome_StillRequiresParserAuthoritativeValidation()
     {
+        var probe = new ParserLookaheadProbe();
+        var probeAlternative = new Alternative(
+            0,
+            Associativity.Left,
+            new Sequence([
+                new Quantifier(new LiteralMatch("x"), 0, 1),
+                new RuleRef("A")
+            ]));
+        var probeResult = probe.Probe(probeAlternative, Token("A", "a"), static _ => null, false);
+
+        Assert.AreEqual(ParserLookaheadProbeKind.Unknown, probeResult.Kind);
+
         var startRule = new Rule(
             "start",
             0,
@@ -322,7 +334,7 @@ public class ParserRuntimeInvariantTests
     }
 
     [TestMethod]
-    public void LookaheadMetadataVariations_DoNotChangeParserAuthoritativeDiagnosticsOutcome()
+    public void ParserEngine_TrailingTokens_RemainsParserAuthoritativeDiagnosticOutcome()
     {
         var startRule = new Rule(
             "start",

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -120,6 +120,17 @@ This section aligns terminology with `RuntimeStateOwnership.md` while keeping a 
 
 Current lookahead behavior is intentionally conservative and shallow.
 
+### Lookahead authority model (limitations view)
+
+Lookahead remains advisory metadata and orchestration guidance only.
+
+- It may expose shallow token prediction and deterministic probe observability.
+- It may help scheduling visibility and ambiguity analysis.
+- It does not own parse acceptance.
+- It does not own diagnostics authority.
+- It is not semantic-equivalence evidence.
+- It is not adaptive parsing capability.
+
 - Lookahead probing is first-token-oriented and does not perform deep parser-rule simulation.
 - Parser-rule references in lookahead remain advisory and may return `Unknown`.
 - Epsilon-sensitive shapes may produce `Unknown`/`EpsilonPossible` to avoid over-claiming acceptance.
@@ -133,6 +144,22 @@ Fallback semantics:
 - `RequiresParse`, `Unknown`, and `EpsilonPossible` are parse-required outcomes.
 - Ambiguous or parser-rule-dependent outcomes must defer to real parsing.
 - Cached lookahead entries are reusable advisory metadata only and do not replace parse execution.
+
+### Probe lifecycle and observability (limitations view)
+
+Probe lifecycle remains deterministic and metadata-only:
+
+1. production,
+2. transport,
+3. observation,
+4. discardability.
+
+Observability boundaries:
+
+- probe observations are audit/debug/test artifacts;
+- probe observations do not authorize syntax acceptance;
+- probe observations do not authorize diagnostics ownership changes;
+- probe reuse does not grant parser replay, rollback, or adaptive execution semantics.
 
 
 ## Continuation metadata model (current, metadata-only)

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -32,6 +32,48 @@ The parser runtime is authority-layered.
 - Supporting runtime components provide orchestration, probing, caching, and metadata.
 - Metadata components are descriptive and cannot decide parse outcomes on their own.
 
+## Lookahead authority model
+
+Lookahead remains explicitly **advisory** in the current runtime.
+
+- Lookahead may provide shallow token prediction, ambiguity visibility, shared-prefix observation, and deterministic probe metadata.
+- Lookahead may influence orchestration and scheduling visibility only.
+- Lookahead cannot independently finalize parse acceptance.
+- Lookahead cannot independently finalize diagnostics authority.
+
+Parse-authoritative execution remains mandatory:
+
+- `ParserEngine` remains the final authority for syntax confirmation.
+- Lookahead observations cannot replace parser-authoritative execution.
+- Any syntax-confirmation boundary must conservatively fall back to real parsing.
+
+## Fallback-to-parse guarantees
+
+The runtime keeps conservative fallback guarantees to prevent authority drift:
+
+- ambiguous lookahead outcomes must fall back to parser-authoritative execution;
+- inconclusive lookahead outcomes must fall back to parser-authoritative execution;
+- epsilon-sensitive uncertainty must fall back to parser-authoritative execution;
+- runtime must not silently skip parser validation because advisory lookahead looked favorable.
+
+These guarantees are invariants, not optimization hooks.
+
+## Probe observability and lifecycle
+
+Lookahead probes are metadata-only artifacts with a deterministic lifecycle:
+
+1. **production** from current rule/alternative and visible token context,
+2. **transport** through scheduler/runtime metadata surfaces,
+3. **observation** for deterministic diagnostics/audit/testing visibility,
+4. **discardability** without changing parse-authoritative outcomes.
+
+Boundary clarifications:
+
+- probe metadata does not reconstruct execution state;
+- probe similarity does not authorize branch merge;
+- deterministic probes do not imply adaptive parsing;
+- probe reuse does not imply replay capability.
+
 ## Deterministic runtime observability model
 
 This section clarifies what is intentionally contractual versus what remains implementation-internal.


### PR DESCRIPTION
### Motivation
- Strengthen and centralize documentation about lookahead being advisory and ensure fallback-to-parse guarantees are explicit so future work cannot drift toward adaptive/speculative parsing.
- Provide focused invariant tests that lock the runtime guarantees (lookahead non-authority, probe lifecycle, and diagnostics authority) without changing runtime behavior or public APIs.

### Description
- Updated `docs/parser/RuntimeStateOwnership.md` to add a dedicated "Lookahead authority model", "Fallback-to-parse guarantees", and "Probe observability and lifecycle" sections clarifying advisory vs authoritative boundaries and anti-adaptive constraints.
- Updated `docs/parser/ParserMetadataAndRuntimeLimitations.md` to add aligned limitations-focused sections: "Lookahead authority model (limitations view)" and "Probe lifecycle and observability (limitations view)" to keep terminology consistent across documentation.
- Added two invariant tests to `UtilsTest/Parser/ParserRuntimeInvariantTests.cs`: `LookaheadProbe_InconclusiveOutcome_StillRequiresParserAuthoritativeValidation` and `LookaheadMetadataVariations_DoNotChangeParserAuthoritativeDiagnosticsOutcome` to assert fallback-to-parse and diagnostics-authority invariants.
- Modified files: `docs/parser/RuntimeStateOwnership.md`, `docs/parser/ParserMetadataAndRuntimeLimitations.md`, `UtilsTest/Parser/ParserRuntimeInvariantTests.cs`.

### Testing
- Ran targeted parser test suites covering lookahead, scheduler, runtime invariants and shared-prefix metadata: `ParserLookaheadProbeTests`, `AlternativeSchedulerTests`, `ParserRuntimeInvariantTests`, and shared-prefix related tests.
- All targeted automated tests passed (A total of 93 tests executed, Passed: 93, Failed: 0).
- No runtime behavior changes were introduced and the tests confirm that parse-tree shape, diagnostics, and public APIs remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0c098eec832691473d64ced71e8a)