### PR TITLE
Add embedded ANTLR code diagnostics taxonomy descriptors

### DIFF
--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -154,6 +154,25 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor UnsupportedAntlrOptionIgnored =
         new("UP1021", "ANTLR option ignored", "ANTLR option '{0}' is currently unsupported and will be ignored.", DefaultCategory);
 
+    /// <summary>Embedded ANTLR code language is not supported in the current execution path.</summary>
+    public static readonly ParserDiagnosticDescriptor EmbeddedCodeLanguageUnsupported =
+        new("UP1024", "Embedded code language unsupported", "Embedded ANTLR code language '{0}' is not supported in the current execution path.", DefaultCategory);
+
+    /// <summary>Embedded ANTLR code requires a compiler, but no compiler is configured.</summary>
+    public static readonly ParserDiagnosticDescriptor EmbeddedCodeCompilerNotConfigured =
+        new("UP1025", "Embedded code compiler not configured", "Embedded ANTLR code for '{0}' requires an explicit embedded-code compiler, but none was configured.", DefaultCategory);
+
+    /// <summary>Embedded ANTLR code compilation failed for the requested construct.</summary>
+    public static readonly ParserDiagnosticDescriptor EmbeddedCodeCompilationFailed =
+        new("UP1026", "Embedded code compilation failed", "Embedded ANTLR code for '{0}' could not be compiled: {1}", DefaultCategory);
+
+    /// <summary>Embedded ANTLR code is preserved as metadata and not compiled in the current execution path.</summary>
+    public static readonly ParserDiagnosticDescriptor EmbeddedCodePreservedNotCompiled =
+        new("UP1027", "Embedded code preserved and not compiled", "Embedded ANTLR code for '{0}' is preserved as metadata and is not compiled in the current execution path.", DefaultCategory);
+
+    /// <summary>Embedded ANTLR code execution is disabled by the current runtime policy.</summary>
+    public static readonly ParserDiagnosticDescriptor EmbeddedCodeExecutionDisabled =
+        new("UP1028", "Embedded code execution disabled", "Embedded ANTLR code execution for '{0}' is disabled by the current runtime policy.", DefaultCategory);
     /// <summary>Label parsed on a non-rule-ref element and ignored.</summary>
     public static readonly ParserDiagnosticDescriptor LabelOnNonRuleReferenceIgnored =
         new("UP1022", "Label ignored on non-rule reference", "Label '{0}' is recognized but ignored because it targets a non-rule-reference element.", DefaultCategory);
@@ -247,6 +266,11 @@ public static class ParserDiagnostics
             [RuleReturnsIgnored.Code] = RuleReturnsIgnored,
             [RuleLocalsIgnored.Code] = RuleLocalsIgnored,
             [RuleExceptionMetadataIgnored.Code] = RuleExceptionMetadataIgnored,
+            [EmbeddedCodeLanguageUnsupported.Code] = EmbeddedCodeLanguageUnsupported,
+            [EmbeddedCodeCompilerNotConfigured.Code] = EmbeddedCodeCompilerNotConfigured,
+            [EmbeddedCodeCompilationFailed.Code] = EmbeddedCodeCompilationFailed,
+            [EmbeddedCodePreservedNotCompiled.Code] = EmbeddedCodePreservedNotCompiled,
+            [EmbeddedCodeExecutionDisabled.Code] = EmbeddedCodeExecutionDisabled,
             [RuntimeGeneratorMismatch.Code] = RuntimeGeneratorMismatch,
             [DirectLeftRecursionDetected.Code] = DirectLeftRecursionDetected,
             [IndirectLeftRecursionNotSupported.Code] = IndirectLeftRecursionNotSupported,

--- a/Utils.Parser.Diagnostics/README.md
+++ b/Utils.Parser.Diagnostics/README.md
@@ -103,6 +103,19 @@ These codes are emitted only when a `DiagnosticBag` is passed to the parse call;
 | UP9005 | `ParserStateRejected` | A parser state was rejected by a safety guard |
 | UP5006 | `DefaultBehaviorApplied` | A grammar construct fell back to a default behavior |
 
