### PR TITLE
Add conservative shared‑prefix structural token metadata

### DIFF
--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -19,7 +19,6 @@ internal sealed class AlternativeScheduler
     private readonly ParserLookaheadSharedPrefixDetector _sharedPrefixDetector = new();
     private readonly ParserContinuationFactory _continuationFactory = new();
     private readonly ParserSharedPrefixPlanFactory _sharedPrefixPlanFactory = new();
-    private readonly AlternativeStructuralPrefixExtractor _structuralPrefixExtractor = new();
 
     /// <summary>
     /// Initializes a scheduler with an optional passive runtime observer.
@@ -40,7 +39,8 @@ internal sealed class AlternativeScheduler
         int originInputPosition,
         int minimumPrecedence,
         DiagnosticBag? diagnostics,
-        Func<Alternative, int, ScheduledAlternativeExecutionResult> parseAlternative)
+        Func<Alternative, int, ScheduledAlternativeExecutionResult> parseAlternative,
+        IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors = null)
     {
         var ordered = alternatives.OrderBy(static a => a.Priority).ToList();
         var lookaheadProbesByAlternative = new ParserLookaheadProbeResult[ordered.Count];
@@ -70,7 +70,7 @@ internal sealed class AlternativeScheduler
 
         if (completedStates.Count == 0)
         {
-            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(rule, ordered, lookaheadProbesByAlternative));
+            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(rule, ordered, lookaheadProbesByAlternative, precomputedDescriptors));
         }
 
         // Deduplication uses scheduling identity (ActiveParseStateKey) and is intentionally
@@ -102,7 +102,7 @@ internal sealed class AlternativeScheduler
             NotifyObserver(observation => _runtimeObserver?.OnAlternativeSelected(observation), CreateObservation(ParserRuntimeObservationKind.AlternativeSelected, winner));
         }
 
-        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(rule, ordered, lookaheadProbesByAlternative));
+        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(rule, ordered, lookaheadProbesByAlternative, precomputedDescriptors));
     }
 
 
@@ -114,7 +114,8 @@ internal sealed class AlternativeScheduler
     private AlternativeSchedulingMetadata BuildMetadata(
         Rule rule,
         IReadOnlyList<Alternative> orderedAlternatives,
-        IReadOnlyList<ParserLookaheadProbeResult> lookaheadProbes)
+        IReadOnlyList<ParserLookaheadProbeResult> lookaheadProbes,
+        IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors)
     {
         // Metadata lifecycle boundary:
         // observations are produced from attempted alternatives, transported through scheduling,
@@ -145,10 +146,9 @@ internal sealed class AlternativeScheduler
         // Shared-prefix plans remain observational scheduler metadata:
         // they expose deterministic grouping information, but never grant
         // replay/resume/merge authority and never replace real parser execution.
-        // Structural descriptors are prepared outside the scheduler by AlternativeStructuralPrefixExtractor,
-        // keeping grammar traversal out of the scheduling path.
-        var structuralDescriptors = _structuralPrefixExtractor.ExtractAll(orderedAlternatives);
-        var plans = _sharedPrefixPlanFactory.CreatePlans(candidates, continuations, structuralDescriptors);
+        // Structural descriptors are prepared by the caller (grammar preparation layer)
+        // and forwarded here; the scheduler does not construct or inspect them.
+        var plans = _sharedPrefixPlanFactory.CreatePlans(candidates, continuations, precomputedDescriptors);
         return new AlternativeSchedulingMetadata { SharedPrefixPlans = plans };
     }
 

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -144,7 +144,10 @@ internal sealed class AlternativeScheduler
         // Shared-prefix plans remain observational scheduler metadata:
         // they expose deterministic grouping information, but never grant
         // replay/resume/merge authority and never replace real parser execution.
-        var plans = _sharedPrefixPlanFactory.CreatePlans(candidates, continuations);
+        var alternativesByIndex = orderedAlternatives
+            .Select((alternative, index) => new KeyValuePair<int, Alternative>(index, alternative))
+            .ToDictionary();
+        var plans = _sharedPrefixPlanFactory.CreatePlans(candidates, continuations, alternativesByIndex);
         return new AlternativeSchedulingMetadata { SharedPrefixPlans = plans };
     }
 

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -19,6 +19,7 @@ internal sealed class AlternativeScheduler
     private readonly ParserLookaheadSharedPrefixDetector _sharedPrefixDetector = new();
     private readonly ParserContinuationFactory _continuationFactory = new();
     private readonly ParserSharedPrefixPlanFactory _sharedPrefixPlanFactory = new();
+    private readonly AlternativeStructuralPrefixExtractor _structuralPrefixExtractor = new();
 
     /// <summary>
     /// Initializes a scheduler with an optional passive runtime observer.
@@ -144,10 +145,10 @@ internal sealed class AlternativeScheduler
         // Shared-prefix plans remain observational scheduler metadata:
         // they expose deterministic grouping information, but never grant
         // replay/resume/merge authority and never replace real parser execution.
