### PR TITLE
Utils.Parser: emit explicit diagnostic for ignored rule returns (UP1007)

### DIFF
--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -76,9 +76,9 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor SemanticPredicateNotEnforced =
         new("UP1006", "Semantic predicate not enforced", "Semantic predicate is recognized but not enforced semantically.", DefaultCategory);
 
-    /// <summary>returns clause partially applied.</summary>
-    public static readonly ParserDiagnosticDescriptor ReturnsPartiallyApplied =
-        new("UP1007", "Returns partially applied", "returns clause for rule '{0}' is parsed but only stored as raw text.", DefaultCategory);
+    /// <summary>returns clause ignored by runtime semantics.</summary>
+    public static readonly ParserDiagnosticDescriptor RuleReturnsIgnored =
+        new("UP1023", "Rule returns ignored", "Rule returns clause for rule '{0}' is recognized but ignored by the current runtime model.", DefaultCategory);
 
     /// <summary>locals/throws/exception metadata ignored.</summary>
     public static readonly ParserDiagnosticDescriptor LocalsIgnored =
@@ -222,7 +222,7 @@ public static class ParserDiagnostics
             [ActionIgnored.Code] = ActionIgnored,
             [InlineActionStoredNotExecuted.Code] = InlineActionStoredNotExecuted,
             [SemanticPredicateNotEnforced.Code] = SemanticPredicateNotEnforced,
-            [ReturnsPartiallyApplied.Code] = ReturnsPartiallyApplied,
+            [RuleReturnsIgnored.Code] = RuleReturnsIgnored,
             [LocalsIgnored.Code] = LocalsIgnored,
             [RuntimeGeneratorMismatch.Code] = RuntimeGeneratorMismatch,
             [DirectLeftRecursionDetected.Code] = DirectLeftRecursionDetected,

--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -78,7 +78,7 @@ public static class ParserDiagnostics
 
     /// <summary>returns clause ignored by runtime semantics.</summary>
     public static readonly ParserDiagnosticDescriptor RuleReturnsIgnored =
-        new("UP1023", "Rule returns ignored", "Rule returns clause for rule '{0}' is recognized but ignored by the current runtime model.", DefaultCategory);
+        new("UP1007", "Rule returns ignored", "Rule returns clause for rule '{0}' is recognized but ignored by the current runtime model.", DefaultCategory);
 
     /// <summary>locals/throws/exception metadata ignored.</summary>
     public static readonly ParserDiagnosticDescriptor LocalsIgnored =

--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -80,6 +80,13 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor RuleReturnsIgnored =
         new("UP1007", "Rule returns ignored", "Rule returns clause for rule '{0}' is recognized but ignored by the current runtime model.", DefaultCategory);
 
+    /// <summary>
+    /// Compatibility alias for the legacy descriptor name.
+    /// </summary>
+    [System.Obsolete("Use RuleReturnsIgnored. This alias is kept for compatibility.")]
+    public static readonly ParserDiagnosticDescriptor ReturnsPartiallyApplied =
+        RuleReturnsIgnored;
+
     /// <summary>locals/throws/exception metadata ignored.</summary>
     public static readonly ParserDiagnosticDescriptor LocalsIgnored =
         new("UP1008", "Locals ignored", "locals/throws/exception metadata for rule '{0}' is parsed but ignored.", DefaultCategory);

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -251,7 +251,7 @@ These capabilities are outside the current runtime model by design. Attempting t
 | Prefix | Severity | Meaning |
 |---|---|---|
 | `UP0xxx` | Error | Blocking — unresolved rules, grammar violations, import failures |
-| `UP1xxx` | Warning | Compatibility behavior that is recognized and ignored / partially normalized (e.g. `UP1002` tokens block ignored, `UP1003` channels block ignored, `UP1007` rule returns ignored, `UP1020` lexer command rejected, `UP1021` option ignored) |
+| `UP1xxx` | Warning | Compatibility behavior that is recognized and ignored / partially normalized (e.g. `UP1002` tokens block ignored, `UP1003` channels block ignored, `UP1007` rule returns ignored, `UP1020` unsupported lexer command ignored, `UP1021` option ignored) |
 | `UP5xxx` | Warning | Best-effort recovery warnings (trailing tokens, ambiguity) |
 | `UP8xxx` | Info | Informational runtime events |
 | `UP9xxx` | Debug | Detailed execution traces |

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -210,7 +210,7 @@ These constructs are recognised without error but produce no runtime effect.
 | Construct | Stored where | Runtime behaviour |
 |---|---|---|
 | Rule parameters `rule[int x]` | `Rule.Parameters` as raw text | No argument passing, no typed binding, no invocation frame. |
