### PR TITLE
ANTLR4 compatibility: explicit diagnostic for rule locals clauses (UP1008)

### DIFF
--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -91,12 +91,16 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor RuleLocalsIgnored =
         new("UP1008", "Rule locals ignored", "Rule locals clause for rule '{0}' is recognized but ignored by the current runtime model.", DefaultCategory);
 
+    /// <summary>Rule throws/catch/finally metadata recognized but ignored by runtime semantics.</summary>
+    public static readonly ParserDiagnosticDescriptor RuleExceptionMetadataIgnored =
+        new("UP1023", "Rule exception metadata ignored", "Rule exception metadata (throws/catch/finally) for rule '{0}' is recognized but ignored by the current runtime model.", DefaultCategory);
+
     /// <summary>
     /// Compatibility alias for the legacy descriptor name.
     /// </summary>
-    [System.Obsolete("Use RuleLocalsIgnored. This alias is kept for compatibility.")]
+    [System.Obsolete("Use RuleExceptionMetadataIgnored. This alias is kept for compatibility.")]
     public static readonly ParserDiagnosticDescriptor LocalsIgnored =
-        RuleLocalsIgnored;
+        RuleExceptionMetadataIgnored;
 
     /// <summary>Runtime and generator support mismatch.</summary>
     public static readonly ParserDiagnosticDescriptor RuntimeGeneratorMismatch =
@@ -242,6 +246,7 @@ public static class ParserDiagnostics
             [SemanticPredicateNotEnforced.Code] = SemanticPredicateNotEnforced,
             [RuleReturnsIgnored.Code] = RuleReturnsIgnored,
             [RuleLocalsIgnored.Code] = RuleLocalsIgnored,
+            [RuleExceptionMetadataIgnored.Code] = RuleExceptionMetadataIgnored,
             [RuntimeGeneratorMismatch.Code] = RuntimeGeneratorMismatch,
             [DirectLeftRecursionDetected.Code] = DirectLeftRecursionDetected,
             [IndirectLeftRecursionNotSupported.Code] = IndirectLeftRecursionNotSupported,

--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -98,9 +98,9 @@ public static class ParserDiagnostics
     /// <summary>
     /// Compatibility alias for the legacy descriptor name.
     /// </summary>
-    [System.Obsolete("Use RuleExceptionMetadataIgnored. This alias is kept for compatibility.")]
+    [System.Obsolete("Use RuleLocalsIgnored. This alias is kept for compatibility.")]
     public static readonly ParserDiagnosticDescriptor LocalsIgnored =
-        RuleExceptionMetadataIgnored;
+        RuleLocalsIgnored;
 
     /// <summary>Runtime and generator support mismatch.</summary>
     public static readonly ParserDiagnosticDescriptor RuntimeGeneratorMismatch =

--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -87,9 +87,16 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor ReturnsPartiallyApplied =
         RuleReturnsIgnored;
 
-    /// <summary>locals/throws/exception metadata ignored.</summary>
+    /// <summary>Rule locals clause recognized but ignored by runtime semantics.</summary>
+    public static readonly ParserDiagnosticDescriptor RuleLocalsIgnored =
+        new("UP1008", "Rule locals ignored", "Rule locals clause for rule '{0}' is recognized but ignored by the current runtime model.", DefaultCategory);
+
+    /// <summary>
+    /// Compatibility alias for the legacy descriptor name.
+    /// </summary>
+    [System.Obsolete("Use RuleLocalsIgnored. This alias is kept for compatibility.")]
     public static readonly ParserDiagnosticDescriptor LocalsIgnored =
-        new("UP1008", "Locals ignored", "locals/throws/exception metadata for rule '{0}' is parsed but ignored.", DefaultCategory);
+        RuleLocalsIgnored;
 
     /// <summary>Runtime and generator support mismatch.</summary>
     public static readonly ParserDiagnosticDescriptor RuntimeGeneratorMismatch =
@@ -234,7 +241,7 @@ public static class ParserDiagnostics
             [InlineActionStoredNotExecuted.Code] = InlineActionStoredNotExecuted,
             [SemanticPredicateNotEnforced.Code] = SemanticPredicateNotEnforced,
             [RuleReturnsIgnored.Code] = RuleReturnsIgnored,
-            [LocalsIgnored.Code] = LocalsIgnored,
+            [RuleLocalsIgnored.Code] = RuleLocalsIgnored,
             [RuntimeGeneratorMismatch.Code] = RuntimeGeneratorMismatch,
             [DirectLeftRecursionDetected.Code] = DirectLeftRecursionDetected,
             [IndirectLeftRecursionNotSupported.Code] = IndirectLeftRecursionNotSupported,