-        var alternativesByIndex = orderedAlternatives
-            .Select((alternative, index) => new KeyValuePair<int, Alternative>(index, alternative))
-            .ToDictionary();
-        var plans = _sharedPrefixPlanFactory.CreatePlans(candidates, continuations, alternativesByIndex);
+        // Structural descriptors are prepared outside the scheduler by AlternativeStructuralPrefixExtractor,
+        // keeping grammar traversal out of the scheduling path.
+        var structuralDescriptors = _structuralPrefixExtractor.ExtractAll(orderedAlternatives);
+        var plans = _sharedPrefixPlanFactory.CreatePlans(candidates, continuations, structuralDescriptors);
         return new AlternativeSchedulingMetadata { SharedPrefixPlans = plans };
     }
 

--- a/Utils.Parser/Runtime/AlternativeStructuralDescriptor.cs
+++ b/Utils.Parser/Runtime/AlternativeStructuralDescriptor.cs
@@ -1,0 +1,20 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Lightweight descriptor capturing the conservative structural token prefix for a single grammar alternative.
+/// Produced by <see cref="AlternativeStructuralPrefixExtractor"/> during grammar-level preparation,
+/// this descriptor carries only ordered token name strings and contains no
+/// <see cref="Utils.Parser.Model.RuleContent"/> references.
+/// It is safe to forward through the scheduler pipeline without coupling the scheduler to grammar internals.
+/// </summary>
+internal readonly record struct AlternativeStructuralDescriptor(
+    /// <summary>Zero-based index matching the alternative's position in its parent alternation.</summary>
+    int AlternativeIndex,
+    /// <summary>
+    /// Ordered structural token sequence extracted conservatively from the alternative's content.
+    /// Only <see cref="Utils.Parser.Model.RuleRef"/> and <see cref="Utils.Parser.Model.LiteralMatch"/>
+    /// elements at the head of a <see cref="Utils.Parser.Model.Sequence"/> are included.
+    /// Complex constructs (quantifiers, nested alternations, actions) stop extraction.
+    /// This list is read-only; callers must not attempt to cast or mutate it.
+    /// </summary>
+    IReadOnlyList<string> StructuralTokens);

--- a/Utils.Parser/Runtime/AlternativeStructuralPrefixExtractor.cs
+++ b/Utils.Parser/Runtime/AlternativeStructuralPrefixExtractor.cs
@@ -52,7 +52,7 @@ internal sealed class AlternativeStructuralPrefixExtractor
 
         return TryGetStructuralToken(content, out var singleToken)
             ? Array.AsReadOnly(new[] { singleToken })
-            : Array.AsReadOnly(Array.Empty<string>());
+            : [];
     }
 
     private static bool TryGetStructuralToken(RuleContent content, out string tokenName)

--- a/Utils.Parser/Runtime/AlternativeStructuralPrefixExtractor.cs
+++ b/Utils.Parser/Runtime/AlternativeStructuralPrefixExtractor.cs
@@ -1,0 +1,73 @@
+using Utils.Parser.Model;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Extracts conservative structural token prefixes from grammar alternatives.
+/// This class encapsulates all grammar-model traversal required for shared-prefix metadata preparation,
+/// keeping grammar inspection out of the scheduler and plan factory paths.
+/// Extraction is deterministic, runtime-independent, and scheduler-independent.
+/// </summary>
+internal sealed class AlternativeStructuralPrefixExtractor
+{
+    /// <summary>
+    /// Extracts a structural descriptor for every alternative in the ordered list.
+    /// The resulting descriptors carry only token name strings; callers receive no grammar model references.
+    /// </summary>
+    /// <param name="alternatives">Ordered alternatives to inspect.</param>
+    /// <returns>
+    /// One descriptor per alternative, with the same ordering as the input list.
+    /// Each descriptor's <see cref="AlternativeStructuralDescriptor.AlternativeIndex"/> matches
+    /// the position in the input list.
+    /// </returns>
+    public IReadOnlyList<AlternativeStructuralDescriptor> ExtractAll(IReadOnlyList<Alternative> alternatives)
+    {
+        var descriptors = new AlternativeStructuralDescriptor[alternatives.Count];
+        for (var index = 0; index < alternatives.Count; index++)
+        {
+            descriptors[index] = new AlternativeStructuralDescriptor(
+                index,
+                ExtractStructuralTokens(alternatives[index].Content));
+        }
+        return descriptors;
+    }
+
+    private static IReadOnlyList<string> ExtractStructuralTokens(RuleContent content)
+    {
+        if (content is Sequence sequence)
+        {
+            var tokens = new List<string>();
+            for (var index = 0; index < sequence.Items.Count; index++)
+            {
+                if (!TryGetStructuralToken(sequence.Items[index], out var token))
+                {
+                    break;
+                }
+
+                tokens.Add(token);
+            }
+
+            return tokens.AsReadOnly();
+        }
+
+        return TryGetStructuralToken(content, out var singleToken)
+            ? Array.AsReadOnly(new[] { singleToken })
+            : Array.AsReadOnly(Array.Empty<string>());
+    }
+
+    private static bool TryGetStructuralToken(RuleContent content, out string tokenName)
+    {
+        switch (content)
+        {
+            case RuleRef reference:
+                tokenName = reference.RuleName;
+                return true;
+            case LiteralMatch literal:
+                tokenName = literal.Value;
+                return true;
+            default:
+                tokenName = string.Empty;
+                return false;
+        }
+    }
+}

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -66,6 +66,11 @@ public sealed class ParserEngine
     /// </summary>
     private readonly AlternativeScheduler _alternativeScheduler;
     /// <summary>
