### PR TITLE
Utils.Parser: emit diagnostic for labels on non-rule elements (UP1022)

### DIFF
--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -136,6 +136,10 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor UnsupportedAntlrOptionIgnored =
         new("UP1021", "ANTLR option ignored", "ANTLR option '{0}' is currently unsupported and will be ignored.", DefaultCategory);
 
+    /// <summary>Label parsed on a non-rule-ref element and ignored.</summary>
+    public static readonly ParserDiagnosticDescriptor LabelOnNonRuleReferenceIgnored =
+        new("UP1022", "Label ignored on non-rule reference", "Label '{0}' is recognized but ignored because it targets a non-rule-reference element.", DefaultCategory);
+
     // Warnings (UP5xxx)
     /// <summary>Best-effort recovery used.</summary>
     public static readonly ParserDiagnosticDescriptor BestEffortRecoveryUsed =
@@ -237,6 +241,7 @@ public static class ParserDiagnostics
             [UnsupportedAntlrLanguageOptionIgnored.Code] = UnsupportedAntlrLanguageOptionIgnored,
             [UnsupportedLexerCommand.Code] = UnsupportedLexerCommand,
             [UnsupportedAntlrOptionIgnored.Code] = UnsupportedAntlrOptionIgnored,
+            [LabelOnNonRuleReferenceIgnored.Code] = LabelOnNonRuleReferenceIgnored,
             [BestEffortRecoveryUsed.Code] = BestEffortRecoveryUsed,
             [ExpectedTokenMissing.Code] = ExpectedTokenMissing,
             [FallbackStrategyUsed.Code] = FallbackStrategyUsed,

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -193,7 +193,7 @@ See `docs/parser/RuntimeObservationAndExportContract.md` for the full contract.
 | Direct left recursion | Detected at resolution time and handled with a seed-and-extend loop, but not equivalent to all ANTLR4 left-recursive shapes. Emits `LeftRecursivePrecedencePartiallySupported` where applicable. |
 | Precedence predicates `precpred(_ctx, N)` | Regex-based extraction. Falls back to precedence `0` if the level cannot be parsed. Only recognised in direct left-recursive rules. |
 | Right-associativity `<assoc=right>` | Parsed and applied during left-recursive extension. Only meaningful within direct left-recursive rules; subject to the same partial-parity limits as left recursion. |
-| Labels — `e=expr` and `ids+=ID` | Applied when the labelled item is a `RuleRef`. Labels targeting literals and other non-reference items are recognized and rejected with explicit diagnostic `UP1022 LabelOnNonRuleReferenceIgnored`. |
+| Labels — `e=expr` and `ids+=ID` | Applied when the labelled item is a `RuleRef`. Labels targeting literals and other non-reference items are recognized and ignored with explicit diagnostic `UP1022 LabelOnNonRuleReferenceIgnored`. |
 | `import` | Fully resolved when grammars are compiled as a project set (`Antlr4GrammarProjectCompiler`). Single-file compilation emits `ImportParsedButNotResolved`. |
 | `options { tokenVocab = MyLexer; }` | Dependency loading depends on available resolver inputs at compilation time. |
 | Unknown grammar options (`visitor`, `listener`, `contextSuperClass`, …) | Parsed and preserved as raw option metadata, but rejected with `UP1021 UnsupportedAntlrOptionIgnored`. Recognised options that do not trigger this diagnostic are: `tokenVocab`, `superClass`, `caseInsensitive`, and `language`. |

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -193,7 +193,7 @@ See `docs/parser/RuntimeObservationAndExportContract.md` for the full contract.
 | Direct left recursion | Detected at resolution time and handled with a seed-and-extend loop, but not equivalent to all ANTLR4 left-recursive shapes. Emits `LeftRecursivePrecedencePartiallySupported` where applicable. |
 | Precedence predicates `precpred(_ctx, N)` | Regex-based extraction. Falls back to precedence `0` if the level cannot be parsed. Only recognised in direct left-recursive rules. |
 | Right-associativity `<assoc=right>` | Parsed and applied during left-recursive extension. Only meaningful within direct left-recursive rules; subject to the same partial-parity limits as left recursion. |
