### PR TITLE
Parser: harden ANTLR4 compatibility diagnostics and docs

### DIFF
--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -132,6 +132,10 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor UnsupportedLexerCommand =
         new("UP1020", "Unsupported lexer command", "Lexer command '{0}' is parsed but not supported by Utils.Parser.", DefaultCategory);
 
+    /// <summary>ANTLR option parsed but not supported by this runtime.</summary>
+    public static readonly ParserDiagnosticDescriptor UnsupportedAntlrOptionIgnored =
+        new("UP1021", "ANTLR option ignored", "ANTLR option '{0}' is currently unsupported and will be ignored.", DefaultCategory);
+
     // Warnings (UP5xxx)
     /// <summary>Best-effort recovery used.</summary>
     public static readonly ParserDiagnosticDescriptor BestEffortRecoveryUsed =
@@ -232,6 +236,7 @@ public static class ParserDiagnostics
             [LeftRecursivePrecedencePartiallySupported.Code] = LeftRecursivePrecedencePartiallySupported,
             [UnsupportedAntlrLanguageOptionIgnored.Code] = UnsupportedAntlrLanguageOptionIgnored,
             [UnsupportedLexerCommand.Code] = UnsupportedLexerCommand,
+            [UnsupportedAntlrOptionIgnored.Code] = UnsupportedAntlrOptionIgnored,
             [BestEffortRecoveryUsed.Code] = BestEffortRecoveryUsed,
             [ExpectedTokenMissing.Code] = ExpectedTokenMissing,
             [FallbackStrategyUsed.Code] = FallbackStrategyUsed,

--- a/Utils.Parser/AGENTS.md
+++ b/Utils.Parser/AGENTS.md
@@ -56,11 +56,22 @@ Agents must not introduce:
 
 Any exception requires a future roadmap phase to explicitly allow it and a dedicated design in the PR.
 
+## ANTLR4 compatibility reference
+
+`ANTLRCompatibility.md` is the authoritative reference for ANTLR4 feature support in Utils.Parser.
+
+Agents must:
+
+- **consult `ANTLRCompatibility.md` before modifying any grammar-related component** (grammar converter, lexer engine, parser engine, model, resolution, diagnostics);
+- **update `ANTLRCompatibility.md` after any change that adds, removes, or alters support for an ANTLR4 feature**, including moving a feature from "not supported" to "partially supported", or from "parsed but not executed" to "supported";
+- document, in the relevant section, **how the feature works when its behaviour differs from standard ANTLR4** (usage examples, API hooks, known constraints).
+
 ## Documentation requirements
 
 For runtime-affecting PRs, agents must update relevant documentation, including:
 
 - `ROADMAP.md`,
+- `ANTLRCompatibility.md`,
 - `docs/parser/RuntimeStateOwnership.md`,
 - `docs/parser/ParserMetadataAndRuntimeLimitations.md`,
 - `docs/parser/Antlr4CompatibilityMatrix.md`,

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -51,23 +51,29 @@ These features are supported but work differently. Read the **Usage** section be
 
 **Standard ANTLR4**: `options { superClass = MyBase; }` sets the generated parser or lexer class's base class.
 
-**Utils.Parser**: `superClass` is parsed and stored in `EffectiveGrammarOptions.ParserSuperClass` / `LexerSuperClass`. It is not used for class inheritance. Instead, it is the key that links a grammar to a registered `ILexerExtension` implementation, which injects tokens at runtime.
+**Utils.Parser**: `superClass` is parsed and stored as metadata in `EffectiveGrammarOptions.ParserSuperClass` / `LexerSuperClass` and in `GrammarExtensionBinding`. It has no effect on class inheritance.
 
-**Usage** — register a lexer extension bound to the declared `superClass` name:
+At runtime, the lexer calls **all** registered `ILexerExtension` instances in sequence — there is no automatic dispatch by `superClass` name. The `superClass` value is readable by an extension via `context.Definition.ExtensionBindings`, which lets the extension decide whether to apply its logic to a given grammar. The runtime enforces one constraint: if `ExtensionBindings.Count > 0` (i.e. the grammar declared `superClass`) but no extensions are registered, a validation error is raised.
+
+**Usage** — implement and register a lexer extension; inspect `ExtensionBindings` to filter by grammar if needed:
 
 ```csharp
 // Grammar declares:  options { superClass = IndentTracker; }
 
 public class IndentTrackerExtension : ILexerExtension
 {
-    public IReadOnlyList<Token> TryReadTokens(LexerExtensionContext context) => [];
-
-    public IReadOnlyList<Token> OnAfterToken(Token token, LexerExtensionContext context)
+    public IReadOnlyList<Token> TryReadTokens(LexerExtensionContext context)
     {
-        // inject INDENT / DEDENT tokens based on indentation changes
+        // Optionally guard by superClass name:
+        bool applies = context.Definition.ExtensionBindings
+            .Any(b => b.SuperClassName == "IndentTracker");
+        if (!applies) return [];
+
+        // Custom token injection logic here.
         return [];
     }
 
+    public IReadOnlyList<Token> OnAfterToken(Token token, LexerExtensionContext context) => [];
     public IReadOnlyList<Token> OnEndOfInput(LexerExtensionContext context) => [];
 }
 
@@ -78,7 +84,7 @@ var options = new LexerEngineOptions
 var lexer = new LexerEngine(definition, options);
 ```
 
-The `GrammarExtensionBinding` record on `ParserDefinition` exposes the declared `SuperClassName`, the owning grammar's lexer rule names, and its declared tokens and channels, so the extension can make context-aware decisions.
+The `GrammarExtensionBinding` record exposes `SuperClassName`, the owning grammar's lexer rule names, declared tokens, and declared channels.
 
 ---
 

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -29,14 +29,7 @@ These features work as in standard ANTLR4.
 | Lexer commands — `-> skip`, `-> more`, `-> channel(...)`, `-> type(...)` | All seven built-in lexer commands are supported. |
 | Maximal munch | Longest-match rule wins; ties are broken by declaration order. |
 | Panic mode | An unrecognised character emits an `ERROR` token and advances by one character. |
-| Direct left recursion | Detected at resolution time and handled with a seed-and-extend loop. |
-| Precedence predicates `precpred(_ctx, N)` | Extracted by pattern; alternative priority ordering is respected. |
-| Right-associativity `<assoc=right>` | Right-associative alternatives are applied during left-recursive extension. |
-| Labels `e=expr` | Supported on `RuleRef` elements within a rule. |
-| Accumulator labels `ids+=ID` | Supported on `RuleRef` elements. |
-| `options { tokenVocab = MyLexer; }` | Vocabulary dependency is loaded during project compilation. |
 | `options { caseInsensitive = true; }` | Honoured by the lexer engine. |
-| Grammar imports (project context) | Multi-file resolution, transitive imports, cycle detection. |
 | Diagnostic codes | Full set of `UP0xxx`–`UP9xxx` and `PARSER0xx` codes. |
 
 ---
@@ -194,11 +187,12 @@ See `docs/parser/RuntimeObservationAndExportContract.md` for the full contract.
 
 | Feature | Limitation |
 |---|---|