+    /// Stateless extractor used to prepare structural descriptors from grammar alternatives
+    /// before scheduling begins. Extraction is grammar-level preparation; the scheduler only consumes results.
+    /// </summary>
+    private static readonly AlternativeStructuralPrefixExtractor _structuralPrefixExtractor = new();
+    /// <summary>
     /// Look-ahead cache scoped to a single parse execution.
     /// Stored entries are advisory probe metadata and do not alter engine-owned parse authority
     /// or trailing-token final validation.
@@ -834,12 +839,17 @@ public sealed class ParserEngine
     {
         var startPosition = context.Position;
         var startToken = context.Peek();
+        // Prepare structural descriptors from the grammar before scheduling begins.
+        // Extraction is grammar-level preparation; the scheduler receives ready-made descriptors.
+        var orderedAlternatives = alternatives.OrderBy(static a => a.Priority).ToList();
+        var structuralDescriptors = _structuralPrefixExtractor.ExtractAll(orderedAlternatives);
         var scheduling = _alternativeScheduler.Run(
             rule,
-            alternatives,
+            orderedAlternatives,
             startPosition,
             precedence,
             diagnostics,
+            precomputedDescriptors: structuralDescriptors,
             parseAlternative: (alternative, alternativeIndex) => _scheduledAlternativeExecutor.Execute(
                 context,
                 rule,

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
@@ -1,9 +1,8 @@
-using Utils.Parser.Model;
-
 namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Creates structural shared-prefix plans from shallow shared-token candidates and continuation metadata.
+/// This factory aggregates pre-computed structural descriptors and does not inspect grammar model objects.
 /// </summary>
 internal sealed class ParserSharedPrefixPlanFactory
 {
@@ -12,6 +11,11 @@ internal sealed class ParserSharedPrefixPlanFactory
     /// </summary>
     /// <param name="candidates">Ordered shared-prefix candidates detected from shallow look-ahead observations.</param>
     /// <param name="continuations">Structural continuation descriptors available for grouping.</param>
+    /// <param name="structuralDescriptors">
+    /// Optional pre-computed per-alternative structural descriptors produced by
+    /// <see cref="AlternativeStructuralPrefixExtractor"/>. When absent the segment falls back to the
+    /// shallow shared token name as a single-element structural prefix.
+    /// </param>
     /// <returns>
     /// Shared-prefix plans with at least two matching continuations each. This metadata is informational only and
     /// does not execute shared prefixes or continuations.
@@ -19,7 +23,7 @@ internal sealed class ParserSharedPrefixPlanFactory
     public IReadOnlyList<ParserSharedPrefixPlan> CreatePlans(
         IReadOnlyList<ParserLookaheadSharedPrefixCandidate> candidates,
         IReadOnlyList<ParserContinuationDescriptor> continuations,
-        IReadOnlyDictionary<int, Alternative>? alternativesByIndex = null)
+        IReadOnlyList<AlternativeStructuralDescriptor>? structuralDescriptors = null)
     {
         if (candidates.Count == 0 || continuations.Count == 0)
         {
@@ -37,7 +41,7 @@ internal sealed class ParserSharedPrefixPlanFactory
 
             var alternativeIndexes = matchingContinuations.Select(static continuation => continuation.Key.AlternativeIndex).ToArray();
             var boundary = BuildBoundary(matchingContinuations);
-            var structuralTokens = BuildStructuralTokens(candidate, alternativesByIndex);
+            var structuralTokens = BuildStructuralTokens(candidate, structuralDescriptors);
             var segment = new ParserSharedPrefixSegment(candidate.TokenName, structuralTokens, boundary);
             plans.Add(new ParserSharedPrefixPlan(candidate.TokenName, alternativeIndexes, matchingContinuations, segment));
         }
@@ -87,9 +91,6 @@ internal sealed class ParserSharedPrefixPlanFactory
     /// <summary>
     /// Determines whether a continuation descriptor contains the candidate token in its shallow expected-token list.
     /// </summary>
-    /// <param name="expectedTokenNames">Shallow expected-token names on a continuation descriptor.</param>
-    /// <param name="tokenName">Candidate shared token.</param>
-    /// <returns><see langword="true"/> when the token name is present; otherwise <see langword="false"/>.</returns>
     private static bool ContainsExpectedToken(IReadOnlyList<string>? expectedTokenNames, string tokenName)
     {
         if (expectedTokenNames is null || expectedTokenNames.Count == 0)
@@ -134,24 +135,34 @@ internal sealed class ParserSharedPrefixPlanFactory
         return new ParserSharedPrefixBoundary(expectedPosition, null);
     }
 
+    /// <summary>
+    /// Aggregates pre-computed structural token sequences from descriptors to determine the shared prefix.
+    /// Falls back to the candidate's shallow token name when descriptors are absent or incomplete.
+    /// </summary>
     private static IReadOnlyList<string> BuildStructuralTokens(
         ParserLookaheadSharedPrefixCandidate candidate,
-        IReadOnlyDictionary<int, Alternative>? alternativesByIndex)
+        IReadOnlyList<AlternativeStructuralDescriptor>? structuralDescriptors)
     {
-        if (alternativesByIndex is null || alternativesByIndex.Count == 0)
+        if (structuralDescriptors is null || structuralDescriptors.Count == 0)
         {
             return [candidate.TokenName];
+        }
+
+        var tokensByIndex = new Dictionary<int, IReadOnlyList<string>>(structuralDescriptors.Count);
+        foreach (var descriptor in structuralDescriptors)
+        {
+            tokensByIndex[descriptor.AlternativeIndex] = descriptor.StructuralTokens;
         }
 
         var tokenSequences = new List<IReadOnlyList<string>>();
         foreach (var alternativeIndex in candidate.AlternativeIndexes)
         {
-            if (!alternativesByIndex.TryGetValue(alternativeIndex, out var alternative))
+            if (!tokensByIndex.TryGetValue(alternativeIndex, out var tokens))
             {
                 return [candidate.TokenName];
             }
 
-            tokenSequences.Add(ExtractStructuralTokens(alternative.Content));
+            tokenSequences.Add(tokens);
         }
 
         if (tokenSequences.Count < 2)
@@ -161,43 +172,6 @@ internal sealed class ParserSharedPrefixPlanFactory
 
         var sharedPrefix = ComputeSharedPrefix(tokenSequences);
         return sharedPrefix.Count == 0 ? [candidate.TokenName] : sharedPrefix;
-    }
-
-    private static IReadOnlyList<string> ExtractStructuralTokens(RuleContent content)
-    {
-        if (content is Sequence sequence)
-        {
-            var tokens = new List<string>();
-            for (var index = 0; index < sequence.Items.Count; index++)
-            {
-                if (!TryGetStructuralToken(sequence.Items[index], out var token))
-                {
-                    break;
-                }
-
-                tokens.Add(token);
-            }
-
-            return tokens;
-        }
-
-        return TryGetStructuralToken(content, out var singleToken) ? [singleToken] : [];
-    }
-
-    private static bool TryGetStructuralToken(RuleContent content, out string tokenName)
-    {
-        switch (content)
-        {
-            case RuleRef reference:
-                tokenName = reference.RuleName;
-                return true;
-            case LiteralMatch literal:
-                tokenName = literal.Value;
-                return true;
-            default:
-                tokenName = string.Empty;
-                return false;
-        }
     }
 
     private static IReadOnlyList<string> ComputeSharedPrefix(IReadOnlyList<IReadOnlyList<string>> sequences)
@@ -226,6 +200,6 @@ internal sealed class ParserSharedPrefixPlanFactory
             prefix.Add(expected);
         }
 
-        return prefix;
+        return prefix.AsReadOnly();
     }
 }

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
@@ -1,3 +1,5 @@
+using Utils.Parser.Model;
+
 namespace Utils.Parser.Runtime;
 
 /// <summary>
