### PR TITLE
refactor(parser): extract continuation metadata preparation from scheduler

### DIFF
--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -17,8 +17,8 @@ internal sealed class AlternativeScheduler
 {
     private readonly IParserRuntimeObserver? _runtimeObserver;
     private readonly ParserLookaheadSharedPrefixDetector _sharedPrefixDetector = new();
-    private readonly ParserContinuationFactory _continuationFactory = new();
     private readonly ParserSharedPrefixPlanFactory _sharedPrefixPlanFactory = new();
+    private readonly ContinuationMetadataPreparation _continuationMetadataPreparation = new();
 
     /// <summary>
     /// Initializes a scheduler with an optional passive runtime observer.
@@ -40,7 +40,8 @@ internal sealed class AlternativeScheduler
         int minimumPrecedence,
         DiagnosticBag? diagnostics,
         Func<Alternative, int, ScheduledAlternativeExecutionResult> parseAlternative,
-        IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors = null)
+        IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors = null,
+        IReadOnlyList<ParserContinuationDescriptor>? precomputedContinuationMetadata = null)
     {
         var ordered = alternatives.OrderBy(static a => a.Priority).ToList();
         var lookaheadProbesByAlternative = new ParserLookaheadProbeResult[ordered.Count];
@@ -70,7 +71,7 @@ internal sealed class AlternativeScheduler
 
         if (completedStates.Count == 0)
         {
-            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(rule, ordered, lookaheadProbesByAlternative, precomputedDescriptors));
+            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(rule, ordered, lookaheadProbesByAlternative, precomputedDescriptors, precomputedContinuationMetadata));
         }
 
         // Deduplication uses scheduling identity (ActiveParseStateKey) and is intentionally
@@ -102,7 +103,7 @@ internal sealed class AlternativeScheduler
             NotifyObserver(observation => _runtimeObserver?.OnAlternativeSelected(observation), CreateObservation(ParserRuntimeObservationKind.AlternativeSelected, winner));
         }
 
-        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(rule, ordered, lookaheadProbesByAlternative, precomputedDescriptors));
+        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(rule, ordered, lookaheadProbesByAlternative, precomputedDescriptors, precomputedContinuationMetadata));
     }
 
 
@@ -115,33 +116,16 @@ internal sealed class AlternativeScheduler
         Rule rule,
         IReadOnlyList<Alternative> orderedAlternatives,
         IReadOnlyList<ParserLookaheadProbeResult> lookaheadProbes,
-        IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors)
+        IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors,
+        IReadOnlyList<ParserContinuationDescriptor>? precomputedContinuationMetadata)
     {
         // Metadata lifecycle boundary:
         // observations are produced from attempted alternatives, transported through scheduling,
         // and exposed for diagnostics/audit tooling. This metadata remains structural-only,
         // independent from parse acceptance, and discardable without semantic changes.
         var candidates = _sharedPrefixDetector.Detect(lookaheadProbes);
-        var candidateIndexes = candidates
-            .SelectMany(static candidate => candidate.AlternativeIndexes)
-            .ToHashSet();
-
-        var continuations = new List<ParserContinuationDescriptor>(orderedAlternatives.Count);
-        for (var index = 0; index < orderedAlternatives.Count; index++)
-        {
-            var expectedTokenNames = lookaheadProbes[index].ExpectedTokenNames;
-            var sharedTokenName = ResolveSharedTokenName(candidates, index);
-            var sharedPrefixSequencePosition = sharedTokenName is null
-                ? 0
-                : _continuationFactory.ComputeSharedPrefixSequencePosition(orderedAlternatives[index], sharedTokenName);
-            continuations.Add(_continuationFactory.Create(
-                rule,
-                orderedAlternatives[index],
-                index,
-                sequencePosition: sharedPrefixSequencePosition,
-                expectedTokenNames,
-                candidateIndexes.Contains(index)));
-        }
+        var continuations = precomputedContinuationMetadata
+            ?? _continuationMetadataPreparation.Prepare(rule, orderedAlternatives, lookaheadProbes, candidates);
 
         // Shared-prefix plans remain observational scheduler metadata:
         // they expose deterministic grouping information, but never grant
@@ -152,23 +136,6 @@ internal sealed class AlternativeScheduler
         return new AlternativeSchedulingMetadata { SharedPrefixPlans = plans };
     }
 
-    /// <summary>
-    /// Resolves the first shared token candidate for an alternative while preserving detector ordering.
-    /// </summary>
-    private static string? ResolveSharedTokenName(
-        IReadOnlyList<ParserLookaheadSharedPrefixCandidate> candidates,
-        int alternativeIndex)
-    {
-        for (var index = 0; index < candidates.Count; index++)
-        {
-            if (candidates[index].AlternativeIndexes.Contains(alternativeIndex))
-            {
-                return candidates[index].TokenName;
-            }
-        }
-
-        return null;
-    }
     /// <summary>
     /// Creates a passive immutable observation payload from a parse state.
     /// </summary>

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -40,10 +40,10 @@ internal sealed class AlternativeScheduler
         DiagnosticBag? diagnostics,
         Func<Alternative, int, ScheduledAlternativeExecutionResult> parseAlternative,
         IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors,
-        IReadOnlyList<ParserContinuationDescriptor> precomputedContinuationMetadata)
+        IReadOnlyList<ParserContinuationDescriptor> precomputedContinuationMetadata,
+        IReadOnlyList<ParserLookaheadProbeResult> precomputedLookaheadProbes)
     {
         var ordered = alternatives.OrderBy(static a => a.Priority).ToList();
-        var lookaheadProbesByAlternative = new ParserLookaheadProbeResult[ordered.Count];
         var completedStates = new List<ActiveParseState>();
         var failedStates = new List<ActiveParseState>();
 
@@ -54,7 +54,6 @@ internal sealed class AlternativeScheduler
             NotifyObserver(observation => _runtimeObserver?.OnAlternativeStarted(observation), CreateObservation(ParserRuntimeObservationKind.AlternativeStarted, initial));
             var scheduled = parseAlternative(alternative, index);
             var parsed = scheduled.State;
-            lookaheadProbesByAlternative[index] = scheduled.Probe;
             if (parsed is null)
             {
                 var failedState = initial.Fail();
@@ -70,7 +69,7 @@ internal sealed class AlternativeScheduler
 
         if (completedStates.Count == 0)
         {
-            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(lookaheadProbesByAlternative, precomputedDescriptors, precomputedContinuationMetadata));
+            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(precomputedLookaheadProbes, precomputedDescriptors, precomputedContinuationMetadata));
         }
 
         // Deduplication uses scheduling identity (ActiveParseStateKey) and is intentionally
@@ -102,7 +101,7 @@ internal sealed class AlternativeScheduler
             NotifyObserver(observation => _runtimeObserver?.OnAlternativeSelected(observation), CreateObservation(ParserRuntimeObservationKind.AlternativeSelected, winner));
         }
 
-        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(lookaheadProbesByAlternative, precomputedDescriptors, precomputedContinuationMetadata));
+        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(precomputedLookaheadProbes, precomputedDescriptors, precomputedContinuationMetadata));
     }
 
 

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -44,6 +44,16 @@ internal sealed class AlternativeScheduler
         IReadOnlyList<ParserLookaheadProbeResult> precomputedLookaheadProbes)
     {
         var ordered = alternatives.OrderBy(static a => a.Priority).ToList();
+        if (precomputedLookaheadProbes.Count != ordered.Count)
+        {
+            throw new ArgumentException("Precomputed look-ahead probe count must match ordered alternatives count.", nameof(precomputedLookaheadProbes));
+        }
+
+        if (precomputedContinuationMetadata.Count != ordered.Count)
+        {
+            throw new ArgumentException("Precomputed continuation metadata count must match ordered alternatives count.", nameof(precomputedContinuationMetadata));
+        }
+
         var completedStates = new List<ActiveParseState>();
         var failedStates = new List<ActiveParseState>();
 

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -16,7 +16,6 @@ namespace Utils.Parser.Runtime;
 internal sealed class AlternativeScheduler
 {
     private readonly IParserRuntimeObserver? _runtimeObserver;
-    private readonly ParserLookaheadSharedPrefixDetector _sharedPrefixDetector = new();
     private readonly ParserSharedPrefixPlanFactory _sharedPrefixPlanFactory = new();
 
     /// <summary>
@@ -41,7 +40,8 @@ internal sealed class AlternativeScheduler
         Func<Alternative, int, ScheduledAlternativeExecutionResult> parseAlternative,
         IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors,
         IReadOnlyList<ParserContinuationDescriptor> precomputedContinuationMetadata,
-        IReadOnlyList<ParserLookaheadProbeResult> precomputedLookaheadProbes)
+        IReadOnlyList<ParserLookaheadProbeResult> precomputedLookaheadProbes,
+        IReadOnlyList<ParserLookaheadSharedPrefixCandidate> precomputedSharedPrefixCandidates)
     {
         var ordered = alternatives.OrderBy(static a => a.Priority).ToList();
         if (precomputedLookaheadProbes.Count != ordered.Count)
@@ -79,7 +79,7 @@ internal sealed class AlternativeScheduler
 
         if (completedStates.Count == 0)
         {
-            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(precomputedLookaheadProbes, precomputedDescriptors, precomputedContinuationMetadata));
+            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(precomputedSharedPrefixCandidates, precomputedDescriptors, precomputedContinuationMetadata));
         }
 
         // Deduplication uses scheduling identity (ActiveParseStateKey) and is intentionally
@@ -111,7 +111,7 @@ internal sealed class AlternativeScheduler
             NotifyObserver(observation => _runtimeObserver?.OnAlternativeSelected(observation), CreateObservation(ParserRuntimeObservationKind.AlternativeSelected, winner));
         }
 
-        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(precomputedLookaheadProbes, precomputedDescriptors, precomputedContinuationMetadata));
+        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(precomputedSharedPrefixCandidates, precomputedDescriptors, precomputedContinuationMetadata));
     }
 
 