-| Direct left recursion | Supported with guards. Not equivalent to all ANTLR4 left-recursive shapes. Emits `LeftRecursivePrecedencePartiallySupported` where applicable. |
-| `precpred` extraction | Regex-based pattern. Falls back to precedence `0` if the level cannot be parsed. |
-| Labels on `labeledElement` | Applied when the labelled item is a `RuleRef`. Ignored on literals and other non-reference items. |
+| Direct left recursion | Detected at resolution time and handled with a seed-and-extend loop, but not equivalent to all ANTLR4 left-recursive shapes. Emits `LeftRecursivePrecedencePartiallySupported` where applicable. |
+| Precedence predicates `precpred(_ctx, N)` | Regex-based extraction. Falls back to precedence `0` if the level cannot be parsed. Only recognised in direct left-recursive rules. |
+| Right-associativity `<assoc=right>` | Parsed and applied during left-recursive extension. Only meaningful within direct left-recursive rules; subject to the same partial-parity limits as left recursion. |
+| Labels — `e=expr` and `ids+=ID` | Applied when the labelled item is a `RuleRef`. Ignored on literals and other non-reference items. |
 | `import` | Fully resolved when grammars are compiled as a project set (`Antlr4GrammarProjectCompiler`). Single-file compilation emits `ImportParsedButNotResolved`. |
-| `tokenVocab` | Dependency loading depends on available resolver inputs at compilation time. |
+| `options { tokenVocab = MyLexer; }` | Dependency loading depends on available resolver inputs at compilation time. |
 | Unknown grammar options (`visitor`, `listener`, `contextSuperClass`, …) | Parsed and preserved as raw option metadata, but rejected with `UP1021 UnsupportedAntlrOptionIgnored`. Recognised options that do not trigger this diagnostic are: `tokenVocab`, `superClass`, `caseInsensitive`, and `language`. |
 | Lexer commands | Only the seven built-in commands are accepted. Any unknown command name is rejected with `UnsupportedLexerCommand`. |
 | `tokens { }` block | Recognised, stored in `GrammarExtensionBinding.DeclaredTokens`, and reported explicitly with `UP1002 TokensBlockIgnored`. Not mapped to runtime token definitions. |

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -193,9 +193,10 @@ See `docs/parser/RuntimeObservationAndExportContract.md` for the full contract.
 | Labels on `labeledElement` | Applied when the labelled item is a `RuleRef`. Ignored on literals and other non-reference items. |
 | `import` | Fully resolved when grammars are compiled as a project set (`Antlr4GrammarProjectCompiler`). Single-file compilation emits `ImportParsedButNotResolved`. |
 | `tokenVocab` | Dependency loading depends on available resolver inputs at compilation time. |
+| Unknown grammar options (`visitor`, `listener`, `contextSuperClass`, …) | Parsed and preserved as raw option metadata, but rejected with `UP1021 UnsupportedAntlrOptionIgnored`. Recognised options that do not trigger this diagnostic are: `tokenVocab`, `superClass`, `caseInsensitive`, and `language`. |
 | Lexer commands | Only the seven built-in commands are accepted. Any unknown command name is rejected with `UnsupportedLexerCommand`. |
-| `tokens { }` block | Recognised by the meta-grammar and stored in `GrammarExtensionBinding.DeclaredTokens`, but not mapped to runtime token definitions. |
-| `channels { }` block | Recognised and stored in `GrammarExtensionBinding.DeclaredChannels`, but not mapped to runtime channel semantics beyond `-> channel(...)` command support. |
+| `tokens { }` block | Recognised, stored in `GrammarExtensionBinding.DeclaredTokens`, and reported explicitly with `UP1002 TokensBlockIgnored`. Not mapped to runtime token definitions. |
+| `channels { }` block | Recognised, stored in `GrammarExtensionBinding.DeclaredChannels`, and reported explicitly with `UP1003 ChannelsBlockIgnored`. Not mapped to runtime channel semantics beyond `-> channel(...)` command support. |
 
 ---
 
@@ -237,7 +238,7 @@ These capabilities are outside the current runtime model by design. Attempting t
 | Prefix | Severity | Meaning |
 |---|---|---|
 | `UP0xxx` | Error | Blocking — unresolved rules, grammar violations, import failures |