@@ -16,7 +18,8 @@ internal sealed class ParserSharedPrefixPlanFactory
     /// </returns>
     public IReadOnlyList<ParserSharedPrefixPlan> CreatePlans(
         IReadOnlyList<ParserLookaheadSharedPrefixCandidate> candidates,
-        IReadOnlyList<ParserContinuationDescriptor> continuations)
+        IReadOnlyList<ParserContinuationDescriptor> continuations,
+        IReadOnlyDictionary<int, Alternative>? alternativesByIndex = null)
     {
         if (candidates.Count == 0 || continuations.Count == 0)
         {
@@ -34,7 +37,8 @@ internal sealed class ParserSharedPrefixPlanFactory
 
             var alternativeIndexes = matchingContinuations.Select(static continuation => continuation.Key.AlternativeIndex).ToArray();
             var boundary = BuildBoundary(matchingContinuations);
-            var segment = new ParserSharedPrefixSegment(candidate.TokenName, boundary);
+            var structuralTokens = BuildStructuralTokens(candidate, alternativesByIndex);
+            var segment = new ParserSharedPrefixSegment(candidate.TokenName, structuralTokens, boundary);
             plans.Add(new ParserSharedPrefixPlan(candidate.TokenName, alternativeIndexes, matchingContinuations, segment));
         }
 
@@ -128,5 +132,100 @@ internal sealed class ParserSharedPrefixPlanFactory
         }
 
         return new ParserSharedPrefixBoundary(expectedPosition, null);