--- a/Utils.Parser.Diagnostics/README.md
+++ b/Utils.Parser.Diagnostics/README.md
@@ -48,7 +48,7 @@ All named descriptors are defined in the `ParserDiagnostics` static class and ac
 | UP1005 | `InlineActionStoredNotExecuted` | An inline `@init` / `@after` action is stored but not executed at runtime |
 | UP1006 | `SemanticPredicateNotEnforced` | A `{...}?` predicate is recognized but not evaluated; it always succeeds |
 | UP1007 | `ReturnsPartiallyApplied` | A `returns [...]` clause is parsed but stored only as raw text |
-| UP1008 | `LocalsIgnored` | `locals`, `throws`, `catch`, `finally` metadata is parsed but not applied |
+| UP1008 | `RuleLocalsIgnored` | A rule `locals [...]` clause is recognized but ignored by the current runtime model |
 | UP1009 | `RuntimeGeneratorMismatch` | A feature behaves differently between the runtime and the source generator |
 | UP1010 | `DirectLeftRecursionDetected` | Direct left recursion was detected and restructured during rule resolution |
 | UP1011 | `IndirectLeftRecursionNotSupported` | Indirect left recursion is not supported and raises `GrammarValidationException` |

--- a/Utils.Parser.Diagnostics/README.md
+++ b/Utils.Parser.Diagnostics/README.md
@@ -49,6 +49,7 @@ All named descriptors are defined in the `ParserDiagnostics` static class and ac
 | UP1006 | `SemanticPredicateNotEnforced` | A `{...}?` predicate is recognized but not evaluated; it always succeeds |
 | UP1007 | `ReturnsPartiallyApplied` | A `returns [...]` clause is parsed but stored only as raw text |
 | UP1008 | `RuleLocalsIgnored` | A rule `locals [...]` clause is recognized but ignored by the current runtime model |
+| UP1023 | `RuleExceptionMetadataIgnored` | Rule `throws` / `catch` / `finally` metadata is recognized but ignored by the current runtime model |
 | UP1009 | `RuntimeGeneratorMismatch` | A feature behaves differently between the runtime and the source generator |
 | UP1010 | `DirectLeftRecursionDetected` | Direct left recursion was detected and restructured during rule resolution |
 | UP1011 | `IndirectLeftRecursionNotSupported` | Indirect left recursion is not supported and raises `GrammarValidationException` |

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -211,7 +211,7 @@ These constructs are recognised without error but produce no runtime effect.
 |---|---|---|
 | Rule parameters `rule[int x]` | `Rule.Parameters` as raw text | No argument passing, no typed binding, no invocation frame. |
 | Rule returns `returns [int x]` | `Rule.ReturnType` as raw text | Recognized, ignored by runtime semantics, and reported with `UP1007 RuleReturnsIgnored`. |
-| `locals [...]` | Parsed, discarded | No runtime semantics. |
+| `locals [...]` | Parsed at rule level and surfaced with `UP1008 RuleLocalsIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
 | `throws ExceptionType` | Parsed, discarded | No runtime semantics. |
 | `catch [...] {...}` / `finally {...}` | Parsed, discarded | No runtime semantics. |
 | Grammar-level actions `@header`, `@members`, etc. | `ParserDefinition.Actions` | Metadata only; not executed. |

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -212,8 +212,8 @@ These constructs are recognised without error but produce no runtime effect.
 | Rule parameters `rule[int x]` | `Rule.Parameters` as raw text | No argument passing, no typed binding, no invocation frame. |
 | Rule returns `returns [int x]` | `Rule.ReturnType` as raw text | Recognized, ignored by runtime semantics, and reported with `UP1007 RuleReturnsIgnored`. |
 | `locals [...]` | Parsed at rule level and surfaced with `UP1008 RuleLocalsIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
-| `throws ExceptionType` | Parsed, discarded | No runtime semantics. |
-| `catch [...] {...}` / `finally {...}` | Parsed, discarded | No runtime semantics. |
+| `throws ExceptionType` | Parsed at rule level and surfaced with `UP1023 RuleExceptionMetadataIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
+| `catch [...] {...}` / `finally {...}` | Parsed at rule level and surfaced with `UP1023 RuleExceptionMetadataIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
 | Grammar-level actions `@header`, `@members`, etc. | `ParserDefinition.Actions` | Metadata only; not executed. |
 | Other rule actions (not `@init`/`@after`) | Parsed, discarded | `ActionIgnored` diagnostic emitted. |
 

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -684,6 +684,7 @@ public sealed class Antlr4GrammarConverter
         EmbeddedAction? initAction = null, afterAction = null;
         bool hasIgnoredRuleMetadata = false;
         bool hasRuleLocalsClause = false;