@@ -121,7 +121,7 @@ internal sealed class AlternativeScheduler
     /// Produced metadata remains non-authoritative and does not change branch execution requirements.
     /// </summary>
     private AlternativeSchedulingMetadata BuildMetadata(
-        IReadOnlyList<ParserLookaheadProbeResult> lookaheadProbes,
+        IReadOnlyList<ParserLookaheadSharedPrefixCandidate> precomputedSharedPrefixCandidates,
         IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors,
         IReadOnlyList<ParserContinuationDescriptor> precomputedContinuationMetadata)
     {
@@ -129,7 +129,6 @@ internal sealed class AlternativeScheduler
         // observations are produced from attempted alternatives, transported through scheduling,
         // and exposed for diagnostics/audit tooling. This metadata remains structural-only,
         // independent from parse acceptance, and discardable without semantic changes.
-        var candidates = _sharedPrefixDetector.Detect(lookaheadProbes);
         var continuations = precomputedContinuationMetadata;
 
         // Shared-prefix plans remain observational scheduler metadata:
@@ -137,7 +136,7 @@ internal sealed class AlternativeScheduler
         // replay/resume/merge authority and never replace real parser execution.
         // Structural descriptors are prepared by the caller (grammar preparation layer)
         // and forwarded here; the scheduler does not construct or inspect them.
-        var plans = _sharedPrefixPlanFactory.CreatePlans(candidates, continuations, precomputedDescriptors);
+        var plans = _sharedPrefixPlanFactory.CreatePlans(precomputedSharedPrefixCandidates, continuations, precomputedDescriptors);
         return new AlternativeSchedulingMetadata { SharedPrefixPlans = plans };
     }
 

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -18,7 +18,6 @@ internal sealed class AlternativeScheduler
     private readonly IParserRuntimeObserver? _runtimeObserver;
     private readonly ParserLookaheadSharedPrefixDetector _sharedPrefixDetector = new();
     private readonly ParserSharedPrefixPlanFactory _sharedPrefixPlanFactory = new();
-    private readonly ContinuationMetadataPreparation _continuationMetadataPreparation = new();
 
     /// <summary>
     /// Initializes a scheduler with an optional passive runtime observer.
@@ -40,8 +39,8 @@ internal sealed class AlternativeScheduler
         int minimumPrecedence,
         DiagnosticBag? diagnostics,
         Func<Alternative, int, ScheduledAlternativeExecutionResult> parseAlternative,
-        IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors = null,
-        IReadOnlyList<ParserContinuationDescriptor>? precomputedContinuationMetadata = null)
+        IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors,
+        IReadOnlyList<ParserContinuationDescriptor> precomputedContinuationMetadata)
     {
         var ordered = alternatives.OrderBy(static a => a.Priority).ToList();
         var lookaheadProbesByAlternative = new ParserLookaheadProbeResult[ordered.Count];
@@ -71,7 +70,7 @@ internal sealed class AlternativeScheduler
 
         if (completedStates.Count == 0)
         {
-            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(rule, ordered, lookaheadProbesByAlternative, precomputedDescriptors, precomputedContinuationMetadata));
+            return new AlternativeSchedulingResult(null, [], failedStates, [], BuildMetadata(lookaheadProbesByAlternative, precomputedDescriptors, precomputedContinuationMetadata));
         }
 
         // Deduplication uses scheduling identity (ActiveParseStateKey) and is intentionally
@@ -103,7 +102,7 @@ internal sealed class AlternativeScheduler
             NotifyObserver(observation => _runtimeObserver?.OnAlternativeSelected(observation), CreateObservation(ParserRuntimeObservationKind.AlternativeSelected, winner));
         }
 
-        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(rule, ordered, lookaheadProbesByAlternative, precomputedDescriptors, precomputedContinuationMetadata));
+        return new AlternativeSchedulingResult(winner, pruned, failedStates, prunedStates, BuildMetadata(lookaheadProbesByAlternative, precomputedDescriptors, precomputedContinuationMetadata));
     }
 
 
