### PR TITLE
test(parser): strengthen low/medium-priority weak tests

### DIFF
--- a/UtilsTest.Functional/Parser/ANTLRCompatibilityDocTests.cs
+++ b/UtilsTest.Functional/Parser/ANTLRCompatibilityDocTests.cs
@@ -390,6 +390,8 @@ public class ANTLRCompatibilityDocTests
 
         Assert.IsTrue(def.AllRules.ContainsKey("start"));
         Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleLocalsIgnored.Code),
+            "Converter must emit exactly one RuleLocalsIgnored diagnostic for the locals clause.");
     }
 
     [TestMethod]
@@ -406,6 +408,8 @@ public class ANTLRCompatibilityDocTests
 
         Assert.IsTrue(def.AllRules.ContainsKey("start"));
         Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleExceptionMetadataIgnored.Code),
+            "Converter must emit exactly one RuleExceptionMetadataIgnored diagnostic for the throws clause.");
     }
 
     [TestMethod]
@@ -423,6 +427,8 @@ public class ANTLRCompatibilityDocTests
 
         Assert.IsTrue(def.AllRules.ContainsKey("start"));
         Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleExceptionMetadataIgnored.Code),
+            "Converter must emit exactly one RuleExceptionMetadataIgnored diagnostic for catch/finally blocks.");
     }
 
     // ─── Partially supported ──────────────────────────────────────────────────

--- a/UtilsTest/Parser/ParserEngineTests.cs
+++ b/UtilsTest/Parser/ParserEngineTests.cs
@@ -69,6 +69,8 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(2, numbers.Count);
+        Assert.IsTrue(FindAllLexerNodesAny(tree).Any(n => n.Token.Text == "*"),
+            "Tree must contain a '*' operator token");
     }
 
     [TestMethod]
@@ -79,6 +81,8 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(2, numbers.Count);
+        Assert.IsTrue(FindAllLexerNodesAny(tree).Any(n => n.Token.Text == "/"),
+            "Tree must contain a '/' operator token");
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -124,6 +128,9 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(3, numbers.Count);
+        var opTexts = FindAllLexerNodesAny(tree).Select(n => n.Token.Text).ToList();
+        CollectionAssert.Contains(opTexts, "-");
+        CollectionAssert.Contains(opTexts, "/");
     }
 
     [TestMethod]
@@ -134,6 +141,8 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(4, numbers.Count);
+        Assert.AreEqual(3, FindAllLexerNodesAny(tree).Count(n => n.Token.Text == "+"),
+            "Three '+' operators expected for 1+2+3+4");
     }
 
     [TestMethod]
@@ -144,6 +153,8 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(4, numbers.Count);
+        Assert.AreEqual(3, FindAllLexerNodesAny(tree).Count(n => n.Token.Text == "*"),
+            "Three '*' operators expected for 2*3*4*5");
     }
 
     // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Identified during a weak-test audit. Two categories of tests were asserting too little to catch real regressions.

**Medium priority — ANTLRCompatibilityDocTests.cs**

Three `_Discarded_NoError` tests claimed to verify discarded behavior but only checked that no exception was thrown and no error diagnostic was emitted. They did not assert that the converter explicitly signalled the discard via a diagnostic.

- `Locals_Discarded_NoError`: now asserts `RuleLocalsIgnored` (UP1008) emitted exactly once
- `Throws_Discarded_NoError`: now asserts `RuleExceptionMetadataIgnored` (UP1023) emitted exactly once
- `CatchFinally_Discarded_NoError`: now asserts `RuleExceptionMetadataIgnored` (UP1023) emitted exactly once

**Low priority — ParserEngineTests.cs**

Five parse-tree tests only counted `Number` tokens without verifying operator tokens were present. A parser that silently dropped `*` and `/` would have passed undetected.

- `Parser_SimpleMultiplication`: adds `*` presence check
- `Parser_SimpleDivision`: adds `/` presence check
- `Parser_SubAndDiv`: adds `-` and `/` presence checks
- `Parser_ChainedAdditions`: pins `+` count to 3 for `1+2+3+4`
- `Parser_ChainedMultiplications`: pins `*` count to 3 for `2*3*4*5`

## Test plan

- [x] 5 ParserEngineTests pass
- [x] 3 ANTLRCompatibilityDocTests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)