### PR TITLE
Add passive runtime observation consumers and deterministic trace exports

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -265,6 +265,27 @@ var compiler = new ParseTreeCompiler<int, int>()
 
 ---
 
+
+## Runtime observation consumers (tooling)
+
+Runtime observations are passive and non-authoritative. They describe scheduler events and must not drive parser execution.
+
+Example consumer usage:
+
+```csharp
+var recorder = new RuntimeObservationRecorder();
+var parser = new ParserEngine(new ParserRuntimeFeaturePolicy
+{
+    RuntimeObserver = recorder
+});
+
+var result = parser.Parse("a", grammar);
+var textTrace = RuntimeObservationTextWriter.Write(recorder.Observations);
+var jsonTrace = RuntimeObservationJsonWriter.Write(recorder.Observations);
+```
+
+Current observation exports are intentionally limited to the observation payload itself. They do not expose scheduler internals, active parser state internals, replay capabilities, or execution control hooks.
+
 ## Build a grammar programmatically
 
 Every grammar can also be constructed in pure C# using the model objects:

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -126,7 +126,6 @@ var definition = Antlr4GrammarConverter.Parse("""
 
 ```csharp
 using Utils.Parser.Runtime;
-using System.IO;
 
 var lexer  = new LexerEngine(definition);
 var tokens = lexer.Tokenize(new StringReader("1 + 2 * 3")).ToList();
@@ -273,13 +272,25 @@ Runtime observations are passive and non-authoritative. They describe scheduler 
 Example consumer usage:
 
 ```csharp
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Runtime;
+
+var definition = Antlr4GrammarConverter.Parse("""
+    grammar Sample;
+    start : A ;
+    A     : 'a' ;
+    WS    : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+    """);
+
 var recorder = new RuntimeObservationRecorder();
-var parser = new ParserEngine(new ParserRuntimeFeaturePolicy
+var policy = ParserRuntimeFeaturePolicy.Default with
 {
     RuntimeObserver = recorder
-});
+};
+var parser = new ParserEngine(definition, policy);
+var tokens = new CompiledGrammar(definition).Tokenize("a");
 
-var result = parser.Parse("a", grammar);
+var result = parser.Parse(tokens);
 var textTrace = RuntimeObservationTextWriter.Write(recorder.Observations);
 var jsonTrace = RuntimeObservationJsonWriter.Write(recorder.Observations);
 ```

--- a/Utils.Parser/Runtime/RuntimeObservationJsonWriter.cs
+++ b/Utils.Parser/Runtime/RuntimeObservationJsonWriter.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Serializes runtime observations to deterministic JSON arrays for tooling experiments.
+/// </summary>
+public static class RuntimeObservationJsonWriter
+{
+    /// <summary>
+    /// Serializes observations in sequence order using stable property naming.
+    /// </summary>
+    /// <param name="observations">Observations to serialize.</param>
+    /// <returns>JSON representation that remains descriptive and non-authoritative.</returns>
+    public static string Write(IEnumerable<AlternativeRuntimeObservation> observations)
+    {
+        var payload = observations.Select(static observation => new RuntimeObservationJsonRecord(
+            observation.Kind.ToString(),
+            observation.Status.ToString(),
+            observation.RuleName,
+            observation.AlternativeIndex,
+            observation.CurrentInputPosition,
+            observation.OriginInputPosition,
+            observation.Priority));
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    /// <summary>
+    /// Represents serialized observation values with explicit stable JSON field names.
+    /// </summary>
+    /// <param name="Kind">Observation kind.</param>
+    /// <param name="Status">Observation status.</param>
+    /// <param name="Rule">Rule name.</param>
+    /// <param name="Alternative">Alternative index.</param>
+    /// <param name="CurrentInputPosition">Token currentInputCurrentInputPosition.</param>
+    /// <param name="OriginInputPosition">Token originInputCurrentInputPosition.</param>
+    /// <param name="Priority">Runtime priority.</param>
+    private sealed record RuntimeObservationJsonRecord(
+        string Kind,
+        string Status,
+        string Rule,
+        int Alternative,
+        int CurrentInputPosition,
+        int OriginInputPosition,
+        int Priority);
+}

--- a/Utils.Parser/Runtime/RuntimeObservationJsonWriter.cs
+++ b/Utils.Parser/Runtime/RuntimeObservationJsonWriter.cs
@@ -33,8 +33,8 @@ public static class RuntimeObservationJsonWriter
     /// <param name="Status">Observation status.</param>
     /// <param name="Rule">Rule name.</param>
     /// <param name="Alternative">Alternative index.</param>
-    /// <param name="CurrentInputPosition">Token currentInputCurrentInputPosition.</param>
-    /// <param name="OriginInputPosition">Token originInputCurrentInputPosition.</param>
+    /// <param name="CurrentInputPosition">Observed current input position.</param>
+    /// <param name="OriginInputPosition">Observed origin input position.</param>
     /// <param name="Priority">Runtime priority.</param>
     private sealed record RuntimeObservationJsonRecord(
         string Kind,

--- a/Utils.Parser/Runtime/RuntimeObservationRecorder.cs
+++ b/Utils.Parser/Runtime/RuntimeObservationRecorder.cs
@@ -1,0 +1,61 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Records parser runtime observations in arrival order for tooling-oriented exports.
+/// </summary>
+public sealed class RuntimeObservationRecorder : IParserRuntimeObserver
+{
+    private readonly List<AlternativeRuntimeObservation> observations = new();
+
+    /// <summary>
+    /// Gets an immutable snapshot of recorded observations.
+    /// </summary>
+    public IReadOnlyList<AlternativeRuntimeObservation> Observations => this.observations;
+
+    /// <summary>
+    /// Clears all currently recorded observations.
+    /// </summary>
+    public void Clear()
+    {
+        this.observations.Clear();
+    }
+
+    /// <inheritdoc />
+    public void OnAlternativeStarted(AlternativeRuntimeObservation observation)
+    {
+        this.Record(observation);
+    }
+
+    /// <inheritdoc />
+    public void OnAlternativeCompleted(AlternativeRuntimeObservation observation)
+    {
+        this.Record(observation);
+    }
+
+    /// <inheritdoc />
+    public void OnAlternativeFailed(AlternativeRuntimeObservation observation)
+    {
+        this.Record(observation);
+    }
+
+    /// <inheritdoc />
+    public void OnAlternativePruned(AlternativeRuntimeObservation observation)
+    {
+        this.Record(observation);
+    }
+
+    /// <inheritdoc />
+    public void OnAlternativeSelected(AlternativeRuntimeObservation observation)
+    {
+        this.Record(observation);
+    }
+
+    /// <summary>
+    /// Stores one immutable observation instance in deterministic sequence order.
+    /// </summary>
+    /// <param name="observation">Observation payload produced by the parser runtime.</param>
+    private void Record(AlternativeRuntimeObservation observation)
+    {
+        this.observations.Add(observation);
+    }
+}

--- a/Utils.Parser/Runtime/RuntimeObservationRecorder.cs
+++ b/Utils.Parser/Runtime/RuntimeObservationRecorder.cs
@@ -8,9 +8,9 @@ public sealed class RuntimeObservationRecorder : IParserRuntimeObserver
     private readonly List<AlternativeRuntimeObservation> observations = new();
 
     /// <summary>
-    /// Gets a defensive immutable snapshot of recorded observations.
+    /// Gets a read-only view over recorded observations.
     /// </summary>
-    public IReadOnlyList<AlternativeRuntimeObservation> Observations => this.observations.ToArray();
+    public IReadOnlyList<AlternativeRuntimeObservation> Observations => this.observations.AsReadOnly();
 
     /// <summary>
     /// Clears all currently recorded observations.

--- a/Utils.Parser/Runtime/RuntimeObservationRecorder.cs
+++ b/Utils.Parser/Runtime/RuntimeObservationRecorder.cs
@@ -8,9 +8,9 @@ public sealed class RuntimeObservationRecorder : IParserRuntimeObserver
     private readonly List<AlternativeRuntimeObservation> observations = new();
 
     /// <summary>
-    /// Gets an immutable snapshot of recorded observations.
+    /// Gets a defensive immutable snapshot of recorded observations.
     /// </summary>
-    public IReadOnlyList<AlternativeRuntimeObservation> Observations => this.observations;
+    public IReadOnlyList<AlternativeRuntimeObservation> Observations => this.observations.ToArray();
 
     /// <summary>
     /// Clears all currently recorded observations.

--- a/Utils.Parser/Runtime/RuntimeObservationTextWriter.cs
+++ b/Utils.Parser/Runtime/RuntimeObservationTextWriter.cs
@@ -1,0 +1,43 @@
+using System.Text;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Formats runtime observations as stable text lines for deterministic tooling traces.
+/// </summary>
+public static class RuntimeObservationTextWriter
+{
+    /// <summary>
+    /// Converts observations into a deterministic text trace.
+    /// </summary>
+    /// <param name="observations">Observations to render in their current sequence.</param>
+    /// <returns>Newline-delimited trace text using invariant formatting.</returns>
+    public static string Write(IEnumerable<AlternativeRuntimeObservation> observations)
+    {
+        var builder = new StringBuilder();
+
+        foreach (var observation in observations)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append('\n');
+            }
+
+            builder.Append(observation.Kind);
+            builder.Append(" status=");
+            builder.Append(observation.Status);
+            builder.Append(" rule=");
+            builder.Append(observation.RuleName);
+            builder.Append(" alt=");
+            builder.Append(observation.AlternativeIndex);
+            builder.Append(" priority=");
+            builder.Append(observation.Priority);
+            builder.Append(" origin=");
+            builder.Append(observation.OriginInputPosition);
+            builder.Append(" current=");
+            builder.Append(observation.CurrentInputPosition);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
+++ b/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
@@ -19,6 +19,19 @@ public class RuntimeObservationConsumersTests
     }
 
     [TestMethod]
+    public void RuntimeObservationRecorder_Observations_ReturnsDefensiveSnapshot()
+    {
+        var recorder = new RuntimeObservationRecorder();
+        recorder.OnAlternativeStarted(CreateObservation(ParserRuntimeObservationKind.AlternativeStarted, ParserRuntimeObservationStatus.Active, 0));
+
+        var firstSnapshot = recorder.Observations;
+        recorder.OnAlternativeCompleted(CreateObservation(ParserRuntimeObservationKind.AlternativeCompleted, ParserRuntimeObservationStatus.Completed, 0));
+
+        Assert.AreEqual(1, firstSnapshot.Count);
+        Assert.AreEqual(2, recorder.Observations.Count);
+    }
+
+    [TestMethod]
     public void RuntimeObservationTextWriter_ProducesStableDeterministicOutput()
     {
         var text = RuntimeObservationTextWriter.Write(CreateTraceObservations());

--- a/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
+++ b/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Diagnostics;
 using Utils.Parser.Runtime;
 
 namespace UtilsTest.Parser;
@@ -55,6 +57,36 @@ public class RuntimeObservationConsumersTests
         var first = RuntimeObservationTextWriter.Write(CreateTraceObservations());
         var second = RuntimeObservationTextWriter.Write(CreateTraceObservations());
         Assert.AreEqual(first, second);
+    }
+
+    [TestMethod]
+    public void RuntimeObservationRecorder_WorksWithRealParserPipeline()
+    {
+        const string grammar = """
+            grammar Sample;
+            start : A ;
+            A : 'a' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+        var definition = Antlr4GrammarConverter.Parse(grammar);
+        var recorder = new RuntimeObservationRecorder();
+        var parser = new ParserEngine(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                RuntimeObserver = recorder
+            });
+        var diagnostics = new DiagnosticBag();
+        var tokens = new CompiledGrammar(definition).Tokenize("a");
+
+        var parseResult = parser.Parse(tokens, diagnostics: diagnostics);
+        var textTrace = RuntimeObservationTextWriter.Write(recorder.Observations);
+        var jsonTrace = RuntimeObservationJsonWriter.Write(recorder.Observations);
+
+        Assert.IsFalse(parseResult is ErrorNode);
+        Assert.IsTrue(recorder.Observations.Count > 0);
+        Assert.IsTrue(textTrace.Length > 0);
+        Assert.IsTrue(jsonTrace.StartsWith("[", StringComparison.Ordinal));
     }
 
     private static AlternativeRuntimeObservation[] CreateTraceObservations()

