### PR TITLE
Utils.Parser: consolidate compatibility boundaries and add invariant test

### DIFF
--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -333,6 +333,11 @@ public class ParserRuntimeInvariantTests
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
     }
 
+    /// <summary>
+    /// Verifies that shared-prefix metadata observability and parseable surface behavior
+    /// do not establish semantic support guarantees, and that parser-authoritative
+    /// trailing-token diagnostics remain decisive for final acceptance.
+    /// </summary>
     [TestMethod]
     public void ParseableSharedPrefixMetadata_DoesNotByItselfEstablishSemanticSupportGuarantees()
     {

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -334,6 +334,36 @@ public class ParserRuntimeInvariantTests
     }
 
     [TestMethod]
+    public void ParseableSharedPrefixMetadata_DoesNotByItselfEstablishSemanticSupportGuarantees()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = new Rule("start", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new RuleRef("A"), "left"),
+            new Alternative(1, Associativity.Left, new RuleRef("A"), "right")
+        ]));
+
+        var scheduleResult = scheduler.Run(
+            rule,
+            rule.Content.Alternatives,
+            0,
+            0,
+            diagnostics: null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, index, 1),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])));
+
+        Assert.AreEqual(1, scheduleResult.Metadata.SharedPrefixPlans.Count);
+        Assert.AreEqual(2, scheduleResult.CompletedStates.Count);
+
+        var parser = new ParserEngine(CreateDefinition(rule, LexerRule("A", "a"), LexerRule("B", "b")));
+        var diagnostics = new DiagnosticBag();
+        var parseResult = parser.Parse([Token("A", "a"), Token("B", "b")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ErrorNode>(parseResult);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.TrailingTokensAfterParse.Code));
+    }
+
+    [TestMethod]
     public void ParserEngine_TrailingTokens_RemainsParserAuthoritativeDiagnosticOutcome()
     {
         var startRule = new Rule(

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -17,6 +17,60 @@ This document consolidates parser documentation that explains what is currently 
 
 It is factual and conservative. It does not define a roadmap commitment.
 
+## Compatibility and conservative fallback boundaries
+
+This document is limitation-first and compatibility-oriented.
+
+### Supported runtime semantics (current compatibility guarantees)
+
+Current supported guarantees are intentionally conservative:
+
+- deterministic, syntax-oriented parser-authoritative execution;
+- explicit orchestration with non-authoritative metadata observability;
+- advisory lookahead with parse-required fallback for non-reject outcomes;
+- invocation-local metadata/reuse lifecycle with deterministic discardability;
+- deterministic diagnostics ownership boundaries.
+
+### Unsupported runtime semantics (intentionally out of scope)
+
+The runtime does not currently support:
+
+- semantic-aware memoization;
+- adaptive parsing;
+- parser replay;
+- rollback parsing;
+- branch merge execution;
+- resumable continuation execution;
+- semantic-aware pruning;
+- speculative parser execution.
+
+Unsupported semantics have no compatibility guarantee and may evolve only through explicit runtime-contract work.
+
+### Parseable vs supported semantics
+
+Some constructs may be syntactically parseable or metadata-observable while still remaining unsupported as runtime semantics.
+
+Examples:
+
+- parser-rule-dependent lookahead observations;
+- shared-prefix/continuation metadata visibility;
+- reusable completion artifacts;
+- conservative fallback behavior.
+
+These observations do not establish semantic compatibility guarantees.
+
+### Future feature activation expectations (boundaries only)
+
+Future support for currently unsupported semantics requires all of the following:
+
+- explicit runtime contracts;
+- explicit diagnostics expectations;
+- dedicated invariant tests;
+- explicit documentation/roadmap updates;
+- explicit authority and lifecycle modeling.
+
+This section defines activation prerequisites only. It does not design those systems.
+
 ## Consolidation note
 
 This document intentionally consolidates previous shared-prefix architecture documents to keep invariants and runtime-limitation guidance in one place:

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -32,6 +32,55 @@ The parser runtime is authority-layered.
 - Supporting runtime components provide orchestration, probing, caching, and metadata.
 - Metadata components are descriptive and cannot decide parse outcomes on their own.
 
+## Supported vs unsupported runtime semantics
+
+This section is intentionally contractual and boundary-oriented.
+
+### Supported runtime semantics (current contract)
+
+The following are explicitly supported runtime guarantees:
+
+- deterministic syntax-oriented parsing with `ParserEngine` as final authority;
+- explicit and conservative scheduling/orchestration;
+- advisory lookahead with mandatory parser-authoritative fallback when uncertain;
+- deterministic diagnostics ownership boundaries;
+- invocation-local reuse/memoization artifacts;
+- metadata-only continuations and metadata-only shared-prefix infrastructure.
+
+### Unsupported runtime semantics (no compatibility contract)
+
+The following are explicitly unsupported in the current runtime:
+
+- semantic-aware memoization;
+- adaptive parsing;
+- parser replay;
+- rollback parsing;
+- branch merge execution;
+- semantic-aware pruning;
+- resumable continuation execution;
+- speculative parser execution.
+
+Unsupported means:
+
+- no runtime guarantee exists;
+- no semantic compatibility contract exists;
+- observed behavior in an edge case must not be treated as supported semantics.
+
+### Parseable vs supported boundaries
+
+Some inputs or grammar shapes may appear parseable, partially executable, or metadata-observable without becoming supported runtime semantics.
+
+Examples of non-contractual observations:
+
+- parser-rule-dependent lookahead observations;
+- metadata grouping or shared-prefix observations;
+- reusable completion artifacts in invocation-local contexts;
+- conservative fallback behavior under uncertainty.
+
+Boundary rule:
+
+- parseable or observable != supported compatibility contract.
+
 ## ParserStateRegistry lifecycle model
 
 `ParserStateRegistry` is parse-lifecycle-scoped runtime storage.


### PR DESCRIPTION
### Motivation
- Make explicit the runtime compatibility boundaries for `Utils.Parser` so contributors and consumers cannot assume unsupported semantics are guaranteed. 
- Consolidate guidance about what is metadata-only versus what is a supported runtime contract to reduce accidental behavioral drift. 
- Provide a focused invariant test that encodes the conservative fallback and metadata-vs-authority distinction without changing runtime behavior.

### Description
- Added a contractual `Supported vs unsupported runtime semantics` section to `docs/parser/RuntimeStateOwnership.md` clarifying supported guarantees, unsupported features, and parseable-vs-supported boundaries. 
- Added a compatibility-and-fallback section to `docs/parser/ParserMetadataAndRuntimeLimitations.md` that documents supported semantics, explicitly-out-of-scope semantics, parseable-vs-supported distinctions, and prerequisites for any future activation. 
- Added one focused invariant test `ParseableSharedPrefixMetadata_DoesNotByItselfEstablishSemanticSupportGuarantees` to `UtilsTest/Parser/ParserRuntimeInvariantTests.cs` to assert that shared-prefix metadata/observability does not become a semantic support guarantee and that `ParserEngine` remains the final diagnostics/acceptance authority.

### Testing
- Ran the targeted parser invariant suite with `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ParserRuntimeInvariantTests"` and all tests passed (`Passed: 20, Failed: 0`). 
- No runtime, parse-tree, diagnostics, or public-API behavior was changed by these modifications; the test run verified invariants only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b73921be483268fac5d3cdc99cc0d)