### PR TITLE
docs(parser): consolidate runtime observation and export contracts

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -104,6 +104,18 @@ decided separately by `HasDistinctSemantics`, which checks label, associativity,
 presence of predicates or actions. Pruning occurs only when both conditions hold: same
 shape key **and** `HasDistinctSemantics` returns `false`.
 
+
+### Runtime observation and export contract
+
+Runtime observation is passive, descriptive, and non-authoritative.
+
+- Observation contract (runtime semantics): `AlternativeRuntimeObservation`, `ParserRuntimeObservationKind`, `ParserRuntimeObservationStatus`, `IParserRuntimeObserver`.
+- Export contract (tooling renderers): `RuntimeObservationTextWriter`, `RuntimeObservationJsonWriter`.
+
+These are intentionally separate contracts. Export formats are deterministic tooling outputs, not replay or parser-control mechanisms.
+
+See [`docs/parser/RuntimeObservationAndExportContract.md`](../docs/parser/RuntimeObservationAndExportContract.md) for guarantees, non-guarantees, and stability boundaries.
+
 ## Quick start
 
 ### 1 — Parse a grammar from a `.g4` string

--- a/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
+++ b/UtilsTest/Parser/RuntimeObservationConsumersTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Parser.Bootstrap;
 using Utils.Parser.Diagnostics;
@@ -59,6 +60,50 @@ public class RuntimeObservationConsumersTests
         Assert.AreEqual(first, second);
     }
 
