### PR TITLE
fix(lexer): isolate commands in sequences and quantifier iterations

### DIFF
--- a/Utils.Parser/Runtime/LexerEngine.cs
+++ b/Utils.Parser/Runtime/LexerEngine.cs
@@ -314,7 +314,10 @@ public sealed class LexerEngine(ParserDefinition definition)
 
         while (quant.Max is null || count < quant.Max.Value)
         {
-            if (!TryMatchContent(input, quant.Inner, offset + total, commands, out int inner))
+            // Isolate each iteration so that commands from a failed attempt — or from
+            // an attempt that matched zero characters — never reach the caller's list.
+            var iterationCommands = commands is null ? null : new List<Model.LexerCommand>();
+            if (!TryMatchContent(input, quant.Inner, offset + total, iterationCommands, out int inner))
             {
                 break;
             }
@@ -324,6 +327,7 @@ public sealed class LexerEngine(ParserDefinition definition)
                 break;
             }
 
+            commands?.AddRange(iterationCommands!);
             total += inner;
             count++;
             if (!quant.Greedy && count >= quant.Min)
@@ -336,12 +340,14 @@ public sealed class LexerEngine(ParserDefinition definition)
         return count >= quant.Min;
     }
 
+    /// <summary>Matches a literal string at <paramref name="offset"/> using the current case-sensitivity setting.</summary>
     private LexerMatchResult MatchLiteralContent(TextReaderBuffer input, LiteralMatch lit, int offset)
     {
         int consumed = TryMatchLiteral(input, lit.Value, offset, _caseInsensitive) ? lit.Value.Length : 0;
         return new(consumed > 0 || lit.Value.Length == 0, consumed);
     }
 
+    /// <summary>Matches a single character within an inclusive character range.</summary>
     private LexerMatchResult MatchRangeContent(TextReaderBuffer input, RangeMatch range, int offset)
     {
         int ch = input.Peek(offset);
@@ -349,6 +355,7 @@ public sealed class LexerEngine(ParserDefinition definition)
         return new(matched, matched ? 1 : 0);
     }
 
+    /// <summary>Matches a single character that is (or is not, when negated) a member of an explicit set.</summary>
     private LexerMatchResult MatchCharSetContent(TextReaderBuffer input, CharSetMatch set, int offset)
     {
         int ch = input.Peek(offset);
@@ -364,12 +371,17 @@ public sealed class LexerEngine(ParserDefinition definition)
         return new(false, 0);
     }
 
+    /// <summary>Matches any single character (the <c>.</c> wildcard) at <paramref name="offset"/>.</summary>
     private static LexerMatchResult MatchAnyCharContent(TextReaderBuffer input, int offset)
     {
         int consumed = input.Peek(offset) >= 0 ? 1 : 0;
         return new(consumed == 1, consumed);
     }
 
+    /// <summary>
+    /// Resolves and matches a rule reference, guarding against direct left-recursion
+    /// via the active-rule-refs set.
+    /// </summary>
     private LexerMatchResult MatchRuleRefContent(TextReaderBuffer input, RuleRef ruleRef, int offset, List<Model.LexerCommand>? commands)
     {
         if (!definition.AllRules.TryGetValue(ruleRef.RuleName, out var referenced))
@@ -394,12 +406,22 @@ public sealed class LexerEngine(ParserDefinition definition)
         }
     }
 
+    /// <summary>
+    /// Matches all items in a sequence in order.
+    /// Commands are accumulated in a local buffer and flushed to <paramref name="commands"/>
+    /// only when the entire sequence succeeds — ensuring that a partially-matched but
+    /// ultimately failed sequence never leaks commands into the caller's list.
+    /// </summary>
     private LexerMatchResult MatchSequenceContent(TextReaderBuffer input, Sequence seq, int offset, List<Model.LexerCommand>? commands)
     {
+        // Accumulate into a local buffer so that commands from partially-matched
+        // items are never visible to the caller when the sequence ultimately fails.
+        // Only flush to `commands` when every item has succeeded.
+        var local = commands is null ? null : new List<Model.LexerCommand>();
         int total = 0;
         foreach (RuleContent item in seq.Items)
         {
-            if (!TryMatchContent(input, item, offset + total, commands, out int part))
+            if (!TryMatchContent(input, item, offset + total, local, out int part))
             {
                 return new(false, 0);
             }
@@ -407,9 +429,15 @@ public sealed class LexerEngine(ParserDefinition definition)
             total += part;
         }
 
+        commands?.AddRange(local!);
         return new(true, total);
     }
 