@@ -113,19 +112,16 @@ internal sealed class AlternativeScheduler
     /// Produced metadata remains non-authoritative and does not change branch execution requirements.
     /// </summary>
     private AlternativeSchedulingMetadata BuildMetadata(
-        Rule rule,
-        IReadOnlyList<Alternative> orderedAlternatives,
         IReadOnlyList<ParserLookaheadProbeResult> lookaheadProbes,
         IReadOnlyList<AlternativeStructuralDescriptor>? precomputedDescriptors,
-        IReadOnlyList<ParserContinuationDescriptor>? precomputedContinuationMetadata)
+        IReadOnlyList<ParserContinuationDescriptor> precomputedContinuationMetadata)
     {
         // Metadata lifecycle boundary:
         // observations are produced from attempted alternatives, transported through scheduling,
         // and exposed for diagnostics/audit tooling. This metadata remains structural-only,
         // independent from parse acceptance, and discardable without semantic changes.
         var candidates = _sharedPrefixDetector.Detect(lookaheadProbes);
-        var continuations = precomputedContinuationMetadata
-            ?? _continuationMetadataPreparation.Prepare(rule, orderedAlternatives, lookaheadProbes, candidates);
+        var continuations = precomputedContinuationMetadata;
 
         // Shared-prefix plans remain observational scheduler metadata:
         // they expose deterministic grouping information, but never grant

--- a/Utils.Parser/Runtime/ContinuationMetadataPreparation.cs
+++ b/Utils.Parser/Runtime/ContinuationMetadataPreparation.cs
@@ -1,0 +1,62 @@
+using Utils.Parser.Model;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Prepares continuation descriptors before scheduler orchestration.
+/// This component is descriptive-only and never transports active runtime state.
+/// </summary>
+internal sealed class ContinuationMetadataPreparation
+{
+    private readonly ParserContinuationFactory _continuationFactory = new();
+    private readonly ContinuationStructuralPositionExtractor _positionExtractor = new();
+
+    /// <summary>
+    /// Produces continuation descriptors for ordered alternatives and look-ahead probes.
+    /// The output is deterministic descriptive metadata and does not authorize execution behavior.
+    /// </summary>
+    public IReadOnlyList<ParserContinuationDescriptor> Prepare(
+        Rule rule,
+        IReadOnlyList<Alternative> orderedAlternatives,
+        IReadOnlyList<ParserLookaheadProbeResult> probes,
+        IReadOnlyList<ParserLookaheadSharedPrefixCandidate> candidates)
+    {
+        var candidateIndexes = candidates
+            .SelectMany(static candidate => candidate.AlternativeIndexes)
+            .ToHashSet();
+
+        var continuations = new List<ParserContinuationDescriptor>(orderedAlternatives.Count);
+        for (var index = 0; index < orderedAlternatives.Count; index++)
+        {
+            var expectedTokenNames = probes[index].ExpectedTokenNames;
+            var sharedTokenName = ResolveSharedTokenName(candidates, index);
+            var sequencePosition = sharedTokenName is null
+                ? 0
+                : _positionExtractor.ExtractSharedPrefixSequencePosition(orderedAlternatives[index], sharedTokenName);
+
+            continuations.Add(_continuationFactory.Create(new ParserContinuationPreparationInput(
+                rule.Name,
+                index,
+                sequencePosition,
+                expectedTokenNames,
+                candidateIndexes.Contains(index))));
+        }
+
+        return continuations;
+    }
+
+    private static string? ResolveSharedTokenName(
+        IReadOnlyList<ParserLookaheadSharedPrefixCandidate> candidates,
+        int alternativeIndex)
+    {
+        for (var index = 0; index < candidates.Count; index++)
+        {
+            if (candidates[index].AlternativeIndexes.Contains(alternativeIndex))
+            {
+                return candidates[index].TokenName;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Utils.Parser/Runtime/ContinuationStructuralPositionExtractor.cs
+++ b/Utils.Parser/Runtime/ContinuationStructuralPositionExtractor.cs
@@ -1,0 +1,75 @@
+using Utils.Parser.Model;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Extracts conservative structural continuation positions from grammar alternatives.
+/// This component only inspects shallow structure and does not classify or create metadata descriptors.
+/// </summary>
+internal sealed class ContinuationStructuralPositionExtractor
+{
+    /// <summary>
+    /// Computes the structural continuation position associated with a shared-token candidate.
+    /// Returns zero when no supported conservative position is available.
+    /// </summary>
+    public int ExtractSharedPrefixSequencePosition(Alternative alternative, string sharedTokenName)
+    {
+        if (alternative.Content is not Sequence sequence)
+        {
+            return 0;
+        }
+
+        var firstMeaningfulItemIndex = -1;
+        for (var index = 0; index < sequence.Items.Count; index++)
+        {
+            if (sequence.Items[index] is EmbeddedAction or LexerCommand)
+            {
+                continue;
+            }
+
+            firstMeaningfulItemIndex = index;
+            break;
+        }
+
+        if (firstMeaningfulItemIndex < 0 || !IsSharedTokenMatchFromProbeMetadata(sequence.Items[firstMeaningfulItemIndex], sharedTokenName))
+        {
+            return 0;
+        }
+
+        return NormalizeMeaningfulSequencePosition(sequence, firstMeaningfulItemIndex + 1);
+    }
+
+    private static int NormalizeMeaningfulSequencePosition(Sequence sequence, int sequencePosition)
+    {
+        if (sequencePosition <= 0)
+        {
+            return 0;
+        }
+
+        var meaningfulIndex = 0;
+        var boundedPosition = sequencePosition > sequence.Items.Count ? sequence.Items.Count : sequencePosition;
+
+        for (var index = 0; index < boundedPosition; index++)
+        {
+            var item = sequence.Items[index];
+            if (item is EmbeddedAction || item is LexerCommand)
+            {
+                continue;
+            }
+
+            meaningfulIndex++;
+        }
+
+        return meaningfulIndex;
+    }
+
+    private static bool IsSharedTokenMatchFromProbeMetadata(RuleContent content, string sharedTokenName)
+    {
+        return content switch
+        {
+            LiteralMatch literal => string.Equals(literal.Value, sharedTokenName, StringComparison.Ordinal),
+            RuleRef ruleRef => string.Equals(ruleRef.RuleName, sharedTokenName, StringComparison.Ordinal),
+            _ => false
+        };
+    }
+}

--- a/Utils.Parser/Runtime/ContinuationStructuralPositionExtractor.cs
+++ b/Utils.Parser/Runtime/ContinuationStructuralPositionExtractor.cs
@@ -52,7 +52,7 @@ internal sealed class ContinuationStructuralPositionExtractor
         for (var index = 0; index < boundedPosition; index++)
         {
             var item = sequence.Items[index];
-            if (item is EmbeddedAction || item is LexerCommand)
+            if (item is EmbeddedAction or LexerCommand)
             {
                 continue;
             }

--- a/Utils.Parser/Runtime/ParserContinuationFactory.cs
+++ b/Utils.Parser/Runtime/ParserContinuationFactory.cs
@@ -9,40 +9,6 @@ namespace Utils.Parser.Runtime;
 internal sealed class ParserContinuationFactory
 {
     /// <summary>
-    /// Computes a conservative sequence position for shared-token continuation metadata.
-    /// This shallow analysis is preparatory only and intentionally avoids deep parser semantics.
-    /// </summary>
-    /// <param name="alternative">Alternative containing the shared token.</param>
-    /// <param name="sharedTokenName">Shared token identifier from look-ahead metadata.</param>
-    /// <returns>Raw sequence-item index after the shared token, or zero when unsupported/ambiguous.</returns>
-    public int ComputeSharedPrefixSequencePosition(Alternative alternative, string sharedTokenName)
-    {
-        if (alternative.Content is not Sequence sequence)
-        {
-            return 0;
-        }
-
-        var firstMeaningfulItemIndex = -1;
-        for (var index = 0; index < sequence.Items.Count; index++)
-        {
-            if (sequence.Items[index] is EmbeddedAction or LexerCommand)
-            {
-                continue;
-            }
-
-            firstMeaningfulItemIndex = index;
-            break;
-        }
-
-        if (firstMeaningfulItemIndex < 0 || !IsSharedTokenMatchFromProbeMetadata(sequence.Items[firstMeaningfulItemIndex], sharedTokenName))
-        {
-            return 0;
-        }
-
-        return firstMeaningfulItemIndex + 1;
-    }
-
-    /// <summary>
     /// Creates a continuation descriptor from shallow rule/alternative location metadata.
     /// The output is observational metadata and can be discarded without changing parse-authoritative outcomes.
     /// </summary>
@@ -54,20 +20,14 @@ internal sealed class ParserContinuationFactory
     /// <param name="isSharedPrefixCandidate">Whether this point was observed from a shared-prefix candidate.</param>
     /// <returns>A structural continuation descriptor.</returns>
     public ParserContinuationDescriptor Create(
-        Rule rule,
-        Alternative alternative,
-        int alternativeIndex,
-        int sequencePosition,
-        IReadOnlyList<string>? expectedTokenNames,
-        bool isSharedPrefixCandidate)
+        ParserContinuationPreparationInput input)
     {
-        var normalizedSequencePosition = ComputeSequencePosition(alternative, sequencePosition);
-        var category = ClassifyContinuation(normalizedSequencePosition, expectedTokenNames, isSharedPrefixCandidate);
+        var category = ClassifyContinuation(input.ExpectedTokenNames, input.IsSharedPrefixCandidate);
         return new ParserContinuationDescriptor(
-            new ParserContinuationKey(rule.Name, alternativeIndex, normalizedSequencePosition),
+            new ParserContinuationKey(input.RuleName, input.AlternativeIndex, input.SequencePosition),
             category,
-            expectedTokenNames?.ToArray(),
-            isSharedPrefixCandidate);
+            input.ExpectedTokenNames?.ToArray(),
+            input.IsSharedPrefixCandidate);
     }
 
     /// <summary>
@@ -79,7 +39,6 @@ internal sealed class ParserContinuationFactory
     /// <param name="isSharedPrefixCandidate">Whether shared-prefix candidate metadata was detected.</param>
     /// <returns>A deterministic descriptive category.</returns>
     private static ParserContinuationCategory ClassifyContinuation(
-        int normalizedSequencePosition,
         IReadOnlyList<string>? expectedTokenNames,
         bool isSharedPrefixCandidate)
     {
@@ -94,56 +53,5 @@ internal sealed class ParserContinuationFactory
         }
 
         return ParserContinuationCategory.Sequential;
-    }
-
-    /// <summary>
-    /// Computes a shallow sequence position for continuation identity.
-    /// </summary>
-    /// <param name="alternative">Alternative that owns the continuation point.</param>
-    /// <param name="sequencePosition">Raw sequence item index in the alternative content.</param>
-    /// <returns>Normalized index among meaningful sequence items, or zero for non-sequence alternatives.</returns>
-    private static int ComputeSequencePosition(Alternative alternative, int sequencePosition)
-    {
-        if (alternative.Content is not Sequence sequence)
-        {
-            return 0;
-        }
-
-        if (sequencePosition <= 0)
-        {
-            return 0;
-        }
-
-        var meaningfulIndex = 0;
-        var boundedPosition = sequencePosition > sequence.Items.Count ? sequence.Items.Count : sequencePosition;
-
-        for (var index = 0; index < boundedPosition; index++)
-        {
-            var item = sequence.Items[index];
-            if (item is EmbeddedAction || item is LexerCommand)
-            {
-                continue;
-            }
-
-            meaningfulIndex++;
-        }
-
-        return meaningfulIndex;
-    }
-
-    /// <summary>
-    /// Determines whether a shallow sequence item matches a shared token name
-    /// coming from look-ahead probe metadata.
-    /// This helper intentionally performs no rule-kind resolution and therefore
-    /// must only be used with probe metadata that already represents shallow token candidates.
-    /// </summary>
-    private static bool IsSharedTokenMatchFromProbeMetadata(RuleContent content, string sharedTokenName)
-    {
-        return content switch
-        {
-            LiteralMatch literal => string.Equals(literal.Value, sharedTokenName, StringComparison.Ordinal),
-            RuleRef ruleRef => string.Equals(ruleRef.RuleName, sharedTokenName, StringComparison.Ordinal),
-            _ => false
-        };
     }
 }

--- a/Utils.Parser/Runtime/ParserContinuationPreparationInput.cs
+++ b/Utils.Parser/Runtime/ParserContinuationPreparationInput.cs
@@ -1,0 +1,17 @@
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Immutable input used to prepare one continuation descriptor.
+/// This model is structural-only and carries no runtime execution authority.
+/// </summary>
+/// <param name="RuleName">Owning rule name.</param>
+/// <param name="AlternativeIndex">Ordered alternative index.</param>
+/// <param name="SequencePosition">Normalized structural sequence position.</param>
+/// <param name="ExpectedTokenNames">Shallow expected token names from look-ahead probe metadata.</param>
+/// <param name="IsSharedPrefixCandidate">Indicates whether this continuation belongs to a detected shared-prefix candidate.</param>
+internal readonly record struct ParserContinuationPreparationInput(
+    string RuleName,
+    int AlternativeIndex,
+    int SequencePosition,
+    IReadOnlyList<string>? ExpectedTokenNames,
+    bool IsSharedPrefixCandidate);

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -81,6 +81,8 @@ public sealed class ParserEngine
     /// Local alternative-execution coordinator used by scheduling flow.
     /// </summary>
     private readonly ScheduledAlternativeExecutor _scheduledAlternativeExecutor;
+    private readonly ParserLookaheadProbe _lookaheadProbe = new();
+    private readonly ContinuationMetadataPreparation _continuationMetadataPreparation = new();
 
     /// <summary>
     /// Policy component used to evaluate semantic predicates under runtime feature constraints.
@@ -157,7 +159,7 @@ public sealed class ParserEngine
         _parserActionExecutor = effectivePolicy.ParserActionExecutor ?? throw new ArgumentNullException(nameof(runtimeFeaturePolicy));
         _caseInsensitive = IsCaseInsensitive(_definition);
         _alternativeScheduler = new AlternativeScheduler(effectivePolicy.RuntimeObserver);
-        _scheduledAlternativeExecutor = new ScheduledAlternativeExecutor(_stateRegistry, _lookaheadCache, new ParserLookaheadProbe());
+        _scheduledAlternativeExecutor = new ScheduledAlternativeExecutor(_stateRegistry, _lookaheadCache, _lookaheadProbe);
     }
 
     /// <summary>
@@ -843,6 +845,12 @@ public sealed class ParserEngine
         // Extraction is grammar-level preparation; the scheduler receives ready-made descriptors.
         var orderedAlternatives = alternatives.OrderBy(static a => a.Priority).ToList();
         var structuralDescriptors = _structuralPrefixExtractor.ExtractAll(orderedAlternatives);
+        var lookaheadToken = context.Peek();
+        var precomputedLookaheadProbes = orderedAlternatives
+            .Select(alternative => _lookaheadProbe.Probe(alternative, lookaheadToken, ResolveRule, _caseInsensitive))
+            .ToArray();
+        var sharedPrefixCandidates = new ParserLookaheadSharedPrefixDetector().Detect(precomputedLookaheadProbes);
+        var continuationDescriptors = _continuationMetadataPreparation.Prepare(rule, orderedAlternatives, precomputedLookaheadProbes, sharedPrefixCandidates);
         var scheduling = _alternativeScheduler.Run(
             rule,
             orderedAlternatives,
@@ -850,6 +858,7 @@ public sealed class ParserEngine
             precedence,
             diagnostics,
             precomputedDescriptors: structuralDescriptors,
+            precomputedContinuationMetadata: continuationDescriptors,
             parseAlternative: (alternative, alternativeIndex) => _scheduledAlternativeExecutor.Execute(
                 context,
                 rule,

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -845,10 +845,7 @@ public sealed class ParserEngine
         // Extraction is grammar-level preparation; the scheduler receives ready-made descriptors.
         var orderedAlternatives = alternatives.OrderBy(static a => a.Priority).ToList();
         var structuralDescriptors = _structuralPrefixExtractor.ExtractAll(orderedAlternatives);
-        var lookaheadToken = context.Peek();
-        var precomputedLookaheadProbes = orderedAlternatives
-            .Select(alternative => _lookaheadProbe.Probe(alternative, lookaheadToken, ResolveRule, _caseInsensitive))
-            .ToArray();
+        var precomputedLookaheadProbes = PrepareSchedulingLookaheadProbes(context, rule, orderedAlternatives, startPosition, precedence, cursorKind, cursorIndex);
         var sharedPrefixCandidates = new ParserLookaheadSharedPrefixDetector().Detect(precomputedLookaheadProbes);
         var continuationDescriptors = _continuationMetadataPreparation.Prepare(rule, orderedAlternatives, precomputedLookaheadProbes, sharedPrefixCandidates);
         var scheduling = _alternativeScheduler.Run(
@@ -891,6 +888,48 @@ public sealed class ParserEngine
 
         var span = ComputeSpan(startToken, context, startPosition);
         return new ParserNode(span, winner.PartialNode.ModeName, rule, [winner.PartialNode]);
+    }
+
+    /// <summary>
+    /// Prepares look-ahead probes for scheduling metadata using the same precedence and cache policy as scheduled execution.
+    /// </summary>
+    private IReadOnlyList<ParserLookaheadProbeResult> PrepareSchedulingLookaheadProbes(
+        ParseContext context,
+        Rule rule,
+        IReadOnlyList<Alternative> orderedAlternatives,
+        int startPosition,
+        int precedence,
+        string cursorKind,
+        int cursorIndex)
+    {
+        var probes = new ParserLookaheadProbeResult[orderedAlternatives.Count];
+        var token = context.Peek();
+
+        for (var index = 0; index < orderedAlternatives.Count; index++)
+        {
+            var alternative = orderedAlternatives[index];
+            if (!CheckPrecedence(alternative, precedence))
+            {
+                probes[index] = new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null);
+                continue;
+            }
+
+            var lookaheadKey = new ParserLookaheadKey(rule.Name, startPosition, index, precedence, cursorKind, cursorIndex);
+            if (_lookaheadCache.TryGet(lookaheadKey, out var cachedProbe))
+            {
+                probes[index] = cachedProbe;
+                continue;
+            }
+
+            var probe = _lookaheadProbe.Probe(alternative, token, ResolveRule, _caseInsensitive);
+            probes[index] = probe;
+            if (probe.Kind != ParserLookaheadProbeKind.Unknown)
+            {
+                _lookaheadCache.TryAdd(lookaheadKey, probe);
+            }
+        }
+
+        return probes;
     }
 
     /// <summary>

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -82,6 +82,7 @@ public sealed class ParserEngine
     /// </summary>
     private readonly ScheduledAlternativeExecutor _scheduledAlternativeExecutor;
     private readonly ParserLookaheadProbe _lookaheadProbe = new();
+    private readonly ParserLookaheadSharedPrefixDetector _sharedPrefixDetector = new();
     private readonly ContinuationMetadataPreparation _continuationMetadataPreparation = new();
 
     /// <summary>
@@ -846,7 +847,7 @@ public sealed class ParserEngine
         var orderedAlternatives = alternatives.OrderBy(static a => a.Priority).ToList();
         var structuralDescriptors = _structuralPrefixExtractor.ExtractAll(orderedAlternatives);
         var precomputedLookaheadProbes = PrepareSchedulingLookaheadProbes(context, rule, orderedAlternatives, startPosition, precedence, cursorKind, cursorIndex);
-        var sharedPrefixCandidates = new ParserLookaheadSharedPrefixDetector().Detect(precomputedLookaheadProbes);
+        var sharedPrefixCandidates = _sharedPrefixDetector.Detect(precomputedLookaheadProbes);
         var continuationDescriptors = _continuationMetadataPreparation.Prepare(rule, orderedAlternatives, precomputedLookaheadProbes, sharedPrefixCandidates);
         var scheduling = _alternativeScheduler.Run(
             rule,
@@ -857,6 +858,7 @@ public sealed class ParserEngine
             precomputedDescriptors: structuralDescriptors,
             precomputedContinuationMetadata: continuationDescriptors,
             precomputedLookaheadProbes: precomputedLookaheadProbes,
+            precomputedSharedPrefixCandidates: sharedPrefixCandidates,
             parseAlternative: (alternative, alternativeIndex) => _scheduledAlternativeExecutor.Execute(
                 context,
                 rule,

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -859,6 +859,7 @@ public sealed class ParserEngine
             diagnostics,
             precomputedDescriptors: structuralDescriptors,
             precomputedContinuationMetadata: continuationDescriptors,
+            precomputedLookaheadProbes,
             parseAlternative: (alternative, alternativeIndex) => _scheduledAlternativeExecutor.Execute(
                 context,
                 rule,

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -856,7 +856,7 @@ public sealed class ParserEngine
             diagnostics,
             precomputedDescriptors: structuralDescriptors,
             precomputedContinuationMetadata: continuationDescriptors,
-            precomputedLookaheadProbes,
+            precomputedLookaheadProbes: precomputedLookaheadProbes,
             parseAlternative: (alternative, alternativeIndex) => _scheduledAlternativeExecutor.Execute(
                 context,
                 rule,

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -72,8 +72,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, 0),
+            precomputedLookaheadProbes: UnknownProbes(0),
             parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
 
         Assert.IsNull(result.SelectedState);
@@ -246,8 +246,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(rule.Content.Alternatives.Count),
             parseAlternative: (alternative, index) => index switch
             {
                 0 => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 10, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)),
@@ -279,8 +279,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 8, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -305,8 +305,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -336,8 +336,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -349,8 +349,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -377,8 +377,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -390,8 +390,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -416,8 +416,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -22,6 +22,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (_, index) => index == 0 || index == 1
                 ? new ScheduledAlternativeExecutionResult(CreateState(rule, alternatives[index], context.Position, 2, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"]))
                 : new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -49,6 +50,7 @@ public class AlternativeSchedulerTests
             diagnostics,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 4, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
 
         Assert.AreEqual(2, result.CompletedStates.Count);
@@ -71,6 +73,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
 
         Assert.IsNull(result.SelectedState);
@@ -92,6 +95,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
 
         Assert.IsNull(result.SelectedState);
@@ -112,6 +116,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => index == 0
                 ? new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null))
                 : new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 5, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -138,6 +143,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) =>
             {
                 var state = CreateState(rule, alternative, context.Position, 4, index)
@@ -164,6 +170,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -176,6 +183,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -204,6 +212,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 2 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -238,6 +247,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => index switch
             {
                 0 => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 10, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)),
@@ -270,6 +280,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 8, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -295,6 +306,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -325,6 +337,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -337,6 +350,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -364,6 +378,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -376,6 +391,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -401,6 +417,7 @@ public class AlternativeSchedulerTests
             diagnostics: null,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -20,6 +20,8 @@ public class AlternativeSchedulerTests
             originInputPosition: context.Position,
             minimumPrecedence: 3,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (_, index) => index == 0 || index == 1
                 ? new ScheduledAlternativeExecutionResult(CreateState(rule, alternatives[index], context.Position, 2, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"]))
                 : new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -45,6 +47,8 @@ public class AlternativeSchedulerTests
             originInputPosition: context.Position,
             minimumPrecedence: 1,
             diagnostics,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 4, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
 
         Assert.AreEqual(2, result.CompletedStates.Count);
@@ -65,6 +69,8 @@ public class AlternativeSchedulerTests
             originInputPosition: 0,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
 
         Assert.IsNull(result.SelectedState);
@@ -84,6 +90,8 @@ public class AlternativeSchedulerTests
             originInputPosition: context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
 
         Assert.IsNull(result.SelectedState);
@@ -102,6 +110,8 @@ public class AlternativeSchedulerTests
             originInputPosition: context.Position,
             minimumPrecedence: 7,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => index == 0
                 ? new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null))
                 : new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 5, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -126,6 +136,8 @@ public class AlternativeSchedulerTests
             originInputPosition: context.Position,
             minimumPrecedence: 2,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) =>
             {
                 var state = CreateState(rule, alternative, context.Position, 4, index)
@@ -150,6 +162,8 @@ public class AlternativeSchedulerTests
             context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -160,6 +174,8 @@ public class AlternativeSchedulerTests
             context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -186,6 +202,8 @@ public class AlternativeSchedulerTests
             originInputPosition: context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 2 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -218,6 +236,8 @@ public class AlternativeSchedulerTests
             originInputPosition: context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => index switch
             {
                 0 => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 10, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)),
@@ -248,6 +268,8 @@ public class AlternativeSchedulerTests
             originInputPosition: context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 8, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -271,6 +293,8 @@ public class AlternativeSchedulerTests
             originInputPosition: context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -299,6 +323,8 @@ public class AlternativeSchedulerTests
             context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -309,6 +335,8 @@ public class AlternativeSchedulerTests
             context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -334,6 +362,8 @@ public class AlternativeSchedulerTests
             context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -344,6 +374,8 @@ public class AlternativeSchedulerTests
             context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -367,6 +399,8 @@ public class AlternativeSchedulerTests
             context.Position,
             minimumPrecedence: 0,
             diagnostics: null,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -21,8 +21,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 3,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (_, index) => index == 0 || index == 1
                 ? new ScheduledAlternativeExecutionResult(CreateState(rule, alternatives[index], context.Position, 2, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"]))
                 : new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -49,8 +49,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 1,
             diagnostics,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(rule.Content.Alternatives.Count),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 4, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
 
         Assert.AreEqual(2, result.CompletedStates.Count);
@@ -94,8 +94,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
 
         Assert.IsNull(result.SelectedState);
@@ -115,8 +115,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 7,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (alternative, index) => index == 0
                 ? new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null))
                 : new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 5, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -142,8 +142,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 2,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(rule.Content.Alternatives.Count),
             parseAlternative: (alternative, index) =>
             {
                 var state = CreateState(rule, alternative, context.Position, 4, index)
@@ -169,8 +169,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: SharedPrefixProbes(alternatives.Count, "ID"),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -182,8 +182,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -211,8 +211,8 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: SharedPrefixContinuations(rule, rule.Content.Alternatives.Count),
+            precomputedLookaheadProbes: SharedPrefixProbes(rule.Content.Alternatives.Count, "ID"),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 2 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -465,6 +465,42 @@ public class AlternativeSchedulerTests
     private static ParseNode CreateNode(Rule rule, int position)
     {
         return new ParserNode(new SourceSpan(0, position), "DEFAULT_MODE", rule, []);
+    }
+
+    private static IReadOnlyList<ParserLookaheadProbeResult> UnknownProbes(int count)
+    {
+        return Enumerable.Range(0, count)
+            .Select(static _ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<ParserLookaheadProbeResult> SharedPrefixProbes(int count, string tokenName)
+    {
+        return Enumerable.Range(0, count)
+            .Select(_ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, tokenName, tokenName.ToLowerInvariant(), [tokenName]))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<ParserContinuationDescriptor> DefaultContinuations(Rule rule, int count)
+    {
+        return Enumerable.Range(0, count)
+            .Select(index => new ParserContinuationDescriptor(
+                new ParserContinuationKey(rule.Name, index, 0),
+                ParserContinuationCategory.Sequential,
+                null,
+                false))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<ParserContinuationDescriptor> SharedPrefixContinuations(Rule rule, int count)
+    {
+        return Enumerable.Range(0, count)
+            .Select(index => new ParserContinuationDescriptor(
+                new ParserContinuationKey(rule.Name, index, 1),
+                ParserContinuationCategory.SharedPrefixCandidate,
+                ["ID"],
+                true))
+            .ToArray();
     }
 
     private static ActiveParseState CreateState(Rule rule, Alternative alternative, int origin, int current, int alternativeIndex)

--- a/UtilsTest/Parser/AlternativeSchedulerTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulerTests.cs
@@ -23,6 +23,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (_, index) => index == 0 || index == 1
                 ? new ScheduledAlternativeExecutionResult(CreateState(rule, alternatives[index], context.Position, 2, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"]))
                 : new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -51,6 +52,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(rule.Content.Alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 4, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
 
         Assert.AreEqual(2, result.CompletedStates.Count);
@@ -74,6 +76,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, 0),
             precomputedLookaheadProbes: UnknownProbes(0),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
 
         Assert.IsNull(result.SelectedState);
@@ -96,6 +99,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (_, _) => new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
 
         Assert.IsNull(result.SelectedState);
@@ -117,6 +121,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => index == 0
                 ? new ScheduledAlternativeExecutionResult(null, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null))
                 : new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 5, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -144,6 +149,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(rule.Content.Alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) =>
             {
                 var state = CreateState(rule, alternative, context.Position, 4, index)
@@ -171,6 +177,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: SharedPrefixProbes(alternatives.Count, "ID"),
+            precomputedSharedPrefixCandidates: SharedPrefixCandidates(alternatives.Count, "ID"),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -184,6 +191,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -213,6 +221,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: SharedPrefixContinuations(rule, rule.Content.Alternatives.Count),
             precomputedLookaheadProbes: SharedPrefixProbes(rule.Content.Alternatives.Count, "ID"),
+            precomputedSharedPrefixCandidates: SharedPrefixCandidates(rule.Content.Alternatives.Count, "ID"),
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 2 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -248,6 +257,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(rule.Content.Alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => index switch
             {
                 0 => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, context.Position, 10, index), new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)),
@@ -279,8 +289,9 @@ public class AlternativeSchedulerTests
             minimumPrecedence: 0,
             diagnostics: null,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
-            precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
+            precomputedLookaheadProbes: UnknownProbes(rule.Content.Alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 8, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -307,6 +318,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 5 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
@@ -338,6 +350,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -351,6 +364,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -379,6 +393,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -392,6 +407,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -418,6 +434,7 @@ public class AlternativeSchedulerTests
             precomputedDescriptors: null,
             precomputedContinuationMetadata: DefaultContinuations(rule, alternatives.Count),
             precomputedLookaheadProbes: UnknownProbes(alternatives.Count),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, context.Position, 7 + index, index),
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)));
@@ -479,6 +496,11 @@ public class AlternativeSchedulerTests
         return Enumerable.Range(0, count)
             .Select(_ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, tokenName, tokenName.ToLowerInvariant(), [tokenName]))
             .ToArray();
+    }
+
+    private static IReadOnlyList<ParserLookaheadSharedPrefixCandidate> SharedPrefixCandidates(int count, string tokenName)
+    {
+        return [new ParserLookaheadSharedPrefixCandidate(tokenName, Enumerable.Range(0, count).ToArray())];
     }
 
     private static IReadOnlyList<ParserContinuationDescriptor> DefaultContinuations(Rule rule, int count)

--- a/UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs
+++ b/UtilsTest/Parser/AlternativeSchedulingMetadataTests.cs
@@ -40,6 +40,7 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(0, Associativity.Left, new LiteralMatch("a"), "X"),
             new Alternative(1, Associativity.Left, new LiteralMatch("a"), "X")
         ]));
