### PR TITLE
test(parser): add executable architecture invariant coverage for runtime boundaries

### DIFF
--- a/UtilsTest/Parser/ArchitectureDocumentationContractTests.cs
+++ b/UtilsTest/Parser/ArchitectureDocumentationContractTests.cs
@@ -11,7 +11,20 @@ public class ArchitectureDocumentationContractTests
         var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../docs/parser/RuntimeArchitecture.md"));
         var content = File.ReadAllText(path);
 
-        var expectedPipeline = "Grammar\n→ Preparation\n→ Scheduler\n→ Execution\n→ Observation\n→ Export\n→ Analysis";
-        StringAssert.Contains(content, expectedPipeline);
+        var grammarIndex = content.IndexOf("Grammar", StringComparison.Ordinal);
+        var preparationIndex = content.IndexOf("→ Preparation", StringComparison.Ordinal);
+        var schedulerIndex = content.IndexOf("→ Scheduler", StringComparison.Ordinal);
+        var executionIndex = content.IndexOf("→ Execution", StringComparison.Ordinal);
+        var observationIndex = content.IndexOf("→ Observation", StringComparison.Ordinal);
+        var exportIndex = content.IndexOf("→ Export", StringComparison.Ordinal);
+        var analysisIndex = content.IndexOf("→ Analysis", StringComparison.Ordinal);
+
+        Assert.IsTrue(grammarIndex >= 0);
+        Assert.IsTrue(preparationIndex > grammarIndex);
+        Assert.IsTrue(schedulerIndex > preparationIndex);
+        Assert.IsTrue(executionIndex > schedulerIndex);
+        Assert.IsTrue(observationIndex > executionIndex);
+        Assert.IsTrue(exportIndex > observationIndex);
+        Assert.IsTrue(analysisIndex > exportIndex);
     }
 }

--- a/UtilsTest/Parser/ArchitectureDocumentationContractTests.cs
+++ b/UtilsTest/Parser/ArchitectureDocumentationContractTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ArchitectureDocumentationContractTests
+{
+    [TestMethod]
+    public void RuntimeArchitecture_ContainsDocumentedPipelineStages()
+    {
+        var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../docs/parser/RuntimeArchitecture.md"));
+        var content = File.ReadAllText(path);
+
+        StringAssert.Contains(content, "Grammar");
+        StringAssert.Contains(content, "Preparation");
+        StringAssert.Contains(content, "Scheduler");
+        StringAssert.Contains(content, "Execution");
+        StringAssert.Contains(content, "Observation");
+        StringAssert.Contains(content, "Export");
+        StringAssert.Contains(content, "Analysis");
+    }
+}

--- a/UtilsTest/Parser/ArchitectureDocumentationContractTests.cs
+++ b/UtilsTest/Parser/ArchitectureDocumentationContractTests.cs
@@ -6,17 +6,12 @@ namespace UtilsTest.Parser;
 public class ArchitectureDocumentationContractTests
 {
     [TestMethod]
-    public void RuntimeArchitecture_ContainsDocumentedPipelineStages()
+    public void RuntimeArchitecture_ContainsPipelineInOrder()
     {
         var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../docs/parser/RuntimeArchitecture.md"));
         var content = File.ReadAllText(path);
 
-        StringAssert.Contains(content, "Grammar");
-        StringAssert.Contains(content, "Preparation");
-        StringAssert.Contains(content, "Scheduler");
-        StringAssert.Contains(content, "Execution");
-        StringAssert.Contains(content, "Observation");
-        StringAssert.Contains(content, "Export");
-        StringAssert.Contains(content, "Analysis");
+        var expectedPipeline = "Grammar\n→ Preparation\n→ Scheduler\n→ Execution\n→ Observation\n→ Export\n→ Analysis";
+        StringAssert.Contains(content, expectedPipeline);
     }
 }

--- a/UtilsTest/Parser/ArchitectureInvariantTests.cs
+++ b/UtilsTest/Parser/ArchitectureInvariantTests.cs
@@ -79,6 +79,35 @@ public class ArchitectureInvariantTests
             precomputedSharedPrefixCandidates: []));
     }
 
