### PR TITLE
Add passive parser runtime observation with isolated callbacks and roadmap note

### DIFF
--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -54,6 +54,7 @@ Current capabilities and responsibilities:
 - `ActiveParseState` provides local descriptive branch state.
 - `ParserLookaheadProbe` and `ParserLookaheadCache` provide conservative shallow lookahead.
 - Runtime feature policies are present.
+- Passive runtime observation hooks are available via policy configuration and remain non-authoritative.
 - Semantic predicate evaluator abstraction is present.
 - Parser action executor abstraction is present.
 - Continuation metadata is present.
@@ -73,6 +74,7 @@ Clarifications that must remain true:
 - `ActiveParseState` is not a runtime invocation frame.
 - Continuations are metadata-only.
 - Shared-prefix infrastructure is metadata-only.
+- Runtime observers are descriptive only and do not control scheduling, pruning, parse acceptance, parse-tree outcomes, or diagnostics authority.
 
 ## Explicit non-goals
 
@@ -144,6 +146,7 @@ Current clarification status:
 - local alternative comparison order is explicitly documented (longest match, then priority, then declaration order),
 - pruning is explicitly documented as orchestration-only and non-syntax-authoritative,
 - structural branch equivalence limits are explicitly documented as conservative and non-semantic-proof.
+- passive runtime observation is available for tooling/audit visibility and is explicitly non-authoritative (no control over scheduling, pruning, parse acceptance, parse-tree outcomes, or diagnostics authority).
 
 Allowed work:
 

--- a/Utils.Parser/Runtime/AlternativeRuntimeObservation.cs
+++ b/Utils.Parser/Runtime/AlternativeRuntimeObservation.cs
@@ -1,0 +1,19 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Describes a passive scheduler observation for a single alternative.
+/// This payload is immutable and descriptive-only.
+/// </summary>
+/// <param name="RuleName">Rule currently being scheduled.</param>
+/// <param name="AlternativeIndex">Deterministic alternative index in the ordered schedule.</param>
+/// <param name="Priority">Alternative priority value.</param>
+/// <param name="OriginInputPosition">Input position where scheduling started.</param>
+/// <param name="CurrentInputPosition">Observed current input position for the event.</param>
+/// <param name="Status">Observed scheduler status label.</param>
+public sealed record AlternativeRuntimeObservation(
+    string RuleName,
+    int AlternativeIndex,
+    int Priority,
+    int OriginInputPosition,
+    int CurrentInputPosition,
+    string Status);

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -15,9 +15,19 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class AlternativeScheduler
 {
+    private readonly IParserRuntimeObserver? _runtimeObserver;
     private readonly ParserLookaheadSharedPrefixDetector _sharedPrefixDetector = new();
     private readonly ParserContinuationFactory _continuationFactory = new();
     private readonly ParserSharedPrefixPlanFactory _sharedPrefixPlanFactory = new();
+
+    /// <summary>
+    /// Initializes a scheduler with an optional passive runtime observer.
+    /// </summary>
+    /// <param name="runtimeObserver">Descriptive observer that cannot influence scheduler decisions.</param>
+    public AlternativeScheduler(IParserRuntimeObserver? runtimeObserver = null)
+    {
+        _runtimeObserver = runtimeObserver;
+    }
     /// <summary>
     /// Drives alternative orchestration for a single alternation parse attempt.
     /// Local outcomes here are descriptive scheduling artifacts:
@@ -40,16 +50,21 @@ internal sealed class AlternativeScheduler
         {
             var alternative = ordered[index];
             var initial = CreateInitialState(rule, alternative, originInputPosition, index);
+            NotifyObserver(observation => _runtimeObserver?.OnAlternativeStarted(observation), CreateObservation(initial));
             var scheduled = parseAlternative(alternative, index);
             var parsed = scheduled.State;
             lookaheadProbesByAlternative[index] = scheduled.Probe;
             if (parsed is null)
             {
-                failedStates.Add(initial.Fail());
+                var failedState = initial.Fail();
+                failedStates.Add(failedState);
+                NotifyObserver(observation => _runtimeObserver?.OnAlternativeFailed(observation), CreateObservation(failedState));
                 continue;
             }
 
-            completedStates.Add(EnsureInitialized(parsed));
+            var completedState = EnsureInitialized(parsed);
+            completedStates.Add(completedState);
+            NotifyObserver(observation => _runtimeObserver?.OnAlternativeCompleted(observation), CreateObservation(completedState));
         }
 
         if (completedStates.Count == 0)
@@ -65,6 +80,10 @@ internal sealed class AlternativeScheduler
         var pruned = PruneEquivalentActiveStates(deduplicated, diagnostics);
         var prunedSet = new HashSet<ActiveParseState>(pruned);
         var prunedStates = deduplicated.Where(s => !prunedSet.Contains(s)).Select(static s => s.Prune()).ToList();
+        foreach (var prunedState in prunedStates)
+        {
+            NotifyObserver(observation => _runtimeObserver?.OnAlternativePruned(observation), CreateObservation(prunedState));
+        }
 
         // The selected state is the scheduler's best local candidate after orchestration filters.
         // ParserEngine still owns final parse acceptance (including trailing-token validation).
@@ -75,6 +94,11 @@ internal sealed class AlternativeScheduler
             {
                 winner = state;
             }
+        }
+
+        if (winner is not null)
+        {
+            NotifyObserver(observation => _runtimeObserver?.OnAlternativeSelected(observation), CreateObservation(winner));
         }
 
         return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(rule, ordered, lookaheadProbesByAlternative));