+        var probes = DefaultProbes(rule.Content.Alternatives.Count);
 
         var result = scheduler.Run(
             rule,
@@ -47,7 +48,11 @@ public class AlternativeSchedulingMetadataTests
             0,
             0,
             new DiagnosticBag(),
-            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")));
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: []);
 
         Assert.AreEqual(1, result.CompletedStates.Count);
         Assert.AreEqual(1, result.PrunedStates.Count);
@@ -62,6 +67,7 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(0, Associativity.Left, new LiteralMatch("a"), "X"),
             new Alternative(1, Associativity.Left, new LiteralMatch("a"), "X")
         ]));
+        var probes = DefaultProbes(rule.Content.Alternatives.Count);
 
         _ = scheduler.Run(
             rule,
@@ -69,7 +75,11 @@ public class AlternativeSchedulingMetadataTests
             0,
             0,
             diagnostics,
-            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")));
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: []);
 
         Assert.AreEqual(1, diagnostics.Count(static d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
     }
@@ -91,19 +101,27 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(1, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("-"), new RuleRef("expr")]), "b")
         };
         var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+        var probes = new[] { Probe("ID"), Probe("ID") };
+        var candidates = new ParserLookaheadSharedPrefixDetector().Detect(probes);
+        var continuations = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, candidates);
+
         var result = scheduler.Run(
             rule,
             alternatives,
             0,
             0,
             null,
-            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), Probe("ID")));
-        var continuations = result.Metadata.SharedPrefixPlans[0].Continuations;
-        Assert.AreEqual(2, continuations.Count);
-        Assert.IsTrue(continuations.All(static c => c.Key.SequencePosition == 1));
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: continuations,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: candidates);
+
+        var planContinuations = result.Metadata.SharedPrefixPlans[0].Continuations;
+        Assert.AreEqual(2, planContinuations.Count);
+        Assert.IsTrue(planContinuations.All(static c => c.Key.SequencePosition == 1));
         Assert.AreEqual(1, result.Metadata.SharedPrefixPlans[0].Segment.Boundary.SequencePosition);
     }