+
+    [TestMethod]
+    public void Scheduler_DoesNotRequireGrammarTraversal()
+    {
+        var scheduler = new AlternativeScheduler();
+        var alternatives = new[]
+        {
+            new Alternative(0, Associativity.Left, new ThrowingRuleContent("alt0")),
+            new Alternative(1, Associativity.Left, new ThrowingRuleContent("alt1"))
+        };
+        var rule = new Rule("expr", 0, false, new Alternation(alternatives));
+        var probes = CreateProbes(alternatives.Length);
+        var continuations = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, []);
+
+        var result = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateCompletedState(rule, alternative, index), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: continuations,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: []);
+
+        Assert.IsNotNull(result.SelectedState);
+    }
+
     [TestMethod]
     public void Preparation_IsDeterministic()
     {
@@ -261,6 +290,15 @@ public class ArchitectureInvariantTests
             Assert.AreEqual(expected[index].Category, actual[index].Category);
             CollectionAssert.AreEqual(expected[index].ExpectedTokenNames.ToArray(), actual[index].ExpectedTokenNames.ToArray());
             Assert.AreEqual(expected[index].IsSharedPrefixCandidate, actual[index].IsSharedPrefixCandidate);
+        }
+    }
+
+
+    private sealed record ThrowingRuleContent(string Name) : RuleContent
+    {
+        public override string ToString()
+        {
+            throw new InvalidOperationException($"Scheduler attempted to traverse grammar content: {Name}");
         }
     }
 

--- a/UtilsTest/Parser/ArchitectureInvariantTests.cs
+++ b/UtilsTest/Parser/ArchitectureInvariantTests.cs
@@ -16,6 +16,7 @@ public class ArchitectureInvariantTests
         var alternatives = rule.Content.Alternatives;
         var probes = CreateProbes(alternatives.Count);
         var prepared = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, []);
+        var before = prepared.Select(static descriptor => descriptor with { }).ToArray();
 
         _ = scheduler.Run(
             rule,
@@ -29,8 +30,7 @@ public class ArchitectureInvariantTests
             precomputedLookaheadProbes: probes,
             precomputedSharedPrefixCandidates: []);
 
-        var preparedSnapshot = prepared.Select(static descriptor => descriptor with { }).ToArray();
-        CollectionAssert.AreEqual(preparedSnapshot, prepared.ToArray());
+        AssertContinuationSetsEqual(before, prepared.ToArray());
     }
 
     [TestMethod]
@@ -55,7 +55,7 @@ public class ArchitectureInvariantTests
             precomputedLookaheadProbes: probes,
             precomputedSharedPrefixCandidates: []);
 
-        CollectionAssert.AreEqual(before, prepared.ToArray());
+        AssertContinuationSetsEqual(before, prepared.ToArray());
     }
 
     [TestMethod]
@@ -83,7 +83,7 @@ public class ArchitectureInvariantTests
     public void Preparation_IsDeterministic()
     {
         var rule = new Rule("expr", 0, false, new Alternation([
-            new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("+"), new RuleRef("expr")])),
+            new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("+"), new RuleRef("expr")])) ,
             new Alternative(1, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("-"), new RuleRef("expr")]))
         ]));
         var alternatives = rule.Content.Alternatives;
@@ -100,16 +100,98 @@ public class ArchitectureInvariantTests
     }
 
     [TestMethod]
-    public void ContinuationMetadata_DoesNotChangeParseResult()
+    public void Preparation_DoesNotModifyGrammar()
     {
-        var grammar = ExpGrammar.Build();
-        var compiled = new CompiledGrammar(grammar);
+        var rule = new Rule("expr", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("+")])) ,
+            new Alternative(1, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("-")]))
+        ]));
+        var alternatives = rule.Content.Alternatives;
+        var grammarSnapshot = SnapshotRule(rule);
+        var probes = CreateProbes(alternatives.Count);
+        var candidates = new ParserLookaheadSharedPrefixDetector().Detect(probes);
+        var preparation = new ContinuationMetadataPreparation();
 
-        var withMetadata = compiled.Parse("1+2");
-        var withoutMetadata = compiled.Parse("1+2");
+        _ = preparation.Prepare(rule, alternatives, probes, candidates);
+        _ = preparation.Prepare(rule, alternatives, probes, candidates);
+        _ = preparation.Prepare(rule, alternatives, probes, candidates);
 
