### PR TITLE
docs(parser): align outcome names and clarify diagnostics taxonomy

### DIFF
--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -182,7 +182,10 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor BestEffortRecoveryUsed =
         new("UP5001", "Best-effort recovery used", "Best-effort recovery was used while parsing '{0}'.", DefaultCategory);
 
-    /// <summary>Expected token missing.</summary>
+    /// <summary>
+    /// Expected token missing.
+    /// Currently reserved for missing-token recovery diagnostics.
+    /// </summary>
     public static readonly ParserDiagnosticDescriptor ExpectedTokenMissing =
         new("UP5002", "Expected token missing", "Expected token '{0}' was not found.", DefaultCategory);
 
@@ -244,6 +247,10 @@ public static class ParserDiagnostics
     /// <summary>
     /// Gets all known parser diagnostics keyed by code.
     /// </summary>
+    /// <remarks>
+    /// Compatibility aliases such as ReturnsPartiallyApplied and LocalsIgnored are intentionally not
+    /// listed separately because <see cref="All"/> is keyed by diagnostic code and exposes canonical descriptors.
+    /// </remarks>
     public static IReadOnlyDictionary<string, ParserDiagnosticDescriptor> All { get; } =
         new Dictionary<string, ParserDiagnosticDescriptor>
         {

--- a/Utils.Parser.Diagnostics/README.md
+++ b/Utils.Parser.Diagnostics/README.md
@@ -45,7 +45,7 @@ All named descriptors are defined in the `ParserDiagnostics` static class and ac
 | UP1002 | `TokensBlockIgnored` | A `tokens { ... }` block is recognized but not mapped into the model |
 | UP1003 | `ChannelsBlockIgnored` | A `channels { ... }` block is recognized but not mapped into the model |
 | UP1004 | `ActionIgnored` | A top-level `@...` action block is recognized but not executed |
-| UP1005 | `InlineActionStoredNotExecuted` | An inline `@init` / `@after` action is stored but not executed at runtime |
+| UP1005 | `InlineActionStoredNotExecuted` | An inline parser action is stored but not executed at runtime |
 | UP1006 | `SemanticPredicateNotEnforced` | A `{...}?` predicate is recognized but not evaluated; it always succeeds |
 | UP1007 | `RuleReturnsIgnored` | A `returns [...]` clause is parsed but stored only as raw text (`ReturnsPartiallyApplied` is a compatibility alias) |
 | UP1008 | `RuleLocalsIgnored` | A rule `locals [...]` clause is recognized but ignored by the current runtime model |

--- a/Utils.Parser.Diagnostics/README.md
+++ b/Utils.Parser.Diagnostics/README.md
@@ -47,7 +47,7 @@ All named descriptors are defined in the `ParserDiagnostics` static class and ac
 | UP1004 | `ActionIgnored` | A top-level `@...` action block is recognized but not executed |
 | UP1005 | `InlineActionStoredNotExecuted` | An inline `@init` / `@after` action is stored but not executed at runtime |
 | UP1006 | `SemanticPredicateNotEnforced` | A `{...}?` predicate is recognized but not evaluated; it always succeeds |
-| UP1007 | `ReturnsPartiallyApplied` | A `returns [...]` clause is parsed but stored only as raw text |
+| UP1007 | `RuleReturnsIgnored` | A `returns [...]` clause is parsed but stored only as raw text (`ReturnsPartiallyApplied` is a compatibility alias) |
 | UP1008 | `RuleLocalsIgnored` | A rule `locals [...]` clause is recognized but ignored by the current runtime model |
 | UP1023 | `RuleExceptionMetadataIgnored` | Rule `throws` / `catch` / `finally` metadata is recognized but ignored by the current runtime model |
 | UP1009 | `RuntimeGeneratorMismatch` | A feature behaves differently between the runtime and the source generator |
@@ -68,7 +68,7 @@ All named descriptors are defined in the `ParserDiagnostics` static class and ac
 | Code | Name | Trigger |
 |---|---|---|
 | UP5001 | `BestEffortRecoveryUsed` | Best-effort recovery was applied during parsing |
-| UP5002 | `ExpectedTokenMissing` | An expected token was absent |
+| UP5002 | `ExpectedTokenMissing` | Reserved for missing-token recovery diagnostics when an expected token is absent |
 | UP5003 | `FallbackStrategyUsed` | A fallback parsing strategy was activated |
 | UP5004 | `TrailingTokensAfterParse` | Unconsumed tokens remain after the root rule matched; `Parse()` returns an `ErrorNode` |
 | UP5005 | `AmbiguousConstructResolvedHeuristically` | An ambiguous construct was resolved by heuristic rather than by grammar priority |

--- a/Utils.Parser/ANTLRCompatibility.md
+++ b/Utils.Parser/ANTLRCompatibility.md
@@ -101,7 +101,7 @@ An optional expression-backed evaluator can be configured explicitly (for exampl
 ```csharp
 public class MyPredicateEvaluator : ISemanticPredicateEvaluator
 {
-    public SemanticPredicateEvaluationResult Evaluate(SemanticPredicateEvaluationContext context)
+    public SemanticPredicateEvaluationOutcome Evaluate(SemanticPredicateEvaluationContext context)
     {
         // context.PredicateCode  — raw predicate text from the .g4 file
         // context.Rule           — current Rule
@@ -110,10 +110,10 @@ public class MyPredicateEvaluator : ISemanticPredicateEvaluator
 
         if (context.PredicateCode == "IsKeyword()")
             return _keywords.Contains(CurrentToken) 
-                ? SemanticPredicateEvaluationResult.Satisfied 
-                : SemanticPredicateEvaluationResult.Rejected;
+                ? SemanticPredicateEvaluationOutcome.Satisfied 
+                : SemanticPredicateEvaluationOutcome.Rejected;
 
-        return SemanticPredicateEvaluationResult.NotEvaluated;
+        return SemanticPredicateEvaluationOutcome.NotEvaluated();
     }
 }
 

--- a/docs/parser/EmbeddedCodeExecutionModel.md
+++ b/docs/parser/EmbeddedCodeExecutionModel.md
@@ -166,8 +166,8 @@ Non-goal boundary:
 Conceptual outcomes:
 
 - compiled boolean expression;
-- `true` -> `SemanticPredicateEvaluationResult.Satisfied`;
-- `false` -> `SemanticPredicateEvaluationResult.Rejected`;
+- `true` -> `SemanticPredicateEvaluationOutcome.Satisfied`;
+- `false` -> `SemanticPredicateEvaluationOutcome.Rejected`;
 - unsupported/failed -> `NotEvaluated` + diagnostic.
 
 ### Parser inline action `{ code }`


### PR DESCRIPTION
### Motivation

- Align documentation and XML comments with the current structured outcome APIs after the outcome/engine consolidation.
- Clarify the status and placement of obsolete diagnostic aliases so `ParserDiagnostics.All` exposes canonical descriptors only.
- Document the intended role of `UP5002 ExpectedTokenMissing` as a recovery/reserved diagnostic to avoid ambiguity about its emission.

### Description

- Replaced stale `SemanticPredicateEvaluationResult.*` mentions with `SemanticPredicateEvaluationOutcome.*` in `docs/parser/EmbeddedCodeExecutionModel.md` and updated the example usage in `Utils.Parser/ANTLRCompatibility.md` to return `SemanticPredicateEvaluationOutcome` (including `NotEvaluated()`), so docs match current runtime types.
- Added XML remarks in `Utils.Parser.Diagnostics/ParserDiagnostics.cs` clarifying that compatibility aliases such as `ReturnsPartiallyApplied` and `LocalsIgnored` are intentionally not listed separately in `All` because the map is keyed by diagnostic code.
- Added XML documentation to `ExpectedTokenMissing` describing it as "Currently reserved for missing-token recovery diagnostics" and updated `Utils.Parser.Diagnostics/README.md` to reflect this reserved/recovery-oriented status and to show `ReturnsPartiallyApplied` as an explicit compatibility alias for `RuleReturnsIgnored`.
- Files changed: `docs/parser/EmbeddedCodeExecutionModel.md`, `Utils.Parser/ANTLRCompatibility.md`, `Utils.Parser.Diagnostics/ParserDiagnostics.cs`, and `Utils.Parser.Diagnostics/README.md`.
- No runtime APIs, behavior, diagnostic codes, or `ParserDiagnostics.All` contents were modified, and no diagnostics were added/removed/renamed.

### Testing

- Performed automated code/markup searches with `rg` to verify no remaining uses of `SemanticPredicateEvaluationResult` or `ParserActionExecutionResult` remain and to confirm `UP1028`, `ExpectedTokenMissing`, `ReturnsPartiallyApplied`, and `LocalsIgnored` occurrences are documented as intended, and all searches returned the expected hits.
- Verified working tree and committed the documentation-only changes (`git status` and commit recorded as short id `29966da`).
- No runtime or unit tests were run because this PR only updates documentation and XML comments and does not change runtime code or public APIs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1330423d908326b4ace3340addac51)