-
 
     [TestMethod]
     public void Scheduler_Metadata_ProducesReadableSharedPrefixDryRunOutput()
@@ -116,6 +134,9 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(1, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("-"), new RuleRef("expr")]), "b")
         };
         var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+        var probes = new[] { Probe("ID"), Probe("ID") };
+        var candidates = new ParserLookaheadSharedPrefixDetector().Detect(probes);
+        var continuations = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, candidates);
 
         var result = scheduler.Run(
             rule,
@@ -123,7 +144,11 @@ public class AlternativeSchedulingMetadataTests
             0,
             0,
             null,
-            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), Probe("ID")));
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: continuations,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: candidates);
 
         Assert.AreEqual(1, result.Metadata.SharedPrefixPlans.Count);
         Assert.AreEqual("ID", result.Metadata.SharedPrefixPlans[0].SharedTokenName);
@@ -147,8 +172,6 @@ public class AlternativeSchedulingMetadataTests
         CollectionAssert.AreEqual(new[] { 0, 1 }, indexes);
     }
 
-
-
     [TestMethod]
     public void Scheduler_Metadata_DoesNotChangeSelection_WhenProbeMetadataDiffers()
     {
@@ -160,26 +183,29 @@ public class AlternativeSchedulingMetadataTests
         };
         var rule = new Rule("expr", 0, false, new Alternation(alternatives));
 
-        ScheduledAlternativeExecutionResult ParseWithProbe(IReadOnlyList<string> expected, int index)
-        {
-            return new ScheduledAlternativeExecutionResult(CreateState(rule, alternatives[index], index, 1), Probe(expected));
-        }
+        var sharedProbes = new[] { Probe("ID"), Probe("ID") };
+        var sharedCandidates = new ParserLookaheadSharedPrefixDetector().Detect(sharedProbes);
+        var sharedContinuations = new ContinuationMetadataPreparation().Prepare(rule, alternatives, sharedProbes, sharedCandidates);
 
         var withSharedPrefix = scheduler.Run(
-            rule,
-            alternatives,
-            0,
-            0,
-            null,
-            (_, index) => ParseWithProbe(["ID"], index));
+            rule, alternatives, 0, 0, null,
+            (_, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternatives[index], index, 1), sharedProbes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: sharedContinuations,
+            precomputedLookaheadProbes: sharedProbes,
+            precomputedSharedPrefixCandidates: sharedCandidates);
+
+        var mixedProbes = new[] { Probe("ID"), Probe("NUMBER") };
+        var mixedCandidates = new ParserLookaheadSharedPrefixDetector().Detect(mixedProbes);
+        var mixedContinuations = new ContinuationMetadataPreparation().Prepare(rule, alternatives, mixedProbes, mixedCandidates);
 
         var withoutSharedPrefix = scheduler.Run(
-            rule,
-            alternatives,
-            0,
-            0,
-            null,
-            (_, index) => index == 0 ? ParseWithProbe(["ID"], index) : ParseWithProbe(["NUMBER"], index));
+            rule, alternatives, 0, 0, null,
+            (_, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternatives[index], index, 1), mixedProbes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: mixedContinuations,
+            precomputedLookaheadProbes: mixedProbes,
+            precomputedSharedPrefixCandidates: mixedCandidates);
 
         Assert.IsNotNull(withSharedPrefix.SelectedState);
         Assert.IsNotNull(withoutSharedPrefix.SelectedState);
@@ -197,16 +223,19 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(1, Associativity.Left, new RuleRef("ID"), "b")
         };
         var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+        var probes = new[] { Probe("ID"), Probe("ID") };
+        var candidates = new ParserLookaheadSharedPrefixDetector().Detect(probes);
+        var continuations = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, candidates);
 
         var result = scheduler.Run(
-            rule,
-            alternatives,
-            0,
-            0,
-            null,
+            rule, alternatives, 0, 0, null,
             (alternative, index) => index == 0
-                ? new ScheduledAlternativeExecutionResult(null, Probe("ID"))
-                : new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), Probe("ID")));
+                ? new ScheduledAlternativeExecutionResult(null, probes[index])
+                : new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: continuations,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: candidates);
 
         Assert.AreEqual(1, result.Metadata.SharedPrefixPlans.Count);
         Assert.AreEqual("ID", result.Metadata.SharedPrefixPlans[0].SharedTokenName);
@@ -235,6 +264,7 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(0, Associativity.Left, new LiteralMatch("a"), "X"),
             new Alternative(1, Associativity.Left, new LiteralMatch("a"), "X")
         ]));
+        var probes = DefaultProbes(rule.Content.Alternatives.Count);
 
         _ = scheduler.Run(
             rule,
@@ -242,7 +272,11 @@ public class AlternativeSchedulingMetadataTests
             0,
             0,
             diagnostics,
-            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")));
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: []);
 
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
     }
@@ -255,6 +289,7 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(0, Associativity.Left, new LiteralMatch("a"), "X"),
             new Alternative(1, Associativity.Left, new LiteralMatch("a"), "Y")
         ]));
+        var probes = DefaultProbes(rule.Content.Alternatives.Count);
 
         var result = scheduler.Run(
             rule,
@@ -262,7 +297,11 @@ public class AlternativeSchedulingMetadataTests
             0,
             0,
             null,
-            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")));
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 2), Probe("ID")),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: DefaultContinuations(rule, rule.Content.Alternatives.Count),
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: []);
 
         Assert.AreEqual(2, result.CompletedStates.Count);
         Assert.AreEqual(0, result.PrunedStates.Count);
@@ -278,14 +317,17 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(1, Associativity.Left, new RuleRef("ID"), "b")
         };
         var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+        var probes = new[] { Probe("ID"), Probe("ID") };
+        var candidates = new ParserLookaheadSharedPrefixDetector().Detect(probes);
+        var continuations = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, candidates);
 
         var result = scheduler.Run(
-            rule,
-            alternatives,
-            0,
-            0,
-            null,
-            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, index == 0 ? 1 : 3), Probe("ID")));
+            rule, alternatives, 0, 0, null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, index == 0 ? 1 : 3), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: continuations,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: candidates);
 
         Assert.IsNotNull(result.SelectedState);
         Assert.AreEqual(1, result.SelectedState.AlternativeIndex);
@@ -301,19 +343,23 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(1, Associativity.Left, new RuleRef("ID"), "b")
         };
         var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+        var probes = new[] { Probe("ID"), Probe("ID") };
+        var candidates = new ParserLookaheadSharedPrefixDetector().Detect(probes);
+        var continuations = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, candidates);
 
         var result = scheduler.Run(
-            rule,
-            alternatives,
-            0,
-            0,
-            null,
-            (alternative, index) => new ScheduledAlternativeExecutionResult(null, Probe("ID")));
+            rule, alternatives, 0, 0, null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(null, probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: continuations,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: candidates);
 
         Assert.IsNull(result.SelectedState);
         Assert.AreEqual(0, result.CompletedStates.Count);
         Assert.AreEqual(1, result.Metadata.SharedPrefixPlans.Count);
     }
