### PR TITLE
docs(parser): document conservative diagnostics–observation correlation contract

### DIFF
--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -65,6 +65,7 @@ Current capabilities and responsibilities:
 - Branch outcome documentation exists.
 - Parser tests are organized to reflect runtime contracts.
 - Runtime observation and export contract is documented (`docs/parser/RuntimeObservationAndExportContract.md`).
+- Diagnostics/observation correlation boundaries are documented (`docs/parser/DiagnosticsObservationCorrelation.md`) as descriptive-only and non-authoritative.
 
 Clarifications that must remain true:
 
@@ -152,6 +153,7 @@ Current clarification status:
 - passive runtime observation is available for tooling/audit visibility and is explicitly non-authoritative (no control over scheduling, pruning, parse acceptance, parse-tree outcomes, or diagnostics authority).
 - observation contracts are normalized as immutable descriptive payloads; observer exceptions are isolated from parser execution semantics.
 - observation and export contract is formally documented in `docs/parser/RuntimeObservationAndExportContract.md`, covering runtime observation guarantees, export format stability, and non-authoritative boundaries.
+- diagnostics/observation correlation boundaries are explicitly documented as optional one-way descriptive identifiers only, with no replay/navigation authority.
 
 Allowed work:
 

--- a/docs/parser/DiagnosticsObservationCorrelation.md
+++ b/docs/parser/DiagnosticsObservationCorrelation.md
@@ -1,0 +1,100 @@
+# Diagnostics / Observation Correlation Contract
+
+This document defines conservative boundaries for correlating parser diagnostics with runtime observations in `Utils.Parser`.
+
+It extends the current passive runtime observation model without changing runtime behavior, parser authority, or export authority.
+
+See also:
+
+- [`docs/parser/RuntimeStateOwnership.md`](./RuntimeStateOwnership.md)
+- [`docs/parser/RuntimeObservationAndExportContract.md`](./RuntimeObservationAndExportContract.md)
+- [`docs/parser/ParserMetadataAndRuntimeLimitations.md`](./ParserMetadataAndRuntimeLimitations.md)
+
+## 1) Contract intent
+
+Correlation is allowed only as descriptive metadata for tooling.
+
+The preferred conservative model is one-way:
+
+- `Diagnostic -> RuntimeObservationId?`
+
+This means a diagnostic may optionally carry an immutable descriptive identifier that points to an observed runtime event in the same parser run.
+
+No reverse ownership link is implied.
+
+## 2) Authority and ownership boundaries
+
+These boundaries are mandatory:
+
+- Diagnostics remain parser-authoritative.
+- Runtime observations remain passive and descriptive.
+- Correlation identifiers do not transfer ownership between diagnostics and observations.
+- Correlation identifiers do not change parser scheduling, parse acceptance, parse-tree shape, or diagnostic authority.
+
+A correlation identifier is not an execution handle.
+
+## 3) Why direct object references are forbidden
+
+Direct references such as `Diagnostic -> Observation object` or `Observation -> Diagnostic[]` are intentionally forbidden because they would:
+
+- blur ownership boundaries,
+- create graph-navigation pressure,
+- risk accidental replay expectations,
+- increase coupling to mutable runtime internals,
+- make export contracts harder to keep deterministic and non-authoritative.
+
+To preserve determinism and ownership boundaries, correlation must stay identifier-based and immutable.
+
+## 4) Correlation identifier semantics
+
+Any future correlation identifier must be interpreted as:
+
+- descriptive only,
+- scoped to a single observed parser run unless explicitly documented otherwise,
+- optional (`null` / missing is valid),
+- non-authoritative,
+- non-navigational.
+
+A correlation identifier must not imply:
+
+- runtime state reachability,
+- runtime object access,
+- replay capability,
+- scheduler authority,
+- parser-control authority,
+- cross-run stability by default.
+
+## 5) Non-goals
+
+This contract does not introduce:
+
+- runtime graph construction,
+- bidirectional diagnostic/observation links,
+- mutable correlation registries,
+- ID-based runtime lookup APIs,
+- trace replay,
+- diagnostic-driven parsing,
+- observation-driven parsing,
+- parser execution control.
+
+## 6) Export-facing expectations
+
+If correlation appears in future text or JSON exports, the field must remain descriptive and optional.
+
+Export constraints remain:
+
+- exports are deterministic for the same input sequence,
+- exports are not replay formats,
+- exports must not expose mutable runtime internals,
+- absence of correlation data must be valid and expected.
+
+## 7) Recommended future shape (documentation-only)
+
+If a runtime identifier type is added in future code, keep it minimal and immutable (for example a small readonly value type).
+
+Any adoption should remain conservative and behavior-neutral:
+
+- no global mutable ID registry,
+- no runtime lookup service,
+- no ownership transfer,
+- no parser-control surface.

--- a/docs/parser/RuntimeObservationAndExportContract.md
+++ b/docs/parser/RuntimeObservationAndExportContract.md
@@ -14,6 +14,7 @@ See also:
 - [`Utils.Parser/ROADMAP.md`](../../Utils.Parser/ROADMAP.md)
 - [`docs/parser/RuntimeStateOwnership.md`](./RuntimeStateOwnership.md)
 - [`docs/parser/ParserMetadataAndRuntimeLimitations.md`](./ParserMetadataAndRuntimeLimitations.md)
+- [`docs/parser/DiagnosticsObservationCorrelation.md`](./DiagnosticsObservationCorrelation.md)
 
 ## 1) Runtime observation contract
 


### PR DESCRIPTION
### Motivation
- Clarify whether and how parser diagnostics may be correlated with runtime observations while preserving existing ownership and non-authoritative boundaries. 
- Provide a conservative, tooling-oriented contract that prevents accidental introduction of runtime graph, replay, or navigation semantics. 
- Keep the `Utils.Parser` roadmap and the canonical observation/export documentation synchronized with this explicit guidance. 

### Description
- Add `docs/parser/DiagnosticsObservationCorrelation.md` describing a one-way, descriptive-only correlation model (`Diagnostic -> RuntimeObservationId?`) and explicit non-goals (no object references, no replay, no registries, no runtime control). 
- Link the new document from `docs/parser/RuntimeObservationAndExportContract.md` to improve discoverability of correlation guidance. 
- Update `Utils.Parser/ROADMAP.md` to record that diagnostics/observation correlation boundaries are now documented and to keep roadmap accuracy per repository rules. 
- This is documentation-only: no runtime code, public API, or export schema changes were introduced. 

### Testing
- No automated tests were executed because this PR is documentation-only and does not modify code or behavior. 
- No behavior, parse-tree shape, or diagnostics execution changes were made and therefore no unit or integration tests were required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f187d33e0832687265619edfd1ad9)