@@ -141,6 +165,45 @@ internal sealed class AlternativeScheduler
 
         return null;
     }
+    /// <summary>
+    /// Creates a passive immutable observation payload from a parse state.
+    /// </summary>
+    /// <param name="state">State to project to observation data.</param>
+    /// <returns>Immutable observation payload.</returns>
+    private static AlternativeRuntimeObservation CreateObservation(ActiveParseState state)
+    {
+        return new AlternativeRuntimeObservation(
+            state.Rule.Name,
+            state.AlternativeIndex,
+            state.Alternative.Priority,
+            state.OriginInputPosition,
+            state.CurrentInputPosition,
+            state.Status.ToString());
+    }
+
+
+    /// <summary>
+    /// Notifies a runtime observer callback while isolating observer exceptions from parser scheduling flow.
+    /// </summary>
+    /// <param name="callback">Observer callback to invoke.</param>
+    /// <param name="observation">Immutable observation payload passed to the callback.</param>
+    private static void NotifyObserver(Action<AlternativeRuntimeObservation>? callback, AlternativeRuntimeObservation observation)
+    {
+        if (callback is null)
+        {
+            return;
+        }
+
+        try
+        {
+            callback(observation);
+        }
+        catch
+        {
+            // Observer callbacks are intentionally isolated from runtime control flow.
+        }
+    }
+
     private static ActiveParseState CreateInitialState(Rule rule, Alternative alternative, int originInputPosition, int alternativeIndex)
     {
         return new ActiveParseState

--- a/Utils.Parser/Runtime/IParserRuntimeObserver.cs
+++ b/Utils.Parser/Runtime/IParserRuntimeObserver.cs
@@ -1,0 +1,40 @@
+using Utils.Parser.Model;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Defines a passive runtime observation contract for parser scheduling events.
+/// Implementations must remain non-authoritative and must not attempt to influence parser behavior.
+/// </summary>
+public interface IParserRuntimeObserver
+{
+    /// <summary>
+    /// Observes that an alternative started local scheduled execution.
+    /// </summary>
+    /// <param name="observation">Immutable observation payload.</param>
+    void OnAlternativeStarted(AlternativeRuntimeObservation observation);
+
+    /// <summary>
+    /// Observes that an alternative completed local scheduled execution.
+    /// </summary>
+    /// <param name="observation">Immutable observation payload.</param>
+    void OnAlternativeCompleted(AlternativeRuntimeObservation observation);
+
+    /// <summary>
+    /// Observes that an alternative failed local scheduled execution.
+    /// </summary>
+    /// <param name="observation">Immutable observation payload.</param>
+    void OnAlternativeFailed(AlternativeRuntimeObservation observation);
+
+    /// <summary>
+    /// Observes that an alternative was pruned by scheduler-level equivalence.
+    /// </summary>
+    /// <param name="observation">Immutable observation payload.</param>
+    void OnAlternativePruned(AlternativeRuntimeObservation observation);
+
+    /// <summary>
+    /// Observes the selected local winner state for a scheduling pass.
+    /// </summary>
+    /// <param name="observation">Immutable observation payload.</param>
+    void OnAlternativeSelected(AlternativeRuntimeObservation observation);
+}

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -151,7 +151,7 @@ public sealed class ParserEngine
         _semanticPredicateEvaluator = effectivePolicy.SemanticPredicateEvaluator ?? throw new ArgumentNullException(nameof(runtimeFeaturePolicy));
         _parserActionExecutor = effectivePolicy.ParserActionExecutor ?? throw new ArgumentNullException(nameof(runtimeFeaturePolicy));
         _caseInsensitive = IsCaseInsensitive(_definition);
-        _alternativeScheduler = new AlternativeScheduler();
+        _alternativeScheduler = new AlternativeScheduler(effectivePolicy.RuntimeObserver);
         _scheduledAlternativeExecutor = new ScheduledAlternativeExecutor(_stateRegistry, _lookaheadCache, new ParserLookaheadProbe());
     }
 