-| Rule returns `returns [int x]` | `Rule.ReturnType` as raw text | No value extraction or propagation. |
+| Rule returns `returns [int x]` | `Rule.ReturnType` as raw text | Recognized, ignored by runtime semantics, and reported with `UP1023 RuleReturnsIgnored`. |
 | `locals [...]` | Parsed, discarded | No runtime semantics. |
 | `throws ExceptionType` | Parsed, discarded | No runtime semantics. |
 | `catch [...] {...}` / `finally {...}` | Parsed, discarded | No runtime semantics. |
@@ -251,7 +251,7 @@ These capabilities are outside the current runtime model by design. Attempting t
 | Prefix | Severity | Meaning |
 |---|---|---|
 | `UP0xxx` | Error | Blocking — unresolved rules, grammar violations, import failures |
-| `UP1xxx` | Warning | Unsupported / ignored / partial behaviour (e.g. `UP1002` tokens block ignored, `UP1003` channels block ignored, `UP1020` unsupported lexer command, `UP1021` unsupported grammar option) |
+| `UP1xxx` | Warning | Compatibility behavior that is recognized and ignored / partially normalized (e.g. `UP1002` tokens block ignored, `UP1003` channels block ignored, `UP1020` lexer command rejected, `UP1021` option ignored, `UP1023` rule returns ignored) |
 | `UP5xxx` | Warning | Best-effort recovery warnings (trailing tokens, ambiguity) |
 | `UP8xxx` | Info | Informational runtime events |
 | `UP9xxx` | Debug | Detailed execution traces |

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -210,7 +210,7 @@ These constructs are recognised without error but produce no runtime effect.
 | Construct | Stored where | Runtime behaviour |
 |---|---|---|
 | Rule parameters `rule[int x]` | `Rule.Parameters` as raw text | No argument passing, no typed binding, no invocation frame. |
-| Rule returns `returns [int x]` | `Rule.ReturnType` as raw text | Recognized, ignored by runtime semantics, and reported with `UP1023 RuleReturnsIgnored`. |
+| Rule returns `returns [int x]` | `Rule.ReturnType` as raw text | Recognized, ignored by runtime semantics, and reported with `UP1007 RuleReturnsIgnored`. |
 | `locals [...]` | Parsed, discarded | No runtime semantics. |
 | `throws ExceptionType` | Parsed, discarded | No runtime semantics. |
 | `catch [...] {...}` / `finally {...}` | Parsed, discarded | No runtime semantics. |
@@ -251,7 +251,7 @@ These capabilities are outside the current runtime model by design. Attempting t
 | Prefix | Severity | Meaning |
 |---|---|---|
 | `UP0xxx` | Error | Blocking — unresolved rules, grammar violations, import failures |
-| `UP1xxx` | Warning | Compatibility behavior that is recognized and ignored / partially normalized (e.g. `UP1002` tokens block ignored, `UP1003` channels block ignored, `UP1020` lexer command rejected, `UP1021` option ignored, `UP1023` rule returns ignored) |
+| `UP1xxx` | Warning | Compatibility behavior that is recognized and ignored / partially normalized (e.g. `UP1002` tokens block ignored, `UP1003` channels block ignored, `UP1007` rule returns ignored, `UP1020` lexer command rejected, `UP1021` option ignored) |
 | `UP5xxx` | Warning | Best-effort recovery warnings (trailing tokens, ambiguity) |
 | `UP8xxx` | Info | Informational runtime events |
 | `UP9xxx` | Debug | Detailed execution traces |

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -676,7 +676,7 @@ public sealed class Antlr4GrammarConverter
                 if (raw.Length > 0)
                 {
                     returns = [new RuleReturn(raw, raw)];
-                    _diagnostics?.AddWithContext(ParserDiagnostics.ReturnsPartiallyApplied, null, null, name, null, name);
+                    _diagnostics?.AddWithContext(ParserDiagnostics.RuleReturnsIgnored, null, null, name, null, name);
                 }
             }
         }

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -268,11 +268,11 @@ public class ParserDiagnosticsTests
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.UnsupportedAntlrLanguageOptionIgnored.Code));
     }
 
-    [TestMethod]
     /// <summary>
     /// Verifies that <c>returns [...]</c> compatibility handling is explicit and deterministic:
     /// recognized by conversion, ignored by runtime semantics, and surfaced by a stable diagnostic.
     /// </summary>
+    [TestMethod]
     public void Converter_ReturnsClause_EmitsExplicitDiagnostic()
     {
         var diagnostics = new DiagnosticBag();
@@ -288,7 +288,7 @@ public class ParserDiagnosticsTests
             .ToList();
 
         Assert.AreEqual(1, returnsDiagnostics.Count);
-        Assert.AreEqual("UP1023", returnsDiagnostics[0].Code);
+        Assert.AreEqual("UP1007", returnsDiagnostics[0].Code);
         StringAssert.Contains(returnsDiagnostics[0].Message, "recognized but ignored");
     }
 

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -269,6 +269,30 @@ public class ParserDiagnosticsTests
     }
 
     [TestMethod]
