### PR TITLE
Clarify semantic predicate runtime policy and precedence distinction

### DIFF
--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -118,7 +118,23 @@ var policy = ParserRuntimeFeaturePolicy.Default with
 var parser = new ParserEngine(definition, policy);
 ```
 
+Recognized and represented as runtime predicate objects.
+Default runtime does not evaluate predicate source code.
+When predicates are not evaluated, runtime conservatively treats them as accepted and emits `UP1006` (`SemanticPredicateNotEnforced`).
+Custom predicate evaluators may satisfy or reject predicates.
+This behavior is runtime-policy-driven, not compatibility metadata.
+
 > **Important**: memoization is keyed by `(rule, input position, precedence)`. Evaluators must be deterministic for identical invocation contexts.
+
+### Gated semantic predicates `{ condition }=>`
+
+When recognized by grammar ingestion, gated predicates are represented as runtime predicate objects and follow the same runtime-policy behavior as `{ condition }?`.
+Default behavior remains conservative acceptance with `UP1006` when not evaluated.
+
+### Precedence predicates `{precpred(_ctx, N)}?`
+
+Recognized and normalized into precedence behavior.
+Not routed through semantic predicate evaluation.
 
 ---
 
@@ -191,7 +207,7 @@ See `docs/parser/RuntimeObservationAndExportContract.md` for the full contract.
 | Feature | Limitation |
 |---|---|
 | Direct left recursion | Detected at resolution time and handled with a seed-and-extend loop, but not equivalent to all ANTLR4 left-recursive shapes. Emits `LeftRecursivePrecedencePartiallySupported` where applicable. |
-| Precedence predicates `precpred(_ctx, N)` | Regex-based extraction. Falls back to precedence `0` if the level cannot be parsed. Only recognised in direct left-recursive rules. |
+| Precedence predicates `precpred(_ctx, N)` | Regex-based extraction. Falls back to precedence `0` if the level cannot be parsed. Only recognised in direct left-recursive rules. Not routed through semantic predicate evaluation and does not emit `UP1006`. |
 | Right-associativity `<assoc=right>` | Parsed and applied during left-recursive extension. Only meaningful within direct left-recursive rules; subject to the same partial-parity limits as left recursion. |
 | Labels — `e=expr` and `ids+=ID` | Applied when the labelled item is a `RuleRef`. Labels targeting literals and other non-reference items are recognized and ignored with explicit diagnostic `UP1022 LabelOnNonRuleReferenceIgnored`. |
 | `import` | Fully resolved when grammars are compiled as a project set (`Antlr4GrammarProjectCompiler`). Single-file compilation emits `ImportParsedButNotResolved`. |

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -128,8 +128,8 @@ This behavior is runtime-policy-driven, not compatibility metadata.
 
 ### Gated semantic predicates `{ condition }=>`
 
-When recognized by grammar ingestion, gated predicates are represented as runtime predicate objects and follow the same runtime-policy behavior as `{ condition }?`.
-Default behavior remains conservative acceptance with `UP1006` when not evaluated.
+ANTLR gated predicates remain a compatibility question unless explicitly proven by converter tests.
+If recognized by grammar ingestion, they follow the same runtime-policy path as semantic predicates (`ISemanticPredicateEvaluator`), including conservative acceptance with `UP1006` when not evaluated.
 
 ### Precedence predicates `{precpred(_ctx, N)}?`
 

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -327,6 +327,7 @@ Current clarification status:
 - labels targeting non-rule-reference elements now emit deterministic compatibility diagnostics instead of being accepted silently,
 - compatibility documentation is aligned with explicit parsed/normalized/rejected boundaries,
 - rule `locals [...]` clauses now emit deterministic explicit compatibility diagnostics (`UP1008 RuleLocalsIgnored`) instead of generic silent metadata discard.
+- semantic predicate default-policy behavior is explicitly documented as runtime-policy-driven (`ISemanticPredicateEvaluator`) with deterministic `UP1006` coverage, and precedence predicates are documented separately as non-generic predicate evaluation flow.
 
 Goal: progressively improve ANTLR4 grammar compatibility.
 

--- a/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
+++ b/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
@@ -54,7 +54,6 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     [TestMethod]
     public void Parser_DefaultSemanticPredicatePolicy_EmitsUP1006()
     {
-        var diagnostics = new DiagnosticBag();
         var definition = Antlr4GrammarConverter.Parse(
             """
             grammar P;
@@ -64,10 +63,12 @@ public class ParserEngineSemanticPredicateEvaluatorTests
 
             A : 'a';
             """,
-            diagnostics: diagnostics);
-        var grammar = new CompiledGrammar(definition);
-        var result = grammar.Parse("a");
-        var semanticPredicateDiagnostics = diagnostics
+            diagnostics: null);
+        var parser = new ParserEngine(definition);
+        var lexer = new LexerEngine(definition);
+        var runtimeDiagnostics = new DiagnosticBag();
+        var result = parser.Parse(lexer.Tokenize(new StringReader("a")), diagnostics: runtimeDiagnostics);
+        var semanticPredicateDiagnostics = runtimeDiagnostics
             .Where(d => d.Code == ParserDiagnostics.SemanticPredicateNotEnforced.Code)
             .ToList();
 

--- a/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
+++ b/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using Utils.Parser.Model;
 using Utils.Parser.Runtime;
 using Utils.Parser.Resolution;
@@ -48,6 +49,63 @@ public class ParserEngineSemanticPredicateEvaluatorTests
         parser.Parse([], diagnostics: diagnostics);
 
         Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.SemanticPredicateNotEnforced.Code));
+    }
+
+    [TestMethod]
+    public void Parser_DefaultSemanticPredicatePolicy_EmitsUP1006()
+    {
+        var diagnostics = new DiagnosticBag();
+        var definition = Antlr4GrammarConverter.Parse(
+            """
+            grammar P;
+            start
+                : {allow()}? A
+                ;
+
+            A : 'a';
+            """,
+            diagnostics: diagnostics);
+        var grammar = new CompiledGrammar(definition);
+        var result = grammar.Parse("a");
+        var semanticPredicateDiagnostics = diagnostics
+            .Where(d => d.Code == ParserDiagnostics.SemanticPredicateNotEnforced.Code)
+            .ToList();
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.AreEqual(1, semanticPredicateDiagnostics.Count);
+    }
+
+    [TestMethod]
+    public void Parser_CustomPredicateEvaluator_CanRejectBranch()
+    {
+        var definition = Antlr4GrammarConverter.Parse(
+            """
+            grammar P;
+            start
+                : {allow()}? A
+                ;
+
+            A : 'a';
+            """,
+            diagnostics: null);
+
+        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Rejected));
+        var lexer = new LexerEngine(definition);
+        var result = parser.Parse(lexer.Tokenize(new StringReader("a")));
+
+        Assert.IsInstanceOfType<ErrorNode>(result);
+    }
+
+    [TestMethod]
+    public void Parser_Precpred_DoesNotEmitUP1006()
+    {
+        var diagnostics = new DiagnosticBag();
+        var startRule = CreateStartRuleWithPredicate(new PrecedencePredicate(2));
+        var definition = CreateDefinition(startRule);
+        var parser = new ParserEngine(definition);
+        parser.Parse([], diagnostics: diagnostics);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.SemanticPredicateNotEnforced.Code));
     }
 
     [TestMethod]

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -46,6 +46,14 @@ The following constructs are parsed and stored, but runtime semantic execution i
 
 Rationale: execution of user code and semantic predicates is policy-controlled. The default runtime keeps deterministic conservative behavior (not evaluated / not executed), while custom policies may alter branch acceptance and action handling within the documented runtime boundaries.
 
+### Semantic predicate and precedence predicate audit table
+
+| Construct | Parsed | Stored | Runtime evaluated | Default behavior | Diagnostic |
+|---|---|---|---|---|---|
+| `{ condition }?` | Yes | Yes (`ValidatingPredicate`) | Yes, via `ISemanticPredicateEvaluator` in `ParserRuntimeFeaturePolicy` | `NotEvaluated` is treated as accepted; parse continues conservatively | `UP1006` (`SemanticPredicateNotEnforced`) when result is `NotEvaluated` |
+| `{ condition }=>` (if recognized) | Yes | Yes (`GatingPredicate`) | Yes, via `ISemanticPredicateEvaluator` in `ParserRuntimeFeaturePolicy` | `NotEvaluated` is treated as accepted; parse continues conservatively | `UP1006` (`SemanticPredicateNotEnforced`) when result is `NotEvaluated` |
+| `precpred(_ctx, N)` | Yes | Yes (`PrecedencePredicate`) | No (not via semantic predicate evaluator) | Normalized into precedence checks (`CheckPrecedence`) | No `UP1006` emission for precedence predicates |
+
 ## Parsed but not fully resolved
 
 The following constructs are recognized but not fully resolved into executable runtime semantics.

--- a/docs/parser/INDEX.md
+++ b/docs/parser/INDEX.md
@@ -18,7 +18,7 @@ This index consolidates the parser documentation set and gives a short summary o
 ## Compatibility and analysis
 
 - [`../Utils.Parser/ANTLRCompatibility.md`](../../Utils.Parser/ANTLRCompatibility.md): Practical compatibility reference with feature-by-feature behavior notes and usage guidance for ANTLR4 constructs that differ from standard runtime semantics.
-- [`Antlr4CompatibilityMatrix.md`](./Antlr4CompatibilityMatrix.md): Current ANTLR4 feature support matrix with explicit levels (supported, partial, parsed-only, unsupported), including continuation metadata support boundaries.
+- [`Antlr4CompatibilityMatrix.md`](./Antlr4CompatibilityMatrix.md): Current ANTLR4 feature support matrix with explicit levels (supported, partial, parsed-only, unsupported), including semantic-predicate vs precedence-predicate runtime-policy distinctions and continuation metadata support boundaries.
 - [`RuntimeTraceAnalysis.md`](./RuntimeTraceAnalysis.md): Tooling-oriented analysis model for runtime traces, focused on descriptive outputs rather than runtime control.
 
 ## Maintenance rule for contributors and agents


### PR DESCRIPTION
### Motivation
- Remove ambiguity around ANTLR `{ condition }?` semantic predicates so the behavior is explicit, deterministic, and documented while preserving existing runtime authority and execution model.
- Ensure `precpred(_ctx, N)` is documented and handled as a precedence construct distinct from generic semantic-predicate evaluation. 
- Add focused test coverage to lock diagnostics emission (`UP1006`) behavior and to validate custom evaluator routing without changing scheduler or runtime architecture.

### Description
- Documented that semantic predicates are parsed/stored and routed to `ISemanticPredicateEvaluator` via `ParserRuntimeFeaturePolicy`, with the default evaluator returning `NotEvaluated` (conservative acceptance) and emitting `UP1006` (`SemanticPredicateNotEnforced`); also documented gated variant `{ condition }=>`. (`Utils.Parser/ANTLRCompatibility.md`).
- Explicitly documented that `precpred(_ctx, N)` is normalized into precedence behavior and is not evaluated by the generic semantic-predicate evaluator and does not emit `UP1006`. (`Utils.Parser/ANTLRCompatibility.md`, `docs/parser/Antlr4CompatibilityMatrix.md`).
- Added an audit table to the compatibility matrix describing parsed/stored/runtime/default/diagnostic for `{ condition }?`, `{ condition }=>` and `precpred(_ctx, N)`. (`docs/parser/Antlr4CompatibilityMatrix.md`).
- Added three targeted unit tests to lock the invariants: `Parser_DefaultSemanticPredicatePolicy_EmitsUP1006`, `Parser_CustomPredicateEvaluator_CanRejectBranch`, and `Parser_Precpred_DoesNotEmitUP1006`. (`UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs`).
- Updated the `Utils.Parser` roadmap and `docs/parser/INDEX.md` to reflect the documented default-policy behavior and the explicit precedence-vs-semantic distinction. (`Utils.Parser/ROADMAP.md`, `docs/parser/INDEX.md`).
- No runtime architecture, scheduling, ownership, execution model, or public APIs were changed; `ISemanticPredicateEvaluator` and runtime policy remain intact.

### Testing
- Added and ran the new focused test class via `dotnet test` filtering on `ParserEngineSemanticPredicateEvaluatorTests`, and the filtered tests passed (8/8 in the class) after the changes. 
- The new tests are: `Parser_DefaultSemanticPredicatePolicy_EmitsUP1006`, `Parser_CustomPredicateEvaluator_CanRejectBranch`, and `Parser_Precpred_DoesNotEmitUP1006`, all of which passed in the CI run. 
- No other runtime tests were modified; the change is documentation + tests + small compatibility-matrix updates and did not introduce failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1071bb0a4c8326afdb4df26515b59a)