### PR TITLE
Clarify continuation metadata ownership & runtime architecture; complete Phase 5 docs

### DIFF
--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -209,7 +209,6 @@ These constructs are recognised without error but produce no runtime effect.
 
 | Construct | Stored where | Runtime behaviour |
 |---|---|---|
-| Continuation metadata descriptors | `ParserContinuationDescriptor` metadata (prepared before scheduling) | Recognized: yes; Preserved: yes; Normalized: yes; Executed: no. |
 | Rule parameters `rule[int x]` | `Rule.Parameters` as raw text | No argument passing, no typed binding, no invocation frame. |
 | Rule returns `returns [int x]` | `Rule.ReturnType` as raw text | No value extraction or propagation. |
 | `locals [...]` | Parsed, discarded | No runtime semantics. |
@@ -217,6 +216,16 @@ These constructs are recognised without error but produce no runtime effect.
 | `catch [...] {...}` / `finally {...}` | Parsed, discarded | No runtime semantics. |
 | Grammar-level actions `@header`, `@members`, etc. | `ParserDefinition.Actions` | Metadata only; not executed. |
 | Other rule actions (not `@init`/`@after`) | Parsed, discarded | `ActionIgnored` diagnostic emitted. |
+
+---
+
+## Runtime metadata boundary
+
+Continuation metadata descriptors are internal runtime metadata.
+They are prepared after grammar resolution.
+They are not ANTLR grammar constructs.
+They are preserved/normalized as descriptive metadata only.
+They are never executed, replayed, or resumed.
 
 ---
 

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -209,6 +209,7 @@ These constructs are recognised without error but produce no runtime effect.
 
 | Construct | Stored where | Runtime behaviour |
 |---|---|---|
+| Continuation metadata descriptors | `ParserContinuationDescriptor` metadata (prepared before scheduling) | Recognized: yes; Preserved: yes; Normalized: yes; Executed: no. |
 | Rule parameters `rule[int x]` | `Rule.Parameters` as raw text | No argument passing, no typed binding, no invocation frame. |
 | Rule returns `returns [int x]` | `Rule.ReturnType` as raw text | No value extraction or propagation. |
 | `locals [...]` | Parsed, discarded | No runtime semantics. |

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -276,7 +276,7 @@ Forbidden work:
 
 ### Phase 5 — Continuation metadata maturity
 
-**Status: in progress.**
+**Status: complete.**
 
 Goal: clarify and mature continuation metadata as descriptive infrastructure only.
 
@@ -286,12 +286,22 @@ Scope:
 - continuation formatting,
 - ownership,
 - relation to `ActiveParseState`,
-- relation to registry metadata.
+- relation to registry metadata,
+- preparation-layer extraction outside scheduler,
+- scheduler transport-only boundaries.
+
+Current clarification status:
+
+- structural extraction moved to preparation layer,
+- scheduler consumes descriptors only,
+- `ParserContinuationFactory` no longer traverses grammar structures,
+- continuation metadata remains descriptive-only and non-authoritative,
+- ownership boundaries are documented and aligned with runtime behavior.
 
 Allowed work:
 
 - metadata tests,
-- documentation,
+- documentation consistency,
 - simplification.
 
 Forbidden work:
@@ -299,6 +309,12 @@ Forbidden work:
 - continuation replay,
 - runtime resume,
 - invocation frame model.
+
+Completed in PR #234:
+
+- move continuation creation out of scheduler,
+- extract continuation descriptors in preparation layer,
+- remove scheduler metadata generation responsibility.
 
 ### Phase 6 — ANTLR4 compatibility expansion
 

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -40,6 +40,7 @@ The following constructs are parsed and stored, but runtime semantic execution i
 
 | Construct | Parsed | Stored | Resolved | Executable | Runtime-supported | Diagnostics |
 |---|---|---|---|---|---|---|
+| Continuation metadata descriptors | Yes | Yes (structural metadata) | Yes (preparation-layer normalization) | No | Metadata-only | N/A (descriptive metadata, non-authoritative) |
 | Semantic predicates (`{ condition }?`) | Yes | Yes (predicate metadata) | Partially (policy-routed) | Policy-dependent only | Conservative by default (`NotEvaluated`) | `SemanticPredicateNotEnforced` when evaluator returns `NotEvaluated` |
 | Inline actions (`{ code }`) | Yes | Yes (embedded action metadata) | No target-language semantic resolution | No by default | Parsed-but-not-executed compatibility only | `InlineActionStoredNotExecuted` |
 | Rule actions (`@init`, `@after`, unsupported action slots) | Yes | Yes (rule/action metadata) | Limited to recognized metadata slots | No | Metadata-only/ignored compatibility path | `ActionIgnored` for ignored rule or grammar action entries; `InlineActionStoredNotExecuted` when an embedded action reaches runtime policy flow |