+
     private static AlternativeSchedulingResult Run(IReadOnlyList<IReadOnlyList<string>> expected)
     {
         var scheduler = new AlternativeScheduler();
@@ -323,13 +369,38 @@ public class AlternativeSchedulingMetadataTests
             new Alternative(1, Associativity.Left, new RuleRef("ID"), "b")
         };
         var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+        var probes = expected.Select(static e => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, null, null, e)).ToArray();
+        var candidates = new ParserLookaheadSharedPrefixDetector().Detect(probes);
+        var continuations = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, candidates);
         return scheduler.Run(
             rule,
             alternatives,
             0,
             0,
             null,
-            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), Probe(expected[index])));
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateState(rule, alternative, index, 1), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: continuations,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: candidates);
+    }
+
+    private static IReadOnlyList<ParserLookaheadProbeResult> DefaultProbes(int count)
+    {
+        return Enumerable.Range(0, count)
+            .Select(static _ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<ParserContinuationDescriptor> DefaultContinuations(Rule rule, int count)
+    {
+        return Enumerable.Range(0, count)
+            .Select(index => new ParserContinuationDescriptor(
+                new ParserContinuationKey(rule.Name, index, 0),
+                ParserContinuationCategory.Sequential,
+                null,
+                false))
+            .ToArray();
     }
 
     private static ParserLookaheadProbeResult Probe(IReadOnlyList<string> expected) =>

--- a/UtilsTest/Parser/ContinuationMetadataPreparationTests.cs
+++ b/UtilsTest/Parser/ContinuationMetadataPreparationTests.cs
@@ -11,7 +11,7 @@ public class ContinuationMetadataPreparationTests
     public void Prepare_SharedPrefix_IgnoresActionsAndLexerCommands()
     {
         var rule = new Rule("expr", 0, false, new Alternation([
-            new Alternative(0, Associativity.Left, new Sequence([new EmbeddedAction("{a}"), new LexerCommand("skip"), new RuleRef("ID")]), "A"),
+            new Alternative(0, Associativity.Left, new Sequence([new EmbeddedAction("{a}", ActionContext.Alternative, ActionPosition.Inline, []), new LexerCommand(LexerCommandType.Skip, null), new RuleRef("ID")]), "A"),
             new Alternative(1, Associativity.Left, new Sequence([new RuleRef("ID"), new RuleRef("NUMBER")]), "B")
         ]));
         var ordered = rule.Content.Alternatives.OrderBy(static a => a.Priority).ToArray();
@@ -29,5 +29,49 @@ public class ContinuationMetadataPreparationTests
         Assert.AreEqual(1, descriptors[0].Key.SequencePosition);
         Assert.AreEqual(1, descriptors[1].Key.SequencePosition);
         Assert.IsTrue(descriptors.All(static d => d.Category == ParserContinuationCategory.SharedPrefixCandidate));
+    }
+
+    [TestMethod]
+    public void Prepare_WithNoSharedPrefixCandidates_ReturnsSequentialCategory()
+    {
+        var rule = new Rule("stmt", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new RuleRef("EQ")]), "A"),
+            new Alternative(1, Associativity.Left, new Sequence([new RuleRef("NUMBER")]), "B")
+        ]));
+        var ordered = rule.Content.Alternatives.OrderBy(static a => a.Priority).ToArray();
+        var probes = new[]
+        {
+            new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"]),
+            new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "NUMBER", "number", ["NUMBER"])
+        };
+
+        var preparation = new ContinuationMetadataPreparation();
+        var descriptors = preparation.Prepare(rule, ordered, probes, []);
+
+        Assert.AreEqual(2, descriptors.Count);
+        Assert.IsTrue(descriptors.All(static d => d.Category == ParserContinuationCategory.Sequential));
+        Assert.IsTrue(descriptors.All(static d => d.Key.SequencePosition == 0));
+    }
+
+    [TestMethod]
+    public void Prepare_WithNonSequenceAlternative_ReturnsZeroSequencePosition()
+    {
+        var rule = new Rule("atom", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"), "A"),
+            new Alternative(1, Associativity.Left, new LiteralMatch("a"), "B")
+        ]));
+        var ordered = rule.Content.Alternatives.OrderBy(static a => a.Priority).ToArray();
+        var probes = new[]
+        {
+            new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"]),
+            new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])
+        };
+        var candidates = new[] { new ParserLookaheadSharedPrefixCandidate("A", [0, 1]) };
+
+        var preparation = new ContinuationMetadataPreparation();
+        var descriptors = preparation.Prepare(rule, ordered, probes, candidates);
+
+        Assert.AreEqual(2, descriptors.Count);
+        Assert.IsTrue(descriptors.All(static d => d.Key.SequencePosition == 0));
     }
 }

--- a/UtilsTest/Parser/ContinuationMetadataPreparationTests.cs
+++ b/UtilsTest/Parser/ContinuationMetadataPreparationTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Model;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ContinuationMetadataPreparationTests
+{
+    [TestMethod]
+    public void Prepare_SharedPrefix_IgnoresActionsAndLexerCommands()
+    {
+        var rule = new Rule("expr", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([new EmbeddedAction("{a}"), new LexerCommand("skip"), new RuleRef("ID")]), "A"),
+            new Alternative(1, Associativity.Left, new Sequence([new RuleRef("ID"), new RuleRef("NUMBER")]), "B")
+        ]));
+        var ordered = rule.Content.Alternatives.OrderBy(static a => a.Priority).ToArray();
+        var probes = new[]
+        {
+            new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"]),
+            new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])
+        };
+        var candidates = new[] { new ParserLookaheadSharedPrefixCandidate("ID", [0, 1]) };
+
+        var preparation = new ContinuationMetadataPreparation();
+        var descriptors = preparation.Prepare(rule, ordered, probes, candidates);
+
+        Assert.AreEqual(2, descriptors.Count);
+        Assert.AreEqual(1, descriptors[0].Key.SequencePosition);
+        Assert.AreEqual(1, descriptors[1].Key.SequencePosition);
+        Assert.IsTrue(descriptors.All(static d => d.Category == ParserContinuationCategory.SharedPrefixCandidate));
+    }
+}

--- a/UtilsTest/Parser/ContinuationStructuralPositionExtractorTests.cs
+++ b/UtilsTest/Parser/ContinuationStructuralPositionExtractorTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Model;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ContinuationStructuralPositionExtractorTests
+{
+    [TestMethod]
+    public void ExtractSharedPrefixSequencePosition_ReturnsZero_ForQuantifierLeadingAlternative()
+    {
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([
+            new Quantifier(new RuleRef("ID"), QuantifierMode.ZeroOrMore),
+            new RuleRef("NUMBER")]), "A");
+
+        var extractor = new ContinuationStructuralPositionExtractor();
+        var position = extractor.ExtractSharedPrefixSequencePosition(alternative, "ID");
+
+        Assert.AreEqual(0, position);
+    }
+}