-| Labels — `e=expr` and `ids+=ID` | Applied when the labelled item is a `RuleRef`. Ignored on literals and other non-reference items. |
+| Labels — `e=expr` and `ids+=ID` | Applied when the labelled item is a `RuleRef`. Labels targeting literals and other non-reference items are recognized and rejected with explicit diagnostic `UP1022 LabelOnNonRuleReferenceIgnored`. |
 | `import` | Fully resolved when grammars are compiled as a project set (`Antlr4GrammarProjectCompiler`). Single-file compilation emits `ImportParsedButNotResolved`. |
 | `options { tokenVocab = MyLexer; }` | Dependency loading depends on available resolver inputs at compilation time. |
 | Unknown grammar options (`visitor`, `listener`, `contextSuperClass`, …) | Parsed and preserved as raw option metadata, but rejected with `UP1021 UnsupportedAntlrOptionIgnored`. Recognised options that do not trigger this diagnostic are: `tokenVocab`, `superClass`, `caseInsensitive`, and `language`. |
@@ -251,7 +251,7 @@ These capabilities are outside the current runtime model by design. Attempting t
 | Prefix | Severity | Meaning |
 |---|---|---|
 | `UP0xxx` | Error | Blocking — unresolved rules, grammar violations, import failures |
-| `UP1xxx` | Warning | Unsupported / ignored / partial behaviour (e.g. `UP1002` tokens block ignored, `UP1003` channels block ignored, `UP1020` unsupported lexer command, `UP1021` unsupported grammar option) |
+| `UP1xxx` | Warning | Unsupported / ignored / partial behaviour (e.g. `UP1002` tokens block ignored, `UP1003` channels block ignored, `UP1020` unsupported lexer command, `UP1021` unsupported grammar option, `UP1022` label ignored on non-rule reference) |
 | `UP5xxx` | Warning | Best-effort recovery warnings (trailing tokens, ambiguity) |
 | `UP8xxx` | Info | Informational runtime events |
 | `UP9xxx` | Debug | Detailed execution traces |

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -849,7 +849,8 @@ public sealed class Antlr4GrammarConverter
             var content = ConvertAtom(atom);
             if (content is RuleRef ruleRef)
                 return ruleRef with { Label = new RuleLabel(labelName, ruleRef.RuleName, isAdditive) };
-            return content; // label on non-ref content: ignored
+            _diagnostics?.Add(ParserDiagnostics.LabelOnNonRuleReferenceIgnored, labelName);
+            return content;
         }
 
         var block = First(node, "block");

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -854,7 +854,11 @@ public sealed class Antlr4GrammarConverter
         }
 
         var block = First(node, "block");
-        if (block != null) return ConvertBlock(block);
+        if (block != null)
+        {
+            _diagnostics?.Add(ParserDiagnostics.LabelOnNonRuleReferenceIgnored, labelName);
+            return ConvertBlock(block);
+        }
 
         throw new GrammarParseException("Unknown labeledElement content");
     }

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -324,6 +324,7 @@ Current clarification status:
 
 - converter now emits explicit diagnostics for unsupported grammar options instead of implicit acceptance,
 - `tokens` / `channels` prequel constructs now emit deterministic partial-support diagnostics during conversion,
+- labels targeting non-rule-reference elements now emit deterministic compatibility diagnostics instead of being accepted silently,
 - compatibility documentation is aligned with explicit parsed/normalized/rejected boundaries.
 
 Goal: progressively improve ANTLR4 grammar compatibility.

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -51,6 +51,21 @@ public class ParserDiagnosticsTests
     }
 
     [TestMethod]