--- a/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
+++ b/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class RuntimeObservationConsumersTests
+{
+    [TestMethod]
+    public void RuntimeObservationRecorder_RecordsDeterministicSequence()
+    {
+        var recorder = new RuntimeObservationRecorder();
+
+        recorder.OnAlternativeStarted(CreateObservation(ParserRuntimeObservationKind.AlternativeStarted, ParserRuntimeObservationStatus.Active, 0));
+        recorder.OnAlternativeCompleted(CreateObservation(ParserRuntimeObservationKind.AlternativeCompleted, ParserRuntimeObservationStatus.Completed, 0));
+        recorder.OnAlternativeSelected(CreateObservation(ParserRuntimeObservationKind.AlternativeSelected, ParserRuntimeObservationStatus.Completed, 0));
+
+        Assert.AreEqual(3, recorder.Observations.Count);
+    }
+
+    [TestMethod]
+    public void RuntimeObservationTextWriter_ProducesStableDeterministicOutput()
+    {
+        var text = RuntimeObservationTextWriter.Write(CreateTraceObservations());
+        var expected = "AlternativeStarted status=Active rule=entry alt=0 priority=0 origin=0 current=1\n" +
+            "AlternativeCompleted status=Completed rule=entry alt=0 priority=0 origin=0 current=3\n" +
+            "AlternativeSelected status=Completed rule=entry alt=0 priority=0 origin=0 current=3";
+        Assert.AreEqual(expected, text);
+    }
+
+    [TestMethod]
+    public void RuntimeObservationJsonWriter_ProducesStableDeterministicOutput()
+    {
+        var json = RuntimeObservationJsonWriter.Write(CreateTraceObservations());
+        var expected = "[{\"Kind\":\"AlternativeStarted\",\"Status\":\"Active\",\"Rule\":\"entry\",\"Alternative\":0,\"CurrentInputPosition\":1,\"OriginInputPosition\":0,\"Priority\":0},{\"Kind\":\"AlternativeCompleted\",\"Status\":\"Completed\",\"Rule\":\"entry\",\"Alternative\":0,\"CurrentInputPosition\":3,\"OriginInputPosition\":0,\"Priority\":0},{\"Kind\":\"AlternativeSelected\",\"Status\":\"Completed\",\"Rule\":\"entry\",\"Alternative\":0,\"CurrentInputPosition\":3,\"OriginInputPosition\":0,\"Priority\":0}]";
+        Assert.AreEqual(expected, json);
+    }
+
+    [TestMethod]
+    public void RuntimeObservationConsumers_AreConsumerReplaceableAcrossRuns()
+    {
+        var first = RuntimeObservationTextWriter.Write(CreateTraceObservations());
+        var second = RuntimeObservationTextWriter.Write(CreateTraceObservations());
+        Assert.AreEqual(first, second);
+    }
+
+    private static AlternativeRuntimeObservation[] CreateTraceObservations()
+    {
+        return
+        [
+            CreateObservation(ParserRuntimeObservationKind.AlternativeStarted, ParserRuntimeObservationStatus.Active, 0, 1),
+            CreateObservation(ParserRuntimeObservationKind.AlternativeCompleted, ParserRuntimeObservationStatus.Completed, 0, 3),
+            CreateObservation(ParserRuntimeObservationKind.AlternativeSelected, ParserRuntimeObservationStatus.Completed, 0, 3)
+        ];
+    }
+
+    private static AlternativeRuntimeObservation CreateObservation(ParserRuntimeObservationKind kind, ParserRuntimeObservationStatus status, int alternativeIndex, int currentInputPosition = 0)
+    {
+        return new AlternativeRuntimeObservation(kind, "entry", alternativeIndex, 0, 0, currentInputPosition, status);
+    }
+}