+    /// <summary>
+    /// Tries each alternative in order using an isolated branch buffer.
+    /// The branch buffer is merged into <paramref name="commands"/> only when
+    /// an alternative succeeds; failed alternatives are discarded without side-effects.
+    /// </summary>
     private LexerMatchResult MatchAlternationContent(TextReaderBuffer input, Alternation alternation, int offset, List<Model.LexerCommand>? commands)
     {
         foreach (Alternative alt in alternation.Alternatives)
@@ -425,18 +453,21 @@ public sealed class LexerEngine(ParserDefinition definition)
         return new(false, 0);
     }
 
+    /// <summary>Delegates to the content of a single <see cref="Alternative"/>.</summary>
     private LexerMatchResult MatchAlternativeContent(TextReaderBuffer input, Alternative alternative, int offset, List<Model.LexerCommand>? commands)
     {
         bool matched = TryMatchContent(input, alternative.Content, offset, commands, out int consumed);
         return new(matched, consumed);
     }
 
+    /// <summary>Delegates to <see cref="TryMatchQuantifier"/> and wraps the result.</summary>
     private LexerMatchResult MatchQuantifierContent(TextReaderBuffer input, Quantifier quant, int offset, List<Model.LexerCommand>? commands)
     {
         bool matched = TryMatchQuantifier(input, quant, offset, commands, out int consumed);
         return new(matched, consumed);
     }
 
+    /// <summary>Implements the <c>~</c> negation operator: succeeds when the inner element does not match.</summary>
     private LexerMatchResult MatchNegationContent(TextReaderBuffer input, Negation neg, int offset)
     {
         if (!TryMatchContent(input, neg.Inner, offset, null, out _) && input.Peek(offset) >= 0)
@@ -447,6 +478,7 @@ public sealed class LexerEngine(ParserDefinition definition)
         return new(false, 0);
     }
 