+        bool hasRuleExceptionMetadata = false;
         foreach (var prequel in All(node, "rulePrequel"))
         {
             if (First(prequel, "localsSpec") != null)
@@ -693,7 +694,10 @@ public sealed class Antlr4GrammarConverter
             }
 
             if (First(prequel, "throwsSpec") != null)
+            {
                 hasIgnoredRuleMetadata = true;
+                hasRuleExceptionMetadata = true;
+            }
 
             var ruleAction = First(prequel, "ruleAction");
             if (ruleAction == null) continue;
@@ -718,14 +722,23 @@ public sealed class Antlr4GrammarConverter
             hasRuleLocalsClause = true;
         }
 
-        if (First(node, "exceptionGroup") != null)
+        if (First(node, "throwsSpec") != null)
+        {
             hasIgnoredRuleMetadata = true;
+            hasRuleExceptionMetadata = true;
+        }
+
+        if (First(node, "exceptionGroup") != null)
+        {
+            hasIgnoredRuleMetadata = true;
+            hasRuleExceptionMetadata = true;
+        }
 
         if (hasRuleLocalsClause)
             _diagnostics?.AddWithContext(ParserDiagnostics.RuleLocalsIgnored, null, null, name, null, name);
 
-        if (hasIgnoredRuleMetadata && !hasRuleLocalsClause)
-            _diagnostics?.AddWithContext(ParserDiagnostics.LocalsIgnored, null, null, name, null, name);
+        if (hasRuleExceptionMetadata)
+            _diagnostics?.AddWithContext(ParserDiagnostics.RuleExceptionMetadataIgnored, null, null, name, null, name);
 
         var ruleBlock = Require(First(node, "ruleBlock"), "Missing ruleBlock");
         var ruleAltList = Require(First(ruleBlock, "ruleAltList"), "Missing ruleAltList");

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -683,9 +683,16 @@ public sealed class Antlr4GrammarConverter
 
         EmbeddedAction? initAction = null, afterAction = null;
         bool hasIgnoredRuleMetadata = false;
+        bool hasRuleLocalsClause = false;
         foreach (var prequel in All(node, "rulePrequel"))
         {
-            if (First(prequel, "localsSpec") != null || First(prequel, "throwsSpec") != null)
+            if (First(prequel, "localsSpec") != null)
+            {
+                hasIgnoredRuleMetadata = true;
+                hasRuleLocalsClause = true;
+            }
+
+            if (First(prequel, "throwsSpec") != null)
                 hasIgnoredRuleMetadata = true;
 
             var ruleAction = First(prequel, "ruleAction");
@@ -705,10 +712,19 @@ public sealed class Antlr4GrammarConverter
             else _diagnostics?.AddWithContext(ParserDiagnostics.ActionIgnored, null, null, name, null, $"rule action @{actionName}");
         }
 
+        if (First(node, "localsSpec") != null)
+        {
+            hasIgnoredRuleMetadata = true;
+            hasRuleLocalsClause = true;
+        }
+
         if (First(node, "exceptionGroup") != null)
             hasIgnoredRuleMetadata = true;
 
-        if (hasIgnoredRuleMetadata)
+        if (hasRuleLocalsClause)
+            _diagnostics?.AddWithContext(ParserDiagnostics.RuleLocalsIgnored, null, null, name, null, name);
+
+        if (hasIgnoredRuleMetadata && !hasRuleLocalsClause)
             _diagnostics?.AddWithContext(ParserDiagnostics.LocalsIgnored, null, null, name, null, name);
 
         var ruleBlock = Require(First(node, "ruleBlock"), "Missing ruleBlock");

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -325,7 +325,8 @@ Current clarification status:
 - converter now emits explicit diagnostics for unsupported grammar options instead of implicit acceptance,
 - `tokens` / `channels` prequel constructs now emit deterministic partial-support diagnostics during conversion,
 - labels targeting non-rule-reference elements now emit deterministic compatibility diagnostics instead of being accepted silently,
-- compatibility documentation is aligned with explicit parsed/normalized/rejected boundaries.
+- compatibility documentation is aligned with explicit parsed/normalized/rejected boundaries,
+- rule `locals [...]` clauses now emit deterministic explicit compatibility diagnostics (`UP1008 RuleLocalsIgnored`) instead of generic silent metadata discard.
 
 Goal: progressively improve ANTLR4 grammar compatibility.
 

--- a/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
@@ -401,6 +401,21 @@ public class Antlr4GrammarConverterTests
         Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleLocalsIgnored.Code));
     }
 
+
+    [TestMethod]
+    public void Converter_ThrowsClause_DoesNotEmitRuleLocalsDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start throws Exception : 'a' ;
+            """, diagnostics);
+
+        Assert.AreEqual(0, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleLocalsIgnored.Code));
+        Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleExceptionMetadataIgnored.Code));
+    }
+
     // ─── 10. Fragment rule ────────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
@@ -366,6 +366,41 @@ public class Antlr4GrammarConverterTests
             """, diagnostics));
     }
 