--- a/UtilsTest/Parser/ContinuationStructuralPositionExtractorTests.cs
+++ b/UtilsTest/Parser/ContinuationStructuralPositionExtractorTests.cs
@@ -11,8 +11,87 @@ public class ContinuationStructuralPositionExtractorTests
     public void ExtractSharedPrefixSequencePosition_ReturnsZero_ForQuantifierLeadingAlternative()
     {
         var alternative = new Alternative(0, Associativity.Left, new Sequence([
-            new Quantifier(new RuleRef("ID"), QuantifierMode.ZeroOrMore),
+            new Quantifier(new RuleRef("ID"), 0, null),
             new RuleRef("NUMBER")]), "A");
+
+        var extractor = new ContinuationStructuralPositionExtractor();
+        var position = extractor.ExtractSharedPrefixSequencePosition(alternative, "ID");
+
+        Assert.AreEqual(0, position);
+    }
+
+    [TestMethod]
+    public void ExtractSharedPrefixSequencePosition_ReturnsZero_ForNonSequenceAlternative()
+    {
+        var alternative = new Alternative(0, Associativity.Left, new LiteralMatch("id"), "A");
+
+        var extractor = new ContinuationStructuralPositionExtractor();
+        var position = extractor.ExtractSharedPrefixSequencePosition(alternative, "id");
+
+        Assert.AreEqual(0, position);
+    }
+
+    [TestMethod]
+    public void ExtractSharedPrefixSequencePosition_ReturnsZero_ForNonMatchingToken()
+    {
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([
+            new RuleRef("NUMBER"),
+            new RuleRef("ID")]), "A");
+
+        var extractor = new ContinuationStructuralPositionExtractor();
+        var position = extractor.ExtractSharedPrefixSequencePosition(alternative, "ID");
+
+        Assert.AreEqual(0, position);
+    }
+
+    [TestMethod]
+    public void ExtractSharedPrefixSequencePosition_ReturnsOne_ForDirectMatchingRuleRef()
+    {
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([
+            new RuleRef("ID"),
+            new RuleRef("NUMBER")]), "A");
+
+        var extractor = new ContinuationStructuralPositionExtractor();
+        var position = extractor.ExtractSharedPrefixSequencePosition(alternative, "ID");
+
+        Assert.AreEqual(1, position);
+    }
+
+    [TestMethod]
+    public void ExtractSharedPrefixSequencePosition_ReturnsOne_ForMatchingLiteralFirst()
+    {
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([
+            new LiteralMatch("id"),
+            new LiteralMatch("+"),
+            new RuleRef("expr")]));
+
+        var extractor = new ContinuationStructuralPositionExtractor();
+        var position = extractor.ExtractSharedPrefixSequencePosition(alternative, "id");
+
+        Assert.AreEqual(1, position);
+    }
+
+    [TestMethod]
+    public void ExtractSharedPrefixSequencePosition_SkipsActionsAndLexerCommandsBeforeSharedToken()
+    {
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([
+            new EmbeddedAction("x();", ActionContext.Alternative, ActionPosition.Inline, []),
+            new LexerCommand(LexerCommandType.Skip, null),
+            new RuleRef("ID"),
+            new LiteralMatch("-")]));
+
+        var extractor = new ContinuationStructuralPositionExtractor();
+        var position = extractor.ExtractSharedPrefixSequencePosition(alternative, "ID");
+
+        Assert.AreEqual(1, position);
+    }
+
+    [TestMethod]
+    public void ExtractSharedPrefixSequencePosition_ReturnsZero_WhenRuleRefNameMismatches()
+    {
+        var alternative = new Alternative(0, Associativity.Left, new Sequence([
+            new RuleRef("expr"),
+            new RuleRef("tail")]));
 
         var extractor = new ContinuationStructuralPositionExtractor();
         var position = extractor.ExtractSharedPrefixSequencePosition(alternative, "ID");

--- a/UtilsTest/Parser/ParserBranchOutcomeModelTests.cs
+++ b/UtilsTest/Parser/ParserBranchOutcomeModelTests.cs
@@ -72,7 +72,9 @@ public class ParserBranchOutcomeModelTests
                 state with { Alternative = rule.Content.Alternatives[index], AlternativeIndex = index },
                 new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])),
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: []);
+            precomputedContinuationMetadata: Enumerable.Range(0, rule.Content.Alternatives.Count).Select(i => new ParserContinuationDescriptor(new ParserContinuationKey(rule.Name, i, 0), ParserContinuationCategory.Sequential, null, false)).ToArray(),
+            precomputedLookaheadProbes: Enumerable.Range(0, rule.Content.Alternatives.Count).Select(static _ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)).ToArray(),
+            precomputedSharedPrefixCandidates: []);
 
         Assert.IsTrue(schedulerDiagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
 

--- a/UtilsTest/Parser/ParserBranchOutcomeModelTests.cs
+++ b/UtilsTest/Parser/ParserBranchOutcomeModelTests.cs
@@ -70,7 +70,9 @@ public class ParserBranchOutcomeModelTests
         _ = scheduler.Run(rule, rule.Content.Alternatives, 0, 0, schedulerDiagnostics, (_, index) =>
             new ScheduledAlternativeExecutionResult(
                 state with { Alternative = rule.Content.Alternatives[index], AlternativeIndex = index },
-                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])));
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: []);
 
         Assert.IsTrue(schedulerDiagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
 

--- a/UtilsTest/Parser/ParserContinuationFactoryTests.cs
+++ b/UtilsTest/Parser/ParserContinuationFactoryTests.cs
@@ -8,45 +8,12 @@ namespace UtilsTest.Parser;
 public class ParserContinuationFactoryTests
 {
     [TestMethod]
-    public void Create_NonSequenceAlternative_UsesPositionZero()
-    {
-        var factory = new ParserContinuationFactory();
-        var rule = new Rule("expr", 0, false, new Alternation([]));
-        var alternative = new Alternative(2, Associativity.Left, new RuleRef("ID"));
-
-        var descriptor = factory.Create(rule, alternative, 0, 3, null, false);
-
-        Assert.AreEqual(0, descriptor.Key.SequencePosition);
-    }
-
-    [TestMethod]
-    public void Create_SequenceAlternative_UsesMeaningfulSequenceIndex()
-    {
-        var factory = new ParserContinuationFactory();
-        var rule = new Rule("stmt", 0, false, new Alternation([]));
-        var sequence = new Sequence([
-            new EmbeddedAction("var x = 0;", ActionContext.Alternative, ActionPosition.Inline, []),
-            new LiteralMatch("if"),
-            new RuleRef("ID")
-        ]);
-        var alternative = new Alternative(1, Associativity.Left, sequence);
-
-        var literalDescriptor = factory.Create(rule, alternative, 0, 1, null, false);
-        var ruleRefDescriptor = factory.Create(rule, alternative, 0, 2, null, false);
-
-        Assert.AreEqual(0, literalDescriptor.Key.SequencePosition);
-        Assert.AreEqual(1, ruleRefDescriptor.Key.SequencePosition);
-    }
-
-    [TestMethod]
     public void Create_PreservesExpectedTokenNames()
     {
         var factory = new ParserContinuationFactory();
-        var rule = new Rule("expr", 0, false, new Alternation([]));
-        var alternative = new Alternative(0, Associativity.Left, new RuleRef("ID"));
         IReadOnlyList<string> expectedTokenNames = ["ID", "NUMBER"];
 
-        var descriptor = factory.Create(rule, alternative, 0, 0, expectedTokenNames, false);
+        var descriptor = factory.Create(new ParserContinuationPreparationInput("expr", 0, 0, expectedTokenNames, false));
 
         CollectionAssert.AreEqual(expectedTokenNames.ToArray(), descriptor.ExpectedTokenNames?.ToArray() ?? []);
     }
@@ -55,10 +22,8 @@ public class ParserContinuationFactoryTests
     public void Create_PreservesSharedPrefixFlag()
     {
         var factory = new ParserContinuationFactory();
-        var rule = new Rule("expr", 0, false, new Alternation([]));
-        var alternative = new Alternative(0, Associativity.Left, new RuleRef("ID"));
 
-        var descriptor = factory.Create(rule, alternative, 0, 0, null, true);
+        var descriptor = factory.Create(new ParserContinuationPreparationInput("expr", 0, 0, null, true));
 
         Assert.IsTrue(descriptor.IsSharedPrefixCandidate);
     }
@@ -67,14 +32,33 @@ public class ParserContinuationFactoryTests
     public void Create_AlternativeIndex_IsIndependentFromPriority()
     {
         var factory = new ParserContinuationFactory();
-        var rule = new Rule("expr", 0, false, new Alternation([]));
-        var firstAlternative = new Alternative(0, Associativity.Left, new RuleRef("ID"));
-        var secondAlternative = new Alternative(0, Associativity.Left, new RuleRef("NUMBER"));
 
-        var firstDescriptor = factory.Create(rule, firstAlternative, 0, 0, null, false);
-        var secondDescriptor = factory.Create(rule, secondAlternative, 1, 0, null, false);
+        var firstDescriptor = factory.Create(new ParserContinuationPreparationInput("expr", 0, 0, null, false));
+        var secondDescriptor = factory.Create(new ParserContinuationPreparationInput("expr", 1, 0, null, false));
 
         Assert.AreNotEqual(firstDescriptor.Key, secondDescriptor.Key);
+    }
+
+    [TestMethod]
+    public void Create_SequencePosition_IsStoredAsProvided()
+    {
+        var factory = new ParserContinuationFactory();
+
+        var descriptor = factory.Create(new ParserContinuationPreparationInput("expr", 0, 3, null, false));
+
+        Assert.AreEqual(3, descriptor.Key.SequencePosition);
+    }
+
+    [TestMethod]
+    public void Create_RuleName_IsStoredAsProvided()
+    {
+        var factory = new ParserContinuationFactory();
+
+        var descriptor = factory.Create(new ParserContinuationPreparationInput("stmt", 2, 1, null, false));
+
+        Assert.AreEqual("stmt", descriptor.Key.RuleName);
+        Assert.AreEqual(2, descriptor.Key.AlternativeIndex);
+        Assert.AreEqual(1, descriptor.Key.SequencePosition);
     }
 
     [TestMethod]
@@ -105,113 +89,5 @@ public class ParserContinuationFactoryTests
         Assert.IsNull(descriptorType.GetProperty("TokenReader"));
         Assert.IsNull(descriptorType.GetProperty("TokenStream"));
         Assert.AreEqual(0, descriptorType.GetProperties().Count(static p => typeof(Delegate).IsAssignableFrom(p.PropertyType)));
-    }
-
-    [TestMethod]
-    public void ComputeSharedPrefixSequencePosition_SequenceWithSharedFirstToken_ReturnsOne()
-    {
-        var factory = new ParserContinuationFactory();
-        var alternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("+"), new RuleRef("expr")]));
-
-        var result = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
-
-        Assert.AreEqual(1, result);
-    }
-
-    [TestMethod]
-    public void ComputeSharedPrefixSequencePosition_IgnoresEmbeddedActionAndLexerCommand()
-    {
-        var factory = new ParserContinuationFactory();
-        var alternative = new Alternative(0, Associativity.Left, new Sequence([
-            new EmbeddedAction("x();", ActionContext.Alternative, ActionPosition.Inline, []),
-            new LexerCommand(LexerCommandType.Skip, null),
-            new RuleRef("ID"),
-            new LiteralMatch("-")
-        ]));
-
-        var result = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
-
-        Assert.AreEqual(3, result);
-    }
-
-    [TestMethod]
-    public void Create_WithRawSharedPrefixSequencePosition_NormalizesMeaningfulBoundary()
-    {
-        var factory = new ParserContinuationFactory();
-        var rule = new Rule("expr", 0, false, new Alternation([]));
-        var alternative = new Alternative(0, Associativity.Left, new Sequence([
-            new EmbeddedAction("x();", ActionContext.Alternative, ActionPosition.Inline, []),
-            new LexerCommand(LexerCommandType.Skip, null),
-            new RuleRef("ID"),
-            new RuleRef("expr")
-        ]));
-
-        var rawSequencePosition = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
-        var descriptor = factory.Create(rule, alternative, 0, rawSequencePosition, ["ID"], true);
-
-        Assert.AreEqual(3, rawSequencePosition);
-        Assert.AreEqual(1, descriptor.Key.SequencePosition);
-    }
-
-    [TestMethod]
-    public void Create_SequenceContinuationAfterFinalItem_PreservesMeaningfulPosition()
-    {
-        var factory = new ParserContinuationFactory();
-        var rule = new Rule("expr", 0, false, new Alternation([]));
-        var alternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID")]));
-
-        var descriptor = factory.Create(rule, alternative, 0, 1, null, false);
-
-        Assert.AreEqual(1, descriptor.Key.SequencePosition);
-    }
-
-    [TestMethod]
-    public void Create_SequenceContinuationAfterMeaningfulItem_IgnoresEmbeddedActionAndLexerCommand()
-    {
-        var factory = new ParserContinuationFactory();
-        var rule = new Rule("expr", 0, false, new Alternation([]));
-        var alternative = new Alternative(0, Associativity.Left, new Sequence([
-            new EmbeddedAction("x();", ActionContext.Alternative, ActionPosition.Inline, []),
-            new LexerCommand(LexerCommandType.Skip, null),
-            new RuleRef("ID")
-        ]));
-
-        var descriptor = factory.Create(rule, alternative, 0, 3, null, false);
-
-        Assert.AreEqual(1, descriptor.Key.SequencePosition);
-    }
-
-    [TestMethod]
-    public void Create_SequenceContinuationBeyondLength_ClampsToSequenceLength()
-    {
-        var factory = new ParserContinuationFactory();
-        var rule = new Rule("expr", 0, false, new Alternation([]));
-        var alternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new RuleRef("expr")]));
-
-        var descriptor = factory.Create(rule, alternative, 0, 99, null, false);
-
-        Assert.AreEqual(2, descriptor.Key.SequencePosition);
-    }
-
-    [TestMethod]
-    public void ComputeSharedPrefixSequencePosition_UnsupportedStructure_FallsBackToZero()
-    {
-        var factory = new ParserContinuationFactory();
-        var alternative = new Alternative(0, Associativity.Left, new RuleRef("expr"));
-
-        var result = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
-
-        Assert.AreEqual(0, result);
-    }
-
-    [TestMethod]
-    public void ComputeSharedPrefixSequencePosition_RuleRefNameMismatch_FallsBackToZero()
-    {
-        var factory = new ParserContinuationFactory();
-        var alternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("expr"), new RuleRef("tail")]));
-
-        var result = factory.ComputeSharedPrefixSequencePosition(alternative, "ID");
-
-        Assert.AreEqual(0, result);
     }
 }

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -199,8 +199,9 @@ public class ParserDiagnosticsTests
             minimumPrecedence: 0,
             diagnostics,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: Enumerable.Range(0, rule.Content.Alternatives.Count).Select(i => new ParserContinuationDescriptor(new ParserContinuationKey(rule.Name, i, 0), ParserContinuationCategory.Sequential, null, false)).ToArray(),
