### PR TITLE
test(parser): replace existence guards with exact rule counts in Antlr4GrammarTests

### DIFF
--- a/UtilsTest.Functional/Parser/ANTLRCompatibilityDocTests.cs
+++ b/UtilsTest.Functional/Parser/ANTLRCompatibilityDocTests.cs
@@ -390,6 +390,8 @@ public class ANTLRCompatibilityDocTests
 
         Assert.IsTrue(def.AllRules.ContainsKey("start"));
         Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleLocalsIgnored.Code),
+            "Converter must emit exactly one RuleLocalsIgnored diagnostic for the locals clause.");
     }
 
     [TestMethod]
@@ -406,6 +408,8 @@ public class ANTLRCompatibilityDocTests
 
         Assert.IsTrue(def.AllRules.ContainsKey("start"));
         Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleExceptionMetadataIgnored.Code),
+            "Converter must emit exactly one RuleExceptionMetadataIgnored diagnostic for the throws clause.");
     }
 
     [TestMethod]
@@ -423,6 +427,8 @@ public class ANTLRCompatibilityDocTests
 
         Assert.IsTrue(def.AllRules.ContainsKey("start"));
         Assert.IsFalse(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.AreEqual(1, diagnostics.Count(d => d.Code == ParserDiagnostics.RuleExceptionMetadataIgnored.Code),
+            "Converter must emit exactly one RuleExceptionMetadataIgnored diagnostic for catch/finally blocks.");
     }
 
     // ─── Partially supported ──────────────────────────────────────────────────

--- a/UtilsTest/Parser/Antlr4GrammarTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarTests.cs
@@ -31,7 +31,8 @@ public class Antlr4GrammarTests
         var definition = Antlr4Grammar.Build();
         var defaultMode = definition.Modes.FirstOrDefault(m => m.Name == "DEFAULT_MODE");
         Assert.IsNotNull(defaultMode);
-        Assert.IsTrue(defaultMode!.Rules.Count > 0);
+        Assert.AreEqual(62, defaultMode!.Rules.Count,
+            "DEFAULT_MODE must contain exactly 62 lexer rules (10 fragments + 52 non-fragments).");
     }
 
     [TestMethod]
@@ -40,7 +41,8 @@ public class Antlr4GrammarTests
         var definition = Antlr4Grammar.Build();
         var argMode = definition.Modes.FirstOrDefault(m => m.Name == "Argument");
         Assert.IsNotNull(argMode);
-        Assert.IsTrue(argMode!.Rules.Count > 0);
+        Assert.AreEqual(7, argMode!.Rules.Count,
+            "Argument mode must contain exactly 7 rules.");
     }
 
     [TestMethod]
@@ -49,14 +51,16 @@ public class Antlr4GrammarTests
         var definition = Antlr4Grammar.Build();
         var charSetMode = definition.Modes.FirstOrDefault(m => m.Name == "LexerCharSet");
         Assert.IsNotNull(charSetMode);
-        Assert.IsTrue(charSetMode!.Rules.Count > 0);
+        Assert.AreEqual(3, charSetMode!.Rules.Count,
+            "LexerCharSet mode must contain exactly 3 rules.");
     }
 
     [TestMethod]
     public void Antlr4Grammar_HasParserRules()
     {
         var definition = Antlr4Grammar.Build();
-        Assert.IsTrue(definition.ParserRules.Count > 0);
+        Assert.AreEqual(68, definition.ParserRules.Count,
+            "Grammar must contain exactly 68 parser rules.");
     }
 
     [TestMethod]
@@ -237,7 +241,8 @@ public class Antlr4GrammarTests
         var resolved = RuleResolver.Resolve(definition);
 
         Assert.IsNotNull(resolved);
-        Assert.IsTrue(resolved.AllRules.Count > 0);
+        Assert.AreEqual(140, resolved.AllRules.Count,
+            "Resolved grammar must contain exactly 140 rules (62 DEFAULT_MODE + 7 Argument + 3 LexerCharSet + 68 parser).");
     }
 
     [TestMethod]
@@ -271,14 +276,12 @@ public class Antlr4GrammarTests
     {
         var definition = Antlr4Grammar.Build();
 
-        // We expect a large number of rules covering the full ANTLR4 grammar
         var totalLexerRules = definition.Modes.Sum(m => m.Rules.Count);
         var totalParserRules = definition.ParserRules.Count;
 
-        // At least 40 lexer rules (including fragments) and 50+ parser rules
-        Assert.IsTrue(totalLexerRules >= 40,
-            $"Expected at least 40 lexer rules, got {totalLexerRules}");
-        Assert.IsTrue(totalParserRules >= 50,
-            $"Expected at least 50 parser rules, got {totalParserRules}");
+        Assert.AreEqual(72, totalLexerRules,
+            "Grammar must contain exactly 72 lexer rules across all modes (62 DEFAULT_MODE + 7 Argument + 3 LexerCharSet).");
+        Assert.AreEqual(68, totalParserRules,
+            "Grammar must contain exactly 68 parser rules.");
     }
 }

--- a/UtilsTest/Parser/ParserEngineTests.cs
+++ b/UtilsTest/Parser/ParserEngineTests.cs
@@ -69,6 +69,8 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(2, numbers.Count);
+        Assert.IsTrue(FindAllLexerNodesAny(tree).Any(n => n.Token.Text == "*"),
+            "Tree must contain a '*' operator token");
     }
 
     [TestMethod]
@@ -79,6 +81,8 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(2, numbers.Count);
+        Assert.IsTrue(FindAllLexerNodesAny(tree).Any(n => n.Token.Text == "/"),
+            "Tree must contain a '/' operator token");
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -124,6 +128,9 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(3, numbers.Count);
+        var opTexts = FindAllLexerNodesAny(tree).Select(n => n.Token.Text).ToList();
+        CollectionAssert.Contains(opTexts, "-");
+        CollectionAssert.Contains(opTexts, "/");
     }
 
     [TestMethod]
@@ -134,6 +141,8 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(4, numbers.Count);
+        Assert.AreEqual(3, FindAllLexerNodesAny(tree).Count(n => n.Token.Text == "+"),
+            "Three '+' operators expected for 1+2+3+4");
     }
 
     [TestMethod]
@@ -144,6 +153,8 @@ public class ParserEngineTests
 
         var numbers = FindAllLexerNodes(tree, "Number");
         Assert.AreEqual(4, numbers.Count);
+        Assert.AreEqual(3, FindAllLexerNodesAny(tree).Count(n => n.Token.Text == "*"),
+            "Three '*' operators expected for 2*3*4*5");
     }
 
     // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Six assertions that used `> 0` or `>= N` now assert exact values
- Tests now fail if rules are accidentally added or removed from the ANTLR4 grammar bootstrap
- Affected tests: `HasDefaultMode` (62), `HasArgumentMode` (7), `HasLexerCharSetMode` (3), `HasParserRules` (68), `ResolvesSuccessfully` (140 resolved), `TotalRuleCount` (72 lexer + 68 parser)

## Test plan
- [x] All 15 `Antlr4GrammarTests` pass