+    /// <summary>
+    /// Verifies that <c>returns [...]</c> compatibility handling is explicit and deterministic:
+    /// recognized by conversion, ignored by runtime semantics, and surfaced by a stable diagnostic.
+    /// </summary>
+    public void Converter_ReturnsClause_EmitsExplicitDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+
+            start returns [int x]
+                : 'a';
+            """, diagnostics);
+
+        var returnsDiagnostics = diagnostics
+            .Where(d => d.Code == ParserDiagnostics.RuleReturnsIgnored.Code)
+            .ToList();
+
+        Assert.AreEqual(1, returnsDiagnostics.Count);
+        Assert.AreEqual("UP1023", returnsDiagnostics[0].Code);
+        StringAssert.Contains(returnsDiagnostics[0].Message, "recognized but ignored");
+    }
+
+    [TestMethod]
     public void ValidCase_EmitsNoErrorDiagnostics()
     {
         var diagnostics = new DiagnosticBag();

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -53,7 +53,7 @@ The following constructs are recognized but not fully resolved into executable r
 | Construct | Current behavior | Limitations |
 |---|---|---|
 | Rule parameters (`rule[int x]`) | Parsed with balanced-text preservation and stored as raw metadata text (including multiline and nested generic-like syntax). | No runtime invocation semantics exist (no argument passing, no typed binding, no invocation-frame model). |
-| Rule returns (`returns [int value]`) | Recognized with balanced-text preservation and stored as raw metadata text. | Ignored by runtime return propagation semantics (no value extraction or runtime binding) and emits `RuleReturnsIgnored` (`UP1023`). |
+| Rule returns (`returns [int value]`) | Recognized with balanced-text preservation and stored as raw metadata text. | Ignored by runtime return propagation semantics (no value extraction or runtime binding) and emits `RuleReturnsIgnored` (`UP1007`). |
 
 These constructs are treated as syntax/metadata compatibility points, not as fully executable semantics.
 

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -53,7 +53,7 @@ The following constructs are recognized but not fully resolved into executable r
 | Construct | Current behavior | Limitations |
 |---|---|---|
 | Rule parameters (`rule[int x]`) | Parsed with balanced-text preservation and stored as raw metadata text (including multiline and nested generic-like syntax). | No runtime invocation semantics exist (no argument passing, no typed binding, no invocation-frame model). |
-| Rule returns (`returns [int value]`) | Parsed with balanced-text preservation and stored as raw metadata text. | No runtime return propagation semantics exist (no value extraction or runtime binding). |
+| Rule returns (`returns [int value]`) | Recognized with balanced-text preservation and stored as raw metadata text. | Ignored by runtime return propagation semantics (no value extraction or runtime binding) and emits `RuleReturnsIgnored` (`UP1023`). |
 
 These constructs are treated as syntax/metadata compatibility points, not as fully executable semantics.
 


### PR DESCRIPTION
### Motivation
- Close an ANTLR compatibility gap for `returns [...]` by making the converter classification deterministic and explicit.
- Previously the converter preserved `returns` as raw metadata while using an ambiguous descriptor name, which could be interpreted as a silent fallback.
- The change must not alter runtime/scheduler/parse-tree behavior but must surface a clear deterministic compatibility diagnostic.

### Description
- Replaced the old `ReturnsPartiallyApplied` descriptor with a new `RuleReturnsIgnored` diagnostic (`UP1007`) describing that a rule `returns` clause is "recognized but ignored by the current runtime model" (`Utils.Parser.Diagnostics/ParserDiagnostics.cs`).
- Updated the ANTLR converter to emit `ParserDiagnostics.RuleReturnsIgnored` when a non-empty `ruleReturns` block is parsed and preserved as raw text (`Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs`).
- Added a focused unit test `Converter_ReturnsClause_EmitsExplicitDiagnostic` verifying a single deterministic emission of the `UP1007` diagnostic and message wording (`UtilsTest/Parser/ParserDiagnosticsTests.cs`).
- Updated compatibility documentation to reflect the new classification and diagnostic (`Utils.Parser/ANTLRCompatibility.md` and `docs/parser/Antlr4CompatibilityMatrix.md`).

### Testing
- Ran the new targeted test with `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ParserDiagnosticsTests.Converter_ReturnsClause_EmitsExplicitDiagnostic"` and it passed (1/1).
- No other automated tests were modified or required; this change is classification-only and introduces no runtime or parse-tree behavior changes.