+    /// <summary>Records a structured lexer command and always succeeds with zero consumed characters.</summary>
     private static LexerMatchResult MatchLexerCommandContent(LexerCommand cmd, List<Model.LexerCommand>? commands)
     {
         commands?.Add(cmd);

--- a/UtilsTest/Parser/LexerEngineTests.cs
+++ b/UtilsTest/Parser/LexerEngineTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Parser.Bootstrap;
 using Utils.Parser.Diagnostics;
 using Utils.Parser.Runtime;
+using Utils.Parser.Resolution;
 using System.IO;
 using Utils.Parser.Model;
 
@@ -827,5 +828,148 @@ public class LexerEngineTests
         [
             new Token(new SourceSpan(context.Position, 0, context.Line, context.Column), "INDENT", "DEFAULT_MODE", "DEFAULT_CHANNEL", ""),
         ];
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Lexer-command scoping — regression tests for command leakage
+    //
+    // Invariant: commands must remain scoped to successful matches only.
+    // A failed sequence or a failed quantifier iteration must not
+    // contribute commands to the enclosing match.
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Builds a lexer-only <see cref="ParserDefinition"/> from the supplied rules,
+    /// running the full resolution pass so that <c>AllRules</c> and <c>Kind</c> are set.
+    /// </summary>
+    private static ParserDefinition BuildLexerDef(params Rule[] rules)
+    {
+        var mode = new LexerMode("DEFAULT_MODE", rules);
+        var def = new ParserDefinition(
+            "Test", GrammarType.Lexer, null, [], [], [mode], [], null);
+        return RuleResolver.Resolve(def, null);
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="content"/> in a single-alternative <see cref="Alternation"/>
+    /// and returns the resulting lexer <see cref="Rule"/>.
+    /// </summary>
+    private static Rule LexerRule(string name, int order, RuleContent content) =>
+        new Rule(name, order, false,
+            new Alternation([new Alternative(0, Associativity.Left, content)]));
+
+    private static List<Token> TokenizeWith(ParserDefinition def, string input)
+    {
+        var lexer = new LexerEngine(def);
+        return lexer.Tokenize(new StringReader(input)).ToList();
+    }
+
+    // ── A: Quantifier — failed iteration must not leak commands ──────────────
+
+    [TestMethod]
+    public void Lexer_QuantifierFailedIteration_DoesNotLeakCommands()
+    {
+        // Rule:  TOK = (channel_cmd 'x')* 'a'
+        //
+        // 'channel_cmd' is a LexerCommand(Channel, HIDDEN) placed as the FIRST
+        // item in the iteration sequence, before the character match.
+        // On input "a" the quantifier attempts one iteration:
+        //   1. channel_cmd always succeeds and appends HIDDEN to the command buffer.
+        //   2. LiteralMatch('x') then fails against 'a'.
+        // Without isolation: the HIDDEN command leaks into the outer buffer,
+        // causing the produced token to land on the HIDDEN channel.
+        // With isolation: the failed iteration's local buffer is discarded.
+
+        var hiddenCmd = new LexerCommand(LexerCommandType.Channel, "HIDDEN");
+        var iterSeq = new Sequence([hiddenCmd, new LiteralMatch("x")]);
+        var quant = new Quantifier(iterSeq, 0, null);      // (cmd 'x')*
+        var outerSeq = new Sequence([quant, new LiteralMatch("a")]);
+        var def = BuildLexerDef(LexerRule("TOK", 0, outerSeq));
+
+        var tokens = TokenizeWith(def, "a");
+
+        Assert.AreEqual(1, tokens.Count);
+        Assert.AreEqual("TOK", tokens[0].RuleName);
+        Assert.AreEqual("DEFAULT_CHANNEL", tokens[0].Channel,
+            "Channel command from a failed quantifier iteration must not leak.");
+    }
+
+    // ── B: Sequence — failed sequence must not leak commands ─────────────────
+
+    [TestMethod]
+    public void Lexer_FailedSequenceItem_DoesNotLeakCommandsFromEarlierItems()
+    {
+        // Rule:  TOK = (skip_cmd 'x' 'y') | 'a'
+        //
+        // Alternative 1 contains Sequence([LexerCommand(Skip), Literal('x'), Literal('y')]).
+        // On input "a": skip_cmd always succeeds (appends Skip), then Literal('x') fails.
+        // Without isolation: the Skip command is already in the buffer when the sequence
+        // fails, so the fallback token from Alternative 2 gets Skip applied and is
+        // discarded — leaving an empty token list.
+        // With isolation: the failed sequence's local buffer is discarded before
+        // Alternative 2 is tried.
+
+        var skipCmd = new LexerCommand(LexerCommandType.Skip, null);
+        var failSeq = new Sequence([skipCmd, new LiteralMatch("x"), new LiteralMatch("y")]);
+        var alt1 = new Alternative(0, Associativity.Left, failSeq);
+        var alt2 = new Alternative(1, Associativity.Left, new LiteralMatch("a"));
+        var rule = new Rule("TOK", 0, false, new Alternation([alt1, alt2]));
+        var def = BuildLexerDef(rule);
+
+        var tokens = TokenizeWith(def, "a");
+
+        Assert.AreEqual(1, tokens.Count,
+            "The skip command from the failed sequence must not be applied to the fallback match.");
+        Assert.AreEqual("TOK", tokens[0].RuleName);
+        Assert.AreEqual("a", tokens[0].Text);
+    }
+
+    // ── C: Sequence — successful sequence still propagates commands ───────────
+
+    [TestMethod]
+    public void Lexer_SuccessfulSequence_PropagatesCommandsCorrectly()
+    {
+        // Rule:  TOK = 'a' channel_cmd
+        //
+        // On input "a": Literal('a') succeeds, then the command is appended.
+        // The sequence succeeds — commands must be flushed to the caller.
+
+        var hiddenCmd = new LexerCommand(LexerCommandType.Channel, "HIDDEN");
+        var seq = new Sequence([new LiteralMatch("a"), hiddenCmd]);
+        var def = BuildLexerDef(LexerRule("TOK", 0, seq));
+
+        var tokens = TokenizeWith(def, "a");
+
+        Assert.AreEqual(1, tokens.Count);
+        Assert.AreEqual("TOK", tokens[0].RuleName);
+        Assert.AreEqual("HIDDEN", tokens[0].Channel,
+            "Command from a successful sequence must be applied.");
+    }
+
+    // ── D: Quantifier — successful iterations still propagate commands ────────
+
+    [TestMethod]
+    public void Lexer_SuccessfulQuantifierIterations_PropagateCommandsCorrectly()
+    {
+        // Rule:  TOK = ('x' channel_cmd)+ 'a'
+        //
+        // channel_cmd = LexerCommand(Channel, HIDDEN).
+        // On input "xa": iteration 1 matches 'x' and records the HIDDEN command.
+        // The quantifier (min=1) then succeeds.
+        // The outer sequence then matches 'a'.
+        // The HIDDEN command from the successful iteration must survive to the token.
+
+        var hiddenCmd = new LexerCommand(LexerCommandType.Channel, "HIDDEN");
+        var iterSeq = new Sequence([new LiteralMatch("x"), hiddenCmd]);
+        var quant = new Quantifier(iterSeq, 1, null);      // (x cmd)+
+        var outerSeq = new Sequence([quant, new LiteralMatch("a")]);
+        var def = BuildLexerDef(LexerRule("TOK", 0, outerSeq));
+
+        var tokens = TokenizeWith(def, "xa");
+
+        Assert.AreEqual(1, tokens.Count);
+        Assert.AreEqual("TOK", tokens[0].RuleName);
+        Assert.AreEqual("HIDDEN", tokens[0].Channel,
+            "Command from a successful quantifier iteration must be applied.");
     }
 }


### PR DESCRIPTION
## Type

Lexer correctness fix.

## Problem

`LexerEngine.TryMatchContent` after the dispatch-table refactoring exposed a
command-scoping regression: both `MatchSequenceContent` and `TryMatchQuantifier`
passed the caller's command list directly into nested match attempts.

When a nested match partially succeeded — executing a `LexerCommand` node —
and then failed on a later element, the command had already been appended to the
shared list. This violated the invariant that **commands must remain scoped to
successful matches only**.

Concrete scenario:

```
Rule:  TOK = (channel_cmd 'x')* 'a'
Input: "a"
```

The quantifier attempts one iteration. `channel_cmd` (a `LexerCommand`) always
succeeds and appends `HIDDEN` to the command buffer. `LiteralMatch('x')` then
fails. Without isolation the `HIDDEN` command survives in the shared list and
the produced `TOK` token ends up on the `HIDDEN` channel.

## Fix

**`MatchSequenceContent`**: accumulates commands in a local buffer; flushes to
the caller only when every item has succeeded. A partially-matched sequence that
ultimately fails discards its local buffer without touching the caller list.

**`TryMatchQuantifier`**: creates an iteration-local command buffer per
repetition attempt; merges into the caller list only on a successful,
progressive iteration. Failed or zero-length iterations leave the caller list
untouched.

Both fixes extend to sequences/quantifiers the same isolation invariant that
`MatchAlternationContent` already enforced for alternation branches.

## Behavior impact

Fixes lexer-command leakage from failed nested matches. All previously
observable correct behaviors are preserved.

## Runtime architecture impact

None. The dispatch-table structure and `ContentMatchers` dictionary are
unchanged.

## Diagnostics impact

None intended.

## Public API impact

None.

## Tests

Four regression tests added to `LexerEngineTests`:

- **A** - Quantifier failed iteration does not leak commands (primary regression).
- **B** - Failed sequence item does not leak commands from earlier successful items.
- **C** - Successful sequence still propagates commands correctly (non-regression).
- **D** - Successful quantifier iterations still propagate commands correctly (non-regression).

All 596 parser tests pass. Existing lexer behaviour preserved except for the leakage fix.

Generated with [Claude Code](https://claude.com/claude-code)
