### PR TITLE
Add parser documentation index and require agents to consult/update it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,11 @@ This project targets **.NET 9**.
 
 ---
 
+
+## Parser documentation index
+
+When working on `Utils.Parser` documentation, agents must consult `docs/parser/INDEX.md` first and keep it updated whenever `docs/parser/*.md` files are added, removed, or materially changed.
+
 ## Codex Mission — Documentation & Discoverability (omy.Utils)
 
 This section **extends** the existing guidelines above.  

--- a/Utils.Parser/AGENTS.md
+++ b/Utils.Parser/AGENTS.md
@@ -66,6 +66,11 @@ Agents must:
 - **update `ANTLRCompatibility.md` after any change that adds, removes, or alters support for an ANTLR4 feature**, including moving a feature from "not supported" to "partially supported", or from "parsed but not executed" to "supported";
 - document, in the relevant section, **how the feature works when its behaviour differs from standard ANTLR4** (usage examples, API hooks, known constraints).
 
+
+## Parser documentation index
+
+Before editing parser documentation, agents must read `docs/parser/INDEX.md` and update it in the same PR when any document under `docs/parser/` is added, removed, or materially changed.
+
 ## Documentation requirements
 
 For runtime-affecting PRs, agents must update relevant documentation, including:

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -6,6 +6,9 @@ For each feature that behaves differently from standard ANTLR4, a **Usage** sect
 
 This document must be consulted before modifying any grammar-related component, and updated whenever a feature's support status changes.
 
+> Note: this reference is complementary to `docs/parser/Antlr4CompatibilityMatrix.md` (high-level matrix).
+> Use this file for implementation-oriented usage guidance when behavior differs from standard ANTLR4.
+
 ---
 
 ## Supported — full runtime support

--- a/docs/parser/INDEX.md
+++ b/docs/parser/INDEX.md
@@ -1,0 +1,24 @@
+# Utils.Parser Documentation Index
+
+This index consolidates the parser documentation set and gives a short summary of each file.
+
+## Core contracts and boundaries
+
+- [`RuntimeStateOwnership.md`](./RuntimeStateOwnership.md): Canonical authority map for runtime responsibilities (parse decisions, diagnostics, parse-tree ownership, scheduler/registry boundaries).
+- [`ParserMetadataAndRuntimeLimitations.md`](./ParserMetadataAndRuntimeLimitations.md): Limitations-first reference that clarifies metadata-only semantics, unsupported runtime semantics, and activation preconditions.
+- [`RuntimeObservationAndExportContract.md`](./RuntimeObservationAndExportContract.md): Defines what runtime observations are allowed to emit and how exporters must remain passive and non-authoritative.
+- [`DiagnosticsObservationCorrelation.md`](./DiagnosticsObservationCorrelation.md): Conservative rules for linking diagnostics to runtime observations without changing runtime authority.
+
+## Metadata and preparation documents
+
+- [`ContinuationMetadata.md`](./ContinuationMetadata.md): Describes continuation metadata lifecycle and explicitly states that metadata does not grant execution/resume authority.
+- [`SharedLookAheadPreparation.md`](./SharedLookAheadPreparation.md): Documents shared-prefix/look-ahead preparation as deterministic advisory metadata only.
+
+## Compatibility and analysis
+
+- [`Antlr4CompatibilityMatrix.md`](./Antlr4CompatibilityMatrix.md): Current ANTLR4 feature support matrix with explicit levels (supported, partial, parsed-only, unsupported).
+- [`RuntimeTraceAnalysis.md`](./RuntimeTraceAnalysis.md): Tooling-oriented analysis model for runtime traces, focused on descriptive outputs rather than runtime control.
+
+## Maintenance rule for contributors and agents
+
+When adding, removing, or materially changing any file in `docs/parser/`, update this index in the same change so summaries stay accurate.

--- a/docs/parser/INDEX.md
+++ b/docs/parser/INDEX.md
@@ -16,6 +16,7 @@ This index consolidates the parser documentation set and gives a short summary o
 
 ## Compatibility and analysis
 
+- [`../Utils.Parser/ANTLRCompatibility.md`](../../Utils.Parser/ANTLRCompatibility.md): Practical compatibility reference with feature-by-feature behavior notes and usage guidance for ANTLR4 constructs that differ from standard runtime semantics.
 - [`Antlr4CompatibilityMatrix.md`](./Antlr4CompatibilityMatrix.md): Current ANTLR4 feature support matrix with explicit levels (supported, partial, parsed-only, unsupported).
 - [`RuntimeTraceAnalysis.md`](./RuntimeTraceAnalysis.md): Tooling-oriented analysis model for runtime traces, focused on descriptive outputs rather than runtime control.
 


### PR DESCRIPTION
### Motivation

- Parser documentation under `Utils.Parser` has grown and needs a central, concise index to improve discoverability and reduce stale or inconsistent updates.
- Agents and contributors must have an explicit, easy-to-find rule to consult and maintain that index when editing parser docs to keep documentation synchronized.

### Description

- Added `docs/parser/INDEX.md` which consolidates the existing `docs/parser/*.md` files and provides a short summary for each major document.
- Updated the repository-level `AGENTS.md` to instruct agents to consult `docs/parser/INDEX.md` before modifying parser documentation and to update the index when files are added, removed, or materially changed.
- Updated `Utils.Parser/AGENTS.md` with the same scoped instruction requiring agents to read and update `docs/parser/INDEX.md` in the same PR when making parser documentation changes.
- These are documentation/process-only changes and do not alter runtime behavior, public APIs, or tests.

### Testing

- No automated tests were run because the changes are documentation and agent-instruction updates only. 
- Build and runtime behavior were intentionally not modified, so no code tests were required or executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f64cfce948326b232c4a26e915fe2)