+    }
+
+    private static IReadOnlyList<string> BuildStructuralTokens(
+        ParserLookaheadSharedPrefixCandidate candidate,
+        IReadOnlyDictionary<int, Alternative>? alternativesByIndex)
+    {
+        if (alternativesByIndex is null || alternativesByIndex.Count == 0)
+        {
+            return [candidate.TokenName];
+        }
+
+        var tokenSequences = new List<IReadOnlyList<string>>();
+        foreach (var alternativeIndex in candidate.AlternativeIndexes)
+        {
+            if (!alternativesByIndex.TryGetValue(alternativeIndex, out var alternative))
+            {
+                return [candidate.TokenName];
+            }
+
+            tokenSequences.Add(ExtractStructuralTokens(alternative.Content));
+        }
+
+        if (tokenSequences.Count < 2)
+        {
+            return [candidate.TokenName];
+        }
+
+        var sharedPrefix = ComputeSharedPrefix(tokenSequences);
+        return sharedPrefix.Count == 0 ? [candidate.TokenName] : sharedPrefix;
+    }
+
+    private static IReadOnlyList<string> ExtractStructuralTokens(RuleContent content)
+    {
+        if (content is Sequence sequence)
+        {
+            var tokens = new List<string>();
+            for (var index = 0; index < sequence.Items.Count; index++)
+            {
+                if (!TryGetStructuralToken(sequence.Items[index], out var token))
+                {
+                    break;
+                }
+
+                tokens.Add(token);
+            }
+
+            return tokens;
+        }
+
+        return TryGetStructuralToken(content, out var singleToken) ? [singleToken] : [];
+    }
+
+    private static bool TryGetStructuralToken(RuleContent content, out string tokenName)
+    {
+        switch (content)
+        {
+            case RuleRef reference:
+                tokenName = reference.RuleName;
+                return true;
+            case LiteralMatch literal:
+                tokenName = literal.Value;
+                return true;
+            default:
+                tokenName = string.Empty;
+                return false;
+        }
+    }
+
+    private static IReadOnlyList<string> ComputeSharedPrefix(IReadOnlyList<IReadOnlyList<string>> sequences)
+    {
+        var minimumLength = sequences.Min(static sequence => sequence.Count);
+        var prefix = new List<string>(minimumLength);
+
+        for (var index = 0; index < minimumLength; index++)
+        {
+            var expected = sequences[0][index];
+            var allMatch = true;
+            for (var sequenceIndex = 1; sequenceIndex < sequences.Count; sequenceIndex++)
+            {
+                if (!string.Equals(sequences[sequenceIndex][index], expected, StringComparison.Ordinal))
+                {
+                    allMatch = false;
+                    break;
+                }
+            }
+
+            if (!allMatch)
+            {
+                break;
+            }
+
+            prefix.Add(expected);
+        }
+
+        return prefix;
     }
 }

--- a/Utils.Parser/Runtime/ParserSharedPrefixSegment.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixSegment.cs
@@ -5,7 +5,9 @@ namespace Utils.Parser.Runtime;
 /// This metadata is preparatory only and is not executable.
 /// </summary>
 /// <param name="SharedTokenName">Shared shallow token identifier.</param>
+/// <param name="StructuralTokens">Ordered structural token sequence shared by all participating alternatives.</param>
 /// <param name="Boundary">Conservative boundary used for future continuation resumption planning.</param>
 internal readonly record struct ParserSharedPrefixSegment(
     string SharedTokenName,
+    IReadOnlyList<string> StructuralTokens,
     ParserSharedPrefixBoundary Boundary);

--- a/UtilsTest/Parser/ParserSharedPrefixExecutionEligibilityAnalyzerTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixExecutionEligibilityAnalyzerTests.cs
@@ -101,7 +101,7 @@ public class ParserSharedPrefixExecutionEligibilityAnalyzerTests
             tokenName,
             alternativeIndexes,
             continuations,
-            new ParserSharedPrefixSegment(tokenName, new ParserSharedPrefixBoundary(boundaryPosition, null)));
+            new ParserSharedPrefixSegment(tokenName, [tokenName], new ParserSharedPrefixBoundary(boundaryPosition, null)));
     }
 
     private static ParserContinuationDescriptor Continuation(int alternativeIndex, int sequencePosition)

--- a/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
@@ -27,6 +27,7 @@ public class ParserSharedPrefixMetadataScenarioTests
         Assert.AreEqual(1, plans.Count);
         var plan = plans[0];
         Assert.AreEqual("ID", plan.Segment.SharedTokenName);
+        CollectionAssert.AreEqual(new[] { "ID" }, plan.Segment.StructuralTokens.ToArray());
         Assert.AreEqual(1, plan.Segment.Boundary.SequencePosition);
         CollectionAssert.AreEqual(new[] { 1, 1 }, plan.Continuations.Select(static c => c.Key.SequencePosition).ToArray());
 
@@ -63,6 +64,7 @@ public class ParserSharedPrefixMetadataScenarioTests
         Assert.AreEqual(1, plans.Count);
         var plan = plans[0];
         Assert.AreEqual("ID", plan.Segment.SharedTokenName);
+        CollectionAssert.AreEqual(new[] { "ID" }, plan.Segment.StructuralTokens.ToArray());
         Assert.AreEqual(1, plan.Segment.Boundary.SequencePosition);
         CollectionAssert.AreEqual(new[] { 1, 1 }, plan.Continuations.Select(static c => c.Key.SequencePosition).ToArray());
 
@@ -89,6 +91,36 @@ public class ParserSharedPrefixMetadataScenarioTests
         var plans = CreatePlansFromAlternatives(alternatives, Token("ID", "x"));
 
         Assert.AreEqual(0, plans.Count);
