### PR TITLE
Parser: add explicit UnsupportedLexerCommand diagnostic (UP1020)

### DIFF
--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -128,6 +128,10 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor UnsupportedAntlrLanguageOptionIgnored =
         new("UP1019", "ANTLR language option ignored", "The ANTLR option 'language' is not supported by Utils.Parser and will be ignored (value: '{0}').", DefaultCategory);
 
+    /// <summary>Unsupported lexer command encountered in grammar source.</summary>
+    public static readonly ParserDiagnosticDescriptor UnsupportedLexerCommand =
+        new("UP1020", "Unsupported lexer command", "Lexer command '{0}' is parsed but not supported by Utils.Parser.", DefaultCategory);
+
     // Warnings (UP5xxx)
     /// <summary>Best-effort recovery used.</summary>
     public static readonly ParserDiagnosticDescriptor BestEffortRecoveryUsed =
@@ -227,6 +231,7 @@ public static class ParserDiagnostics
             [ParseMemoMiss.Code] = ParseMemoMiss,
             [LeftRecursivePrecedencePartiallySupported.Code] = LeftRecursivePrecedencePartiallySupported,
             [UnsupportedAntlrLanguageOptionIgnored.Code] = UnsupportedAntlrLanguageOptionIgnored,
+            [UnsupportedLexerCommand.Code] = UnsupportedLexerCommand,
             [BestEffortRecoveryUsed.Code] = BestEffortRecoveryUsed,
             [ExpectedTokenMissing.Code] = ExpectedTokenMissing,
             [FallbackStrategyUsed.Code] = FallbackStrategyUsed,

--- a/Utils.Parser.Diagnostics/README.md
+++ b/Utils.Parser.Diagnostics/README.md
@@ -60,6 +60,7 @@ All named descriptors are defined in the `ParserDiagnostics` static class and ac
 | UP1017 | `ParseMemoMiss` | No cached result existed for a (rule, position, precedence) triple |
 | UP1018 | `LeftRecursivePrecedencePartiallySupported` | Left-recursive precedence predicates are only partially handled |
 | UP1019 | `UnsupportedAntlrLanguageOptionIgnored` | The ANTLR4 `language` option is not supported and is silently ignored |
+| UP1020 | `UnsupportedLexerCommand` | A lexer command was parsed but is outside the currently supported command set |
 
 ### UP5xxx — Warnings (recovery / best-effort)
 

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -616,7 +616,7 @@ public sealed class Antlr4GrammarConverter
     /// <returns>Exception to throw.</returns>
     private GrammarParseException UnknownLexerCommand(string commandName)
     {
-        _diagnostics?.Add(ParserDiagnostics.UnexpectedToken, commandName);
+        _diagnostics?.Add(ParserDiagnostics.UnsupportedLexerCommand, commandName);
         return new GrammarParseException($"Unknown lexer command: '{commandName}'");
     }
 

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -189,6 +189,7 @@ Current clarification status:
 - local vs global diagnostics lifecycle is explicitly documented,
 - orchestration diagnostics (pruning/backtracking) are explicitly separated from engine-authoritative parse diagnostics,
 - compatibility diagnostics are explicitly documented as independent from parse success/failure.
+- unsupported ANTLR4 lexer-command constructs are now surfaced via explicit deterministic compatibility diagnostics.
 
 ### Phase 3 — Lookahead contract consolidation
 

--- a/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
@@ -239,6 +239,20 @@ public class Antlr4GrammarConverterTests
         Assert.AreEqual(Associativity.Left, powerAlternative.Assoc);
     }
 
+    [TestMethod]
+    public void ParseLexerRule_UnsupportedLexerCommand_EmitsDeterministicDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+
+        Assert.ThrowsException<GrammarParseException>(() => Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : ID ;
+            ID : 'a' -> customCommand ;
+            """, diagnostics));
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.UnsupportedLexerCommand.Code));
+    }
+
     // ─── 8. Alternative label # Label ─────────────────────────────────────────
 
     [TestMethod]

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -66,6 +66,7 @@ Additional architectural context and explicit non-goals are documented in `docs/
 | `import` usage | Fully resolved when grammars are compiled as a project input set; isolated single-file compilation may emit `ImportParsedButNotResolved` when no resolver context is provided. |
 | `tokenVocab` | Dependency loading is supported; effective behavior depends on available resolver inputs and vocabulary source availability in the compilation context. |
 | Left-recursive precedence parity | Implemented for current runtime model, but not equivalent to all ANTLR4 precedence scenarios; the runtime can emit `LeftRecursivePrecedencePartiallySupported` where applicable. |
+| Lexer command set | Supported commands are `skip`, `more`, `channel`, `type`, `pushMode`, `popMode`, `mode`. Any other command is rejected deterministically with `UnsupportedLexerCommand`. |
 
 ## Unsupported
 


### PR DESCRIPTION
### Motivation
- Make ANTLR4 lexer-command compatibility explicit and auditable by surfacing unsupported lexer commands with a deterministic, dedicated diagnostic rather than a generic token error.  
- Preserve conservative runtime semantics and deterministic diagnostics while improving clarity for converters and consumers.  

### Description
- Added a new diagnostic descriptor `UnsupportedLexerCommand` (`UP1020`) to `ParserDiagnostics` and registered it in the descriptor map for deterministic lookup (`Utils.Parser.Diagnostics/ParserDiagnostics.cs`).  
- Updated the ANTLR4 converter to emit `ParserDiagnostics.UnsupportedLexerCommand` when encountering unknown lexer commands (`Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs`).  
- Extended compatibility documentation to list the supported lexer-command set and the deterministic rejection behavior for others (`docs/parser/Antlr4CompatibilityMatrix.md`).  
- Updated the diagnostics README to include `UP1020` and made a minimal `ROADMAP.md` note about the clarified compatibility diagnostics.  
- Added a focused regression test `ParseLexerRule_UnsupportedLexerCommand_EmitsDeterministicDiagnostic` to assert deterministic diagnostic emission for unsupported lexer commands (`UtilsTest/Parser/Antlr4GrammarConverterTests.cs`).  

### Testing
- Ran the targeted tests with: `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~Antlr4GrammarConverterTests.ParseLexerRule_UnsupportedLexerCommand_EmitsDeterministicDiagnostic|FullyQualifiedName~ParserDiagnosticsTests.DescriptorTable_LookupByCode_Works"`, and both tests passed (2/2).  
- The change is small and focused; full test-suite execution was not requested here, and existing repository restore/build warnings unrelated to this change remained during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0caa684fe483269b56cd2661ed5b83)