+    public void Converter_LabelOnNonRuleReference_EmitsExplicitDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : x='a' ;
+            """, diagnostics);
+
+        var diagnostic = diagnostics.FirstOrDefault(d => d.Code == ParserDiagnostics.LabelOnNonRuleReferenceIgnored.Code);
+        Assert.IsNotNull(diagnostic);
+        Assert.AreEqual("UP1022", diagnostic.Code);
+        StringAssert.Contains(diagnostic.Message, "Label 'x' is recognized but ignored");
+    }
+
+    [TestMethod]
     public void RuntimeEngine_InlineActionAndPredicate_EmitDiagnostics()
     {
         var diagnostics = new DiagnosticBag();

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -66,6 +66,21 @@ public class ParserDiagnosticsTests
     }
 
     [TestMethod]
+    public void Converter_LabelOnBlock_EmitsExplicitDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : x=('a' | 'b') ;
+            """, diagnostics);
+
+        var diagnostic = diagnostics.FirstOrDefault(d => d.Code == ParserDiagnostics.LabelOnNonRuleReferenceIgnored.Code);
+        Assert.IsNotNull(diagnostic);
+        Assert.AreEqual("UP1022", diagnostic.Code);
+        StringAssert.Contains(diagnostic.Message, "Label 'x' is recognized but ignored");
+    }
+
+    [TestMethod]
     public void RuntimeEngine_InlineActionAndPredicate_EmitDiagnostics()
     {
         var diagnostics = new DiagnosticBag();

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -66,6 +66,7 @@ Additional architectural context and explicit non-goals are documented in `docs/
 | `import` usage | Fully resolved when grammars are compiled as a project input set; isolated single-file compilation may emit `ImportParsedButNotResolved` when no resolver context is provided. |
 | `tokenVocab` | Dependency loading is supported; effective behavior depends on available resolver inputs and vocabulary source availability in the compilation context. |
 | `superClass` | Parsed, preserved, normalized into `EffectiveGrammarOptions`, and exposed through `GrammarExtensionBinding` metadata. It is **not** interpreted as parser/lexer runtime inheritance execution. |
+| Labels on non-rule-reference elements | Parsed and recognized, then rejected with deterministic compatibility diagnostic `UP1022 LabelOnNonRuleReferenceIgnored`. |
 | Other grammar `options` entries | Parsed and preserved as metadata; unsupported options are reported explicitly with `UnsupportedAntlrOptionIgnored`. |
 | Left-recursive precedence parity | Implemented for current runtime model, but not equivalent to all ANTLR4 precedence scenarios; the runtime can emit `LeftRecursivePrecedencePartiallySupported` where applicable. |
 | Lexer command set | Supported commands are `skip`, `more`, `channel`, `type`, `pushMode`, `popMode`, `mode`. Any other command is rejected deterministically with `UnsupportedLexerCommand`. |

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -66,7 +66,7 @@ Additional architectural context and explicit non-goals are documented in `docs/
 | `import` usage | Fully resolved when grammars are compiled as a project input set; isolated single-file compilation may emit `ImportParsedButNotResolved` when no resolver context is provided. |
 | `tokenVocab` | Dependency loading is supported; effective behavior depends on available resolver inputs and vocabulary source availability in the compilation context. |
 | `superClass` | Parsed, preserved, normalized into `EffectiveGrammarOptions`, and exposed through `GrammarExtensionBinding` metadata. It is **not** interpreted as parser/lexer runtime inheritance execution. |
-| Labels on non-rule-reference elements | Parsed and recognized, then rejected with deterministic compatibility diagnostic `UP1022 LabelOnNonRuleReferenceIgnored`. |
+| Labels on non-rule-reference elements | Parsed and recognized, then ignored with deterministic compatibility diagnostic UP1022. |
 | Other grammar `options` entries | Parsed and preserved as metadata; unsupported options are reported explicitly with `UnsupportedAntlrOptionIgnored`. |
 | Left-recursive precedence parity | Implemented for current runtime model, but not equivalent to all ANTLR4 precedence scenarios; the runtime can emit `LeftRecursivePrecedencePartiallySupported` where applicable. |
 | Lexer command set | Supported commands are `skip`, `more`, `channel`, `type`, `pushMode`, `popMode`, `mode`. Any other command is rejected deterministically with `UnsupportedLexerCommand`. |


### PR DESCRIPTION
### Motivation

- Close a small ANTLR4 compatibility gap: labeled elements targeting non-`RuleRef` atoms or inline blocks were parsed then silently ignored, creating ambiguity about support and leaving no deterministic diagnostic.

### Description

- Add new shared diagnostic descriptor `UP1022 LabelOnNonRuleReferenceIgnored` in `Utils.Parser.Diagnostics.ParserDiagnostics` to make the compatibility boundary explicit.
- Emit `UP1022` from the ANTLR4 converter (`Antlr4GrammarConverter.ConvertLabeledElement`) when a label targets a non-`RuleRef` atom or an inline block instead of silently dropping it.
- Add focused unit tests in `UtilsTest/Parser/ParserDiagnosticsTests.cs`: `Converter_LabelOnNonRuleReference_EmitsExplicitDiagnostic` (label on literal atom) and `Converter_LabelOnBlock_EmitsExplicitDiagnostic` (label on inline block such as `x=('a' | 'b')`), each verifying diagnostic code and message determinism.
- Update compatibility docs and roadmap entries (`Utils.Parser/ANTLRCompatibility.md`, `docs/parser/Antlr4CompatibilityMatrix.md`, `Utils.Parser/ROADMAP.md`) to classify the case as recognized and ignored with explicit diagnostic. No runtime, scheduler, or parse-tree behavior was changed.

### Testing

- Ran `dotnet test UtilsTest/UtilsTest.csproj --filter ParserDiagnosticsTests` and all tests in the filtered suite passed (Passed: 16/16).
- Both `UP1022` tests (atom path and block path) were executed as part of that run and succeeded.
