### PR TITLE
Enrich semantic predicate evaluation with structured outcomes and diagnostics

### DIFF
--- a/Utils.Parser.Expressions/ExpressionSemanticPredicateEvaluator.cs
+++ b/Utils.Parser.Expressions/ExpressionSemanticPredicateEvaluator.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using Utils.Expressions;
+using Utils.Parser.Diagnostics;
 using Utils.Parser.Runtime;
 
 namespace Utils.Parser.Expressions;
@@ -25,64 +26,59 @@ public sealed class ExpressionSemanticPredicateEvaluator : ISemanticPredicateEva
         };
 
     private readonly IExpressionCompiler _compiler;
-    private readonly ConcurrentDictionary<string, Func<bool>?> _compiledPredicateByCode = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, SemanticPredicateEvaluationOutcome> _compiledPredicateByCode = new(StringComparer.Ordinal);
 
-    /// <summary>
-    /// Initializes a new evaluator that compiles semantic predicate source code with the provided compiler.
-    /// </summary>
-    /// <param name="compiler">Expression compiler used to compile predicate source code.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="compiler"/> is <c>null</c>.</exception>
     public ExpressionSemanticPredicateEvaluator(IExpressionCompiler compiler)
     {
         _compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
     }
 
-    /// <inheritdoc />
-    public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+    public SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        var compiledPredicate = UsesContextualSymbols(context.PredicateCode)
-            ? CompilePredicate(context.PredicateCode, context)
-            : _compiledPredicateByCode.GetOrAdd(context.PredicateCode, code => CompilePredicate(code, context));
-
-        if (compiledPredicate is null)
+        if (UsesContextualSymbols(context.PredicateCode))
         {
-            return SemanticPredicateEvaluationResult.NotEvaluated;
+            return CompilePredicate(context.PredicateCode, context);
         }
 
-        return compiledPredicate() ? SemanticPredicateEvaluationResult.Satisfied : SemanticPredicateEvaluationResult.Rejected;
+        return _compiledPredicateByCode.GetOrAdd(context.PredicateCode, code => CompilePredicate(code, context));
     }
 
-    private Func<bool>? CompilePredicate(string predicateCode, SemanticPredicateEvaluationContext context)
+    private SemanticPredicateEvaluationOutcome CompilePredicate(string predicateCode, SemanticPredicateEvaluationContext context)
     {
         try
         {
             var symbols = BuildSymbols(context);
             var expression = _compiler.Compile(predicateCode, symbols);
-
             if (expression.Type != typeof(bool))
             {
-                return null;
+                return SemanticPredicateEvaluationOutcome.NotEvaluated(
+                    ParserDiagnostics.EmbeddedCodeCompilationFailed,
+                    null,
+                    "semantic predicate",
+                    $"Expected Boolean result, got {expression.Type.Name}.");
             }
 
-            return Expression.Lambda<Func<bool>>(expression).Compile();
+            return Expression.Lambda<Func<bool>>(expression).Compile()()
+                ? SemanticPredicateEvaluationOutcome.Satisfied
+                : SemanticPredicateEvaluationOutcome.Rejected;
         }
-        catch
+        catch (Exception exception)
         {
-            return null;
+            return SemanticPredicateEvaluationOutcome.NotEvaluated(
+                ParserDiagnostics.EmbeddedCodeCompilationFailed,
+                exception,
+                "semantic predicate",
+                exception.Message);
         }
     }
 
-    private static bool UsesContextualSymbols(string predicateCode)
-    {
-        return ContextSymbolRegex.IsMatch(predicateCode);
-    }
+    private static bool UsesContextualSymbols(string predicateCode) => ContextSymbolRegex.IsMatch(predicateCode);
 
     private static IReadOnlyDictionary<string, Expression> BuildSymbols(SemanticPredicateEvaluationContext context)
     {
         var symbols = new Dictionary<string, Expression>(SymbolFactoryByName.Count, StringComparer.Ordinal);
-
         foreach (var symbolEntry in SymbolFactoryByName)
         {
             symbols[symbolEntry.Key] = symbolEntry.Value(context);

--- a/Utils.Parser.Expressions/ExpressionSemanticPredicateEvaluator.cs
+++ b/Utils.Parser.Expressions/ExpressionSemanticPredicateEvaluator.cs
@@ -26,26 +26,33 @@ public sealed class ExpressionSemanticPredicateEvaluator : ISemanticPredicateEva
         };
 
     private readonly IExpressionCompiler _compiler;
-    private readonly ConcurrentDictionary<string, SemanticPredicateEvaluationOutcome> _compiledPredicateByCode = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Func<SemanticPredicateEvaluationOutcome>> _compiledPredicateByCode = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Initializes a new evaluator that compiles semantic predicate source code with the provided compiler.
+    /// </summary>
+    /// <param name="compiler">Expression compiler used to compile predicate source code.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="compiler"/> is <c>null</c>.</exception>
     public ExpressionSemanticPredicateEvaluator(IExpressionCompiler compiler)
     {
         _compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
     }
 
+    /// <inheritdoc />
     public SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
 
         if (UsesContextualSymbols(context.PredicateCode))
         {
-            return CompilePredicate(context.PredicateCode, context);
+            return CompilePredicate(context.PredicateCode, context)();
         }
 
-        return _compiledPredicateByCode.GetOrAdd(context.PredicateCode, code => CompilePredicate(code, context));
+        var evaluator = _compiledPredicateByCode.GetOrAdd(context.PredicateCode, code => CompilePredicate(code, context));
+        return evaluator();
     }
 