+    }
+
+    [TestMethod]
+    public void Pipeline_SharedIdDotPrefix_ProducesTwoTokenStructuralPrefix()
+    {
+        var alternatives = new[]
+        {
+            Alternative(0, Sequence(new RuleRef("ID"), new LiteralMatch("."), new RuleRef("A"))),
+            Alternative(1, Sequence(new RuleRef("ID"), new LiteralMatch("."), new RuleRef("B")))
+        };
+
+        var plans = CreatePlansFromAlternatives(alternatives, Token("ID", "x"));
+
+        Assert.AreEqual(1, plans.Count);
+        CollectionAssert.AreEqual(new[] { "ID", "." }, plans[0].Segment.StructuralTokens.ToArray());
+    }
+
+    [TestMethod]
+    public void Pipeline_NestedParenthesizedRuleRefs_ProducesSingleTokenStructuralPrefix()
+    {
+        var alternatives = new[]
+        {
+            Alternative(0, Sequence(new RuleRef("ID"), new Quantifier(new RuleRef("A"), 1, 1))),
+            Alternative(1, Sequence(new RuleRef("ID"), new Quantifier(new RuleRef("B"), 1, 1)))
+        };
+
+        var plans = CreatePlansFromAlternatives(alternatives, Token("ID", "x"));
+
+        Assert.AreEqual(1, plans.Count);
+        CollectionAssert.AreEqual(new[] { "ID" }, plans[0].Segment.StructuralTokens.ToArray());
     }
 
     /// <summary>
@@ -176,7 +208,10 @@ public class ParserSharedPrefixMetadataScenarioTests
             }))
             .ToArray();
 
-        return planFactory.CreatePlans(candidates, continuations);
+        var alternativesByIndex = alternatives
+            .Select((alternative, index) => new KeyValuePair<int, Alternative>(index, alternative))
+            .ToDictionary();
+        return planFactory.CreatePlans(candidates, continuations, alternativesByIndex);
     }
 
     /// <summary>
@@ -202,7 +237,7 @@ public class ParserSharedPrefixMetadataScenarioTests
             tokenName,
             alternativeIndexes,
             continuations,
-            new ParserSharedPrefixSegment(tokenName, new ParserSharedPrefixBoundary(boundaryPosition, null)));
+            new ParserSharedPrefixSegment(tokenName, [tokenName], new ParserSharedPrefixBoundary(boundaryPosition, null)));
     }
 
     /// <summary>

--- a/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
@@ -184,6 +184,123 @@ public class ParserSharedPrefixMetadataScenarioTests
         Assert.IsTrue(validation.Issues.Any(static i => i.Message.Contains("non-fallback", StringComparison.Ordinal)));
     }
 