@@ -77,6 +78,7 @@ The following capabilities are currently unsupported by design:
 - adaptive LL prediction;
 - GLL parsing;
 - speculative parsing and continuation replay;
+- runtime continuation execution/resume;
 - parser graph execution;
 - parse-forest generation;
 - parallel parsing;
@@ -99,7 +101,7 @@ Compatibility diagnostics are intended to document capability boundaries, not to
 Current parser architecture includes explicit metadata infrastructure for future-safe analysis, while preserving deterministic execution boundaries.
 
 - Shared-prefix infrastructure is **metadata-only**.
-- Continuation descriptors are structural metadata, not runtime replay state.
+- Continuation metadata support is recognized/preserved/normalized as structural metadata; execution support is intentionally disabled.
 - No shared-prefix execution pipeline is active.
 - `AlternativeScheduler` provides explicit deterministic orchestration.
 - `ParserStateRegistry` centralizes parser state guards.

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -40,7 +40,6 @@ The following constructs are parsed and stored, but runtime semantic execution i
 
 | Construct | Parsed | Stored | Resolved | Executable | Runtime-supported | Diagnostics |
 |---|---|---|---|---|---|---|
-| Continuation metadata descriptors | Yes | Yes (structural metadata) | Yes (preparation-layer normalization) | No | Metadata-only | N/A (descriptive metadata, non-authoritative) |
 | Semantic predicates (`{ condition }?`) | Yes | Yes (predicate metadata) | Partially (policy-routed) | Policy-dependent only | Conservative by default (`NotEvaluated`) | `SemanticPredicateNotEnforced` when evaluator returns `NotEvaluated` |
 | Inline actions (`{ code }`) | Yes | Yes (embedded action metadata) | No target-language semantic resolution | No by default | Parsed-but-not-executed compatibility only | `InlineActionStoredNotExecuted` |
 | Rule actions (`@init`, `@after`, unsupported action slots) | Yes | Yes (rule/action metadata) | Limited to recognized metadata slots | No | Metadata-only/ignored compatibility path | `ActionIgnored` for ignored rule or grammar action entries; `InlineActionStoredNotExecuted` when an embedded action reaches runtime policy flow |