+
+## Embedded ANTLR code diagnostics
+
+Shared embedded-code diagnostics are available for runtime, generator, and tooling boundaries:
+
+- `UP1024 EmbeddedCodeLanguageUnsupported`
+- `UP1025 EmbeddedCodeCompilerNotConfigured`
+- `UP1026 EmbeddedCodeCompilationFailed`
+- `UP1027 EmbeddedCodePreservedNotCompiled`
+- `UP1028 EmbeddedCodeExecutionDisabled`
+
+These diagnostics describe language support, compilation, and execution boundaries for embedded ANTLR code. They do not imply embedded-code execution is implemented.
+
 ## Related packages
 
 - `omy.Utils.Parser`

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -88,6 +88,8 @@ The `GrammarExtensionBinding` record exposes `SuperClassName`, the owning gramma
 
 See [`EmbeddedCodeExecutionModel.md`](../docs/parser/EmbeddedCodeExecutionModel.md) for the two-path execution boundary (source generation C# vs runtime expression compilation) and project responsibility map.
 
+The shared embedded-code diagnostics taxonomy is documented in `EmbeddedCodeExecutionModel.md` and `ParserDiagnostics`.
+
 
 **Standard ANTLR4**: The predicate body is target-language code evaluated inline during parsing.
 

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -147,6 +147,7 @@ Scope:
 
 Current clarification status:
 
+- shared embedded-code diagnostic taxonomy is defined for future runtime, generator, and tooling paths without enabling execution.
 - local alternative comparison order is explicitly documented (longest match, then priority, then declaration order),
 - pruning is explicitly documented as orchestration-only and non-syntax-authoritative,
 - structural branch equivalence limits are explicitly documented as conservative and non-semantic-proof.

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -147,7 +147,6 @@ Scope:
 
 Current clarification status:
 
-- shared embedded-code diagnostic taxonomy is defined for future runtime, generator, and tooling paths without enabling execution.
 - local alternative comparison order is explicitly documented (longest match, then priority, then declaration order),
 - pruning is explicitly documented as orchestration-only and non-syntax-authoritative,
 - structural branch equivalence limits are explicitly documented as conservative and non-semantic-proof.
@@ -330,6 +329,7 @@ Current clarification status:
 - rule `locals [...]` clauses now emit deterministic explicit compatibility diagnostics (`UP1008 RuleLocalsIgnored`) instead of generic silent metadata discard.
 - semantic predicate default-policy behavior is explicitly documented as runtime-policy-driven (`ISemanticPredicateEvaluator`) with deterministic `UP1006` coverage, and precedence predicates are documented separately as non-generic predicate evaluation flow.
 - embedded ANTLR code execution model is documented as a future-safe boundary between source-generation C# and runtime expression-compilation paths, including multi-project responsibilities.
+- shared embedded-code diagnostic taxonomy is defined for future runtime, generator, and tooling paths without enabling execution.
 
 Goal: progressively improve ANTLR4 grammar compatibility.
 

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -398,4 +398,29 @@ public class ParserDiagnosticsTests
         Assert.IsNotNull(grammar);
         Assert.AreEqual("G", grammar.Name);
     }
+    [TestMethod]
+    public void ParserDiagnostics_EmbeddedCodeDescriptors_HaveStableCodes()
+    {
+        Assert.AreEqual("UP1024", ParserDiagnostics.EmbeddedCodeLanguageUnsupported.Code);
+        Assert.AreEqual("UP1025", ParserDiagnostics.EmbeddedCodeCompilerNotConfigured.Code);
+        Assert.AreEqual("UP1026", ParserDiagnostics.EmbeddedCodeCompilationFailed.Code);
+        Assert.AreEqual("UP1027", ParserDiagnostics.EmbeddedCodePreservedNotCompiled.Code);
+        Assert.AreEqual("UP1028", ParserDiagnostics.EmbeddedCodeExecutionDisabled.Code);
+    }
+
+    [TestMethod]
+    public void ParserDiagnostics_AllDescriptors_HaveUniqueCodesAndNonEmptyMetadata()
+    {
+        var descriptors = ParserDiagnostics.All.Values.ToList();
+
+        Assert.AreEqual(descriptors.Count, descriptors.Select(static descriptor => descriptor.Code).Distinct().Count());
+
+        foreach (var descriptor in descriptors)
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(descriptor.Code));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(descriptor.Title));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(descriptor.MessageFormat));
+        }
+    }
+
 }

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -398,6 +398,7 @@ public class ParserDiagnosticsTests
         Assert.IsNotNull(grammar);
         Assert.AreEqual("G", grammar.Name);
     }