-| `UP1xxx` | Warning | Unsupported / ignored / partial behaviour |
+| `UP1xxx` | Warning | Unsupported / ignored / partial behaviour (e.g. `UP1002` tokens block ignored, `UP1003` channels block ignored, `UP1020` unsupported lexer command, `UP1021` unsupported grammar option) |
 | `UP5xxx` | Warning | Best-effort recovery warnings (trailing tokens, ambiguity) |
 | `UP8xxx` | Info | Informational runtime events |
 | `UP9xxx` | Debug | Detailed execution traces |

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -1,0 +1,247 @@
+# ANTLR4 Compatibility Reference
+
+This document lists ANTLR4 grammar features and their support status in Utils.Parser.
+
+For each feature that behaves differently from standard ANTLR4, a **Usage** section explains how to achieve the equivalent result.
+
+This document must be consulted before modifying any grammar-related component, and updated whenever a feature's support status changes.
+
+---
+
+## Supported — full runtime support
+
+These features work as in standard ANTLR4.
+
+| Feature | Notes |
+|---|---|
+| `grammar Name;` / `lexer grammar Name;` / `parser grammar Name;` | Combined, lexer-only, and parser-only grammars are all supported. |
+| Literal matching `'text'` | Exact string match in lexer and parser rules. |
+| Character ranges `'a'..'z'` | Range match in lexer rules. |
+| Character classes `[a-zA-Z_0-9]` | Set match, including Unicode ranges. |
+| Negated character classes `[^...]` | Inverted set match. |
+| Wildcard `.` | Matches any single character (lexer) or any single token (parser). |
+| Quantifiers `*`, `+`, `?`, `{n,m}` | All quantifier forms are supported. |
+| Alternation `a \| b \| c` | Alternatives are tried in declaration order. |
+| Grouping `(...)` | Inline groups are supported in lexer and parser rules. |
+| Negation `~a` | Supported in lexer and parser rules. |
+| `fragment` rules | Fragment rules are never emitted as tokens; they serve as reusable building blocks. |
+| Lexer modes — `mode Name;`, `-> pushMode(...)`, `-> popMode`, `-> mode(...)` | Full mode-stack behaviour is implemented. |
+| Lexer commands — `-> skip`, `-> more`, `-> channel(...)`, `-> type(...)` | All seven built-in lexer commands are supported. |
+| Maximal munch | Longest-match rule wins; ties are broken by declaration order. |
+| Panic mode | An unrecognised character emits an `ERROR` token and advances by one character. |
+| Direct left recursion | Detected at resolution time and handled with a seed-and-extend loop. |
+| Precedence predicates `precpred(_ctx, N)` | Extracted by pattern; alternative priority ordering is respected. |
+| Right-associativity `<assoc=right>` | Right-associative alternatives are applied during left-recursive extension. |
+| Labels `e=expr` | Supported on `RuleRef` elements within a rule. |
+| Accumulator labels `ids+=ID` | Supported on `RuleRef` elements. |
+| `options { tokenVocab = MyLexer; }` | Vocabulary dependency is loaded during project compilation. |
+| `options { caseInsensitive = true; }` | Honoured by the lexer engine. |
+| Grammar imports (project context) | Multi-file resolution, transitive imports, cycle detection. |
+| Diagnostic codes | Full set of `UP0xxx`–`UP9xxx` and `PARSER0xx` codes. |
+
+---
+
+## Supported — behaviour differs from standard ANTLR4
+
+These features are supported but work differently. Read the **Usage** section before using them.
+
+---
+
+### `superClass` option
+
+**Standard ANTLR4**: `options { superClass = MyBase; }` sets the generated parser or lexer class's base class.
+
+**Utils.Parser**: `superClass` is parsed and stored in `EffectiveGrammarOptions.ParserSuperClass` / `LexerSuperClass`. It is not used for class inheritance. Instead, it is the key that links a grammar to a registered `ILexerExtension` implementation, which injects tokens at runtime.
+
+**Usage** — register a lexer extension bound to the declared `superClass` name:
+
+```csharp
+// Grammar declares:  options { superClass = IndentTracker; }
+
+public class IndentTrackerExtension : ILexerExtension
+{
+    public IReadOnlyList<Token> TryReadTokens(LexerExtensionContext context) => [];
+
+    public IReadOnlyList<Token> OnAfterToken(Token token, LexerExtensionContext context)
+    {
+        // inject INDENT / DEDENT tokens based on indentation changes
+        return [];
+    }
+
+    public IReadOnlyList<Token> OnEndOfInput(LexerExtensionContext context) => [];
+}
+
+var options = new LexerEngineOptions
+{
+    Extensions = [new IndentTrackerExtension()]
+};
+var lexer = new LexerEngine(definition, options);
+```
+
+The `GrammarExtensionBinding` record on `ParserDefinition` exposes the declared `SuperClassName`, the owning grammar's lexer rule names, and its declared tokens and channels, so the extension can make context-aware decisions.
+
+---
+
+### Semantic predicates `{ condition }?`
+
+**Standard ANTLR4**: The predicate body is target-language code evaluated inline during parsing.
+
+**Utils.Parser**: Predicates are parsed and stored. Evaluation is delegated to an `ISemanticPredicateEvaluator` registered in `ParserRuntimeFeaturePolicy`. The default policy returns `NotEvaluated`, which does **not** reject the branch — it acts as if the predicate passed.
+
+**Usage** — implement `ISemanticPredicateEvaluator` and pass it via the policy:
+
+```csharp
+public class MyPredicateEvaluator : ISemanticPredicateEvaluator
+{
+    public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+    {
+        // context.PredicateCode  — raw predicate text from the .g4 file
+        // context.Rule           — current Rule
+        // context.InputPosition  — current token index
+        // context.AlternativeIndex / ElementIndex — position within the rule
+
+        if (context.PredicateCode == "IsKeyword()")
+            return _keywords.Contains(CurrentToken) 
+                ? SemanticPredicateEvaluationResult.Satisfied 
+                : SemanticPredicateEvaluationResult.Rejected;
+
+        return SemanticPredicateEvaluationResult.NotEvaluated;
+    }
+}
+
+var policy = ParserRuntimeFeaturePolicy.Default with
+{
+    SemanticPredicateEvaluator = new MyPredicateEvaluator()
+};
+var parser = new ParserEngine(definition, policy);
+```
+
+> **Important**: memoization is keyed by `(rule, input position, precedence)`. Evaluators must be deterministic for identical invocation contexts.
+
+---
+
+### Inline actions `{ code }`
+
+**Standard ANTLR4**: Action code is target-language code executed as a side effect during parsing.
+
+**Utils.Parser**: Actions are parsed and stored. Execution is delegated to an `IParserActionExecutor` registered in `ParserRuntimeFeaturePolicy`. The default policy returns `NotExecuted`.
+
+**Usage** — implement `IParserActionExecutor`:
+
+```csharp
+public class MyActionExecutor : IParserActionExecutor
+{
+    public ParserActionExecutionResult Execute(ParserActionExecutionContext context)
+    {
+        // context.ActionCode     — raw action text from the .g4 file
+        // context.Rule           — current Rule
+        // context.InputPosition  — current token index
+        // context.AlternativeIndex / ElementIndex — position within the rule
+
+        Console.WriteLine($"Action in rule {context.Rule.Name}: {context.ActionCode}");
+        return ParserActionExecutionResult.Executed;
+    }
+}
+
+var policy = ParserRuntimeFeaturePolicy.Default with
+{
+    ParserActionExecutor = new MyActionExecutor()
+};
+var parser = new ParserEngine(definition, policy);
+```
+
+> **Important**: actions may fire in branches that are later rejected by backtracking. There is no rollback mechanism. Keep executors side-effect-free or idempotent where possible.
+
+---
+
+### Rule actions `@init { }` and `@after { }`
+
+**Standard ANTLR4**: `@init` runs before the rule body; `@after` runs after.
+
+**Utils.Parser**: Both are parsed and stored in `Rule.InitAction` / `Rule.AfterAction` as raw text. They are not executed automatically. To act on them, inspect the `Rule` model and invoke custom logic at the appropriate parse-tree traversal step using `ParseTreeCompiler<TContext, TResult>`.
+
+---
+
+### Runtime observation
+
+**Standard ANTLR4**: no built-in scheduling observation API.
+
+**Utils.Parser**: a passive, non-authoritative observer can be attached via `ParserRuntimeFeaturePolicy.RuntimeObserver`. It receives `AlternativeRuntimeObservation` records describing scheduler events in deterministic order without affecting parse outcomes.
+
+**Usage**:
+
+```csharp
+var recorder = new RuntimeObservationRecorder();
+var policy = ParserRuntimeFeaturePolicy.Default with { RuntimeObserver = recorder };
+var parser = new ParserEngine(definition, policy);
+parser.Parse(tokens);
+
+string text = RuntimeObservationTextWriter.Write(recorder.Observations);
+string json  = RuntimeObservationJsonWriter.Write(recorder.Observations);
+```
+
+See `docs/parser/RuntimeObservationAndExportContract.md` for the full contract.
+
+---
+
+## Partially supported
+
+| Feature | Limitation |
+|---|---|
+| Direct left recursion | Supported with guards. Not equivalent to all ANTLR4 left-recursive shapes. Emits `LeftRecursivePrecedencePartiallySupported` where applicable. |
+| `precpred` extraction | Regex-based pattern. Falls back to precedence `0` if the level cannot be parsed. |
+| Labels on `labeledElement` | Applied when the labelled item is a `RuleRef`. Ignored on literals and other non-reference items. |
+| `import` | Fully resolved when grammars are compiled as a project set (`Antlr4GrammarProjectCompiler`). Single-file compilation emits `ImportParsedButNotResolved`. |
+| `tokenVocab` | Dependency loading depends on available resolver inputs at compilation time. |
+| Lexer commands | Only the seven built-in commands are accepted. Any unknown command name is rejected with `UnsupportedLexerCommand`. |
+| `tokens { }` block | Recognised by the meta-grammar and stored in `GrammarExtensionBinding.DeclaredTokens`, but not mapped to runtime token definitions. |
+| `channels { }` block | Recognised and stored in `GrammarExtensionBinding.DeclaredChannels`, but not mapped to runtime channel semantics beyond `-> channel(...)` command support. |
+
+---
+
+## Parsed and stored — no runtime semantics
+
+These constructs are recognised without error but produce no runtime effect.
+
+| Construct | Stored where | Runtime behaviour |
+|---|---|---|
+| Rule parameters `rule[int x]` | `Rule.Parameters` as raw text | No argument passing, no typed binding, no invocation frame. |
+| Rule returns `returns [int x]` | `Rule.ReturnType` as raw text | No value extraction or propagation. |
+| `locals [...]` | Parsed, discarded | No runtime semantics. |
+| `throws ExceptionType` | Parsed, discarded | No runtime semantics. |
+| `catch [...] {...}` / `finally {...}` | Parsed, discarded | No runtime semantics. |
+| Grammar-level actions `@header`, `@members`, etc. | `ParserDefinition.Actions` | Metadata only; not executed. |
+| Other rule actions (not `@init`/`@after`) | Parsed, discarded | `ActionIgnored` diagnostic emitted. |
+
+---
+
+## Not supported — intentional exclusions
+
+These capabilities are outside the current runtime model by design. Attempting to use them produces explicit diagnostics or has no effect.
+
+| Capability | Diagnostic / behaviour |
+|---|---|
+| Indirect left recursion | Error `UP0xxx` — explicitly unsupported. Rewrite as direct recursion or factor out the common prefix. |
+| Adaptive LL / GLL prediction | Not implemented. The runtime uses sequential backtracking with memoization. |
+| Error recovery (resync, token insertion/deletion) | No recovery strategy. `ParserEngine.Parse()` returns `ErrorNode` on failure. |
+| Speculative parsing / continuation replay | Not implemented. Continuation metadata exists but is descriptive only. |
+| Parse-forest generation | A single parse tree is produced. |
+| Async or parallel parsing | Not implemented. |
+| Target-language action execution engines | Actions are stored as raw text strings. Execution requires a custom `IParserActionExecutor`. |
+| `superClass` class inheritance (generated code) | `superClass` is repurposed as an extension-binding key. See the **Usage** section above. |
+
+---
+
+## Diagnostics quick reference
+
+| Prefix | Severity | Meaning |
+|---|---|---|
+| `UP0xxx` | Error | Blocking — unresolved rules, grammar violations, import failures |
+| `UP1xxx` | Warning | Unsupported / ignored / partial behaviour |
+| `UP5xxx` | Warning | Best-effort recovery warnings (trailing tokens, ambiguity) |
+| `UP8xxx` | Info | Informational runtime events |
+| `UP9xxx` | Debug | Detailed execution traces |
+| `PARSER0xx` | Warning/Info | Runtime safety guards (cycle detection, non-progressive loop termination) |
+| `APU0xxx` | Error/Warning | Source-generator diagnostics (Roslyn pipeline) |
+
+Full descriptor table: `ParserDiagnostics.All`.

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -291,25 +291,27 @@ public sealed class Antlr4GrammarConverter
         var delegGrammars = First(node, "delegateGrammars");
         if (delegGrammars != null) { imports.AddRange(ConvertDelegateGrammars(delegGrammars, diagnostics)); return; }
 