@@ -70,6 +69,14 @@ Additional architectural context and explicit non-goals are documented in `docs/
 | Other grammar `options` entries | Parsed and preserved as metadata; unsupported options are reported explicitly with `UnsupportedAntlrOptionIgnored`. |
 | Left-recursive precedence parity | Implemented for current runtime model, but not equivalent to all ANTLR4 precedence scenarios; the runtime can emit `LeftRecursivePrecedencePartiallySupported` where applicable. |
 | Lexer command set | Supported commands are `skip`, `more`, `channel`, `type`, `pushMode`, `popMode`, `mode`. Any other command is rejected deterministically with `UnsupportedLexerCommand`. |
+
+## Runtime metadata boundary
+
+Continuation metadata descriptors are internal runtime metadata.
+They are prepared after grammar resolution.
+They are not ANTLR grammar constructs.
+They are preserved/normalized as descriptive metadata only.
+They are never executed, replayed, or resumed.
 
 ## Unsupported
 

--- a/docs/parser/ContinuationMetadata.md
+++ b/docs/parser/ContinuationMetadata.md
@@ -12,12 +12,16 @@ Continuation metadata provides a deterministic, structural description of potent
 
 The current ownership flow is:
 
-ParserEngine preparation  
-→ continuation metadata production  
-→ scheduler/runtime transport
+Grammar  
+→ Preparation  
+→ Scheduler  
+→ Execution  
+→ Observation  
+→ Export  
+→ Analysis
 
-Continuation metadata is produced before scheduler execution and then transported during scheduling/runtime flow.  
-The scheduler does not gain continuation preparation or execution authority.
+Preparation owns continuation metadata production before scheduling starts.  
+The scheduler transports metadata and does not gain preparation or execution authority.
 
 ## Descriptor model
 

--- a/docs/parser/INDEX.md
+++ b/docs/parser/INDEX.md
@@ -13,11 +13,12 @@ This index consolidates the parser documentation set and gives a short summary o
 
 - [`ContinuationMetadata.md`](./ContinuationMetadata.md): Describes continuation metadata lifecycle and explicitly states that metadata does not grant execution/resume authority.
 - [`SharedLookAheadPreparation.md`](./SharedLookAheadPreparation.md): Documents shared-prefix/look-ahead preparation as deterministic advisory metadata only.
+- [`RuntimeArchitecture.md`](./RuntimeArchitecture.md): Canonical pipeline and ownership map from preparation through analysis, including metadata authority boundaries.
 
 ## Compatibility and analysis
 
 - [`../Utils.Parser/ANTLRCompatibility.md`](../../Utils.Parser/ANTLRCompatibility.md): Practical compatibility reference with feature-by-feature behavior notes and usage guidance for ANTLR4 constructs that differ from standard runtime semantics.
-- [`Antlr4CompatibilityMatrix.md`](./Antlr4CompatibilityMatrix.md): Current ANTLR4 feature support matrix with explicit levels (supported, partial, parsed-only, unsupported).
+- [`Antlr4CompatibilityMatrix.md`](./Antlr4CompatibilityMatrix.md): Current ANTLR4 feature support matrix with explicit levels (supported, partial, parsed-only, unsupported), including continuation metadata support boundaries.
 - [`RuntimeTraceAnalysis.md`](./RuntimeTraceAnalysis.md): Tooling-oriented analysis model for runtime traces, focused on descriptive outputs rather than runtime control.
 
 ## Maintenance rule for contributors and agents

--- a/docs/parser/RuntimeArchitecture.md
+++ b/docs/parser/RuntimeArchitecture.md
@@ -1,0 +1,29 @@
+# Runtime Architecture
+
+## Pipeline
+
+The current parser runtime pipeline is:
+
+Grammar  
+→ Preparation  
+→ Scheduler  
+→ Execution  
+→ Observation  
+→ Export  
+→ Analysis
+
+## Ownership boundaries
+
+- **Preparation** owns metadata production (structural descriptors, lookahead probes, shared-prefix candidates, continuation descriptors).
+- **Scheduler** owns deterministic orchestration only and transports prepared metadata.
+- **Execution** owns parse decisions through `ParserEngine`.
+- **Observation** owns passive runtime observation payloads.
+- **Export** owns serialization of observations.
+- **Analysis** owns post-runtime tooling and interpretation.
+
+## Authority model
+
+- Metadata is descriptive only.
+- Scheduler is not a metadata producer.
+- Continuation metadata is not replay/resume authority.
+- Parse acceptance, final diagnostics, and parse-tree outcomes remain owned by `ParserEngine`.

--- a/docs/parser/SharedLookAheadPreparation.md
+++ b/docs/parser/SharedLookAheadPreparation.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document defines the current **shared-prefix identification metadata** prepared during grammar/runtime metadata preparation.
+This document defines the current **shared-prefix identification metadata** produced by the preparation layer.
 
 The intent is to prepare future duplicated-work reduction research while preserving the current parser runtime contract.
 
@@ -41,8 +41,8 @@ Shared-prefix metadata does **not** mean:
 
 ## Structural token preparation
 
-Structural token sequences are computed by `AlternativeStructuralPrefixExtractor` during grammar-level preparation,
-**before** scheduling begins.
+Structural token sequences are computed by `AlternativeStructuralPrefixExtractor` during preparation,
+**before** scheduler orchestration begins.
 
 The extractor inspects grammar model objects (`RuleContent`, `Sequence`, `RuleRef`, `LiteralMatch`) and produces
 lightweight `AlternativeStructuralDescriptor` records carrying only token name strings.


### PR DESCRIPTION
### Motivation

Clarify that continuation metadata descriptors are **not** ANTLR grammar constructs and carry no execution, replay, or resume authority. The previous wording implied they were listed as parsed/stored metadata inside the ANTLR construct tables, which was incorrect and potentially misleading for tooling and contributors.

### Description

- **`Utils.Parser/ANTLRCompatibility.md`** and **`docs/parser/Antlr4CompatibilityMatrix.md`**: clarify the runtime metadata boundary for continuation metadata descriptors and document that they are internal preparation-layer metadata rather than ANTLR grammar constructs. Add `runtime continuation execution/resume` to the intentional exclusions list.
- **`docs/parser/Antlr4CompatibilityMatrix.md`**: update the closing bullet to make explicit that continuation metadata support means recognized/preserved/normalized as structural metadata; execution support is intentionally disabled.
- **`Utils.Parser/ROADMAP.md`**: mark Phase 5 — Continuation metadata maturity as **complete**; document the moved responsibilities (preparation-layer extraction, scheduler transport-only, `ParserContinuationFactory` changes) completed in PR #234.
- **`docs/parser/RuntimeArchitecture.md`** (new): canonical pipeline and ownership map (Grammar → Preparation → Scheduler → Execution → Observation → Export → Analysis) with explicit authority boundaries.
- **`docs/parser/ContinuationMetadata.md`**: update ownership flow to use the canonical pipeline and clarify that preparation owns metadata production; scheduler transports only.
- **`docs/parser/SharedLookAheadPreparation.md`**: minor wording alignment with the canonical pipeline terminology.
- **`docs/parser/INDEX.md`**: add entry for `RuntimeArchitecture.md`; update `Antlr4CompatibilityMatrix.md` description to mention continuation metadata support boundaries.

### Testing

No runtime or code changes — documentation only. No unit tests required or modified.
