### PR TITLE
docs(parser): add runtime trace tooling examples and boundary guidance

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -309,6 +309,34 @@ var jsonTrace = RuntimeObservationJsonWriter.Write(recorder.Observations);
 
 Current observation exports are intentionally limited to the observation payload itself. They do not expose scheduler internals, active parser state internals, replay capabilities, or execution control hooks.
 
+
+### Runtime trace tooling workflow (illustrative)
+
+The current tooling flow is intentionally one-way and descriptive:
+
+1. Parse with a `RuntimeObservationRecorder` attached to `ParserRuntimeFeaturePolicy`.
+2. Export recorder observations with `RuntimeObservationTextWriter` / `RuntimeObservationJsonWriter`.
+3. Analyze deterministic observation sequences via `RuntimeTraceAnalyzer.Summarize(...)` and `RuntimeTraceAnalyzer.Compare(...)`.
+
+```csharp
+var recorder = new RuntimeObservationRecorder();
+var policy = ParserRuntimeFeaturePolicy.Default with
+{
+    RuntimeObserver = recorder
+};
+
+var parser = new ParserEngine(definition, policy);
+var result = parser.Parse(tokens);
+
+var textExport = RuntimeObservationTextWriter.Write(recorder.Observations);
+var jsonExport = RuntimeObservationJsonWriter.Write(recorder.Observations);
+
+var summary = RuntimeTraceAnalyzer.Summarize(recorder.Observations);
+```
+
+For full end-to-end examples and boundary guidance, see
+[`docs/parser/RuntimeTraceAnalysis.md`](../docs/parser/RuntimeTraceAnalysis.md).
+
 ## Build a grammar programmatically
 
 Every grammar can also be constructed in pure C# using the model objects:

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -367,6 +367,7 @@ Current clarification status:
 
 - runtime trace analysis abstractions are available as tooling-only, read-only, deterministic consumers of passive observations/exports,
 - analysis outputs are explicitly descriptive and non-authoritative (no replay, no runtime ownership transfer, no parser/diagnostics authority transfer).
+- end-to-end runtime-observation/export/analysis usage guidance is documented as illustrative tooling only, with explicit non-framework/non-authoritative boundaries.
 
 ### Phase 8 — Future runtime research gates
 

--- a/docs/parser/RuntimeTraceAnalysis.md
+++ b/docs/parser/RuntimeTraceAnalysis.md
@@ -121,9 +121,9 @@ RuntimeTraceSummary baselineSummary = RuntimeTraceAnalyzer.Summarize(baseline);
 RuntimeTraceSummary candidateSummary = RuntimeTraceAnalyzer.Summarize(candidate);
 RuntimeTraceComparison comparison = RuntimeTraceAnalyzer.Compare(baseline, candidate);
 
-Console.WriteLine($"Baseline events: {baselineSummary.TotalObservationCount}");
-Console.WriteLine($"Candidate events: {candidateSummary.TotalObservationCount}");
-Console.WriteLine($"Delta events: {comparison.TotalObservationCountDelta}");
+Console.WriteLine($"Baseline events: {baselineSummary.TotalObservations}");
+Console.WriteLine($"Candidate events: {candidateSummary.TotalObservations}");
+Console.WriteLine($"Delta events: {comparison.FirstTotalObservations - comparison.SecondTotalObservations}");
 Console.WriteLine($"Text export identical: {comparison.AreTextExportsIdentical}");
 Console.WriteLine($"Json export identical: {comparison.AreJsonExportsIdentical}");
 ```

--- a/docs/parser/RuntimeTraceAnalysis.md
+++ b/docs/parser/RuntimeTraceAnalysis.md
@@ -123,7 +123,7 @@ RuntimeTraceComparison comparison = RuntimeTraceAnalyzer.Compare(baseline, candi
 
 Console.WriteLine($"Baseline events: {baselineSummary.TotalObservations}");
 Console.WriteLine($"Candidate events: {candidateSummary.TotalObservations}");
-Console.WriteLine($"Delta events: {comparison.FirstTotalObservations - comparison.SecondTotalObservations}");
+Console.WriteLine($"Delta events: {comparison.EventCountDelta}");
 Console.WriteLine($"Text export identical: {comparison.AreTextExportsIdentical}");
 Console.WriteLine($"Json export identical: {comparison.AreJsonExportsIdentical}");
 ```

--- a/docs/parser/RuntimeTraceAnalysis.md
+++ b/docs/parser/RuntimeTraceAnalysis.md
@@ -57,3 +57,88 @@ Examples of allowed descriptive outputs:
 - optional export identity indicators (`AreTextExportsIdentical`, `AreJsonExportsIdentical`) treated as informational only.
 
 These outputs are diagnostic aids for tooling only.