+
+
+    [TestMethod]
+    public void RuntimeObservationJsonWriter_UsesStableFieldNamesAndDistinctKindStatus()
+    {
+        var json = RuntimeObservationJsonWriter.Write(CreateTraceObservations());
+        using var document = JsonDocument.Parse(json);
+        var first = document.RootElement[0];
+
+        Assert.IsTrue(first.TryGetProperty("Kind", out var kind));
+        Assert.IsTrue(first.TryGetProperty("Status", out var status));
+        Assert.IsTrue(first.TryGetProperty("Rule", out _));
+        Assert.IsTrue(first.TryGetProperty("Alternative", out _));
+        Assert.IsTrue(first.TryGetProperty("CurrentInputPosition", out _));
+        Assert.IsTrue(first.TryGetProperty("OriginInputPosition", out _));
+        Assert.IsTrue(first.TryGetProperty("Priority", out _));
+        Assert.AreEqual("AlternativeStarted", kind.GetString());
+        Assert.AreEqual("Active", status.GetString());
+    }
+
+    [TestMethod]
+    public void RuntimeObservationExports_DoNotExposeActiveParseStateInternals()
+    {
+        var observations = CreateTraceObservations();
+
+        var text = RuntimeObservationTextWriter.Write(observations);
+        var json = RuntimeObservationJsonWriter.Write(observations);
+
+        Assert.IsFalse(text.Contains("ActiveParseState", StringComparison.Ordinal));
+        Assert.IsFalse(text.Contains("StateKey", StringComparison.Ordinal));
+        Assert.IsFalse(json.Contains("ActiveParseState", StringComparison.Ordinal));
+        Assert.IsFalse(json.Contains("StateKey", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void RuntimeObservationExports_AreDeterministicAcrossEquivalentParserRuns()
+    {
+        var first = RunObservedParse("a");
+        var second = RunObservedParse("a");
+
+        Assert.AreEqual(first.TextTrace, second.TextTrace);
+        Assert.AreEqual(first.JsonTrace, second.JsonTrace);
+    }
+
     [TestMethod]
     public void RuntimeObservationRecorder_WorksWithRealParserPipeline()
     {
@@ -87,6 +132,35 @@ public class RuntimeObservationConsumersTests
         Assert.IsTrue(recorder.Observations.Count > 0);
         Assert.IsTrue(textTrace.Length > 0);
         Assert.IsTrue(jsonTrace.StartsWith("[", StringComparison.Ordinal));
+    }
+
+
+
+    private static (string TextTrace, string JsonTrace) RunObservedParse(string input)
+    {
+        const string grammar = """
+            grammar Sample;
+            start : A ;
+            A : 'a' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """;
+
+        var definition = Antlr4GrammarConverter.Parse(grammar);
+        var recorder = new RuntimeObservationRecorder();
+        var parser = new ParserEngine(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                RuntimeObserver = recorder
+            });
+        var diagnostics = new DiagnosticBag();
+        var tokens = new CompiledGrammar(definition).Tokenize(input);
+
+        _ = parser.Parse(tokens, diagnostics: diagnostics);
+
+        return (
+            RuntimeObservationTextWriter.Write(recorder.Observations),
+            RuntimeObservationJsonWriter.Write(recorder.Observations));
     }
 
     private static AlternativeRuntimeObservation[] CreateTraceObservations()

--- a/docs/parser/RuntimeObservationAndExportContract.md
+++ b/docs/parser/RuntimeObservationAndExportContract.md
@@ -1,0 +1,100 @@
+# Runtime Observation and Export Contract
+
+This document defines the contract boundaries for parser runtime observation in `Utils.Parser`.
+
+It intentionally separates:
+
+1. the **runtime observation contract** (what the parser runtime emits), and
+2. the **export contract** (how tooling can render/export those observations).
+
+Observation and export remain passive, descriptive, and non-authoritative.
+
+See also:
+
+- [`Utils.Parser/ROADMAP.md`](../../Utils.Parser/ROADMAP.md)
+- [`docs/parser/RuntimeStateOwnership.md`](./RuntimeStateOwnership.md)
+- [`docs/parser/ParserMetadataAndRuntimeLimitations.md`](./ParserMetadataAndRuntimeLimitations.md)
+
+## 1) Runtime observation contract
+
+Applicable types:
+
+- `AlternativeRuntimeObservation`
+- `ParserRuntimeObservationKind`
+- `ParserRuntimeObservationStatus`
+- `IParserRuntimeObserver`
+
+### Guarantees
+
+- Observations are emitted in the deterministic scheduling order of a deterministic parser run.
+- Observation payloads are immutable (`AlternativeRuntimeObservation` record values).
+- Observation callbacks are passive and non-authoritative.
+- Observer callback exceptions are isolated and must not alter parser execution semantics.
+- `Kind` describes **which scheduler event was observed**.
+- `Status` describes **the observed runtime status at that moment**.
+- `Kind` and `Status` are distinct dimensions and must not be collapsed into a single semantic channel.
+- Runtime observation does not grant replay, control, or execution authority.
+
+### Non-guarantees
+
+- No guarantee of exhaustive internal scheduler state exposure.
+- No exposure of `ActiveParseState` internals via observation payloads.
+- No proof of semantic equivalence from observations alone.
+- No branch replay/resume contract.
+- No commitment that every future runtime internal detail will be surfaced in observations.
+- No commitment that observation payload fields model complete runtime internals.
+
+## 2) Export contract
+
+Applicable types:
+
+- `RuntimeObservationTextWriter`
+- `RuntimeObservationJsonWriter`
+
+Exports are tooling-oriented diagnostics. They are not parser execution contracts.
+
+### Shared guarantees
+
+- Export functions are deterministic for the same input observation sequence.
+- Exports are descriptive only and not authoritative parse state.
+- Exports are not replay formats.
+- Exports do not expose internal runtime structures such as `ActiveParseState`.
+
+### Text export contract
+
+`RuntimeObservationTextWriter.Write` outputs one line per observation with:
+
+- invariant token labels,
+- stable field order,
+- no trailing newline (lines separated by `\n`).
+
+Intended use:
+
+- deterministic diagnostics,
+- snapshot-like tooling comparisons.
+
+### JSON export contract
+
+`RuntimeObservationJsonWriter.Write` outputs a JSON array with one object per observation.
+
+Current object field names are:
+
+- `Kind`
+- `Status`
+- `Rule`
+- `Alternative`
+- `CurrentInputPosition`
+- `OriginInputPosition`
+- `Priority`
+
+Additional expectations:
+
+- enum values are emitted as enum names (`ToString()` representation),
+- object property order is stable for the current implementation and covered by tests,
+- output is intentionally minimal and descriptive.
+
+## 3) Stability boundary
+
+Within the current major line, this contract is intended to be stable for tooling-oriented comparisons, while staying explicitly non-authoritative for runtime execution.
+
+If future runtime internals evolve, observation/export additions should preserve these passive boundaries and avoid implying execution or replay semantics.


### PR DESCRIPTION
### Motivation

- Clarify and lock down the boundaries between the runtime observation model and tooling export formats to prevent accidental public-contract drift.
- Make explicit what observers and exporters guarantee (and do not guarantee) so tooling consumers know which aspects are stable and which are descriptive-only.
- Provide deterministic, test-backed documentation that preserves the runtime’s passive/non-authoritative semantics without changing parser behavior.

### Description

- Added a dedicated contract document at `docs/parser/RuntimeObservationAndExportContract.md` that separates the runtime observation contract (`AlternativeRuntimeObservation`, `ParserRuntimeObservationKind`, `ParserRuntimeObservationStatus`, `IParserRuntimeObserver`) from the export contract (`RuntimeObservationTextWriter`, `RuntimeObservationJsonWriter`).
- Updated `Utils.Parser/README.md` with a concise cross-referenced section that points to the new contract document and reiterates the passive, non-authoritative nature of observations and exports.
- Strengthened `UtilsTest/Parser/RuntimeObservationConsumersTests.cs` with contract-focused tests that validate stable JSON field names, distinct `Kind` vs `Status` export dimensions, absence of leaked `ActiveParseState` internals in exports, and deterministic text/JSON outputs across equivalent parser runs.
- No runtime behavioral changes, no new observation events or callbacks, and no public API changes were introduced.

### Testing

- Ran the targeted test set with `dotnet test UtilsTest/UtilsTest.csproj --filter RuntimeObservationConsumersTests`, and the selected tests passed (Passed: 9/9).
- The new/updated tests assert stable text output via `RuntimeObservationTextWriter.Write`, stable JSON structure via `RuntimeObservationJsonWriter.Write` and `System.Text.Json`, absence of internal identifiers in exports, and deterministic equality of traces across equivalent parser runs, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0ed7ac4483268edf1a7085b11667)