--- a/Utils.Parser/Runtime/ParserRuntimeFeaturePolicy.cs
+++ b/Utils.Parser/Runtime/ParserRuntimeFeaturePolicy.cs
@@ -14,7 +14,8 @@ public sealed record ParserRuntimeFeaturePolicy
     public static ParserRuntimeFeaturePolicy Default { get; } = new()
     {
         SemanticPredicateEvaluator = new DefaultSemanticPredicateEvaluator(),
-        ParserActionExecutor = new DefaultParserActionExecutor()
+        ParserActionExecutor = new DefaultParserActionExecutor(),
+        RuntimeObserver = null
     };
 
     /// <summary>
@@ -26,4 +27,11 @@ public sealed record ParserRuntimeFeaturePolicy
     /// Gets the parser action execution strategy.
     /// </summary>
     public required IParserActionExecutor ParserActionExecutor { get; init; }
+
+    /// <summary>
+    /// Gets the optional passive runtime observer for scheduling introspection.
+    /// This observer is descriptive-only and does not control parser execution.
+    /// </summary>
+    public IParserRuntimeObserver? RuntimeObserver { get; init; }
 }
+

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -227,6 +227,102 @@ public class AlternativeSchedulerTests
         Assert.IsTrue(result.CompletedStates.Any(static state => state.Alternative.Label == "Y"));
     }
 
+    [TestMethod]
+    public void Run_WithObserver_ProducesDeterministicEventOrdering()
+    {
+        var observer = new RecordingRuntimeObserver();
+        var scheduler = new AlternativeScheduler(observer);
+        var (context, rule, alternatives) = CreateAlternatives();
+
+        _ = scheduler.Run(
+            rule,
+            alternatives,
+            originInputPosition: context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, context.Position, 5 + index, index),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
+
+        CollectionAssert.AreEqual(
+            new string[]
+            {
+                "started:0", "completed:0",
+                "started:1", "completed:1",
+                "started:2", "completed:2",
+                "selected:2"
+            },
+            observer.Events);
+    }
+
+    [TestMethod]
+    public void Run_WithObserver_DoesNotChangeSchedulerSelection()
+    {
+        var withObserverScheduler = new AlternativeScheduler(new RecordingRuntimeObserver());
+        var withoutObserverScheduler = new AlternativeScheduler();
+        var (context, rule, alternatives) = CreateAlternatives();
+
+        var withObserver = withObserverScheduler.Run(
+            rule,
+            alternatives,
+            context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, context.Position, 7 + index, index),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
+
+        var withoutObserver = withoutObserverScheduler.Run(
+            rule,
+            alternatives,
+            context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, context.Position, 7 + index, index),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
+
+        Assert.IsNotNull(withObserver.SelectedState);
+        Assert.IsNotNull(withoutObserver.SelectedState);
+        Assert.AreEqual(withoutObserver.SelectedState.AlternativeIndex, withObserver.SelectedState.AlternativeIndex);
+        Assert.AreEqual(withoutObserver.SelectedState.CurrentInputPosition, withObserver.SelectedState.CurrentInputPosition);
+    }
+
+
+
+    [TestMethod]
+    public void Run_WithThrowingObserver_DoesNotChangeSchedulerSelection()
+    {
+        var withThrowingObserverScheduler = new AlternativeScheduler(new ThrowingRuntimeObserver());
+        var withoutObserverScheduler = new AlternativeScheduler();
+        var (context, rule, alternatives) = CreateAlternatives();
+
+        var withThrowingObserver = withThrowingObserverScheduler.Run(
+            rule,
+            alternatives,
+            context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, context.Position, 7 + index, index),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
+
+        var withoutObserver = withoutObserverScheduler.Run(
+            rule,
+            alternatives,
+            context.Position,
+            minimumPrecedence: 0,
+            diagnostics: null,
+            parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
+                CreateState(rule, alternative, context.Position, 7 + index, index),
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
+
+        Assert.IsNotNull(withThrowingObserver.SelectedState);
+        Assert.IsNotNull(withoutObserver.SelectedState);
+        Assert.AreEqual(withoutObserver.SelectedState.AlternativeIndex, withThrowingObserver.SelectedState.AlternativeIndex);
+        Assert.AreEqual(withoutObserver.SelectedState.CurrentInputPosition, withThrowingObserver.SelectedState.CurrentInputPosition);
+    }
+
     private static (ParseContext Context, Rule Rule, IReadOnlyList<Alternative> Alternatives) CreateAlternatives()
     {
         var a = new Alternative(2, Associativity.Left, new LiteralMatch("a"), "A");
@@ -260,5 +356,35 @@ public class AlternativeSchedulerTests
             Depth = 0,
             Continuation = null
         };
+    }
+
+
+
+    private sealed class ThrowingRuntimeObserver : IParserRuntimeObserver
+    {
+        public void OnAlternativeStarted(AlternativeRuntimeObservation observation) => throw new InvalidOperationException("observer exception");
+
+        public void OnAlternativeCompleted(AlternativeRuntimeObservation observation) => throw new InvalidOperationException("observer exception");
+
+        public void OnAlternativeFailed(AlternativeRuntimeObservation observation) => throw new InvalidOperationException("observer exception");
+
+        public void OnAlternativePruned(AlternativeRuntimeObservation observation) => throw new InvalidOperationException("observer exception");
+
+        public void OnAlternativeSelected(AlternativeRuntimeObservation observation) => throw new InvalidOperationException("observer exception");
+    }
+
+    private sealed class RecordingRuntimeObserver : IParserRuntimeObserver
+    {
+        public List<string> Events { get; } = [];
+
+        public void OnAlternativeStarted(AlternativeRuntimeObservation observation) => Events.Add($"started:{observation.AlternativeIndex}");
+
+        public void OnAlternativeCompleted(AlternativeRuntimeObservation observation) => Events.Add($"completed:{observation.AlternativeIndex}");
+
+        public void OnAlternativeFailed(AlternativeRuntimeObservation observation) => Events.Add($"failed:{observation.AlternativeIndex}");
+
+        public void OnAlternativePruned(AlternativeRuntimeObservation observation) => Events.Add($"pruned:{observation.AlternativeIndex}");
+
+        public void OnAlternativeSelected(AlternativeRuntimeObservation observation) => Events.Add($"selected:{observation.AlternativeIndex}");
     }
 }

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -162,3 +162,8 @@ No support for:
 - semantic-aware memoization.
 
 These boundaries are current-contract statements only.