+
     [TestMethod]
     public void ParserDiagnostics_EmbeddedCodeDescriptors_HaveStableCodes()
     {

--- a/UtilsTest/Parser/ParserDiagnosticsTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticsTests.cs
@@ -9,6 +9,7 @@ using Utils.Parser.Runtime;
 using System.IO;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace UtilsTest.Parser;
 
@@ -412,15 +413,23 @@ public class ParserDiagnosticsTests
     [TestMethod]
     public void ParserDiagnostics_AllDescriptors_HaveUniqueCodesAndNonEmptyMetadata()
     {
-        var descriptors = ParserDiagnostics.All.Values.ToList();
+        var descriptors = typeof(ParserDiagnostics)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(static field => field.FieldType == typeof(ParserDiagnosticDescriptor))
+            .Select(static field => (ParserDiagnosticDescriptor)field.GetValue(null)!)
+            .Distinct()
+            .ToList();
 
-        Assert.AreEqual(descriptors.Count, descriptors.Select(static descriptor => descriptor.Code).Distinct().Count());
+        Assert.AreEqual(
+            descriptors.Count,
+            descriptors.Select(static descriptor => descriptor.Code).Distinct(StringComparer.Ordinal).Count());
 
         foreach (var descriptor in descriptors)
         {
             Assert.IsFalse(string.IsNullOrWhiteSpace(descriptor.Code));
             Assert.IsFalse(string.IsNullOrWhiteSpace(descriptor.Title));
             Assert.IsFalse(string.IsNullOrWhiteSpace(descriptor.MessageFormat));
+            Assert.IsTrue(ParserDiagnostics.All.ContainsKey(descriptor.Code));
         }
     }
 

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -153,3 +153,6 @@ However, invocation memoization remains keyed by `(rule, input position, precede
 Parser invocation reuse is currently keyed by rule, input position, and precedence.
 This model currently assumes policy handlers are deterministic for equivalent invocations and does not include evaluator/executor external state in the memoization key.
 Custom policies should therefore avoid invocation-count-dependent decisions and externally observable mutable semantic state.
+
+
+> Future embedded-code execution paths will use the shared diagnostics taxonomy documented in `EmbeddedCodeExecutionModel.md`.

--- a/docs/parser/EmbeddedCodeExecutionModel.md
+++ b/docs/parser/EmbeddedCodeExecutionModel.md
@@ -216,13 +216,15 @@ Responsible for shared diagnostic descriptors across runtime and generator/tooli
 
 Future shared embedded-code diagnostics should live here when shared by runtime and generator paths.
 
-Examples (future, not implemented in this PR):
+The shared embedded-code diagnostic taxonomy is:
 
-- `EmbeddedCodeLanguageUnsupported`
-- `EmbeddedCodeCompilerNotConfigured`
-- `EmbeddedCodeCompilationFailed`
-- `EmbeddedCodePreservedNotCompiled`
-- `EmbeddedCodeExecutionDisabled`
+- `UP1024 EmbeddedCodeLanguageUnsupported`
+- `UP1025 EmbeddedCodeCompilerNotConfigured`
+- `UP1026 EmbeddedCodeCompilationFailed`
+- `UP1027 EmbeddedCodePreservedNotCompiled`
+- `UP1028 EmbeddedCodeExecutionDisabled`
+
+These diagnostics define future capability boundaries. They may be emitted by runtime ingestion, source generator reporting, or tooling adapters. This PR defines the taxonomy only and does not change behavior.
 
 ### `Utils.Parser.Generators`
 


### PR DESCRIPTION
### Motivation
- Define a stable, shared diagnostic vocabulary for future embedded ANTLR code support so runtime, source-generator, and tooling adapters can reference the same descriptors without changing runtime behavior. 
- Prepare the parser diagnostics surface to express language/compilation/execution boundaries for embedded code without wiring execution or adding new dependencies.

### Description
- Added five public diagnostic descriptors in `Utils.Parser.Diagnostics.ParserDiagnostics`: `UP1024`..`UP1028` as `EmbeddedCodeLanguageUnsupported`, `EmbeddedCodeCompilerNotConfigured`, `EmbeddedCodeCompilationFailed`, `EmbeddedCodePreservedNotCompiled`, and `EmbeddedCodeExecutionDisabled`, and registered them in `ParserDiagnostics.All` for catalog access. 
- Added tests in `UtilsTest/Parser/ParserDiagnosticsTests.cs`: `ParserDiagnostics_EmbeddedCodeDescriptors_HaveStableCodes` and `ParserDiagnostics_AllDescriptors_HaveUniqueCodesAndNonEmptyMetadata` to verify descriptor codes, accessibility, uniqueness, and non-empty metadata. 
- Updated documentation to make the embedded-code diagnostics taxonomy normative and to clarify this PR is taxonomy-only: `docs/parser/EmbeddedCodeExecutionModel.md`, `Utils.Parser.Diagnostics/README.md`, `Utils.Parser/ANTLRCompatibility.md`, `docs/parser/Antlr4CompatibilityMatrix.md`, and `Utils.Parser/ROADMAP.md` were updated with the taxonomy and guidance. 
- No behavioral changes were introduced: no runtime execution, no generator execution changes, no Scheduler/ParserEngine changes, no expression compiler adapters, and no new project dependencies.

### Testing
- Ran `dotnet test UtilsTest/UtilsTest.csproj --filter "ParserDiagnosticsTests.ParserDiagnostics_EmbeddedCodeDescriptors_HaveStableCodes|ParserDiagnosticsTests.ParserDiagnostics_AllDescriptors_HaveUniqueCodesAndNonEmptyMetadata"` and both added tests passed. 
- An initial test run failed due to a temporary test property name mismatch (`MessageTemplate` vs `MessageFormat`), which was corrected and re-run; the final automated test run succeeded for the new tests. 
- The change includes a catalog integrity test that asserts all `ParserDiagnostics.All` descriptor codes are unique and that each descriptor has non-empty `Code`, `Title`, and `MessageFormat` fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a128273153c83269dc16278aebd1e68)