+
+    [TestMethod]
+    public void Converter_LocalsClause_EmitsExplicitDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start returns [int value] locals [int x] : 'a' ;
+            """, diagnostics);
+
+        var matches = diagnostics
+            .Where(d => d.Code == ParserDiagnostics.RuleLocalsIgnored.Code)
+            .ToList();
+
+        Assert.AreEqual(1, matches.Count);
+        Assert.AreEqual("UP1008", matches[0].Code);
+        StringAssert.Contains(matches[0].Message, "recognized but ignored");
+        StringAssert.Contains(matches[0].Message, "start");
+    }
+
+    [TestMethod]
+    public void Converter_ReturnsAndLocals_EmitIndependentDiagnostics()
+    {
+        var diagnostics = new DiagnosticBag();
+
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start returns [int value] locals [int x] : 'a' ;
+            """, diagnostics);
+
+        Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleReturnsIgnored.Code));
+        Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleLocalsIgnored.Code));
+    }
+
     // ─── 10. Fragment rule ────────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
@@ -416,6 +416,14 @@ public class Antlr4GrammarConverterTests
         Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleExceptionMetadataIgnored.Code));
     }
 
+
+    [TestMethod]
+    public void LocalsIgnoredAlias_PreservesLegacyCodeUp1008()
+    {
+        Assert.AreEqual("UP1008", ParserDiagnostics.LocalsIgnored.Code);
+        Assert.AreEqual(ParserDiagnostics.RuleLocalsIgnored.Code, ParserDiagnostics.LocalsIgnored.Code);
+    }
+
     // ─── 10. Fragment rule ────────────────────────────────────────────────────
 
     [TestMethod]

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -53,6 +53,7 @@ The following constructs are recognized but not fully resolved into executable r
 | Construct | Current behavior | Limitations |
 |---|---|---|
 | Rule parameters (`rule[int x]`) | Parsed with balanced-text preservation and stored as raw metadata text (including multiline and nested generic-like syntax). | No runtime invocation semantics exist (no argument passing, no typed binding, no invocation-frame model). |
+| Rule locals (`locals [int x]`) | Recognized at rule prequel parsing stage and emitted as explicit compatibility diagnostic `RuleLocalsIgnored` (`UP1008`). | Not executed, not preserved as runtime state, and no invocation frame is created. |
 | Rule returns (`returns [int value]`) | Recognized with balanced-text preservation and stored as raw metadata text. | Ignored by runtime return propagation semantics (no value extraction or runtime binding) and emits `RuleReturnsIgnored` (`UP1007`). |
 
 These constructs are treated as syntax/metadata compatibility points, not as fully executable semantics.


### PR DESCRIPTION
### Motivation
- Improve ANTLR4 compatibility by making `locals [...]` clauses explicitly recognised and diagnosable rather than silently discarded.
- Keep existing runtime semantics unchanged (no execution, no invocation frame, no scheduler/parse-tree changes).

### Description
- Introduced a dedicated diagnostic descriptor `RuleLocalsIgnored` (`UP1008`) and kept `LocalsIgnored` as an `[Obsolete]` compatibility alias in `ParserDiagnostics`.
- Added `UP1023 RuleExceptionMetadataIgnored` for `throws`/`catch`/`finally` metadata so locals and exception metadata have distinct deterministic diagnostics.
- Updated the ANTLR converter (`Antlr4GrammarConverter`) to detect `localsSpec` deterministically and emit exactly one `RuleLocalsIgnored` diagnostic per clause, and to emit `RuleExceptionMetadataIgnored` for exception-related metadata.
- Added focused tests `Converter_LocalsClause_EmitsExplicitDiagnostic` and `Converter_ReturnsAndLocals_EmitIndependentDiagnostics` to validate emission, message content, rule name presence, and independence from `returns` diagnostics. Added test to verify `throws` does not emit `RuleLocalsIgnored` and to preserve the legacy `UP1008` code.
- Updated documentation entries to reflect the new behavior in `Utils.Parser/ANTLRCompatibility.md`, `docs/parser/Antlr4CompatibilityMatrix.md`, `Utils.Parser.Diagnostics/README.md`, and added a Phase 6 note in `Utils.Parser/ROADMAP.md` about deterministic locals diagnostics.

### Testing
- Ran the targeted unit tests with `dotnet test` (filtering for the new converter tests) and all new tests passed.
- Confirmed `ParserDiagnostics` lookup remains consistent after introducing `RuleLocalsIgnored` and `RuleExceptionMetadataIgnored` by running the related diagnostic mapping test during development.