+    // ─── AlternativeStructuralPrefixExtractor tests ──────────────────────────
+
+    [TestMethod]
+    public void Extractor_SequenceAlternatives_ProducesCorrectDescriptors()
+    {
+        var extractor = new AlternativeStructuralPrefixExtractor();
+        var alternatives = new[]
+        {
+            Alternative(0, Sequence(new RuleRef("ID"), new LiteralMatch("."), new RuleRef("A"))),
+            Alternative(1, Sequence(new RuleRef("ID"), new LiteralMatch("."), new RuleRef("B")))
+        };
+
+        var descriptors = extractor.ExtractAll(alternatives);
+
+        Assert.AreEqual(2, descriptors.Count);
+        Assert.AreEqual(0, descriptors[0].AlternativeIndex);
+        Assert.AreEqual(1, descriptors[1].AlternativeIndex);
+        CollectionAssert.AreEqual(new[] { "ID", ".", "A" }, descriptors[0].StructuralTokens.ToArray());
+        CollectionAssert.AreEqual(new[] { "ID", ".", "B" }, descriptors[1].StructuralTokens.ToArray());
+    }
+
+    [TestMethod]
+    public void Extractor_QuantifierStopsExtraction_Conservatively()
+    {
+        var extractor = new AlternativeStructuralPrefixExtractor();
+        var alternatives = new[]
+        {
+            Alternative(0, Sequence(new RuleRef("ID"), new Quantifier(new RuleRef("X"), 1, 1)))
+        };
+
+        var descriptors = extractor.ExtractAll(alternatives);
+
+        CollectionAssert.AreEqual(new[] { "ID" }, descriptors[0].StructuralTokens.ToArray());
+    }
+
+    [TestMethod]
+    public void Extractor_SingleRuleRef_ProducesSingleTokenDescriptor()
+    {
+        var extractor = new AlternativeStructuralPrefixExtractor();
+        var alternatives = new[]
+        {
+            Alternative(0, new RuleRef("ID"))
+        };
+
+        var descriptors = extractor.ExtractAll(alternatives);
+
+        CollectionAssert.AreEqual(new[] { "ID" }, descriptors[0].StructuralTokens.ToArray());
+    }
+
+    [TestMethod]
+    public void Extractor_StructuralTokens_IsReadOnly_CannotBeMutated()
+    {
+        var extractor = new AlternativeStructuralPrefixExtractor();
+        var alternatives = new[]
+        {
+            Alternative(0, Sequence(new RuleRef("ID"), new LiteralMatch("+")))
+        };
+
+        var tokens = extractor.ExtractAll(alternatives)[0].StructuralTokens;
+
+        Assert.IsTrue(((ICollection<string>)tokens).IsReadOnly,
+            "StructuralTokens must be wrapped in a read-only collection");
+    }
+
+    [TestMethod]
+    public void Factory_WithNoDescriptors_FallsBackToSharedTokenName()
+    {
+        var candidates = new[]
+        {
+            new ParserLookaheadSharedPrefixCandidate("ID", [0, 1])
+        };
+        var continuations = new[]
+        {
+            Continuation(0, 1),
+            Continuation(1, 1)
+        };
+
+        var plans = new ParserSharedPrefixPlanFactory().CreatePlans(candidates, continuations);
+
+        Assert.AreEqual(1, plans.Count);
+        CollectionAssert.AreEqual(new[] { "ID" }, plans[0].Segment.StructuralTokens.ToArray());
+    }
+
+    // ─── Regression: scheduler integration ───────────────────────────────────
+
+    [TestMethod]
+    public void Regression_SharedIdDotPrefix_StillProducesTwoTokenPrefix()
+    {
+        var alternatives = new[]
+        {
+            Alternative(0, Sequence(new RuleRef("ID"), new LiteralMatch("."), new RuleRef("A"))),
+            Alternative(1, Sequence(new RuleRef("ID"), new LiteralMatch("."), new RuleRef("B")))
+        };
+
+        var plans = CreatePlansFromAlternatives(alternatives, Token("ID", "x"));
+
+        Assert.AreEqual(1, plans.Count);
+        CollectionAssert.AreEqual(new[] { "ID", "." }, plans[0].Segment.StructuralTokens.ToArray());
+    }
+
+    [TestMethod]
+    public void Regression_QuantifierAlternatives_StillProducesSingleTokenPrefix()
+    {
+        var alternatives = new[]
+        {
+            Alternative(0, Sequence(new RuleRef("ID"), new Quantifier(new RuleRef("A"), 1, 1))),
+            Alternative(1, Sequence(new RuleRef("ID"), new Quantifier(new RuleRef("B"), 1, 1)))
+        };
+
+        var plans = CreatePlansFromAlternatives(alternatives, Token("ID", "x"));
+
+        Assert.AreEqual(1, plans.Count);
+        CollectionAssert.AreEqual(new[] { "ID" }, plans[0].Segment.StructuralTokens.ToArray());
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
     /// <summary>
     /// Builds shared-prefix plans by probing alternatives and flowing metadata through detector, continuation, and plan factories.
     /// </summary>
@@ -208,10 +325,8 @@ public class ParserSharedPrefixMetadataScenarioTests
             }))
             .ToArray();
 
-        var alternativesByIndex = alternatives
-            .Select((alternative, index) => new KeyValuePair<int, Alternative>(index, alternative))
-            .ToDictionary();
-        return planFactory.CreatePlans(candidates, continuations, alternativesByIndex);
+        var descriptors = new AlternativeStructuralPrefixExtractor().ExtractAll(alternatives);
+        return planFactory.CreatePlans(candidates, continuations, descriptors);
     }
 
     /// <summary>

--- a/UtilsTest/Parser/ParserSharedPrefixPlanFormatterTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixPlanFormatterTests.cs
@@ -142,7 +142,7 @@ public class ParserSharedPrefixPlanFormatterTests
             tokenName,
             alternativeIndexes,
             continuations,
-            new ParserSharedPrefixSegment(tokenName, new ParserSharedPrefixBoundary(boundaryPosition, null)));
+            new ParserSharedPrefixSegment(tokenName, [tokenName], new ParserSharedPrefixBoundary(boundaryPosition, null)));
     }
 
     private static ParserContinuationDescriptor Continuation(int alternativeIndex, int sequencePosition)

--- a/UtilsTest/Parser/ParserSharedPrefixPlanValidatorTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixPlanValidatorTests.cs
@@ -115,7 +115,7 @@ public class ParserSharedPrefixPlanValidatorTests
             tokenName,
             alternativeIndexes,
             continuations,
-            new ParserSharedPrefixSegment(tokenName, new ParserSharedPrefixBoundary(boundaryPosition, null)));
+            new ParserSharedPrefixSegment(tokenName, [tokenName], new ParserSharedPrefixBoundary(boundaryPosition, null)));
     }
 
     private static ParserContinuationDescriptor Continuation(int alternativeIndex, int sequencePosition)