-        if (First(node, "tokensSpec") != null)
+        if (First(node, "tokensSpec") is { } tokensSpecNode)
         {
             diagnostics?.Add(ParserDiagnostics.TokensBlockIgnored);
-            foreach (var tokenName in ExtractIdentifiers(First(node, "tokensSpec")!))
+            var idListNode = First(tokensSpecNode, "idList");
+            if (idListNode != null)
             {
-                declaredTokens.Add(tokenName);
+                foreach (var tokenName in ExtractIdentifiers(idListNode))
+                    declaredTokens.Add(tokenName);
             }
-
             return;
         }
 
-        if (First(node, "channelsSpec") != null)
+        if (First(node, "channelsSpec") is { } channelsSpecNode)
         {
             diagnostics?.Add(ParserDiagnostics.ChannelsBlockIgnored);
-            foreach (var channelName in ExtractIdentifiers(First(node, "channelsSpec")!))
+            var idListNode = First(channelsSpecNode, "idList");
+            if (idListNode != null)
             {
-                declaredChannels.Add(channelName);
+                foreach (var channelName in ExtractIdentifiers(idListNode))
+                    declaredChannels.Add(channelName);
             }
-
             return;
         }
 

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -394,6 +394,7 @@ public sealed class Antlr4GrammarConverter
 
         return !string.Equals(optionName, "language", StringComparison.Ordinal)
             && !string.Equals(optionName, "superClass", StringComparison.Ordinal)
+            && !string.Equals(optionName, "caseInsensitive", StringComparison.Ordinal)
             && !string.Equals(optionName, "tokenVocab", StringComparison.Ordinal);
     }
 

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -276,7 +276,7 @@ public sealed class Antlr4GrammarConverter
     /// Processes a single <c>prequelConstruct</c> node (options, imports, or top-level action)
     /// and populates the corresponding output collection.
     /// </summary>