-        Assert.AreEqual(withMetadata.ToString(), withoutMetadata.ToString());
-        Assert.AreEqual(withMetadata is ErrorNode, withoutMetadata is ErrorNode);
+        Assert.AreEqual(grammarSnapshot, SnapshotRule(rule));
+    }
+
+    [TestMethod]
+    public void SharedPrefixMetadata_DoesNotChangeExecution()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = CreateRule();
+        var alternatives = rule.Content.Alternatives;
+        var probes = CreateProbes(alternatives.Count);
+
+        var withoutShared = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            new DiagnosticBag(),
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateCompletedState(rule, alternative, index), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, []),
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: []);
+
+        var shared = new[] { new ParserLookaheadSharedPrefixCandidate("ID", [0, 1]) };
+        var withShared = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            new DiagnosticBag(),
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateCompletedState(rule, alternative, index), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, shared),
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: shared);
+
+        Assert.IsNotNull(withoutShared.SelectedState);
+        Assert.IsNotNull(withShared.SelectedState);
+        Assert.AreEqual(withoutShared.SelectedState.AlternativeIndex, withShared.SelectedState.AlternativeIndex);
+        Assert.AreEqual(withoutShared.SelectedState.CurrentInputPosition, withShared.SelectedState.CurrentInputPosition);
+    }
+
+    [TestMethod]
+    public void Execution_RemainsDecisionOwner_WithContradictoryMetadata()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = new Rule("expr", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new RuleRef("ID")),
+            new Alternative(1, Associativity.Left, new RuleRef("NUMBER"))
+        ]));
+        var alternatives = rule.Content.Alternatives;
+        var probes = CreateProbes(alternatives.Count);
+        var contradictoryShared = new[] { new ParserLookaheadSharedPrefixCandidate("NUMBER", [0, 1]) };
+        var contradictoryContinuations = new[]
+        {
+            new ParserContinuationDescriptor(new ParserContinuationKey(rule.Name, 0, 99), ParserContinuationCategory.SharedPrefixCandidate, ["NUMBER"], true),
+            new ParserContinuationDescriptor(new ParserContinuationKey(rule.Name, 1, 99), ParserContinuationCategory.SharedPrefixCandidate, ["NUMBER"], true)
+        };
+
+        var result = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => index == 0
+                ? new ScheduledAlternativeExecutionResult(CreateCompletedState(rule, alternative, index, 3), probes[index])
+                : new ScheduledAlternativeExecutionResult(CreateCompletedState(rule, alternative, index, 1), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: contradictoryContinuations,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: contradictoryShared);
+
+        Assert.IsNotNull(result.SelectedState);
+        Assert.AreEqual(0, result.SelectedState.AlternativeIndex);
+        Assert.AreEqual(3, result.SelectedState.CurrentInputPosition);
     }
 
     [TestMethod]
@@ -131,6 +213,11 @@ public class ArchitectureInvariantTests
         Assert.AreEqual(defaultResult is ErrorNode, observedResult is ErrorNode);
     }
 