+            precomputedLookaheadProbes: Enumerable.Range(0, rule.Content.Alternatives.Count).Select(static _ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)).ToArray(),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 new ActiveParseState
                 {

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -198,6 +198,8 @@ public class ParserDiagnosticsTests
             originInputPosition: 0,
             minimumPrecedence: 0,
             diagnostics,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 new ActiveParseState
                 {

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -200,6 +200,7 @@ public class ParserDiagnosticsTests
             diagnostics,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 new ActiveParseState
                 {

--- a/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
+++ b/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
@@ -139,6 +139,8 @@ public class ParserEngineAlternativeSelectionTests
             originInputPosition: 0,
             minimumPrecedence: 0,
             diagnostics,
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 new ActiveParseState
                 {

--- a/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
+++ b/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
@@ -141,6 +141,7 @@ public class ParserEngineAlternativeSelectionTests
             diagnostics,
             precomputedDescriptors: null,
             precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 new ActiveParseState
                 {

--- a/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
+++ b/UtilsTest/Parser/ParserEngineAlternativeSelectionTests.cs
@@ -140,8 +140,9 @@ public class ParserEngineAlternativeSelectionTests
             minimumPrecedence: 0,
             diagnostics,
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: [],
-            precomputedLookaheadProbes: [],
+            precomputedContinuationMetadata: Enumerable.Range(0, rule.Content.Alternatives.Count).Select(i => new ParserContinuationDescriptor(new ParserContinuationKey(rule.Name, i, 0), ParserContinuationCategory.Sequential, null, false)).ToArray(),
+            precomputedLookaheadProbes: Enumerable.Range(0, rule.Content.Alternatives.Count).Select(static _ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)).ToArray(),
+            precomputedSharedPrefixCandidates: [],
             parseAlternative: (alternative, index) => new ScheduledAlternativeExecutionResult(
                 new ActiveParseState
                 {

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -221,10 +221,13 @@ public class ParserRuntimeInvariantTests
         };
         var diagnostics = new DiagnosticBag();
 
+        var count = rule.Content.Alternatives.Count;
         _ = scheduler.Run(rule, rule.Content.Alternatives, 0, 0, diagnostics, (_, i) =>
             new ScheduledAlternativeExecutionResult(state with { Alternative = rule.Content.Alternatives[i], AlternativeIndex = i }, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])),
             precomputedDescriptors: null,
-            precomputedContinuationMetadata: []);
+            precomputedContinuationMetadata: Enumerable.Range(0, count).Select(i => new ParserContinuationDescriptor(new ParserContinuationKey(rule.Name, i, 0), ParserContinuationCategory.Sequential, null, false)).ToArray(),
+            precomputedLookaheadProbes: Enumerable.Range(0, count).Select(static _ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.Unknown, null, null)).ToArray(),
+            precomputedSharedPrefixCandidates: []);
 
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));
@@ -349,6 +352,12 @@ public class ParserRuntimeInvariantTests
             new Alternative(1, Associativity.Left, new RuleRef("A"), "right")
         ]));
 
+        var probes = rule.Content.Alternatives
+            .Select(static _ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"]))
+            .ToArray();
+        var candidates = new ParserLookaheadSharedPrefixDetector().Detect(probes);
+        var continuations = new ContinuationMetadataPreparation().Prepare(rule, rule.Content.Alternatives.ToList(), probes, candidates);
+
         var scheduleResult = scheduler.Run(
             rule,
             rule.Content.Alternatives,
@@ -357,7 +366,11 @@ public class ParserRuntimeInvariantTests
             diagnostics: null,
             (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, index, 1),
-                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])));
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: continuations,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: candidates);
 
         Assert.AreEqual(1, scheduleResult.Metadata.SharedPrefixPlans.Count);
         Assert.AreEqual(2, scheduleResult.CompletedStates.Count);
@@ -501,6 +514,12 @@ public class ParserRuntimeInvariantTests
             new Alternative(1, Associativity.Left, new RuleRef("ID"), "label-b")
         ]));
 
+        var probesId = rule.Content.Alternatives
+            .Select(static _ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"]))
+            .ToArray();
+        var candidatesId = new ParserLookaheadSharedPrefixDetector().Detect(probesId);
+        var continuationsId = new ContinuationMetadataPreparation().Prepare(rule, rule.Content.Alternatives.ToList(), probesId, candidatesId);
+
         var result = scheduler.Run(
             rule,
             rule.Content.Alternatives,
@@ -509,7 +528,11 @@ public class ParserRuntimeInvariantTests
             diagnostics: null,
             (alternative, index) => new ScheduledAlternativeExecutionResult(
                 CreateState(rule, alternative, index, 1),
-                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])));
+                new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"])),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: continuationsId,
+            precomputedLookaheadProbes: probesId,
+            precomputedSharedPrefixCandidates: candidatesId);
 
         Assert.AreEqual(1, result.Metadata.SharedPrefixPlans.Count);
         CollectionAssert.AreEquivalent(new[] { 0, 1 }, result.Metadata.SharedPrefixPlans[0].AlternativeIndexes.ToArray());

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -222,7 +222,9 @@ public class ParserRuntimeInvariantTests
         var diagnostics = new DiagnosticBag();
 
         _ = scheduler.Run(rule, rule.Content.Alternatives, 0, 0, diagnostics, (_, i) =>
-            new ScheduledAlternativeExecutionResult(state with { Alternative = rule.Content.Alternatives[i], AlternativeIndex = i }, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])));
+            new ScheduledAlternativeExecutionResult(state with { Alternative = rule.Content.Alternatives[i], AlternativeIndex = i }, new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "A", "a", ["A"])),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: []);
 
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.AmbiguousAlternativesPruned.Code));
         Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ParseFailure.Code));

--- a/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
@@ -316,12 +316,13 @@ public class ParserSharedPrefixMetadataScenarioTests
             .Select(alternative => lookaheadProbe.Probe(alternative, token, ResolveRule, false))
             .ToArray();
         var candidates = detector.Detect(probes);
+        var positionExtractor = new ContinuationStructuralPositionExtractor();
         var continuations = candidates
             .SelectMany(candidate => candidate.AlternativeIndexes.Select(alternativeIndex =>
             {
                 var alternative = alternatives[alternativeIndex];
-                var rawPosition = continuationFactory.ComputeSharedPrefixSequencePosition(alternative, candidate.TokenName);
-                return continuationFactory.Create(rule, alternative, alternativeIndex, rawPosition, [candidate.TokenName], true);
+                var position = positionExtractor.ExtractSharedPrefixSequencePosition(alternative, candidate.TokenName);
+                return continuationFactory.Create(new ParserContinuationPreparationInput(rule.Name, alternativeIndex, position, [candidate.TokenName], true));
             }))
             .ToArray();
 

--- a/docs/parser/ContinuationMetadata.md
+++ b/docs/parser/ContinuationMetadata.md
@@ -12,12 +12,12 @@ Continuation metadata provides a deterministic, structural description of potent
 
 The current ownership flow is:
 
-Scheduler preparation  
+ParserEngine preparation  
 → continuation metadata production  
-→ runtime transport
+→ scheduler/runtime transport
 
-Continuation metadata is produced during scheduling preparation and transported during execution.  
-The scheduler does not gain continuation execution authority.
+Continuation metadata is produced before scheduler execution and then transported during scheduling/runtime flow.  
+The scheduler does not gain continuation preparation or execution authority.
 
 ## Descriptor model
 


### PR DESCRIPTION
### Motivation

Extract all continuation-metadata preparation out of `AlternativeScheduler`, which becomes a transport-only consumer. Centralise shallow grammar inspection and descriptor construction in dedicated components while preserving existing runtime behaviour and public APIs.

### Changes

**New components**

- `ContinuationMetadataPreparation` — produces `ParserContinuationDescriptor` instances from ordered alternatives, lookahead probes and shared-prefix candidates. Descriptive-only; no runtime state or scheduling decisions.
- `ContinuationStructuralPositionExtractor` — shallow grammar inspection for computing normalized shared-prefix sequence positions. Extracted from `ParserContinuationFactory`, which no longer does grammar traversal.
- `ParserContinuationPreparationInput` — immutable `readonly record struct` consumed by `ParserContinuationFactory.Create()` instead of the previous 6-parameter overload.

**Modified components**

| Component | What changed |
|---|---|
| `ParserContinuationFactory` | `Create()` now accepts `ParserContinuationPreparationInput`; `ComputeSharedPrefixSequencePosition`, `ComputeSequencePosition` and `IsSharedTokenMatchFromProbeMetadata` removed (logic moved to `ContinuationStructuralPositionExtractor`). |
| `AlternativeScheduler.Run()` | Now requires `precomputedContinuationMetadata`, `precomputedLookaheadProbes` and `precomputedSharedPrefixCandidates` — all required, no fallback. `_sharedPrefixDetector` field removed; `BuildMetadata` receives pre-computed candidates instead of re-detecting from probes. |
| `ParserEngine` | `_lookaheadProbe`, `_sharedPrefixDetector` and `_continuationMetadataPreparation` are class fields. Before scheduling: probes are prepared via `PrepareSchedulingLookaheadProbes()`, candidates via `_sharedPrefixDetector.Detect()`, descriptors via `ContinuationMetadataPreparation.Prepare()`. All three are forwarded to the scheduler. |
| `ContinuationMetadata.md` | Ownership flow updated: preparation belongs to `ParserEngine`, scheduler is transport-only. |

No observable runtime behaviour changes. Continuation metadata remains descriptive-only; scheduling logic remains orchestration-only.

### Tests

- All existing scheduler tests updated with the three new required parameters (`precomputedLookaheadProbes`, `precomputedContinuationMetadata`, `precomputedSharedPrefixCandidates`).
- `AlternativeSchedulingMetadataTests` rewritten: the `Run()` helper now drives `ParserLookaheadSharedPrefixDetector` and `ContinuationMetadataPreparation` to build pre-computed inputs, mirroring the `ParserEngine` flow.
- `ParserContinuationFactoryTests` updated to the `ParserContinuationPreparationInput` API; position-normalization tests moved to `ContinuationStructuralPositionExtractorTests`.
- `ContinuationMetadataPreparationTests` — 3 tests (shared prefix with embedded actions/lexer commands, no candidates, non-sequence alternative).
- `ContinuationStructuralPositionExtractorTests` — 6 tests (quantifier, non-sequence, token mismatch, direct match, actions/commands skipped, literal match).
- All 1 511 tests pass (7 pre-existing ignores unrelated to this change).

---
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc2a24d248326a3d601b6919a1ccc)