--- a/docs/parser/SharedLookAheadPreparation.md
+++ b/docs/parser/SharedLookAheadPreparation.md
@@ -1,0 +1,64 @@
+# Shared Look-Ahead Preparation
+
+## Purpose
+
+This document defines the current **shared-prefix identification metadata** prepared during grammar/runtime metadata preparation.
+
+The intent is to prepare future duplicated-work reduction research while preserving the current parser runtime contract.
+
+> Shared-prefix metadata does not change parser execution.
+
+## Scope and boundaries
+
+Current shared-prefix preparation is:
+
+- deterministic;
+- conservative;
+- structural;
+- advisory metadata only.
+
+Current shared-prefix preparation is **not**:
+
+- shared-prefix execution;
+- parser graph execution;
+- continuation replay;
+- scheduler control;
+- parse-tree control;
+- diagnostics authority.
+
+## Metadata semantics
+
+Shared-prefix metadata means only:
+
+- participating alternatives begin with structurally similar token/reference prefixes;
+- prefix depth can be described in ordered structural token form.
+
+Shared-prefix metadata does **not** mean:
+
+- alternatives are semantically equivalent;
+- alternatives are interchangeable;
+- one alternative can be executed on behalf of another.
+
+## Conservative detection model
+
+Detection is intentionally under-approximated.
+
+It reports shared prefixes when they are structurally obvious from rule metadata (for example, identical leading `RuleRef` and `LiteralMatch` sequences).
+
+It does not attempt semantic equivalence or deep inference over complex nested constructs.
+
+## Determinism and non-authority
+
+For a given grammar snapshot, produced shared-prefix metadata is deterministic.
+
+Produced metadata remains non-authoritative:
+
+- parser acceptance remains owned by `ParserEngine`;
+- scheduling remains sequential and deterministic;
+- diagnostics ownership remains unchanged.
+
+## Future intent
+
+This metadata enables future, explicitly gated design exploration for duplicated-work reduction.
+
+Any future execution activation requires dedicated design, tests, and roadmap updates, and is out of scope for this preparation step.

--- a/docs/parser/SharedLookAheadPreparation.md
+++ b/docs/parser/SharedLookAheadPreparation.md
@@ -39,6 +39,19 @@ Shared-prefix metadata does **not** mean:
 - alternatives are interchangeable;
 - one alternative can be executed on behalf of another.
 
+## Structural token preparation
+
+Structural token sequences are computed by `AlternativeStructuralPrefixExtractor` during grammar-level preparation,
+**before** scheduling begins.
+
+The extractor inspects grammar model objects (`RuleContent`, `Sequence`, `RuleRef`, `LiteralMatch`) and produces
+lightweight `AlternativeStructuralDescriptor` records carrying only token name strings.
+These descriptors are forwarded to `ParserSharedPrefixPlanFactory`, which aggregates them without accessing
+grammar model objects.
+
+`AlternativeScheduler` receives pre-computed descriptors and forwards them; it does not inspect rule content,
+traverse grammar structures, or extract tokens itself.
+
 ## Conservative detection model
 
 Detection is intentionally under-approximated.


### PR DESCRIPTION
### Motivation
- Prepare deterministic, metadata-only shared-prefix information to enable future duplicated-work reduction without changing parser execution. 
- Provide richer structural description (ordered token sequence) so tooling and future experiments can reason about obvious shared prefixes while preserving current runtime contracts. 
- This work is conservative by design: it only inspects grammar-level shapes (e.g., `RuleRef`, `LiteralMatch`) and under-detects rather than infers semantic equivalence. 
- No roadmap phase status change is required because this stays inside Phase 4 (shared-prefix metadata maturity) and does not alter metadata semantics or enable execution. 

### Description
- Added `StructuralTokens` to the shared-prefix segment model (`Utils.Parser/Runtime/ParserSharedPrefixSegment.cs`) to record an ordered, conservative token sequence. 
- Extended `ParserSharedPrefixPlanFactory` to accept per-alternative descriptors and compute a conservative structural token prefix using only obvious `RuleRef`/`LiteralMatch` elements, with fallback to the shallow shared token when uncertain. 
- Wired the scheduler to supply per-alternative descriptors into plan creation (`Utils.Parser/Runtime/AlternativeScheduler.cs`) while explicitly keeping all produced plans metadata-only and non-authoritative. 
- Updated and added deterministic unit tests under `UtilsTest/Parser` to validate structural-token detection scenarios (single-token and multi-token prefixes, nested/quantified under-detection) and adjusted existing shared-prefix validator/formatter/eligibility tests to the enriched metadata shape. 
- Added documentation `docs/parser/SharedLookAheadPreparation.md` that states intent, conservative detection rules, and the explicit guarantee that shared-prefix metadata does not change parser execution. 

### Testing
- Added and updated unit tests in `UtilsTest/Parser` (e.g. `ParserSharedPrefixMetadataScenarioTests`, `ParserSharedPrefixPlanFormatterTests`, `ParserSharedPrefixPlanValidatorTests`, `ParserSharedPrefixExecutionEligibilityAnalyzerTests`) to cover the new `StructuralTokens` shape and conservative detection cases. 
- Ran a targeted test invocation: `dotnet test UtilsTest/UtilsTest.csproj --no-restore --filter "FullyQualifiedName~ParserSharedPrefixMetadataScenarioTests"`; initial compilation errors from test call sites were fixed by updating tests to the new segment constructor, after which the targeted parser tests compiled and executed in this environment. 
- Recommend CI to run the full test matrix (server-side) to produce a definitive pass/fail report for the entire suite; no runtime behavior changes are expected from these metadata-only additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f45e13fec83268d9203b78143fbd9)