+    private static string SnapshotRule(Rule rule)
+    {
+        return string.Join("|", rule.Content.Alternatives.Select(static alternative => $"{alternative.Priority}:{alternative.Content}"));
+    }
+
     private static Rule CreateRule()
     {
         return new Rule("expr", 0, false, new Alternation([
@@ -146,25 +233,24 @@ public class ArchitectureInvariantTests
             .ToArray();
     }
 
-    private static ActiveParseState CreateCompletedState(Rule rule, Alternative alternative, int index)
+    private static ActiveParseState CreateCompletedState(Rule rule, Alternative alternative, int index, int endPosition = 1)
     {
         return new ActiveParseState
         {
             Rule = rule,
             Alternative = alternative,
             OriginInputPosition = 0,
-            CurrentInputPosition = 1,
+            CurrentInputPosition = endPosition,
             AlternativeIndex = index,
             Cursor = new RuleContentCursor { Index = 0, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot },
-            PartialNode = new ParserNode(new SourceSpan(0, 1), "DEFAULT_MODE", rule, []),
-            EndPosition = 1,
+            PartialNode = new ParserNode(new SourceSpan(0, endPosition), "DEFAULT_MODE", rule, []),
+            EndPosition = endPosition,
             Status = ActiveParseStateStatus.Completed,
             ParentStateKey = null,
             Depth = 0,
             Continuation = null
         };
     }
-
 
     private static void AssertContinuationSetsEqual(IReadOnlyList<ParserContinuationDescriptor> expected, IReadOnlyList<ParserContinuationDescriptor> actual)
     {

--- a/UtilsTest/Parser/ArchitectureInvariantTests.cs
+++ b/UtilsTest/Parser/ArchitectureInvariantTests.cs
@@ -1,0 +1,189 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Model;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class ArchitectureInvariantTests
+{
+    [TestMethod]
+    public void Scheduler_DoesNotProduceContinuationMetadata()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = CreateRule();
+        var alternatives = rule.Content.Alternatives;
+        var probes = CreateProbes(alternatives.Count);
+        var prepared = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, []);
+
+        _ = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateCompletedState(rule, alternative, index), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: prepared,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: []);
+
+        var preparedSnapshot = prepared.Select(static descriptor => descriptor with { }).ToArray();
+        CollectionAssert.AreEqual(preparedSnapshot, prepared.ToArray());
+    }
+
+    [TestMethod]
+    public void Scheduler_DoesNotMutatePreparedMetadata()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = CreateRule();
+        var alternatives = rule.Content.Alternatives;
+        var probes = CreateProbes(alternatives.Count);
+        var prepared = new ContinuationMetadataPreparation().Prepare(rule, alternatives, probes, []);
+        var before = prepared.ToArray();
+
+        _ = scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateCompletedState(rule, alternative, index), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: prepared,
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: []);
+
+        CollectionAssert.AreEqual(before, prepared.ToArray());
+    }
+
+    [TestMethod]
+    public void Scheduler_DoesNotOwnPreparation()
+    {
+        var scheduler = new AlternativeScheduler();
+        var rule = CreateRule();
+        var alternatives = rule.Content.Alternatives;
+        var probes = CreateProbes(alternatives.Count);
+
+        _ = Assert.ThrowsException<ArgumentException>(() => scheduler.Run(
+            rule,
+            alternatives,
+            0,
+            0,
+            null,
+            (alternative, index) => new ScheduledAlternativeExecutionResult(CreateCompletedState(rule, alternative, index), probes[index]),
+            precomputedDescriptors: null,
+            precomputedContinuationMetadata: [],
+            precomputedLookaheadProbes: probes,
+            precomputedSharedPrefixCandidates: []));
+    }
+
+    [TestMethod]
+    public void Preparation_IsDeterministic()
+    {
+        var rule = new Rule("expr", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("+"), new RuleRef("expr")])),
+            new Alternative(1, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("-"), new RuleRef("expr")]))
+        ]));
+        var alternatives = rule.Content.Alternatives;
+        var probes = CreateProbes(alternatives.Count);
+        var candidates = new ParserLookaheadSharedPrefixDetector().Detect(probes);
+        var preparation = new ContinuationMetadataPreparation();
+
+        var first = preparation.Prepare(rule, alternatives, probes, candidates).ToArray();
+        var second = preparation.Prepare(rule, alternatives, probes, candidates).ToArray();
+        var third = preparation.Prepare(rule, alternatives, probes, candidates).ToArray();
+
+        AssertContinuationSetsEqual(first, second);
+        AssertContinuationSetsEqual(second, third);
+    }
+
+    [TestMethod]
+    public void ContinuationMetadata_DoesNotChangeParseResult()
+    {
+        var grammar = ExpGrammar.Build();
+        var compiled = new CompiledGrammar(grammar);
+
+        var withMetadata = compiled.Parse("1+2");
+        var withoutMetadata = compiled.Parse("1+2");
+
+        Assert.AreEqual(withMetadata.ToString(), withoutMetadata.ToString());
+        Assert.AreEqual(withMetadata is ErrorNode, withoutMetadata is ErrorNode);
+    }
+
+    [TestMethod]
+    public void Observation_DoesNotChangeResult()
+    {
+        var definition = ExpGrammar.Build();
+        var tokens = new[]
+        {
+            new Token(new SourceSpan(0, 1), "INT", "DEFAULT_MODE", "DEFAULT_CHANNEL", "1")
+        };
+
+        var defaultParser = new ParserEngine(definition);
+        var observedParser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { RuntimeObserver = new NoopObserver() });
+
+        var defaultResult = defaultParser.Parse(tokens);
+        var observedResult = observedParser.Parse(tokens);
+
+        Assert.AreEqual(defaultResult.ToString(), observedResult.ToString());
+        Assert.AreEqual(defaultResult is ErrorNode, observedResult is ErrorNode);
+    }
+
+    private static Rule CreateRule()
+    {
+        return new Rule("expr", 0, false, new Alternation([
+            new Alternative(0, Associativity.Left, new RuleRef("ID")),
+            new Alternative(1, Associativity.Left, new RuleRef("NUMBER"))
+        ]));
+    }
+
+    private static ParserLookaheadProbeResult[] CreateProbes(int count)
+    {
+        return Enumerable.Range(0, count)
+            .Select(static _ => new ParserLookaheadProbeResult(ParserLookaheadProbeKind.RequiresParse, "ID", "id", ["ID"]))
+            .ToArray();
+    }
+
+    private static ActiveParseState CreateCompletedState(Rule rule, Alternative alternative, int index)
+    {
+        return new ActiveParseState
+        {
+            Rule = rule,
+            Alternative = alternative,
+            OriginInputPosition = 0,
+            CurrentInputPosition = 1,
+            AlternativeIndex = index,
+            Cursor = new RuleContentCursor { Index = 0, Kind = ScheduledAlternativeCursorKinds.AlternativeRoot },
+            PartialNode = new ParserNode(new SourceSpan(0, 1), "DEFAULT_MODE", rule, []),
+            EndPosition = 1,
+            Status = ActiveParseStateStatus.Completed,
+            ParentStateKey = null,
+            Depth = 0,
+            Continuation = null
+        };
+    }
+
+
+    private static void AssertContinuationSetsEqual(IReadOnlyList<ParserContinuationDescriptor> expected, IReadOnlyList<ParserContinuationDescriptor> actual)
+    {
+        Assert.AreEqual(expected.Count, actual.Count);
+        for (var index = 0; index < expected.Count; index++)
+        {
+            Assert.AreEqual(expected[index].Key, actual[index].Key);
+            Assert.AreEqual(expected[index].Category, actual[index].Category);
+            CollectionAssert.AreEqual(expected[index].ExpectedTokenNames.ToArray(), actual[index].ExpectedTokenNames.ToArray());
+            Assert.AreEqual(expected[index].IsSharedPrefixCandidate, actual[index].IsSharedPrefixCandidate);
+        }
+    }
+
+    private sealed class NoopObserver : IParserRuntimeObserver
+    {
+        public void OnAlternativeStarted(AlternativeRuntimeObservation observation) { }
+        public void OnAlternativeCompleted(AlternativeRuntimeObservation observation) { }
+        public void OnAlternativeFailed(AlternativeRuntimeObservation observation) { }
+        public void OnAlternativePruned(AlternativeRuntimeObservation observation) { }
+        public void OnAlternativeSelected(AlternativeRuntimeObservation observation) { }
+    }
+}


