### PR TITLE
Clarify ANTLR4 compatibility diagnostics for predicates and actions

### DIFF
--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -85,6 +85,7 @@ public class ParserDiagnosticsTests
         parser.Parse([], diagnostics: diagnostics);
 
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.SemanticPredicateNotEnforced.Code));
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.InlineActionStoredNotExecuted.Code));
     }
 
     [TestMethod]
@@ -218,6 +219,28 @@ public class ParserDiagnosticsTests
         Assert.IsNotNull(result.SelectedState);
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
+    }
+
+
+
+    [TestMethod]
+    /// <summary>
+    /// Verifies that rule-level ANTLR4 actions remain metadata-only compatibility points
+    /// and emit explicit deterministic ignored-action diagnostics.
+    /// </summary>
+    public void SemanticPredicateCompatibilityDiagnostic_IsDeterministic_AndIndependentFromParseSuccess()
+    {
+        var diagnostics = new DiagnosticBag();
+        var definition = Antlr4GrammarConverter.Parse("""
+            grammar PredicateDiag;
+            start : {canProceed}? 'a' ;
+            """, diagnostics);
+
+        var parser = new ParserEngine(definition);
+        var node = parser.Parse([new Token(new SourceSpan(0, 1), "a", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(node);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.SemanticPredicateNotEnforced.Code));
     }
 
     [TestMethod]

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -225,8 +225,8 @@ public class ParserDiagnosticsTests
 
     [TestMethod]
     /// <summary>
-    /// Verifies that rule-level ANTLR4 actions remain metadata-only compatibility points
-    /// and emit explicit deterministic ignored-action diagnostics.
+    /// Verifies that semantic-predicate compatibility diagnostics remain deterministic
+    /// and observable independently from final parse success.
     /// </summary>
     public void SemanticPredicateCompatibilityDiagnostic_IsDeterministic_AndIndependentFromParseSuccess()
     {

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -38,11 +38,11 @@ The features below are operational in current runtime and project-compilation fl
 
 The following constructs are parsed and stored, but runtime semantic execution is intentionally disabled.
 
-| Construct | Current behavior | Diagnostics |
-|---|---|---|
-| Semantic predicates (`{ condition }?`) | Parsed and represented in grammar model; runtime uses an evaluation abstraction (`ISemanticPredicateEvaluator`). Default policy is `NotEvaluated` (no predicate execution). | `SemanticPredicateNotEnforced` when evaluator returns `NotEvaluated` |
-| Inline actions (`{ code }`) | Parsed and stored; runtime does not execute target-language code blocks. | `InlineActionStoredNotExecuted` |
-| Rule actions (`@init`, `@after`) | Parsed as action metadata where present; no execution hook is active in runtime parsing. | `InlineActionStoredNotExecuted` when represented as runtime embedded actions; `ActionIgnored` may apply to top-level/pipeline actions. |
+| Construct | Parsed | Stored | Resolved | Executable | Runtime-supported | Diagnostics |
+|---|---|---|---|---|---|---|
+| Semantic predicates (`{ condition }?`) | Yes | Yes (predicate metadata) | Partially (policy-routed) | Policy-dependent only | Conservative by default (`NotEvaluated`) | `SemanticPredicateNotEnforced` when evaluator returns `NotEvaluated` |
+| Inline actions (`{ code }`) | Yes | Yes (embedded action metadata) | No target-language semantic resolution | No by default | Parsed-but-not-executed compatibility only | `InlineActionStoredNotExecuted` |
+| Rule actions (`@init`, `@after`, unsupported action slots) | Yes | Yes (rule/action metadata) | Limited to recognized metadata slots | No | Metadata-only/ignored compatibility path | `ActionIgnored` for ignored rule or grammar action entries; `InlineActionStoredNotExecuted` when an embedded action reaches runtime policy flow |
 
 Rationale: execution of user code and semantic predicates is policy-controlled. The default runtime keeps deterministic conservative behavior (not evaluated / not executed), while custom policies may alter branch acceptance and action handling within the documented runtime boundaries.
 


### PR DESCRIPTION
### Motivation
- Make ANTLR4 compatibility boundaries explicit by surfacing deterministic diagnostics for parsed-but-not-executed constructs such as semantic predicates and embedded actions. 
- Improve auditability and reduce ambiguity between parseability/metadata and runtime execution support without changing runtime semantics or public APIs.

### Description
- Added and strengthened regression assertions in `ParserDiagnosticsTests` to verify both predicate and inline-action compatibility diagnostics (`ParserDiagnostics.SemanticPredicateNotEnforced` and `ParserDiagnostics.InlineActionStoredNotExecuted`) in conservative parse flows. 
- Added a focused test `SemanticPredicateCompatibilityDiagnostic_IsDeterministic_AndIndependentFromParseSuccess` that asserts predicate compatibility diagnostics remain observable even when the parse succeeds. 
- Updated `docs/parser/Antlr4CompatibilityMatrix.md` to express a status matrix (Parsed / Stored / Resolved / Executable / Runtime-supported / Diagnostics) for semantic predicates, inline actions and rule actions to clearly separate metadata presence from runtime execution support. 
- No runtime codepaths, parser algorithms, scheduling, memoization, parse-tree shapes, or public APIs were changed.

### Testing
- Ran the parser diagnostics test suite with `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~UtilsTest.Parser.ParserDiagnosticsTests"` and all tests in that group passed (14 passed, 0 failed). 
- Verified that the change is documentation-and-test-only with a review of `Utils.Parser/ROADMAP.md`, and concluded a roadmap update was not required because this PR clarifies compatibility diagnostics and does not alter runtime direction or capabilities.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7ed4f94c8326be00c995e9e59c83)