+
+
+## Runtime observation
+
+The optional `IParserRuntimeObserver` infrastructure is passive and descriptive only. Observer callbacks do not return control decisions and cannot influence scheduling, pruning, parse acceptance, parse-tree shape, or diagnostics authority.


### PR DESCRIPTION
### Motivation

- Provide passive, descriptive runtime observation hooks to enable tooling, auditing, and runtime introspection without changing parser authority or behavior. 
- Ensure observer implementations cannot influence scheduling or parsing even if they throw by isolating observer callbacks from scheduler control flow. 
- Make the repository roadmap reflect the presence and non-authoritative semantics of the new observation infrastructure. 

### Description

- Add a passive observer contract `IParserRuntimeObserver` and an immutable payload `AlternativeRuntimeObservation` to represent scheduler events. 
- Instrument `AlternativeScheduler` to emit events (`started`, `completed`, `failed`, `pruned`, `selected`) and route all notifications through a `NotifyObserver(...)` helper that catches observer exceptions so they cannot affect scheduling decisions. 
- Wire the observer through `ParserRuntimeFeaturePolicy` (`RuntimeObserver` property) and propagate it into `ParserEngine` so observation is opt-in via policy. 
- Add focused tests (`Run_WithObserver_ProducesDeterministicEventOrdering`, `Run_WithObserver_DoesNotChangeSchedulerSelection`, `Run_WithThrowingObserver_DoesNotChangeSchedulerSelection`) and update `Utils.Parser/ROADMAP.md` and `docs/parser/RuntimeStateOwnership.md` to document that observers are passive and non-authoritative. 

### Testing

- Ran the alternative-scheduler unit tests including the three observer-focused tests under the parser test suite; the observer tests passed and showed deterministic ordering and that a throwing observer does not change selection. 
- The final change to `Utils.Parser/ROADMAP.md` was documentation-only and therefore no additional test run was required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd6d7866083268f707ded6abd4984)