### PR TITLE
docs(parser): document embedded ANTLR code execution model and project boundaries

### DIFF
--- a/Utils.Parser.Generators/README.md
+++ b/Utils.Parser.Generators/README.md
@@ -170,3 +170,8 @@ internal static partial class ExpGrammar
 ## License
 
 Apache 2.0 — see the repository root for details.
+
+
+## Embedded code note
+
+The generator currently preserves embedded ANTLR code as raw model strings. Future executable C# embedded-code support belongs to the generator path and must remain explicit. Runtime expression compilation is a separate path.

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -86,6 +86,9 @@ The `GrammarExtensionBinding` record exposes `SuperClassName`, the owning gramma
 
 ### Semantic predicates `{ condition }?`
 
+See `docs/parser/EmbeddedCodeExecutionModel.md` for the two-path execution boundary (source generation C# vs runtime expression compilation) and project responsibility map.
+
+
 **Standard ANTLR4**: The predicate body is target-language code evaluated inline during parsing.
 
 **Utils.Parser**: Predicates are parsed and stored. Evaluation is delegated to an `ISemanticPredicateEvaluator` registered in `ParserRuntimeFeaturePolicy`. The default policy returns `NotEvaluated`, which does **not** reject the branch — it acts as if the predicate passed.
@@ -140,6 +143,9 @@ Not routed through semantic predicate evaluation.
 
 ### Inline actions `{ code }`
 
+See `docs/parser/EmbeddedCodeExecutionModel.md` for explicit compiler/executor separation and non-goals.
+
+
 **Standard ANTLR4**: Action code is target-language code executed as a side effect during parsing.
 
 **Utils.Parser**: Actions are parsed and stored. Execution is delegated to an `IParserActionExecutor` registered in `ParserRuntimeFeaturePolicy`. The default policy returns `NotExecuted`.
@@ -173,6 +179,9 @@ var parser = new ParserEngine(definition, policy);
 ---
 
 ### Rule actions `@init { }` and `@after { }`
+
+See `docs/parser/EmbeddedCodeExecutionModel.md` for future-safe boundaries between stored metadata and explicit execution paths.
+
 
 **Standard ANTLR4**: `@init` runs before the rule body; `@after` runs after.
 
@@ -230,7 +239,7 @@ These constructs are recognised without error but produce no runtime effect.
 | `locals [...]` | Parsed at rule level and surfaced with `UP1008 RuleLocalsIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
 | `throws ExceptionType` | Parsed at rule level and surfaced with `UP1023 RuleExceptionMetadataIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
 | `catch [...] {...}` / `finally {...}` | Parsed at rule level and surfaced with `UP1023 RuleExceptionMetadataIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
-| Grammar-level actions `@header`, `@members`, etc. | `ParserDefinition.Actions` | Metadata only; not executed. |
+| Grammar-level actions `@header`, `@members`, etc. | `ParserDefinition.Actions` | Metadata only; not executed. See `docs/parser/EmbeddedCodeExecutionModel.md`. |
 | Other rule actions (not `@init`/`@after`) | Parsed, discarded | `ActionIgnored` diagnostic emitted. |
 
 ---

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -86,7 +86,7 @@ The `GrammarExtensionBinding` record exposes `SuperClassName`, the owning gramma
 
 ### Semantic predicates `{ condition }?`
 
-See `docs/parser/EmbeddedCodeExecutionModel.md` for the two-path execution boundary (source generation C# vs runtime expression compilation) and project responsibility map.
+See [`EmbeddedCodeExecutionModel.md`](../docs/parser/EmbeddedCodeExecutionModel.md) for the two-path execution boundary (source generation C# vs runtime expression compilation) and project responsibility map.
 
 
 **Standard ANTLR4**: The predicate body is target-language code evaluated inline during parsing.
@@ -143,7 +143,7 @@ Not routed through semantic predicate evaluation.
 
 ### Inline actions `{ code }`
 
-See `docs/parser/EmbeddedCodeExecutionModel.md` for explicit compiler/executor separation and non-goals.
+See [`EmbeddedCodeExecutionModel.md`](../docs/parser/EmbeddedCodeExecutionModel.md) for explicit compiler/executor separation and non-goals.
 
 
 **Standard ANTLR4**: Action code is target-language code executed as a side effect during parsing.
@@ -180,7 +180,7 @@ var parser = new ParserEngine(definition, policy);
 
 ### Rule actions `@init { }` and `@after { }`
 
-See `docs/parser/EmbeddedCodeExecutionModel.md` for future-safe boundaries between stored metadata and explicit execution paths.
+See [`EmbeddedCodeExecutionModel.md`](../docs/parser/EmbeddedCodeExecutionModel.md) for future-safe boundaries between stored metadata and explicit execution paths.
 
 
 **Standard ANTLR4**: `@init` runs before the rule body; `@after` runs after.
@@ -239,7 +239,7 @@ These constructs are recognised without error but produce no runtime effect.
 | `locals [...]` | Parsed at rule level and surfaced with `UP1008 RuleLocalsIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
 | `throws ExceptionType` | Parsed at rule level and surfaced with `UP1023 RuleExceptionMetadataIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
 | `catch [...] {...}` / `finally {...}` | Parsed at rule level and surfaced with `UP1023 RuleExceptionMetadataIgnored` | Recognized, ignored, not executed, and no runtime invocation frame is created. |
-| Grammar-level actions `@header`, `@members`, etc. | `ParserDefinition.Actions` | Metadata only; not executed. See `docs/parser/EmbeddedCodeExecutionModel.md`. |
+| Grammar-level actions `@header`, `@members`, etc. | `ParserDefinition.Actions` | Metadata only; not executed. See [`EmbeddedCodeExecutionModel.md`](../docs/parser/EmbeddedCodeExecutionModel.md). |
 | Other rule actions (not `@init`/`@after`) | Parsed, discarded | `ActionIgnored` diagnostic emitted. |
 
 ---

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -457,3 +457,8 @@ Future runtime PRs should include:
 ## Current safety summary
 
 The runtime currently remains conservative and deterministic. Metadata-rich infrastructure exists, but it is not execution authority. No replay, rollback, semantic-state-aware memoization, graph execution, async parsing, or parallel parsing exists today.
+
+
+### Phase 6 note — embedded code boundary
+
+Embedded ANTLR code execution model is documented as a future-safe boundary between source-generation C# and runtime expression-compilation paths, including multi-project responsibilities.

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -328,6 +328,7 @@ Current clarification status:
 - compatibility documentation is aligned with explicit parsed/normalized/rejected boundaries,
 - rule `locals [...]` clauses now emit deterministic explicit compatibility diagnostics (`UP1008 RuleLocalsIgnored`) instead of generic silent metadata discard.
 - semantic predicate default-policy behavior is explicitly documented as runtime-policy-driven (`ISemanticPredicateEvaluator`) with deterministic `UP1006` coverage, and precedence predicates are documented separately as non-generic predicate evaluation flow.
+- embedded ANTLR code execution model is documented as a future-safe boundary between source-generation C# and runtime expression-compilation paths, including multi-project responsibilities.
 
 Goal: progressively improve ANTLR4 grammar compatibility.
 
@@ -458,7 +459,3 @@ Future runtime PRs should include:
 
 The runtime currently remains conservative and deterministic. Metadata-rich infrastructure exists, but it is not execution authority. No replay, rollback, semantic-state-aware memoization, graph execution, async parsing, or parallel parsing exists today.
 
-
-### Phase 6 note — embedded code boundary
-
-Embedded ANTLR code execution model is documented as a future-safe boundary between source-generation C# and runtime expression-compilation paths, including multi-project responsibilities.

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -44,7 +44,7 @@ The following constructs are parsed and stored, but runtime semantic execution i
 | Inline actions (`{ code }`) | Yes | Yes (embedded action metadata) | No target-language semantic resolution | No by default | Parsed-but-not-executed compatibility only | `InlineActionStoredNotExecuted` |
 | Rule actions (`@init`, `@after`, unsupported action slots) | Yes | Yes (rule/action metadata) | Limited to recognized metadata slots | No | Metadata-only/ignored compatibility path | `ActionIgnored` for ignored rule or grammar action entries; `InlineActionStoredNotExecuted` when an embedded action reaches runtime policy flow |
 
-Rationale: execution of user code and semantic predicates is policy-controlled. The default runtime keeps deterministic conservative behavior (not evaluated / not executed), while custom policies may alter branch acceptance and action handling within the documented runtime boundaries.
+Rationale: execution of user code and semantic predicates is policy-controlled. The default runtime keeps deterministic conservative behavior (not evaluated / not executed), while custom policies may alter branch acceptance and action handling within the documented runtime boundaries. The architecture boundary and future two-path model are documented in `docs/parser/EmbeddedCodeExecutionModel.md`.
 
 ### Semantic predicate and precedence predicate audit table
 

--- a/docs/parser/EmbeddedCodeExecutionModel.md
+++ b/docs/parser/EmbeddedCodeExecutionModel.md
@@ -1,0 +1,334 @@
+# Embedded ANTLR Code Execution Model
+
+## 1. Introduction
+
+This document defines the architecture boundary for embedded ANTLR code in `Utils.Parser`.
+
+It is a **design and documentation** reference only. It does not introduce execution behavior changes.
+
+The goal is to maximize ANTLR compatibility while preserving runtime determinism, parser authority, and language-neutral core responsibilities.
+
+## 2. ANTLR standard behavior
+
+In standard ANTLR, embedded code is interpreted as target-language code and injected into generated lexer/parser code.
+
+Typical constructs:
+
+- semantic predicates: `{ condition }?`
+- inline parser actions: `{ code }`
+- rule actions: `@init { code }`, `@after { code }`
+- grammar actions: `@header`, `@members`, `@parser::members`, `@lexer::members`
+- lexer predicates and lexer actions
+
+Standard ANTLR semantics:
+
+- `{ code }` is emitted as target-language executable code.
+- `{ condition }?` is emitted as target-language conditional logic.
+- `@members` adds members to the generated target-language class.
+
+## 3. Current `Utils.Parser` behavior
+
+Current behavior is intentionally conservative.
+
+- Semantic predicates are recognized and routed through `ISemanticPredicateEvaluator`.
+- Inline parser actions are recognized and routed through `IParserActionExecutor`.
+- `@init` and `@after` are recognized and stored on the rule model.
+- Grammar actions are preserved as metadata only.
+- No raw embedded ANTLR target-language code is executed automatically.
+
+Important distinction:
+
+- **source-generated model construction** is already implemented;
+- **source-generated executable embedded code** is not implemented.
+
+Current generator output preserves embedded code as model metadata strings (for example `ValidatingPredicate("...")` and `EmbeddedAction("...", ...)`) and does not compile those strings to executable delegates.
+
+## 4. Two-path target architecture
+
+The target architecture uses **two implementation paths** over **one shared parser model**:
+
+1. Source-generation path (compile-time `.g4` ingestion, C# code generation).
+2. Runtime-ingestion path (runtime `.g4` ingestion with explicit expression compilation adapters).
+
+Shared expectations across both paths:
+
+- same ANTLR construct classification;
+- same model concepts;
+- same deterministic diagnostic vocabulary;
+- same runtime authority boundaries.
+
+Adapters may differ by path, but model semantics must stay aligned.
+
+## 5. Source generator C# path
+
+Pipeline:
+
+- `.g4` consumed as `AdditionalFiles` by `Utils.Parser.Generators`;
+- grammar parsed by internal G4 tokenizer/parser;
+- C# emitted by `GrammarEmitter`;
+- final compilation performed by Roslyn.
+
+Boundary rules:
+
+- executable target-language support in this path is **C#-only** initially;
+- language choice must be explicit or safely defaulted;
+- non-C# embedded target code must be diagnosed or preserved as non-executable metadata;
+- generator diagnostics must be Roslyn-visible;
+- no implicit runtime interpretation of C# source;
+- no silent execution capability.
+
+Natural ownership: build-time C# embedded-code execution support belongs to `Utils.Parser.Generators`, not `ParserEngine`.
+
+## 6. Runtime expression compiler path
+
+Pipeline:
+
+- `.g4` parsed at runtime;
+- embedded ANTLR code preserved as raw text;
+- explicit embedded-code compiler configured by policy;
+- compiler delegates to `IExpressionCompiler`;
+- expression/delegate executed through runtime policy interfaces.
+
+Conceptual mapping:
+
+- semantic predicates map to `ISemanticPredicateEvaluator`;
+- parser inline actions map to `IParserActionExecutor`.
+
+Strict rules:
+
+- no raw target-language execution;
+- no implicit language selection;
+- `IExpressionCompiler` must be explicitly injected;
+- `Utils.Parser` core must not reference `Utils.Expressions.CSyntax` or `Utils.Expressions.VBSyntax` directly.
+
+## 7. Interface boundary
+
+A future conceptual compiler boundary should be explicit and separated from runtime execution interfaces.
+
+Example conceptual interface:
+
+```csharp
+public interface IEmbeddedCodeCompiler
+{
+    CompiledSemanticPredicate CompileSemanticPredicate(
+        EmbeddedCodeSource source,
+        EmbeddedCodeCompilationContext context);
+
+    CompiledParserAction CompileParserAction(
+        EmbeddedCodeSource source,
+        EmbeddedCodeCompilationContext context);
+}
+```
+
+Separation of concerns:
+
+- compilation/preparation boundary: `IEmbeddedCodeCompiler` (future);
+- runtime evaluation boundary: `ISemanticPredicateEvaluator`;
+- runtime execution boundary: `IParserActionExecutor`.
+
+## 8. Cache boundary
+
+Allowed cache scope for future embedded-code compilation:
+
+- key: raw embedded code + compilation context;
+- value: compiled expression/delegate artifact.
+
+Example conceptual key fields:
+
+- source text;
+- construct kind;
+- expected result type;
+- compiler identity/language;
+- symbol model version.
+
+Non-goal boundary:
+
+- this compilation cache is **not** parse-result memoization;
+- no `(input position + rule) -> parse result` semantic memoization changes.
+
+## 9. Predicate vs action mapping
+
+### Semantic predicate `{ condition }?`
+
+Conceptual outcomes:
+
+- compiled boolean expression;
+- `true` -> `SemanticPredicateEvaluationResult.Satisfied`;
+- `false` -> `SemanticPredicateEvaluationResult.Rejected`;
+- unsupported/failed -> `NotEvaluated` + diagnostic.
+
+### Parser inline action `{ code }`
+
+Conceptual outcomes:
+
+- compiled action/effect expression;
+- executable path -> `ParserActionExecutionResult.Executed`;
+- unavailable/disabled path -> `ParserActionExecutionResult.NotExecuted` + diagnostic.
+
+### Rule actions `@init` / `@after`
+
+Current status:
+
+- recognized;
+- stored on `Rule.InitAction` / `Rule.AfterAction`;
+- not automatically executed.
+
+Future possibilities (separate PRs):
+
+- source generator C# hook path;
+- runtime explicit compiler + explicit runtime policy.
+
+### Grammar actions
+
+`@header`, `@members`, `@parser::members`, `@lexer::members` remain metadata-only by default.
+
+Future source generator mapping may provide C#-specific explicit hooks. Runtime ingestion must not execute raw grammar members.
+
+### Lexer actions and predicates
+
+Lexer embedded semantics are a separate, higher-risk domain because they can affect tokenization, mode transitions, channel/type behavior, and stateful lexing.
+
+They must be handled in dedicated future design/implementation work and not conflated with parser inline action support.
+
+## 10. Project responsibilities
+
+### `Utils.Parser`
+
+Responsible for:
+
+- runtime grammar ingestion;
+- embedded-code recognition/classification;
+- raw source preservation in model metadata;
+- routing via runtime policy abstractions;
+- deterministic diagnostics;
+- preserving `ParserEngine` authority.
+
+Not responsible for:
+
+- interpreting C# or VB source;
+- implicit language selection;
+- direct target-language compilation/execution;
+- hidden semantic state ownership.
+
+### `Utils.Parser.Diagnostics`
+
+Responsible for shared diagnostic descriptors across runtime and generator/tooling surfaces.
+
+Future shared embedded-code diagnostics should live here when shared by runtime and generator paths.
+
+Examples (future, not implemented in this PR):
+
+- `EmbeddedCodeLanguageUnsupported`
+- `EmbeddedCodeCompilerNotConfigured`
+- `EmbeddedCodeCompilationFailed`
+- `EmbeddedCodePreservedNotCompiled`
+- `EmbeddedCodeExecutionDisabled`
+
+### `Utils.Parser.Generators`
+
+Current responsibilities:
+
+- Roslyn source generation (`netstandard2.0` analyzer/generator project);
+- compile-time `.g4` ingestion via `AdditionalFiles`;
+- internal G4 parsing and C# emission;
+- preservation of embedded code as raw model metadata strings;
+- Roslyn diagnostic reporting.
+
+Future responsibilities (source-generation path):
+
+- C#-only executable embedded-code hooks (explicit);
+- language compatibility diagnostics;
+- clear distinction between preserved raw metadata and executable generated hooks.
+
+### `Utils.Parser.VisualStudio`
+
+Responsible for tooling and integration surfaces (diagnostic/grammar information presentation), not execution of embedded grammar code.
+
+### `Utils.Parser.VisualStudio.Worker`
+
+Responsible for isolated tooling worker scenarios and future diagnostics surfacing, not arbitrary embedded-code execution without explicit future policy.
+
+### `Utils.Expressions.*`
+
+Role:
+
+- optional expression compiler providers;
+- shared contract via `IExpressionCompiler`;
+- examples: `Utils.Expressions.CSyntax`, `Utils.Expressions.VBSyntax`.
+
+Usage rules:
+
+- injected explicitly by consumers/adapters;
+- used through contracts;
+- no direct dependency from `Utils.Parser` core.
+
+## 11. Diagnostics strategy
+
+No new diagnostics are introduced in this documentation PR.
+
+Future PRs should define shared diagnostics in `Utils.Parser.Diagnostics` so they can be used by:
+
+- runtime ingestion;
+- source generator Roslyn reporting;
+- Visual Studio/tooling display.
+
+Candidate shared diagnostics include:
+
+- embedded code language unsupported;
+- embedded code compiler not configured;
+- embedded code compilation failed;
+- embedded code preserved but not compiled;
+- embedded code execution disabled by policy.
+
+## 12. Non-goals
+
+This model explicitly excludes:
+
+- runtime C# compilation in `Utils.Parser` core;
+- implicit embedded-code language inference;
+- automatic execution of raw ANTLR target code;
+- parser scheduler changes;
+- `ParserEngine` authority transfer;
+- rollback/replay semantics;
+- hidden semantic runtime state;
+- parse-tree shape changes;
+- direct `Utils.Parser` dependency on `Utils.Expressions.CSyntax` or `Utils.Expressions.VBSyntax`;
+- implementation changes in this PR.
+
+## 13. Future PR plan
+
+### PR 1 — Documentation/design (current PR)
+
+- document model, boundaries, and project responsibilities;
+- no behavior change.
+
+### PR 2 — Diagnostics taxonomy
+
+- add shared embedded-code diagnostics;
+- no execution behavior added.
+
+### PR 3 — Runtime predicate adapter prototype
+
+- map `IExpressionCompiler` into `ISemanticPredicateEvaluator` for `{ condition }?`;
+- outcomes:
+  - `true` -> `Satisfied`
+  - `false` -> `Rejected`
+  - failed/unsupported -> `NotEvaluated` + diagnostic.
+
+### PR 4 — Runtime parser inline action adapter
+
+- map `IExpressionCompiler` into `IParserActionExecutor` for `{ code }`;
+- define allowed side-effects, mutable context boundaries, idempotence expectations, and backtracking caveats.
+
+### PR 5 — Source generator C# path
+
+- add explicit C# embedded-code hook support in generator path;
+- define language option handling;
+- support C# only initially;
+- report Roslyn diagnostics for unsupported/invalid embedded code;
+- document generated hook shape.
+
+### PR 6 — Lexer actions/predicates
+
+- separate design and implementation;
+- account for tokenization and lexer state impact.

--- a/docs/parser/INDEX.md
+++ b/docs/parser/INDEX.md
@@ -17,6 +17,7 @@ This index consolidates the parser documentation set and gives a short summary o
 
 ## Compatibility and analysis
 
+- [`EmbeddedCodeExecutionModel.md`](./EmbeddedCodeExecutionModel.md): Architecture boundary for ANTLR embedded code, including current behavior, future two-path model (source generation C# vs runtime expression compilation), cache limits, and multi-project responsibilities.
 - [`../Utils.Parser/ANTLRCompatibility.md`](../../Utils.Parser/ANTLRCompatibility.md): Practical compatibility reference with feature-by-feature behavior notes and usage guidance for ANTLR4 constructs that differ from standard runtime semantics.
 - [`Antlr4CompatibilityMatrix.md`](./Antlr4CompatibilityMatrix.md): Current ANTLR4 feature support matrix with explicit levels (supported, partial, parsed-only, unsupported), including semantic-predicate vs precedence-predicate runtime-policy distinctions and continuation metadata support boundaries.
 - [`RuntimeTraceAnalysis.md`](./RuntimeTraceAnalysis.md): Tooling-oriented analysis model for runtime traces, focused on descriptive outputs rather than runtime control.


### PR DESCRIPTION
### Motivation

- Clarify how embedded ANTLR target-language code (predicates, inline actions, rule/grammar members, lexer actions) must be handled by `Utils.Parser` without changing runtime behavior or public APIs. 
- Provide a future-safe architecture that separates build-time C# source-generation concerns from runtime expression-compilation concerns while preserving a single shared parser model and deterministic diagnostics. 
- Make the multi-project responsibilities explicit so future implementation PRs can target the correct project (`Generators` vs runtime adapters) and avoid accidental dependencies on `Utils.Expressions.*` from core parser code. 

### Description

- Added `docs/parser/EmbeddedCodeExecutionModel.md` describing current behavior, ANTLR standard semantics, a two-path architecture (source-generator C# path vs runtime expression-compiler path), interface/cache boundaries, predicate/action mapping, lexer risks, non-goals, and a phased PR plan. 
- Updated `docs/parser/INDEX.md` to reference the new document and added cross-links from `Utils.Parser/ANTLRCompatibility.md` and `docs/parser/Antlr4CompatibilityMatrix.md` to point readers to the execution-model guidance. 
- Appended a short note to `Utils.Parser.Generators/README.md` and added a Phase 6 note to `Utils.Parser/ROADMAP.md` to reflect the documented boundary and generator ownership for build-time C# embedded-code hooks. 
- Preserved the stated constraints and non-goals (no runtime C# compilation in core, no implicit language inference, no automatic execution of raw ANTLR code, no parser-engine or scheduler changes) so this PR remains documentation/design-only. 

### Testing

- No automated tests were added because this PR is documentation-only and does not change runtime or generator behavior. 
- Existing test suite and runtime behavior remain authoritative and unchanged. 
- Roadmap and parser documentation indexes were updated in the same change to satisfy repository documentation rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127d64767883269ab80778d3bb1495)