-    private SemanticPredicateEvaluationOutcome CompilePredicate(string predicateCode, SemanticPredicateEvaluationContext context)
+    private Func<SemanticPredicateEvaluationOutcome> CompilePredicate(string predicateCode, SemanticPredicateEvaluationContext context)
     {
         try
         {
@@ -53,20 +60,21 @@ public sealed class ExpressionSemanticPredicateEvaluator : ISemanticPredicateEva
             var expression = _compiler.Compile(predicateCode, symbols);
             if (expression.Type != typeof(bool))
             {
-                return SemanticPredicateEvaluationOutcome.NotEvaluated(
+                return () => SemanticPredicateEvaluationOutcome.NotEvaluated(
                     ParserDiagnostics.EmbeddedCodeCompilationFailed,
                     null,
                     "semantic predicate",
                     $"Expected Boolean result, got {expression.Type.Name}.");
             }
 
-            return Expression.Lambda<Func<bool>>(expression).Compile()()
+            var compiledPredicate = Expression.Lambda<Func<bool>>(expression).Compile();
+            return () => compiledPredicate()
                 ? SemanticPredicateEvaluationOutcome.Satisfied
                 : SemanticPredicateEvaluationOutcome.Rejected;
         }
         catch (Exception exception)
         {
-            return SemanticPredicateEvaluationOutcome.NotEvaluated(
+            return () => SemanticPredicateEvaluationOutcome.NotEvaluated(
                 ParserDiagnostics.EmbeddedCodeCompilationFailed,
                 exception,
                 "semantic predicate",

--- a/Utils.Parser.Expressions/README.md
+++ b/Utils.Parser.Expressions/README.md
@@ -28,3 +28,5 @@ var parser = new ParserEngine(definition, policy);
 - Predicates that do not reference contextual symbols are cached by predicate source code.
 - Predicates referencing `ruleName`, `inputPosition`, `alternativeIndex`, or `elementIndex` are recompiled per evaluation to avoid capturing runtime context.
 - Does not evaluate lexer predicates or lexer actions.
+
+- Compilation failures and non-boolean expression results are surfaced as structured `NotEvaluated` outcomes with `UP1026` metadata; `ParserEngine` emits diagnostics when a `DiagnosticBag` is provided.

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -93,7 +93,7 @@ The shared embedded-code diagnostics taxonomy is documented in `EmbeddedCodeExec
 
 **Standard ANTLR4**: The predicate body is target-language code evaluated inline during parsing.
 
-**Utils.Parser**: Predicates are parsed and stored. Evaluation is delegated to an `ISemanticPredicateEvaluator` registered in `ParserRuntimeFeaturePolicy`. The default policy returns `NotEvaluated`, which does **not** reject the branch — it acts as if the predicate passed.
+**Utils.Parser**: Predicates are parsed and stored. Evaluation is delegated to an `ISemanticPredicateEvaluator` registered in `ParserRuntimeFeaturePolicy`. The default policy returns `NotEvaluated` without detailed diagnostic metadata, which does **not** reject the branch — it acts as if the predicate passed and `ParserEngine` emits `UP1006`.
 An optional expression-backed evaluator can be configured explicitly (for example through `omy.Utils.Parser.Expressions`) to enforce predicate outcomes when a consumer provides an `IExpressionCompiler`.
 
 **Usage** — implement `ISemanticPredicateEvaluator` and pass it via the policy:

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -57,6 +57,7 @@ Current capabilities and responsibilities:
 - Passive runtime observation hooks are available via policy configuration and remain non-authoritative.
 - Semantic predicate evaluator abstraction is present.
 - Runtime expression-backed semantic predicate evaluator is available as an explicit optional adapter without changing default parser behavior.
+- Semantic predicate evaluation now returns structured outcomes so `ParserEngine` can emit fallback `UP1006` or detailed embedded-code diagnostics such as `UP1026` without giving evaluators direct `DiagnosticBag` access.
 - Parser action executor abstraction is present.
 - Continuation metadata is present.
 - Shared-prefix metadata is present.

--- a/Utils.Parser/Runtime/DefaultSemanticPredicateEvaluator.cs
+++ b/Utils.Parser/Runtime/DefaultSemanticPredicateEvaluator.cs
@@ -2,13 +2,13 @@ namespace Utils.Parser.Runtime;
 
 /// <summary>
 /// Default evaluator that preserves conservative legacy behavior by not evaluating
-/// semantic predicate source code and returning <see cref="SemanticPredicateEvaluationResult.NotEvaluated"/>.
+/// semantic predicate source code and returning <see cref="SemanticPredicateEvaluationStatus.NotEvaluated"/>.
 /// </summary>
 internal sealed class DefaultSemanticPredicateEvaluator : ISemanticPredicateEvaluator
 {
     /// <inheritdoc />
-    public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+    public SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context)
     {
-        return SemanticPredicateEvaluationResult.NotEvaluated;
+        return SemanticPredicateEvaluationOutcome.NotEvaluated();
     }
 }

--- a/Utils.Parser/Runtime/ISemanticPredicateEvaluator.cs
+++ b/Utils.Parser/Runtime/ISemanticPredicateEvaluator.cs
@@ -12,5 +12,5 @@ public interface ISemanticPredicateEvaluator
     /// <param name="context">Predicate metadata and parser location.</param>
     /// <returns>Evaluation outcome controlling branch acceptance.
     /// Implementations are expected to remain deterministic for identical invocation context when memoization is enabled.</returns>
-    SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context);
+    SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context);
 }

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -24,7 +24,7 @@ namespace Utils.Parser.Runtime;
 /// and embedded actions (<see cref="EmbeddedAction"/>) are controlled by the configured
 /// <see cref="ParserRuntimeFeaturePolicy"/>.
 /// The default policy preserves conservative behavior:
-/// semantic predicates return <see cref="SemanticPredicateEvaluationResult.NotEvaluated"/>
+/// semantic predicates return <see cref="SemanticPredicateEvaluationStatus.NotEvaluated"/>
 /// and parser actions return <see cref="ParserActionExecutionResult.NotExecuted"/>.
 /// Custom injected policies may reject alternatives and may execute action handlers,
 /// which can influence parse outcomes.
@@ -664,17 +664,31 @@ public sealed class ParserEngine
             elementIndex);
 
         var evaluation = _semanticPredicateEvaluator.Evaluate(evaluationContext);
-        switch (evaluation)
+        switch (evaluation.Status)
         {
-            case SemanticPredicateEvaluationResult.Satisfied:
+            case SemanticPredicateEvaluationStatus.Satisfied:
                 return CreateEmptyNode(context, rule);
-            case SemanticPredicateEvaluationResult.Rejected:
+            case SemanticPredicateEvaluationStatus.Rejected:
                 return null;
-            case SemanticPredicateEvaluationResult.NotEvaluated:
-                diagnostics?.AddWithContext(ParserDiagnostics.SemanticPredicateNotEnforced, null, null, rule.Name, null);
+            case SemanticPredicateEvaluationStatus.NotEvaluated:
+                if (evaluation.Diagnostic is null)
+                {
+                    diagnostics?.AddWithContext(ParserDiagnostics.SemanticPredicateNotEnforced, null, null, rule.Name, null);
+                }
+                else
+                {
+                    diagnostics?.AddWithContext(
+                        evaluation.Diagnostic,
+                        null,
+                        null,
+                        rule.Name,
+                        evaluation.Exception,
+                        evaluation.DiagnosticArguments.ToArray());
+                }
+
                 return CreateEmptyNode(context, rule);
             default:
-                throw new InvalidOperationException($"Unsupported semantic predicate evaluation result: {evaluation}.");
+                throw new InvalidOperationException($"Unsupported semantic predicate evaluation status: {evaluation.Status}.");
         }
     }
 

--- a/Utils.Parser/Runtime/SemanticPredicateEvaluationOutcome.cs
+++ b/Utils.Parser/Runtime/SemanticPredicateEvaluationOutcome.cs
@@ -1,0 +1,87 @@
+using Utils.Parser.Diagnostics;
+
+namespace Utils.Parser.Runtime;
+
+/// <summary>
+/// Represents a semantic predicate evaluation outcome with optional diagnostic metadata.
+/// </summary>
+public sealed record SemanticPredicateEvaluationOutcome
+{
+    /// <summary>
+    /// Initializes a new semantic predicate evaluation outcome.
+    /// </summary>
+    /// <param name="status">Evaluation status.</param>
+    /// <param name="diagnostic">Optional diagnostic descriptor to emit from parser runtime.</param>
+    /// <param name="exception">Optional exception associated with the evaluation attempt.</param>
+    /// <param name="diagnosticArguments">Optional diagnostic formatting arguments.</param>
+    public SemanticPredicateEvaluationOutcome(
+        SemanticPredicateEvaluationStatus status,
+        ParserDiagnosticDescriptor? diagnostic = null,
+        Exception? exception = null,
+        IReadOnlyList<object?>? diagnosticArguments = null)
+    {
+        Status = status;
+        Diagnostic = diagnostic;
+        Exception = exception;
+        DiagnosticArguments = diagnosticArguments ?? [];
+    }
+
+    /// <summary>
+    /// Gets the evaluation status.
+    /// </summary>
+    public SemanticPredicateEvaluationStatus Status { get; }
+
+    /// <summary>
+    /// Gets an optional diagnostic descriptor.
+    /// </summary>
+    public ParserDiagnosticDescriptor? Diagnostic { get; }
+
+    /// <summary>
+    /// Gets optional diagnostic arguments. Never <c>null</c>.
+    /// </summary>
+    public IReadOnlyList<object?> DiagnosticArguments { get; }
+
+    /// <summary>
+    /// Gets an optional exception that can be attached to diagnostics.
+    /// </summary>
+    public Exception? Exception { get; }
+
+    /// <summary>
+    /// Gets a successful predicate outcome.
+    /// </summary>
+    public static SemanticPredicateEvaluationOutcome Satisfied { get; } = new(SemanticPredicateEvaluationStatus.Satisfied);
+
+    /// <summary>
+    /// Gets a rejected predicate outcome.
+    /// </summary>
+    public static SemanticPredicateEvaluationOutcome Rejected { get; } = new(SemanticPredicateEvaluationStatus.Rejected);
+
+    /// <summary>
+    /// Creates a conservative non-evaluated outcome with no detailed diagnostic metadata.
+    /// </summary>
+    /// <returns>Non-evaluated outcome without explicit diagnostic.</returns>
+    public static SemanticPredicateEvaluationOutcome NotEvaluated()
+    {
+        return new SemanticPredicateEvaluationOutcome(SemanticPredicateEvaluationStatus.NotEvaluated);
+    }
+
+    /// <summary>
+    /// Creates a non-evaluated outcome with explicit diagnostic metadata.
+    /// </summary>
+    /// <param name="diagnostic">Diagnostic descriptor to emit.</param>
+    /// <param name="exception">Optional evaluation exception.</param>
+    /// <param name="diagnosticArguments">Optional diagnostic formatting arguments.</param>
+    /// <returns>Non-evaluated outcome with detailed diagnostic metadata.</returns>
+    public static SemanticPredicateEvaluationOutcome NotEvaluated(
+        ParserDiagnosticDescriptor diagnostic,
+        Exception? exception,
+        params object?[] diagnosticArguments)
+    {
+        ArgumentNullException.ThrowIfNull(diagnostic);
+        return new SemanticPredicateEvaluationOutcome(
+            SemanticPredicateEvaluationStatus.NotEvaluated,
+            diagnostic,
+            exception,
+            diagnosticArguments);
+    }
+}

--- a/Utils.Parser/Runtime/SemanticPredicateEvaluationResult.cs
+++ b/Utils.Parser/Runtime/SemanticPredicateEvaluationResult.cs
@@ -1,9 +1,9 @@
 namespace Utils.Parser.Runtime;
 
 /// <summary>
-/// Represents the outcome of a semantic predicate evaluation.
+/// Represents the status of a semantic predicate evaluation.
 /// </summary>
-public enum SemanticPredicateEvaluationResult
+public enum SemanticPredicateEvaluationStatus
 {
     /// <summary>
     /// The predicate passed and the parser may continue.
@@ -16,7 +16,7 @@ public enum SemanticPredicateEvaluationResult
     Rejected,
 
     /// <summary>
-    /// The predicate was intentionally not evaluated by policy.
+    /// The predicate was not evaluated by runtime policy.
     /// </summary>
     NotEvaluated
 }

--- a/UtilsTest/Parser/ANTLRCompatibilityDocTests.cs
+++ b/UtilsTest/Parser/ANTLRCompatibilityDocTests.cs
@@ -162,7 +162,7 @@ public class ANTLRCompatibilityDocTests
         var evaluator = new CapturingPredicateEvaluator(ctx =>
         {
             capturedCode = ctx.PredicateCode;
-            return SemanticPredicateEvaluationResult.NotEvaluated;
+            return SemanticPredicateEvaluationOutcome.NotEvaluated();
         });
         var policy = ParserRuntimeFeaturePolicy.Default with
         {
@@ -191,7 +191,7 @@ public class ANTLRCompatibilityDocTests
         {
             capturedRule = ctx.Rule;
             capturedPosition = ctx.InputPosition;
-            return SemanticPredicateEvaluationResult.Satisfied;
+            return SemanticPredicateEvaluationOutcome.Satisfied;
         });
         var policy = ParserRuntimeFeaturePolicy.Default with
         {
@@ -594,10 +594,10 @@ public class ANTLRCompatibilityDocTests
     }
 
     private sealed class CapturingPredicateEvaluator(
-        Func<SemanticPredicateEvaluationContext, SemanticPredicateEvaluationResult> evaluate)
+        Func<SemanticPredicateEvaluationContext, SemanticPredicateEvaluationOutcome> evaluate)
         : ISemanticPredicateEvaluator
     {
-        public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+        public SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context)
             => evaluate(context);
     }
 

--- a/UtilsTest/Parser/ExpressionSemanticPredicateEvaluatorTests.cs
+++ b/UtilsTest/Parser/ExpressionSemanticPredicateEvaluatorTests.cs
@@ -20,7 +20,7 @@ public class ExpressionSemanticPredicateEvaluatorTests
 
         var result = evaluator.Evaluate(CreateContext("true"));
 
-        Assert.AreEqual(SemanticPredicateEvaluationResult.Satisfied, result);
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.Satisfied, result.Status);
     }
 
     [TestMethod]
@@ -30,7 +30,7 @@ public class ExpressionSemanticPredicateEvaluatorTests
 
         var result = evaluator.Evaluate(CreateContext("false"));
 
-        Assert.AreEqual(SemanticPredicateEvaluationResult.Rejected, result);
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.Rejected, result.Status);
     }
 
     [TestMethod]
@@ -40,7 +40,7 @@ public class ExpressionSemanticPredicateEvaluatorTests
 
         var result = evaluator.Evaluate(CreateContext("ruleName == \"start\""));
 
-        Assert.AreEqual(SemanticPredicateEvaluationResult.Satisfied, result);
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.Satisfied, result.Status);
     }
 
     [TestMethod]
@@ -50,7 +50,7 @@ public class ExpressionSemanticPredicateEvaluatorTests
 
         var result = evaluator.Evaluate(CreateContext("throw"));
 
-        Assert.AreEqual(SemanticPredicateEvaluationResult.NotEvaluated, result);
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.NotEvaluated, result.Status);
     }
 
     [TestMethod]
@@ -60,7 +60,7 @@ public class ExpressionSemanticPredicateEvaluatorTests
 
         var result = evaluator.Evaluate(CreateContext("42"));
 
-        Assert.AreEqual(SemanticPredicateEvaluationResult.NotEvaluated, result);
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.NotEvaluated, result.Status);
     }
 
     [TestMethod]
@@ -83,8 +83,8 @@ public class ExpressionSemanticPredicateEvaluatorTests
         var firstResult = evaluator.Evaluate(CreateContext("ruleName == \"start\"", "start"));
         var secondResult = evaluator.Evaluate(CreateContext("ruleName == \"start\"", "other"));
 
-        Assert.AreEqual(SemanticPredicateEvaluationResult.Satisfied, firstResult);
-        Assert.AreEqual(SemanticPredicateEvaluationResult.Rejected, secondResult);
+        Assert.AreEqual(SemanticPredicateEvaluationOutcome.Satisfied, firstResult);
+        Assert.AreEqual(SemanticPredicateEvaluationOutcome.Rejected, secondResult);
     }
 
     private static SemanticPredicateEvaluationContext CreateContext(string predicateCode, string ruleName = "start")

--- a/UtilsTest/Parser/ExpressionSemanticPredicateEvaluatorTests.cs
+++ b/UtilsTest/Parser/ExpressionSemanticPredicateEvaluatorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq.Expressions;
 using Utils.Expressions;
+using Utils.Parser.Diagnostics;
 using Utils.Parser.Expressions;
 using Utils.Parser.Model;
 using Utils.Parser.Runtime;
@@ -63,6 +64,48 @@ public class ExpressionSemanticPredicateEvaluatorTests
         Assert.AreEqual(SemanticPredicateEvaluationStatus.NotEvaluated, result.Status);
     }
 
+
+    [TestMethod]
+    public void Evaluate_WhenCachedPredicateDelegateIsReused_ReevaluatesPredicateEachTime()
+    {
+        var compiler = new FakeExpressionCompiler();
+        var evaluator = new ExpressionSemanticPredicateEvaluator(compiler);
+
+        var firstResult = evaluator.Evaluate(CreateContext("toggle"));
+        var secondResult = evaluator.Evaluate(CreateContext("toggle"));
+
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.Satisfied, firstResult.Status);
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.Rejected, secondResult.Status);
+        Assert.AreEqual(1, compiler.CompileCount);
+    }
+
+    [TestMethod]
+    public void Evaluate_WhenCompilationThrows_PreservesEmbeddedCodeDiagnosticDetails()
+    {
+        var evaluator = new ExpressionSemanticPredicateEvaluator(new FakeExpressionCompiler());
+
+        var result = evaluator.Evaluate(CreateContext("throw"));
+
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.NotEvaluated, result.Status);
+        Assert.AreEqual(ParserDiagnostics.EmbeddedCodeCompilationFailed, result.Diagnostic);
+        Assert.IsNotNull(result.Exception);
+        CollectionAssert.AreEqual(new object?[] { "semantic predicate", "boom" }, result.DiagnosticArguments.ToArray());
+    }
+
+    [TestMethod]
+    public void Evaluate_WhenExpressionIsNotBoolean_PreservesEmbeddedCodeDiagnosticDetails()
+    {
+        var evaluator = new ExpressionSemanticPredicateEvaluator(new FakeExpressionCompiler());
+
+        var result = evaluator.Evaluate(CreateContext("42"));
+
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.NotEvaluated, result.Status);
+        Assert.AreEqual(ParserDiagnostics.EmbeddedCodeCompilationFailed, result.Diagnostic);
+        Assert.IsNull(result.Exception);
+        Assert.AreEqual("semantic predicate", result.DiagnosticArguments[0]);
+        StringAssert.Contains((string)result.DiagnosticArguments[1]!, "Expected Boolean result");
+    }
+
     [TestMethod]
     public void Evaluate_WhenPredicateIsReused_UsesCompilationCache()
     {
@@ -117,6 +160,8 @@ public class ExpressionSemanticPredicateEvaluatorTests
         public int CompileCount { get; private set; }
 
         /// <inheritdoc />
+        private bool _toggleState;
+
         public Expression Compile(string content, IReadOnlyDictionary<string, Expression>? symbols = null)
         {
             CompileCount++;
@@ -133,8 +178,15 @@ public class ExpressionSemanticPredicateEvaluatorTests
                     Expression.Constant(0, typeof(int))),
                 "42" => Expression.Constant(42),
                 "throw" => throw new InvalidOperationException("boom"),
+                "toggle" => Expression.Call(Expression.Constant(this), nameof(NextToggleResult), Type.EmptyTypes),
                 _ => Expression.Constant(true)
             };
+        }
+
+        private bool NextToggleResult()
+        {
+            _toggleState = !_toggleState;
+            return _toggleState;
         }
     }
 }

--- a/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
+++ b/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
@@ -19,7 +19,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     {
         var startRule = CreateStartRuleWithPredicate(new ValidatingPredicate("canProceed"));
         var definition = CreateDefinition(startRule);
-        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Rejected));
+        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected));
 
         var result = parser.Parse([]);
 
@@ -31,7 +31,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     {
         var startRule = CreateStartRuleWithPredicate(new GatingPredicate("canProceed"));
         var definition = CreateDefinition(startRule);
-        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Satisfied));
+        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied));
 
         var result = parser.Parse([]);
 
@@ -43,7 +43,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     {
         var startRule = CreateStartRuleWithPredicate(new ValidatingPredicate("canProceed"));
         var definition = CreateDefinition(startRule);
-        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.NotEvaluated));
+        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.NotEvaluated()));
         var diagnostics = new DiagnosticBag();
 
         parser.Parse([], diagnostics: diagnostics);
@@ -90,7 +90,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
             """,
             diagnostics: null);
 
-        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Rejected));
+        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected));
         var lexer = new LexerEngine(definition);
         var result = parser.Parse(lexer.Tokenize(new StringReader("a")));
 
@@ -139,7 +139,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
             ParserRules: [startRule],
             RootRule: startRule));
 
-        var observer = new ObservingSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Satisfied);
+        var observer = new ObservingSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied);
         var tokens = new List<Token>
         {
             new(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")
@@ -167,7 +167,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
 
         var grammar = new CompiledGrammar(
             definition,
-            new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Rejected));
+            new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected));
 
         var result = grammar.Parse("a");
 
@@ -211,19 +211,19 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     /// </summary>
     private sealed class ConstantSemanticPredicateEvaluator : ISemanticPredicateEvaluator
     {
-        private readonly SemanticPredicateEvaluationResult _result;
+        private readonly SemanticPredicateEvaluationOutcome _result;
 
         /// <summary>
         /// Initializes the evaluator.
         /// </summary>
         /// <param name="result">Result returned by <see cref="Evaluate"/>.</param>
-        public ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult result)
+        public ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome result)
         {
             _result = result;
         }
 
         /// <inheritdoc />
-        public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+        public SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context)
         {
             return _result;
         }
@@ -234,13 +234,13 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     /// </summary>
     private sealed class ObservingSemanticPredicateEvaluator : ISemanticPredicateEvaluator
     {
-        private readonly SemanticPredicateEvaluationResult _result;
+        private readonly SemanticPredicateEvaluationOutcome _result;
 
         /// <summary>
         /// Initializes the evaluator.
         /// </summary>
         /// <param name="result">Result returned by <see cref="Evaluate"/>.</param>
-        public ObservingSemanticPredicateEvaluator(SemanticPredicateEvaluationResult result)
+        public ObservingSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome result)
         {
             _result = result;
         }
@@ -251,7 +251,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
         public SemanticPredicateEvaluationContext? LastContext { get; private set; }
 
         /// <inheritdoc />
-        public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+        public SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context)
         {
             LastContext = context;
             return _result;

--- a/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
+++ b/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
@@ -1,10 +1,13 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq.Expressions;
 using System.IO;
 using Utils.Parser.Model;
 using Utils.Parser.Runtime;
 using Utils.Parser.Resolution;
+using Utils.Expressions;
 using Utils.Parser.Diagnostics;
 using Utils.Parser.Bootstrap;
+using Utils.Parser.Expressions;
 
 namespace UtilsTest.Parser;
 
@@ -97,6 +100,37 @@ public class ParserEngineSemanticPredicateEvaluatorTests
         Assert.IsInstanceOfType<ErrorNode>(result);
     }
 
+
+    [TestMethod]
+    public void Parser_ExpressionEvaluator_WhenCompilationThrows_EmitsUP1026WithoutUP1006()
+    {
+        var definition = CreateSemanticPredicateGrammarDefinition();
+        var parser = new ParserEngine(definition, new ExpressionSemanticPredicateEvaluator(new ThrowingExpressionCompiler()));
+        var lexer = new LexerEngine(definition);
+        var diagnostics = new DiagnosticBag();
+
+        var result = parser.Parse(lexer.Tokenize(new StringReader("a")), diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.EmbeddedCodeCompilationFailed.Code));
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.SemanticPredicateNotEnforced.Code));
+    }
+
+    [TestMethod]
+    public void Parser_ExpressionEvaluator_WhenExpressionIsNotBoolean_EmitsUP1026WithoutUP1006()
+    {
+        var definition = CreateSemanticPredicateGrammarDefinition();
+        var parser = new ParserEngine(definition, new ExpressionSemanticPredicateEvaluator(new NonBooleanExpressionCompiler()));
+        var lexer = new LexerEngine(definition);
+        var diagnostics = new DiagnosticBag();
+
+        var result = parser.Parse(lexer.Tokenize(new StringReader("a")), diagnostics: diagnostics);
+
+        Assert.IsInstanceOfType<ParserNode>(result);
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.EmbeddedCodeCompilationFailed.Code));
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.SemanticPredicateNotEnforced.Code));
+    }
+
     [TestMethod]
     public void Parser_Precpred_DoesNotEmitUP1006()
     {
@@ -172,6 +206,17 @@ public class ParserEngineSemanticPredicateEvaluatorTests
         var result = grammar.Parse("a");
 
         Assert.IsInstanceOfType<ErrorNode>(result);
+    }
+
+    private static ParserDefinition CreateSemanticPredicateGrammarDefinition()
+    {
+        return Antlr4GrammarConverter.Parse(
+            """
+            grammar P;
+            start : {allow()}? A ;
+            A : 'a' ;
+            """,
+            diagnostics: null);
     }
 
     private static Rule CreateStartRuleWithPredicate(RuleContent predicate)
@@ -255,6 +300,22 @@ public class ParserEngineSemanticPredicateEvaluatorTests
         {
             LastContext = context;
             return _result;
+        }
+    }
+
+    private sealed class ThrowingExpressionCompiler : IExpressionCompiler
+    {
+        public Expression Compile(string content, IReadOnlyDictionary<string, Expression>? symbols = null)
+        {
+            throw new InvalidOperationException("boom");
+        }
+    }
+
+    private sealed class NonBooleanExpressionCompiler : IExpressionCompiler
+    {
+        public Expression Compile(string content, IReadOnlyDictionary<string, Expression>? symbols = null)
+        {
+            return Expression.Constant(42);
         }
     }
 }

--- a/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
@@ -30,7 +30,7 @@ public class ParserRuntimeFeaturePolicyTests
     public void ParserEngine_ExistingOverloads_ProduceEquivalentPolicies()
     {
         var definition = CreateMinimalDefinition();
-        var evaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Satisfied);
+        var evaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied);
         var executor = new ConstantParserActionExecutor(ParserActionExecutionResult.Executed);
 
         var evaluatorOnly = new ParserEngine(definition, evaluator);
@@ -54,7 +54,7 @@ public class ParserRuntimeFeaturePolicyTests
     public void ParserRuntimeFeaturePolicy_CustomStrategies_ArePropagated()
     {
         var definition = CreateMinimalDefinition();
-        var evaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult.Satisfied);
+        var evaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied);
         var executor = new ConstantParserActionExecutor(ParserActionExecutionResult.Executed);
         var policy = ParserRuntimeFeaturePolicy.Default with
         {
@@ -146,13 +146,13 @@ public class ParserRuntimeFeaturePolicyTests
     /// </summary>
     private sealed class ConstantSemanticPredicateEvaluator : ISemanticPredicateEvaluator
     {
-        private readonly SemanticPredicateEvaluationResult _result;
+        private readonly SemanticPredicateEvaluationOutcome _result;
 
         /// <summary>
         /// Initializes the evaluator with the configured evaluation result.
         /// </summary>
         /// <param name="result">Result returned for all predicate evaluations.</param>
-        public ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationResult result)
+        public ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome result)
         {
             _result = result;
         }
@@ -162,7 +162,7 @@ public class ParserRuntimeFeaturePolicyTests
         /// </summary>
         /// <param name="context">Semantic predicate evaluation context.</param>
         /// <returns>The configured result.</returns>
-        public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+        public SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context)
         {
             return _result;
         }

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -37,7 +37,7 @@ public class ParserRuntimeInvariantTests
                 new Alternative(1, Associativity.Left, new RuleRef("sub"))
             ]));
         var definition = CreateDefinition(startRule, [subRule], LexerRule("A", "a"), LexerRule("B", "b"));
-        var evaluator = new CountingPredicateEvaluator(SemanticPredicateEvaluationResult.Satisfied);
+        var evaluator = new CountingPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied);
         var parser = new ParserEngine(definition, evaluator, new CountingActionExecutor(ParserActionExecutionResult.NotExecuted));
 
         var result = parser.Parse([Token("A", "a")]);
@@ -87,7 +87,7 @@ public class ParserRuntimeInvariantTests
                 new Alternative(1, Associativity.Left, new RuleRef("A"))
             ]));
         var definition = CreateDefinition(startRule, LexerRule("A", "a"), LexerRule("B", "b"));
-        var evaluator = new CountingPredicateEvaluator(SemanticPredicateEvaluationResult.Satisfied);
+        var evaluator = new CountingPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied);
         var parser = new ParserEngine(definition, evaluator, new CountingActionExecutor(ParserActionExecutionResult.NotExecuted));
         var diagnostics = new DiagnosticBag();
 
@@ -115,7 +115,7 @@ public class ParserRuntimeInvariantTests
                 new Alternative(1, Associativity.Left, new RuleRef("A"))
             ]));
         var definition = CreateDefinition(startRule, LexerRule("A", "a"), LexerRule("B", "b"));
-        var evaluator = new CountingPredicateEvaluator(SemanticPredicateEvaluationResult.Rejected);
+        var evaluator = new CountingPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected);
         var parser = new ParserEngine(definition, evaluator, new CountingActionExecutor(ParserActionExecutionResult.NotExecuted));
         var diagnostics = new DiagnosticBag();
 
@@ -596,16 +596,16 @@ public class ParserRuntimeInvariantTests
 
     private sealed class CountingPredicateEvaluator : ISemanticPredicateEvaluator
     {
-        private readonly SemanticPredicateEvaluationResult _result;
+        private readonly SemanticPredicateEvaluationOutcome _result;
 
-        public CountingPredicateEvaluator(SemanticPredicateEvaluationResult result)
+        public CountingPredicateEvaluator(SemanticPredicateEvaluationOutcome result)
         {
             _result = result;
         }
 
         public int EvaluationCount { get; private set; }
 
-        public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+        public SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context)
         {
             EvaluationCount++;
             return _result;

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -40,7 +40,7 @@ The following constructs are parsed and stored, but runtime semantic execution i
 
 | Construct | Parsed | Stored | Resolved | Executable | Runtime-supported | Diagnostics |
 |---|---|---|---|---|---|---|
-| Semantic predicates (`{ condition }?`) | Yes | Yes (predicate metadata) | Partially (policy-routed) | Policy-dependent only | Policy-routed: conservative by default (`NotEvaluated`), with optional expression-backed evaluator when explicitly configured | `SemanticPredicateNotEnforced` when evaluator returns `NotEvaluated` |
+| Semantic predicates (`{ condition }?`) | Yes | Yes (predicate metadata) | Partially (policy-routed) | Policy-dependent only | Policy-routed: conservative by default (`NotEvaluated`), with optional expression-backed evaluator when explicitly configured | `SemanticPredicateNotEnforced` (`UP1006`) when evaluator returns `NotEvaluated` without detailed metadata; `UP1026` when an expression-backed evaluator returns a detailed compile/type-failure outcome |
 | Inline actions (`{ code }`) | Yes | Yes (embedded action metadata) | No target-language semantic resolution | No by default | Parsed-but-not-executed compatibility only | `InlineActionStoredNotExecuted` |
 | Rule actions (`@init`, `@after`, unsupported action slots) | Yes | Yes (rule/action metadata) | Limited to recognized metadata slots | No | Metadata-only/ignored compatibility path | `ActionIgnored` for ignored rule or grammar action entries; `InlineActionStoredNotExecuted` when an embedded action reaches runtime policy flow |
 

--- a/docs/parser/EmbeddedCodeExecutionModel.md
+++ b/docs/parser/EmbeddedCodeExecutionModel.md
@@ -105,7 +105,7 @@ Strict rules:
 Prototype status update:
 
 - A first optional runtime adapter now exists to map `IExpressionCompiler` to `ISemanticPredicateEvaluator` for semantic predicates (`{ condition }?`).
-- Default parser runtime behavior is unchanged (`NotEvaluated` with `UP1006` when applicable).
+- Default parser runtime behavior is unchanged (`NotEvaluated` with `UP1006` when applicable). Expression-backed semantic predicate evaluation now returns a structured outcome so compilation failures and non-boolean expression results can carry `UP1026` metadata, while `ParserEngine` remains the only component that emits diagnostics.
 - Current adapter scope is limited to parser semantic predicates only.
 - Inline parser actions, lexer actions, lexer predicates, and grammar members remain outside this runtime adapter.
 - The symbol model is intentionally minimal and read-only (`ruleName`, `inputPosition`, `alternativeIndex`, `elementIndex`).


### PR DESCRIPTION
### Motivation
- Replace the coarse `SemanticPredicateEvaluationResult` enum with a structured outcome so evaluators can convey both decision and reason without writing diagnostics directly. 
- Allow `ParserEngine` to remain the single owner of diagnostic emission while enabling expression-backed evaluators to surface compilation/type failures (e.g. `UP1026`).
- Preserve conservative default behavior (existing `UP1006` fallback) while enabling finer-grained diagnostics from evaluators when appropriate.

### Description
- Introduced `SemanticPredicateEvaluationOutcome` (immutable record) carrying `Status` (`SemanticPredicateEvaluationStatus`), optional `ParserDiagnosticDescriptor`, optional `Exception`, and `DiagnosticArguments`; added factory helpers `Satisfied`, `Rejected`, `NotEvaluated()` and `NotEvaluated(diagnostic, exception, params)`.
- Renamed the former enum to `SemanticPredicateEvaluationStatus` (`Satisfied`, `Rejected`, `NotEvaluated`) and changed `ISemanticPredicateEvaluator` to return `SemanticPredicateEvaluationOutcome`.
- Updated `ParserEngine.EvaluateSemanticPredicate` to switch on `evaluation.Status` and: emit the legacy `UP1006` (`SemanticPredicateNotEnforced`) when `NotEvaluated` without diagnostic metadata, or emit the evaluator-provided diagnostic (and pass exception / arguments) when the outcome carries one; parse-effect behavior remains conservative.
- Updated `DefaultSemanticPredicateEvaluator` to return `SemanticPredicateEvaluationOutcome.NotEvaluated()` (no detailed diagnostic) to preserve legacy `UP1006` emission by `ParserEngine`.
- Enhanced `ExpressionSemanticPredicateEvaluator` to return structured outcomes: `Satisfied` / `Rejected` for boolean results, `NotEvaluated(ParserDiagnostics.EmbeddedCodeCompilationFailed, exception, ...)` for compilation exceptions, and `NotEvaluated(ParserDiagnostics.EmbeddedCodeCompilationFailed, null, "semantic predicate", "Expected Boolean result...")` for non-boolean results; caching behavior preserved for non-contextual predicates.
- Updated unit/integration tests and parser docs to reflect the new API and diagnostic flow; docs updated include `docs/parser/EmbeddedCodeExecutionModel.md`, `Utils.Parser/ANTLRCompatibility.md`, `docs/parser/Antlr4CompatibilityMatrix.md`, `Utils.Parser.Expressions/README.md`, and `Utils.Parser/ROADMAP.md`.
- Preserved constraints: evaluators do not receive or mutate `DiagnosticBag`, `ParserEngine` remains diagnostic owner, no scheduler/generator/lexer/action/runtime semantics changes.

### Testing
- Built `Utils.Parser.Expressions` successfully with `dotnet build Utils.Parser.Expressions/Utils.Parser.Expressions.csproj` (OK).
- Ran targeted test suite for the changed areas with `dotnet test UtilsTest/UtilsTest.csproj --filter "FullyQualifiedName~ExpressionSemanticPredicateEvaluatorTests|FullyQualifiedName~ParserEngineSemanticPredicateEvaluatorTests"`; the filtered tests passed (Passed: 15, Failed: 0).
- Note: an initial `dotnet test --no-restore` attempt failed in this environment due to missing restore assets (environment-specific); subsequent restore/build+test runs for the scoped tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12bbfa0ce08326bd24d96849d1b6db)