--- a/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
+++ b/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
@@ -21,7 +21,7 @@ public class RuntimeObservationConsumersTests
     }
 
     [TestMethod]
-    public void RuntimeObservationRecorder_Observations_ReturnsDefensiveSnapshot()
+    public void RuntimeObservationRecorder_Observations_ReturnsLiveReadOnlyView()
     {
         var recorder = new RuntimeObservationRecorder();
         recorder.OnAlternativeStarted(CreateObservation(ParserRuntimeObservationKind.AlternativeStarted, ParserRuntimeObservationStatus.Active, 0));
@@ -29,7 +29,7 @@ public class RuntimeObservationConsumersTests
         var firstSnapshot = recorder.Observations;
         recorder.OnAlternativeCompleted(CreateObservation(ParserRuntimeObservationKind.AlternativeCompleted, ParserRuntimeObservationStatus.Completed, 0));
 
-        Assert.AreEqual(1, firstSnapshot.Count);
+        Assert.AreEqual(2, firstSnapshot.Count);
         Assert.AreEqual(2, recorder.Observations.Count);
     }
 


### PR DESCRIPTION
### Motivation

- Validate that the existing immutable observation contract is usable by tooling without changing runtime semantics. 
- Provide small, reusable, deterministic consumers and exporters to support tooling experiments while keeping observers passive and non-authoritative.

### Description

- Add `RuntimeObservationRecorder` implementing `IParserRuntimeObserver` that records immutable `AlternativeRuntimeObservation` instances in arrival order for tooling consumption (`Utils.Parser/Runtime/RuntimeObservationRecorder.cs`).
- Add `RuntimeObservationTextWriter` which renders a stable, newline-delimited text trace from an observation sequence (`Utils.Parser/Runtime/RuntimeObservationTextWriter.cs`).
- Add `RuntimeObservationJsonWriter` which serializes observations to a deterministic JSON array with explicit field names (`Utils.Parser/Runtime/RuntimeObservationJsonWriter.cs`).
- Add focused tests validating deterministic recording and exports and consumer replaceability, and add a short README snippet documenting intended usage and the non-authoritative nature of observations (`UtilsTest/Parser/RuntimeObservationConsumersTests.cs`, `Utils.Parser/README.md`).

### Testing

- Ran the new test set with `dotnet test UtilsTest/UtilsTest.csproj --filter RuntimeObservationConsumersTests --no-restore` and the targeted tests passed (`Passed: 4, Failed: 0`).
- The tests exercise recorder ordering, stable text export, stable JSON export, and reproducible outputs across runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee59b575083268b952898f374b013)