+
+
+## End-to-end usage examples (runtime → observation → export → analysis)
+
+The examples below intentionally demonstrate consumption of **existing** APIs only.
+They are illustrative tooling snippets, not a supported framework surface.
+
+### Example A — Record observations during parsing
+
+```csharp
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Model;
+using Utils.Parser.Runtime;
+
+var definition = Antlr4GrammarConverter.Parse("""
+    grammar Sample;
+    start : Number ('+' Number)* EOF ;
+    Number : [0-9]+ ;
+    WS : [ 	
+]+ -> skip ;
+    """);
+
+var recorder = new RuntimeObservationRecorder();
+var policy = ParserRuntimeFeaturePolicy.Default with
+{
+    RuntimeObserver = recorder
+};
+
+var parser = new ParserEngine(definition, policy);
+var lexer = new LexerEngine(definition);
+var tokens = lexer.Tokenize(new StringReader("1+2+3")).ToList();
+
+var parseResult = parser.Parse(tokens);
+
+// Immutable deterministic payloads emitted in scheduler order.
+IReadOnlyList<AlternativeRuntimeObservation> observations = recorder.Observations;
+```
+
+### Example B — Produce deterministic exports from observations
+
+```csharp
+using Utils.Parser.Runtime;
+
+IReadOnlyList<AlternativeRuntimeObservation> observations = recorder.Observations;
+
+var textTrace = RuntimeObservationTextWriter.Write(observations);
+var jsonTrace = RuntimeObservationJsonWriter.Write(observations);
+
+File.WriteAllText("trace.txt", textTrace);
+File.WriteAllText("trace.json", jsonTrace);
+```
+
+### Example C — Run deterministic analysis and compare traces
+
+```csharp
+using Utils.Parser.Runtime;
+
+IReadOnlyList<AlternativeRuntimeObservation> baseline = baselineRecorder.Observations;
+IReadOnlyList<AlternativeRuntimeObservation> candidate = candidateRecorder.Observations;
+
+RuntimeTraceSummary baselineSummary = RuntimeTraceAnalyzer.Summarize(baseline);
+RuntimeTraceSummary candidateSummary = RuntimeTraceAnalyzer.Summarize(candidate);
+RuntimeTraceComparison comparison = RuntimeTraceAnalyzer.Compare(baseline, candidate);
+
+Console.WriteLine($"Baseline events: {baselineSummary.TotalObservationCount}");
+Console.WriteLine($"Candidate events: {candidateSummary.TotalObservationCount}");
+Console.WriteLine($"Delta events: {comparison.TotalObservationCountDelta}");
+Console.WriteLine($"Text export identical: {comparison.AreTextExportsIdentical}");
+Console.WriteLine($"Json export identical: {comparison.AreJsonExportsIdentical}");
+```
+
+## Tooling boundary guidance
+
+Keep runtime trace tooling strictly on the descriptive side:
+
+- ✅ allowed: record observations, export deterministic text/JSON, summarize distributions, compare trace sets.
+- ❌ not allowed: parser replay, scheduler manipulation, branch forcing, diagnostics ownership changes, parse-tree control.
+- ❌ not exposed: runtime object graph navigation, execution handles, parser state mutation APIs.
+
+Practical interpretation:
+
+- Runtime remains the only execution authority.
+- Observation remains passive.
+- Export remains neutral formatting.
+- Analysis remains read-only interpretation.


### PR DESCRIPTION
### Motivation
- Provide concrete, end-to-end examples that demonstrate how to consume the existing runtime observation APIs, produce deterministic exports, and run read-only analysis without changing runtime behavior or public APIs. 
- Improve discoverability by surfacing a concise tooling workflow in the package README and linking to the detailed examples. 
- Emphasize tooling boundaries so exporters and analyzers remain descriptive and non-authoritative. 

### Description
- Added an "End-to-end usage examples (runtime → observation → export → analysis)" section to `docs/parser/RuntimeTraceAnalysis.md` containing three illustrative snippets: (A) record observations with `RuntimeObservationRecorder`, (B) produce deterministic text/JSON exports with `RuntimeObservationTextWriter` / `RuntimeObservationJsonWriter`, and (C) summarize and compare traces with `RuntimeTraceAnalyzer`. 
- Inserted a short "Runtime trace tooling workflow (illustrative)" snippet into `Utils.Parser/README.md` that demonstrates attaching a `RuntimeObservationRecorder`, exporting observations, and summarizing them, and links to the detailed doc. 
- Updated `Utils.Parser/ROADMAP.md` (Phase 7 clarification) to state that end-to-end observation/export/analysis guidance is documented as illustrative tooling only and remains non-authoritative. 
- Files modified: `docs/parser/RuntimeTraceAnalysis.md`, `Utils.Parser/README.md`, `Utils.Parser/ROADMAP.md`. 

### Testing
- This is a documentation-only change; no code paths or public APIs were modified, and no automated tests were executed for code changes. 
- Per project roadmap rules, `ROADMAP.md` was updated in the same PR to reflect the new documentation guidance. 
- No regressions are expected because runtime behavior and exports were not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f2185e5788326b15447d7fd3e0ff0)