### PR DESCRIPTION
### Motivation
- Protect the documented parser runtime boundaries (Preparation → Scheduler → Execution → Observation → Export → Analysis) by turning architecture invariants into executable tests to catch silent regressions.
- Changes are strictly test-only to avoid any runtime or public-API modifications and to respect the repository's invariants and guidance.
- I consulted the parser guidance and docs (`Utils.Parser/AGENTS.md`, `Utils.Parser/ROADMAP.md`, `docs/parser/INDEX.md`, `docs/parser/RuntimeArchitecture.md`, `docs/parser/ContinuationMetadata.md`, `docs/parser/SharedLookAheadPreparation.md`) and did not update `ROADMAP.md` because no runtime, scheduling, memoization, diagnostics, or metadata semantics were changed.

### Description
- Added `UtilsTest/Parser/ArchitectureInvariantTests.cs` which implements tests asserting scheduler, preparation, metadata, execution and observation invariants (scheduler does not produce or mutate continuation metadata, scheduler does not own preparation, preparation is deterministic, continuation/shared-prefix metadata are non-authoritative, and observation is passive).
- Added `UtilsTest/Parser/ArchitectureDocumentationContractTests.cs` which asserts the canonical pipeline stages are still present in `docs/parser/RuntimeArchitecture.md` to prevent documentation drift.
- All changes are test additions only and no runtime/production sources such as `ParserEngine` or `AlternativeScheduler` were modified, and no test-only APIs or hooks were introduced.

### Testing
- Ran the targeted tests with `dotnet test UtilsTest/UtilsTest.csproj -f net9.0 --filter "FullyQualifiedName~ArchitectureInvariantTests|FullyQualifiedName~ArchitectureDocumentationContractTests"` on the repository and the filtered suite passed (10/10 targeted tests passed).
- The change is covered by the newly added test files `UtilsTest/Parser/ArchitectureInvariantTests.cs` and `UtilsTest/Parser/ArchitectureDocumentationContractTests.cs` and no other automated tests were modified.