-    private static void ProcessPrequelConstruct(
+    private void ProcessPrequelConstruct(
         ParserNode node,
         ref GrammarOptions? options,
         List<GrammarImport> imports,
@@ -293,6 +293,7 @@ public sealed class Antlr4GrammarConverter
 
         if (First(node, "tokensSpec") != null)
         {
+            diagnostics?.Add(ParserDiagnostics.TokensBlockIgnored);
             foreach (var tokenName in ExtractIdentifiers(First(node, "tokensSpec")!))
             {
                 declaredTokens.Add(tokenName);
@@ -303,6 +304,7 @@ public sealed class Antlr4GrammarConverter
 
         if (First(node, "channelsSpec") != null)
         {
+            diagnostics?.Add(ParserDiagnostics.ChannelsBlockIgnored);
             foreach (var channelName in ExtractIdentifiers(First(node, "channelsSpec")!))
             {
                 declaredChannels.Add(channelName);
@@ -359,7 +361,7 @@ public sealed class Antlr4GrammarConverter
     }
 
     /// <summary>Converts an <c>optionsSpec</c> node into a <see cref="GrammarOptions"/> record.</summary>
-    private static GrammarOptions ConvertOptionsSpec(ParserNode node)
+    private GrammarOptions ConvertOptionsSpec(ParserNode node)
     {
         var values = new Dictionary<string, string>();
         foreach (var option in All(node, "option"))
@@ -369,8 +371,30 @@ public sealed class Antlr4GrammarConverter
             var valueNode = First(option, "optionValue");
             var value = valueNode != null ? GetOptionValueText(valueNode) : "";
             values[key] = value;
+
+            if (IsExplicitlyUnsupportedOption(key))
+            {
+                _diagnostics?.Add(ParserDiagnostics.UnsupportedAntlrOptionIgnored, key);
+            }
         }
         return new GrammarOptions(values);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when an ANTLR option is accepted as syntax but intentionally unsupported.
+    /// </summary>
+    /// <param name="optionName">ANTLR option name.</param>
+    /// <returns><c>true</c> when the option should emit an explicit compatibility diagnostic.</returns>
+    private static bool IsExplicitlyUnsupportedOption(string optionName)
+    {
+        if (string.IsNullOrWhiteSpace(optionName))
+        {
+            return false;
+        }
+
+        return !string.Equals(optionName, "language", StringComparison.Ordinal)
+            && !string.Equals(optionName, "superClass", StringComparison.Ordinal)
+            && !string.Equals(optionName, "tokenVocab", StringComparison.Ordinal);
     }
 
     /// <summary>Yields <see cref="GrammarImport"/> records from a <c>delegateGrammars</c> node.</summary>

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -43,6 +43,17 @@ If a grammar relies on one of these areas, validate it with targeted tests befor
 
 For a detailed, implementation-aligned compatibility status (including diagnostics mapping and architectural limits), see [`docs/parser/Antlr4CompatibilityMatrix.md`](../docs/parser/Antlr4CompatibilityMatrix.md).
 
+### `superClass` compatibility contract
+
+`superClass` is treated as compatibility metadata:
+
+- accepted by grammar ingestion,
+- preserved in grammar options,
+- normalized into `EffectiveGrammarOptions` (`ParserSuperClass` / `LexerSuperClass`),
+- exposed through extension metadata (`GrammarExtensionBinding`).
+
+It is not interpreted as automatic runtime inheritance execution for parser or lexer behavior.
+
 ## Key concepts
 
 | Class / Type | Role |

--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -20,6 +20,9 @@ dotnet add package omy.Utils.Parser
 
 ANTLR4 `.g4` support is currently **partial**.
 
+ANTLR4 compatibility is intentionally conservative: unsupported constructs fail explicitly through diagnostics instead of being silently ignored.
+
+
 - ✅ Scenarios covered by the `UtilsTest.Parser` test suite are supported.
 - ⚠️ Full ANTLR4 compatibility is not guaranteed for every advanced syntax/rule.
 - ✅ If you need stricter build-time guarantees, also use `omy.Utils.Parser.Generators`.

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -302,7 +302,13 @@ Forbidden work:
 
 ### Phase 6 — ANTLR4 compatibility expansion
 
-**Status: not started.**
+**Status: in progress.**
+
+Current clarification status:
+
+- converter now emits explicit diagnostics for unsupported grammar options instead of implicit acceptance,
+- `tokens` / `channels` prequel constructs now emit deterministic partial-support diagnostics during conversion,
+- compatibility documentation is aligned with explicit parsed/normalized/rejected boundaries.
 
 Goal: progressively improve ANTLR4 grammar compatibility.
 

--- a/UtilsTest/Parser/ANTLRCompatibilityDocTests.cs
+++ b/UtilsTest/Parser/ANTLRCompatibilityDocTests.cs
@@ -1,0 +1,611 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Model;
+using Utils.Parser.Resolution;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Verifies every claim and usage example in Utils.Parser/ANTLRCompatibility.md.
+/// Each test is named after the section it covers.
+/// </summary>
+[TestClass]
+public class ANTLRCompatibilityDocTests
+{
+    // ─── superClass / ILexerExtension ─────────────────────────────────────────
+
+    [TestMethod]
+    public void SuperClass_IsStoredInEffectiveOptions()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            options { superClass = IndentTracker; }
+            start : 'x' ;
+            """);
+
+        Assert.AreEqual("IndentTracker", def.EffectiveOptions.ParserSuperClass);
+    }
+
+    [TestMethod]
+    public void SuperClass_IsStoredInExtensionBindings()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            options { superClass = IndentTracker; }
+            start : 'x' ;
+            """);
+
+        Assert.AreEqual(1, def.ExtensionBindings.Count);
+        var binding = def.ExtensionBindings[0];
+        Assert.AreEqual("IndentTracker", binding.SuperClassName);
+    }
+
+    [TestMethod]
+    public void SuperClass_ExtensionBinding_ExposesLexerRuleNames()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            options { superClass = MyExt; }
+            start : ID ;
+            ID : ('a'..'z')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """);
+
+        var binding = def.ExtensionBindings[0];
+        Assert.IsTrue(binding.LexerRuleNames.Contains("ID"));
+        Assert.IsTrue(binding.LexerRuleNames.Contains("WS"));
+    }
+
+    [TestMethod]
+    public void SuperClass_ExtensionBinding_ExposesDeclaredTokensAndChannels()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            options { superClass = MyExt; }
+            tokens { INDENT, DEDENT }
+            channels { COMMENTS }
+            start : 'x' ;
+            """);
+
+        // Tokens and channels from tokens{}/channels{} blocks land in both
+        // ParserDefinition.DeclaredTokens / DeclaredChannels and in ExtensionBindings.
+        Assert.IsTrue(def.DeclaredTokens.Contains("INDENT"));
+        Assert.IsTrue(def.DeclaredTokens.Contains("DEDENT"));
+        Assert.IsTrue(def.DeclaredChannels.Contains("COMMENTS"));
+
+        // ExtensionBindings mirrors the same sets.
+        var binding = def.ExtensionBindings[0];
+        Assert.IsTrue(binding.DeclaredTokens.Contains("INDENT"));
+        Assert.IsTrue(binding.DeclaredTokens.Contains("DEDENT"));
+        Assert.IsTrue(binding.DeclaredChannels.Contains("COMMENTS"));
+    }
+
+    [TestMethod]
+    public void SuperClass_ExtensionRegistered_ContextExposesBindings()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            options { superClass = IndentTracker; }
+            start : 'x' ;
+            X : 'x' ;
+            """);
+
+        LexerExtensionContext? capturedContext = null;
+        var ext = new CapturingLexerExtension(ctx => capturedContext = ctx);
+        var lexer = new LexerEngine(def);
+        _ = lexer.Tokenize(new StringReader("x"), new LexerEngineOptions { Extensions = [ext] }).ToList();
+
+        Assert.IsNotNull(capturedContext);
+        Assert.AreEqual(1, capturedContext!.Definition.ExtensionBindings.Count);
+        Assert.AreEqual("IndentTracker",
+            capturedContext.Definition.ExtensionBindings[0].SuperClassName);
+    }
+
+    [TestMethod]
+    public void SuperClass_AllExtensionHooksAreCalled()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            options { superClass = MyExt; }
+            start : 'x' ;
+            X : 'x' ;
+            """);
+
+        bool tryReadCalled = false, afterTokenCalled = false, endOfInputCalled = false;
+        var ext = new CallTrackingLexerExtension(
+            onTryRead: () => tryReadCalled = true,
+            onAfterToken: () => afterTokenCalled = true,
+            onEndOfInput: () => endOfInputCalled = true);
+
+        var lexer = new LexerEngine(def);
+        _ = lexer.Tokenize(new StringReader("x"), new LexerEngineOptions { Extensions = [ext] }).ToList();
+
+        Assert.IsTrue(tryReadCalled,    "TryReadTokens was not called");
+        Assert.IsTrue(afterTokenCalled, "OnAfterToken was not called");
+        Assert.IsTrue(endOfInputCalled, "OnEndOfInput was not called");
+    }
+
+    [TestMethod]
+    public void SuperClass_ExtensionCanGuardBySuperClassName()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            options { superClass = IndentTracker; }
+            start : 'x' ;
+            X : 'x' ;
+            """);
+
+        int guardedCallCount = 0;
+        var ext = new GuardingLexerExtension("IndentTracker", onMatch: () => guardedCallCount++);
+        var lexer = new LexerEngine(def);
+        _ = lexer.Tokenize(new StringReader("x"), new LexerEngineOptions { Extensions = [ext] }).ToList();
+
+        Assert.IsTrue(guardedCallCount > 0,
+            "Extension guard matched superClass name but was not invoked");
+    }
+
+    // ─── Semantic predicates ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void SemanticPredicate_EvaluatorReceivesPredicateCode()
+    {
+        string? capturedCode = null;
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : {IsKeyword()}? ID | ID ;
+            ID : ('a'..'z')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """);
+
+        var evaluator = new CapturingPredicateEvaluator(ctx =>
+        {
+            capturedCode = ctx.PredicateCode;
+            return SemanticPredicateEvaluationResult.NotEvaluated;
+        });
+        var policy = ParserRuntimeFeaturePolicy.Default with
+        {
+            SemanticPredicateEvaluator = evaluator
+        };
+        var tokens = new LexerEngine(def).Tokenize(new StringReader("foo")).ToList();
+        new ParserEngine(def, policy).Parse(tokens);
+
+        Assert.IsNotNull(capturedCode);
+        Assert.IsTrue(capturedCode!.Contains("IsKeyword()"));
+    }
+
+    [TestMethod]
+    public void SemanticPredicate_EvaluatorReceivesRuleAndPosition()
+    {
+        Rule? capturedRule = null;
+        int capturedPosition = -1;
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : {check()}? ID ;
+            ID : ('a'..'z')+ ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """);
+
+        var evaluator = new CapturingPredicateEvaluator(ctx =>
+        {
+            capturedRule = ctx.Rule;
+            capturedPosition = ctx.InputPosition;
+            return SemanticPredicateEvaluationResult.Satisfied;
+        });
+        var policy = ParserRuntimeFeaturePolicy.Default with
+        {
+            SemanticPredicateEvaluator = evaluator
+        };
+        var tokens = new LexerEngine(def).Tokenize(new StringReader("foo")).ToList();
+        new ParserEngine(def, policy).Parse(tokens);
+
+        Assert.IsNotNull(capturedRule);
+        Assert.AreEqual("start", capturedRule!.Name);
+        Assert.AreEqual(0, capturedPosition);
+    }
+
+    // ─── Inline actions ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void InlineAction_ExecutorReceivesActionCodeAndContext()
+    {
+        string? capturedCode = null;
+        Rule? capturedRule = null;
+        int capturedPosition = -1;
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : { doSomething(); } 'x' ;
+            X : 'x' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """);
+
+        var executor = new CapturingActionExecutor(ctx =>
+        {
+            capturedCode = ctx.ActionCode;
+            capturedRule = ctx.Rule;
+            capturedPosition = ctx.InputPosition;
+            return ParserActionExecutionResult.Executed;
+        });
+        var policy = ParserRuntimeFeaturePolicy.Default with
+        {
+            ParserActionExecutor = executor
+        };
+        var tokens = new LexerEngine(def).Tokenize(new StringReader("x")).ToList();
+        new ParserEngine(def, policy).Parse(tokens);
+
+        Assert.IsNotNull(capturedCode);
+        Assert.IsTrue(capturedCode!.Contains("doSomething()"));
+        Assert.AreEqual("start", capturedRule!.Name);
+        Assert.AreEqual(0, capturedPosition);
+    }
+
+    [TestMethod]
+    public void InlineAction_DefaultPolicy_DoesNotExecuteAction()
+    {
+        bool executorCalled = false;
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : { sideEffect(); } 'x' ;
+            X : 'x' ;
+            """);
+
+        var executor = new CapturingActionExecutor(_ =>
+        {
+            executorCalled = true;
+            return ParserActionExecutionResult.Executed;
+        });
+
+        // default policy — executor not registered
+        var tokens = new LexerEngine(def).Tokenize(new StringReader("x")).ToList();
+        new ParserEngine(def).Parse(tokens);
+
+        Assert.IsFalse(executorCalled);
+    }
+
+    // ─── Rule actions @init / @after ──────────────────────────────────────────
+
+    [TestMethod]
+    public void RuleAction_Init_StoredInRule()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start
+                @init { int x = 0; }
+                : 'x' ;
+            X : 'x' ;
+            """);
+
+        var rule = def.AllRules["start"];
+        Assert.IsNotNull(rule.InitAction);
+        Assert.IsTrue(rule.InitAction!.RawCode.Contains("int x = 0"));
+    }
+
+    [TestMethod]
+    public void RuleAction_After_StoredInRule()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start
+                @after { cleanup(); }
+                : 'x' ;
+            X : 'x' ;
+            """);
+
+        var rule = def.AllRules["start"];
+        Assert.IsNotNull(rule.AfterAction);
+        Assert.IsTrue(rule.AfterAction!.RawCode.Contains("cleanup()"));
+    }
+
+    [TestMethod]
+    public void RuleAction_UnknownName_EmitsActionIgnoredDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start
+                @before { setup(); }
+                : 'x' ;
+            X : 'x' ;
+            """, diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.ActionIgnored.Code));
+    }
+
+    // ─── Grammar-level actions ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void GrammarAction_Header_StoredInDefinition()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            @header { using System; }
+            start : 'x' ;
+            X : 'x' ;
+            """);
+
+        Assert.IsTrue(def.Actions.Any(a => a.Name == "header"));
+        var header = def.Actions.First(a => a.Name == "header");
+        Assert.IsTrue(header.RawCode.Contains("using System"));
+    }
+
+    [TestMethod]
+    public void GrammarAction_Members_StoredInDefinition()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            @members { int counter = 0; }
+            start : 'x' ;
+            X : 'x' ;
+            """);
+
+        Assert.IsTrue(def.Actions.Any(a => a.Name == "members"));
+    }
+
+    // ─── Parsed and stored — no runtime semantics ────────────────────────────
+
+    [TestMethod]
+    public void RuleParameters_StoredAsRawText()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start[int level] : 'x' ;
+            X : 'x' ;
+            """);
+
+        var rule = def.AllRules["start"];
+        Assert.IsNotNull(rule.Parameters);
+        Assert.IsTrue(rule.Parameters!.Count > 0);
+        Assert.IsTrue(rule.Parameters![0].Type.Contains("int level")
+                   || rule.Parameters[0].Name.Contains("int level"));
+    }
+
+    [TestMethod]
+    public void RuleReturns_StoredAsRawText()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start returns [int value] : 'x' ;
+            X : 'x' ;
+            """);
+
+        var rule = def.AllRules["start"];
+        Assert.IsNotNull(rule.Returns);
+        Assert.IsTrue(rule.Returns!.Count > 0);
+        Assert.IsTrue(rule.Returns![0].Type.Contains("int value")
+                   || rule.Returns[0].Name.Contains("int value"));
+    }
+
+    [TestMethod]
+    public void Locals_Discarded_NoError()
+    {
+        var diagnostics = new DiagnosticBag();
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start
+                locals [int x]
+                : 'x' ;
+            X : 'x' ;
+            """, diagnostics);
+
+        Assert.IsTrue(def.AllRules.ContainsKey("start"));
+        Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+    }
+
+    [TestMethod]
+    public void Throws_Discarded_NoError()
+    {
+        var diagnostics = new DiagnosticBag();
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start
+                throws RecognitionException
+                : 'x' ;
+            X : 'x' ;
+            """, diagnostics);
+
+        Assert.IsTrue(def.AllRules.ContainsKey("start"));
+        Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+    }
+
+    [TestMethod]
+    public void CatchFinally_Discarded_NoError()
+    {
+        var diagnostics = new DiagnosticBag();
+        // catch/finally must appear immediately after the rule's semicolon (still part of that rule spec).
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : X ;
+            catch [Exception e] { handle(e); }
+            finally { cleanup(); }
+            X : 'x' ;
+            """, diagnostics);
+
+        Assert.IsTrue(def.AllRules.ContainsKey("start"));
+        Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+    }
+
+    // ─── Partially supported ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Labels_OnRuleRef_AreStored()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : e=term other=term ;
+            term  : ID | NUM ;
+            ID    : ('a'..'z' | 'A'..'Z' | '_')+ ;
+            NUM   : ('0'..'9')+ ;
+            WS    : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """);
+
+        var startRule = def.AllRules["start"];
+        var alt = ((Alternation)startRule.Content).Alternatives[0];
+        var items = ((Sequence)alt.Content).Items;
+        var labeledRefs = items.OfType<RuleRef>().Where(r => r.Label != null).ToList();
+        Assert.IsTrue(labeledRefs.Count >= 1);
+        Assert.IsTrue(labeledRefs.Any(r => r.Label!.Label == "e"));
+    }
+
+    [TestMethod]
+    public void Import_SingleFile_EmitsImportParsedButNotResolvedDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        Antlr4GrammarConverter.Parse("""
+            grammar G;
+            import CommonLexer;
+            start : 'x' ;
+            X : 'x' ;
+            """, diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(d =>
+            d.Code == ParserDiagnostics.ImportParsedButNotResolved.Code));
+    }
+
+    // ─── Not supported — intentional exclusions ───────────────────────────────
+
+    [TestMethod]
+    public void IndirectLeftRecursion_ThrowsAndEmitsDiagnosticError()
+    {
+        var diagnostics = new DiagnosticBag();
+        Assert.ThrowsException<GrammarValidationException>(() =>
+            Antlr4GrammarConverter.Parse("""
+                grammar G;
+                start : a ;
+                a : b ;
+                b : a '+' INT | INT ;
+                INT : ('0'..'9')+ ;
+                WS  : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+                """, diagnostics));
+
+        Assert.IsTrue(diagnostics.Any(d =>
+            d.Code == ParserDiagnostics.IndirectLeftRecursionNotSupported.Code));
+    }
+
+    [TestMethod]
+    public void ParseFailure_ReturnsErrorNode()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : 'x' ;
+            X : 'x' ;
+            """);
+
+        var tokens = new LexerEngine(def).Tokenize(new StringReader("y")).ToList();
+        var result = new ParserEngine(def).Parse(tokens);
+
+        Assert.IsInstanceOfType(result, typeof(ErrorNode));
+    }
+
+    // ─── Runtime observation ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void RuntimeObservation_RecorderAndWriters_FullWorkflow()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : 'x' ;
+            X : 'x' ;
+            WS : (' ' | '\t' | '\r' | '\n')+ -> skip ;
+            """);
+
+        var recorder = new RuntimeObservationRecorder();
+        var policy = ParserRuntimeFeaturePolicy.Default with { RuntimeObserver = recorder };
+        var tokens = new LexerEngine(def).Tokenize(new StringReader("x")).ToList();
+        var result = new ParserEngine(def, policy).Parse(tokens);
+
+        Assert.IsNotInstanceOfType(result, typeof(ErrorNode));
+        Assert.IsTrue(recorder.Observations.Count > 0);
+
+        string text = RuntimeObservationTextWriter.Write(recorder.Observations);
+        string json = RuntimeObservationJsonWriter.Write(recorder.Observations);
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(text));
+        Assert.IsTrue(json.StartsWith("["));
+    }
+
+    [TestMethod]
+    public void RuntimeObservation_DoesNotAffectParseOutcome()
+    {
+        var def = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : 'x' ;
+            X : 'x' ;
+            """);
+
+        var tokens = new LexerEngine(def).Tokenize(new StringReader("x")).ToList();
+
+        var withoutObserver = new ParserEngine(def).Parse(tokens);
+
+        var recorder = new RuntimeObservationRecorder();
+        var policy = ParserRuntimeFeaturePolicy.Default with { RuntimeObserver = recorder };
+        var withObserver = new ParserEngine(def, policy).Parse(tokens);
+
+        Assert.IsNotInstanceOfType(withoutObserver, typeof(ErrorNode));
+        Assert.IsNotInstanceOfType(withObserver, typeof(ErrorNode));
+        Assert.AreEqual(withoutObserver.Rule.Name, withObserver.Rule.Name);
+    }
+
+    // ─── Private helpers ──────────────────────────────────────────────────────
+
+    private sealed class CapturingLexerExtension(Action<LexerExtensionContext> capture) : ILexerExtension
+    {
+        public IReadOnlyList<Token> TryReadTokens(LexerExtensionContext context)
+        {
+            capture(context);
+            return [];
+        }
+        public IReadOnlyList<Token> OnAfterToken(Token token, LexerExtensionContext context) => [];
+        public IReadOnlyList<Token> OnEndOfInput(LexerExtensionContext context) => [];
+    }
+
+    private sealed class CallTrackingLexerExtension(
+        Action onTryRead,
+        Action onAfterToken,
+        Action onEndOfInput) : ILexerExtension
+    {
+        public IReadOnlyList<Token> TryReadTokens(LexerExtensionContext context)
+        {
+            onTryRead();
+            return [];
+        }
+        public IReadOnlyList<Token> OnAfterToken(Token token, LexerExtensionContext context)
+        {
+            onAfterToken();
+            return [];
+        }
+        public IReadOnlyList<Token> OnEndOfInput(LexerExtensionContext context)
+        {
+            onEndOfInput();
+            return [];
+        }
+    }
+
+    private sealed class GuardingLexerExtension(string superClassName, Action onMatch) : ILexerExtension
+    {
+        public IReadOnlyList<Token> TryReadTokens(LexerExtensionContext context)
+        {
+            if (context.Definition.ExtensionBindings.Any(b => b.SuperClassName == superClassName))
+                onMatch();
+            return [];
+        }
+        public IReadOnlyList<Token> OnAfterToken(Token token, LexerExtensionContext context) => [];
+        public IReadOnlyList<Token> OnEndOfInput(LexerExtensionContext context) => [];
+    }
+
+    private sealed class CapturingPredicateEvaluator(
+        Func<SemanticPredicateEvaluationContext, SemanticPredicateEvaluationResult> evaluate)
+        : ISemanticPredicateEvaluator
+    {
+        public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+            => evaluate(context);
+    }
+
+    private sealed class CapturingActionExecutor(
+        Func<ParserActionExecutionContext, ParserActionExecutionResult> execute)
+        : IParserActionExecutor
+    {
+        public ParserActionExecutionResult Execute(ParserActionExecutionContext context)
+            => execute(context);
+    }
+}

--- a/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
@@ -573,6 +573,19 @@ public class Antlr4GrammarConverterTests
         Assert.IsFalse(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.UnsupportedAntlrOptionIgnored.Code));
     }
 
+    [TestMethod]
+    public void ParseCaseInsensitive_DoesNotEmitUnsupportedOptionDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        Antlr4GrammarConverter.Parse("""
+            grammar C;
+            options { caseInsensitive=true; }
+            start : 'x' ;
+            """, diagnostics);
+
+        Assert.IsFalse(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.UnsupportedAntlrOptionIgnored.Code));
+    }
+
     [DataTestMethod]
     [DataRow("CSharp")]
     [DataRow("Java")]

--- a/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
@@ -575,6 +575,34 @@ public class Antlr4GrammarConverterTests
         Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.UnsupportedAntlrLanguageOptionIgnored.Code));
     }
 
+    [TestMethod]
+    public void ParseUnsupportedOption_EmitsExplicitDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        Antlr4GrammarConverter.Parse("""
+            grammar C;
+            options { visitor=true; }
+            start : 'x' ;
+            """, diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.UnsupportedAntlrOptionIgnored.Code));
+    }
+
+    [TestMethod]
+    public void ParseTokensAndChannelsSpec_EmitsPartialSupportDiagnostics()
+    {
+        var diagnostics = new DiagnosticBag();
+        Antlr4GrammarConverter.Parse("""
+            grammar C;
+            tokens { A, B }
+            channels { COMMENTS }
+            start : 'x' ;
+            """, diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.TokensBlockIgnored.Code));
+        Assert.IsTrue(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.ChannelsBlockIgnored.Code));
+    }
+
     // ─── 15. grammaire invalide → exception ──────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
@@ -560,6 +560,19 @@ public class Antlr4GrammarConverterTests
         Assert.IsNull(def.EffectiveOptions.LexerSuperClass);
     }
 
+    [TestMethod]
+    public void ParseSuperClass_DoesNotEmitUnsupportedOptionDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        Antlr4GrammarConverter.Parse("""
+            grammar C;
+            options { superClass=MyBaseParser; }
+            start : 'x' ;
+            """, diagnostics);
+
+        Assert.IsFalse(diagnostics.Any(diagnostic => diagnostic.Code == ParserDiagnostics.UnsupportedAntlrOptionIgnored.Code));
+    }
+
     [DataTestMethod]
     [DataRow("CSharp")]
     [DataRow("Java")]

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -65,6 +65,7 @@ Additional architectural context and explicit non-goals are documented in `docs/
 |---|---|
 | `import` usage | Fully resolved when grammars are compiled as a project input set; isolated single-file compilation may emit `ImportParsedButNotResolved` when no resolver context is provided. |
 | `tokenVocab` | Dependency loading is supported; effective behavior depends on available resolver inputs and vocabulary source availability in the compilation context. |
+| Other grammar `options` entries | Parsed and preserved as metadata; unsupported options are reported explicitly with `UnsupportedAntlrOptionIgnored`. |
 | Left-recursive precedence parity | Implemented for current runtime model, but not equivalent to all ANTLR4 precedence scenarios; the runtime can emit `LeftRecursivePrecedencePartiallySupported` where applicable. |
 | Lexer command set | Supported commands are `skip`, `more`, `channel`, `type`, `pushMode`, `popMode`, `mode`. Any other command is rejected deterministically with `UnsupportedLexerCommand`. |
 

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -65,6 +65,7 @@ Additional architectural context and explicit non-goals are documented in `docs/
 |---|---|
 | `import` usage | Fully resolved when grammars are compiled as a project input set; isolated single-file compilation may emit `ImportParsedButNotResolved` when no resolver context is provided. |
 | `tokenVocab` | Dependency loading is supported; effective behavior depends on available resolver inputs and vocabulary source availability in the compilation context. |
+| `superClass` | Parsed, preserved, normalized into `EffectiveGrammarOptions`, and exposed through `GrammarExtensionBinding` metadata. It is **not** interpreted as parser/lexer runtime inheritance execution. |
 | Other grammar `options` entries | Parsed and preserved as metadata; unsupported options are reported explicitly with `UnsupportedAntlrOptionIgnored`. |
 | Left-recursive precedence parity | Implemented for current runtime model, but not equivalent to all ANTLR4 precedence scenarios; the runtime can emit `LeftRecursivePrecedencePartiallySupported` where applicable. |
 | Lexer command set | Supported commands are `skip`, `more`, `channel`, `type`, `pushMode`, `popMode`, `mode`. Any other command is rejected deterministically with `UnsupportedLexerCommand`. |


### PR DESCRIPTION
## Summary

- Emit explicit diagnostics for `tokens { }` and `channels { }` blocks during conversion (`UP1002 TokensBlockIgnored`, `UP1003 ChannelsBlockIgnored`), and fix extraction of declared token/channel names into `DeclaredTokens` / `DeclaredChannels` (previously dead code due to `FlatChildren` not descending into `idList`).
- Add `UP1021 UnsupportedAntlrOptionIgnored` for unrecognised grammar options; whitelist `tokenVocab`, `superClass`, `caseInsensitive`, and `language`.
- Add `caseInsensitive` to the supported-option whitelist (it is actively consumed by the lexer engine).
- Add `ANTLRCompatibility.md`: user-facing reference listing every ANTLR4 feature with its support status, usage examples for features that differ from standard ANTLR4 (`superClass`/`ILexerExtension`, semantic predicates, inline actions, runtime observation), and corrected double-qualification (direct left recursion, `precpred`, `<assoc=right>`, labels, `import`, `tokenVocab` moved from "full support" to "partially supported").
- Update `AGENTS.md` to require consulting and updating `ANTLRCompatibility.md` before and after any grammar-related change.
- Set Phase 6 in `ROADMAP.md` to `in progress` with current clarification status.
- Update `docs/parser/Antlr4CompatibilityMatrix.md` and `Utils.Parser/README.md` with `superClass` contract and conservative-compatibility note.

## Testing

- 27 new tests in `ANTLRCompatibilityDocTests.cs` covering every documented section: `superClass`/`ILexerExtension` wiring, `ISemanticPredicateEvaluator` context fields and outcomes, `IParserActionExecutor` invocation, `@init`/`@after` storage, grammar-level actions, rule parameters/returns, `locals`/`throws`/`catch`/`finally` handling, labels, single-file import diagnostic, indirect recursion exception + diagnostic, `ErrorNode` on failure, and runtime observation full workflow.
- 4 targeted converter tests: `ParseSuperClass_DoesNotEmitUnsupportedOptionDiagnostic`, `ParseCaseInsensitive_DoesNotEmitUnsupportedOptionDiagnostic`, `ParseUnsupportedOption_EmitsExplicitDiagnostic`, `ParseTokensAndChannelsSpec_EmitsPartialSupportDiagnostics`.
- Full suite: 1499 passed, 0 failed.
