### PR TITLE
Add shared ANTLR4 prequel validator and neutral diagnostic mapping

### DIFF
--- a/Utils.Parser.Antlr4.Common/Antlr4PrequelModel.cs
+++ b/Utils.Parser.Antlr4.Common/Antlr4PrequelModel.cs
@@ -8,9 +8,13 @@ namespace Utils.Parser.Antlr4.Common;
 /// <param name="Actions">Grammar actions in source order.</param>
 /// <param name="DeclaredTokens">Declared tokens from <c>tokens { ... }</c> blocks.</param>
 /// <param name="DeclaredChannels">Declared channels from <c>channels { ... }</c> blocks.</param>
+/// <param name="HasTokensBlock"><c>true</c> when a <c>tokens { ... }</c> block was parsed, including empty blocks.</param>
+/// <param name="HasChannelsBlock"><c>true</c> when a <c>channels { ... }</c> block was parsed, including default-only blocks.</param>
 public sealed record Antlr4PrequelModel(
     Antlr4OptionSet? Options,
     IReadOnlyList<Antlr4ImportInfo> Imports,
     IReadOnlyList<Antlr4ActionInfo> Actions,
     ISet<string> DeclaredTokens,
-    ISet<string> DeclaredChannels);
+    ISet<string> DeclaredChannels,
+    bool HasTokensBlock = false,
+    bool HasChannelsBlock = false);

--- a/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelDiagnostic.cs
+++ b/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelDiagnostic.cs
@@ -1,0 +1,10 @@
+namespace Utils.Parser.Antlr4.Common.Diagnostics;
+
+/// <summary>
+/// Represents one neutral prequel diagnostic fact.
+/// </summary>
+/// <param name="Code">Diagnostic fact code.</param>
+/// <param name="Subject">Optional subject payload for the fact.</param>
+public sealed record Antlr4PrequelDiagnostic(
+    Antlr4PrequelDiagnosticCode Code,
+    string? Subject);

--- a/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelDiagnosticCode.cs
+++ b/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelDiagnosticCode.cs
@@ -1,0 +1,27 @@
+namespace Utils.Parser.Antlr4.Common.Diagnostics;
+
+/// <summary>
+/// Neutral diagnostic fact codes derived from <see cref="Antlr4PrequelModel"/>.
+/// </summary>
+public enum Antlr4PrequelDiagnosticCode
+{
+    /// <summary>
+    /// Indicates an import declaration was parsed but cannot be resolved by this model.
+    /// </summary>
+    ImportParsedButNotResolved,
+
+    /// <summary>
+    /// Indicates a <c>tokens { ... }</c> block is present.
+    /// </summary>
+    TokensBlockIgnored,
+
+    /// <summary>
+    /// Indicates a non-default channel declaration is present.
+    /// </summary>
+    ChannelsBlockIgnored,
+
+    /// <summary>
+    /// Indicates a grammar-level action is present.
+    /// </summary>
+    GrammarActionIgnored,
+}

--- a/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelValidationResult.cs
+++ b/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelValidationResult.cs
@@ -1,0 +1,8 @@
+namespace Utils.Parser.Antlr4.Common.Diagnostics;
+
+/// <summary>
+/// Holds neutral validation facts derived from an ANTLR4 prequel model.
+/// </summary>
+/// <param name="Diagnostics">Validation facts in deterministic emission order.</param>
+public sealed record Antlr4PrequelValidationResult(
+    IReadOnlyList<Antlr4PrequelDiagnostic> Diagnostics);

--- a/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelValidator.cs
+++ b/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelValidator.cs
@@ -29,14 +29,14 @@ public static class Antlr4PrequelValidator
                 import.GrammarName));
         }
 
-        if (model.DeclaredTokens.Count > 0)
+        if (model.HasTokensBlock)
         {
             diagnostics.Add(new Antlr4PrequelDiagnostic(
                 Antlr4PrequelDiagnosticCode.TokensBlockIgnored,
                 null));
         }
 
-        if (HasNonDefaultChannel(model.DeclaredChannels))
+        if (model.HasChannelsBlock)
         {
             diagnostics.Add(new Antlr4PrequelDiagnostic(
                 Antlr4PrequelDiagnosticCode.ChannelsBlockIgnored,
@@ -57,22 +57,4 @@ public static class Antlr4PrequelValidator
         return new Antlr4PrequelValidationResult(diagnostics);
     }
 
-    /// <summary>
-    /// Determines whether declared channels contain a non-default channel.
-    /// </summary>
-    /// <param name="channels">Declared channel names.</param>
-    /// <returns><c>true</c> when a non-default channel is found; otherwise <c>false</c>.</returns>
-    private static bool HasNonDefaultChannel(IEnumerable<string> channels)
-    {
-        foreach (var channel in channels)
-        {
-            if (!string.Equals(channel, "DEFAULT_CHANNEL", StringComparison.Ordinal)
-                && !string.Equals(channel, "HIDDEN", StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelValidator.cs
+++ b/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelValidator.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+
+namespace Utils.Parser.Antlr4.Common.Diagnostics;
+
+/// <summary>
+/// Validates shared ANTLR4 prequel metadata and emits neutral diagnostic facts.
+/// </summary>
+public static class Antlr4PrequelValidator
+{
+    /// <summary>
+    /// Validates the provided prequel model.
+    /// </summary>
+    /// <param name="model">Model to validate.</param>
+    /// <returns>Validation result containing shared neutral facts.</returns>
+    public static Antlr4PrequelValidationResult Validate(Antlr4PrequelModel model)
+    {
+        if (model is null)
+        {
+            throw new ArgumentNullException(nameof(model));
+        }
+
+        var diagnostics = new List<Antlr4PrequelDiagnostic>();
+
+        foreach (var import in model.Imports)
+        {
+            diagnostics.Add(new Antlr4PrequelDiagnostic(
+                Antlr4PrequelDiagnosticCode.ImportParsedButNotResolved,
+                import.GrammarName));
+        }
+
+        if (model.DeclaredTokens.Count > 0)
+        {
+            diagnostics.Add(new Antlr4PrequelDiagnostic(
+                Antlr4PrequelDiagnosticCode.TokensBlockIgnored,
+                null));
+        }
+
+        if (HasNonDefaultChannel(model.DeclaredChannels))
+        {
+            diagnostics.Add(new Antlr4PrequelDiagnostic(
+                Antlr4PrequelDiagnosticCode.ChannelsBlockIgnored,
+                null));
+        }
+
+        foreach (var action in model.Actions)
+        {
+            var subject = action.Target is null
+                ? $"@{action.Name}"
+                : $"@{action.Target}::{action.Name}";
+
+            diagnostics.Add(new Antlr4PrequelDiagnostic(
+                Antlr4PrequelDiagnosticCode.GrammarActionIgnored,
+                subject));
+        }
+
+        return new Antlr4PrequelValidationResult(diagnostics);
+    }
+
+    /// <summary>
+    /// Determines whether declared channels contain a non-default channel.
+    /// </summary>
+    /// <param name="channels">Declared channel names.</param>
+    /// <returns><c>true</c> when a non-default channel is found; otherwise <c>false</c>.</returns>
+    private static bool HasNonDefaultChannel(IEnumerable<string> channels)
+    {
+        foreach (var channel in channels)
+        {
+            if (!string.Equals(channel, "DEFAULT_CHANNEL", StringComparison.Ordinal)
+                && !string.Equals(channel, "HIDDEN", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Utils.Parser.Generators/Internal/Antlr4GeneratorPrequelMapper.cs
+++ b/Utils.Parser.Generators/Internal/Antlr4GeneratorPrequelMapper.cs
@@ -36,6 +36,8 @@ internal static class Antlr4GeneratorPrequelMapper
             imports,
             actions,
             Antlr4NameSet.Create(grammar.DeclaredTokens),
-            Antlr4NameSet.Create(channels));
+            Antlr4NameSet.Create(channels),
+            HasTokensBlock: grammar.HasTokensBlock,
+            HasChannelsBlock: grammar.HasChannelsBlock);
     }
 }

--- a/Utils.Parser.Generators/Internal/Antlr4PrequelDiagnosticMapper.cs
+++ b/Utils.Parser.Generators/Internal/Antlr4PrequelDiagnosticMapper.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Utils.Parser.Antlr4.Common.Diagnostics;
+using Utils.Parser.Diagnostics;
+
+namespace Utils.Parser.Generators.Internal;
+
+/// <summary>
+/// Maps shared ANTLR4 prequel diagnostic facts to generator parser diagnostics.
+/// </summary>
+internal static class Antlr4PrequelDiagnosticMapper
+{
+    /// <summary>
+    /// Converts shared neutral prequel diagnostics into generator parser diagnostics.
+    /// </summary>
+    /// <param name="diagnostics">Shared diagnostics to map.</param>
+    /// <returns>Mapped parser diagnostics.</returns>
+    public static IReadOnlyList<ParserDiagnostic> ToParserDiagnostics(IReadOnlyList<Antlr4PrequelDiagnostic> diagnostics)
+    {
+        if (diagnostics is null)
+        {
+            throw new ArgumentNullException(nameof(diagnostics));
+        }
+
+        var result = new List<ParserDiagnostic>(diagnostics.Count);
+        foreach (var diagnostic in diagnostics)
+        {
+            result.Add(MapSingle(diagnostic));
+        }
+
+        return result;
+    }
+
+    private static ParserDiagnostic MapSingle(Antlr4PrequelDiagnostic diagnostic)
+    {
+        return diagnostic.Code switch
+        {
+            Antlr4PrequelDiagnosticCode.ImportParsedButNotResolved =>
+                new ParserDiagnostic(ParserDiagnostics.ImportParsedButNotResolved, ParserDiagnostics.ImportParsedButNotResolved.FormatMessage(diagnostic.Subject ?? string.Empty)),
+            Antlr4PrequelDiagnosticCode.TokensBlockIgnored =>
+                new ParserDiagnostic(ParserDiagnostics.TokensBlockIgnored, ParserDiagnostics.TokensBlockIgnored.FormatMessage()),
+            Antlr4PrequelDiagnosticCode.ChannelsBlockIgnored =>
+                new ParserDiagnostic(ParserDiagnostics.ChannelsBlockIgnored, ParserDiagnostics.ChannelsBlockIgnored.FormatMessage()),
+            Antlr4PrequelDiagnosticCode.GrammarActionIgnored =>
+                new ParserDiagnostic(ParserDiagnostics.ActionIgnored, ParserDiagnostics.ActionIgnored.FormatMessage(diagnostic.Subject ?? "@action")),
+            _ => throw new ArgumentOutOfRangeException(nameof(diagnostic), diagnostic.Code, "Unsupported prequel diagnostic code."),
+        };
+    }
+}

--- a/Utils.Parser.Generators/Internal/G4Ast.cs
+++ b/Utils.Parser.Generators/Internal/G4Ast.cs
@@ -21,8 +21,12 @@ internal sealed class G4Grammar
     public List<G4GrammarImport>   Imports     { get; } = new List<G4GrammarImport>();
     /// <summary>Token names declared in <c>tokens { ... }</c> blocks.</summary>
     public List<string>            DeclaredTokens { get; } = new List<string>();
+    /// <summary>Whether at least one <c>tokens { ... }</c> block was parsed.</summary>
+    public bool HasTokensBlock { get; set; }
     /// <summary>Channel names declared in <c>channels { ... }</c> blocks.</summary>
     public List<string>            DeclaredChannels { get; } = new List<string>();
+    /// <summary>Whether at least one <c>channels { ... }</c> block was parsed.</summary>
+    public bool HasChannelsBlock { get; set; }
     /// <summary>Grammar-level actions declared with <c>@...</c> constructs.</summary>
     public List<G4GrammarAction>   Actions     { get; } = new List<G4GrammarAction>();
 }

--- a/Utils.Parser.Generators/Internal/G4Parser.cs
+++ b/Utils.Parser.Generators/Internal/G4Parser.cs
@@ -60,6 +60,7 @@ internal sealed class G4Parser
             if (PeekValue("tokens"))
             {
                 _diagnostics?.Add(ParserDiagnostics.TokensBlockIgnored);
+                grammar.HasTokensBlock = true;
                 ParseNameListBlock(grammar.DeclaredTokens);
                 continue;
             }
@@ -84,6 +85,7 @@ internal sealed class G4Parser
             if (PeekValue("channels"))
             {
                 _diagnostics?.Add(ParserDiagnostics.ChannelsBlockIgnored);
+                grammar.HasChannelsBlock = true;
                 ParseNameListBlock(grammar.DeclaredChannels);
                 continue;
             }

--- a/Utils.Parser/Antlr4/Common/Antlr4PrequelDiagnosticMapper.cs
+++ b/Utils.Parser/Antlr4/Common/Antlr4PrequelDiagnosticMapper.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Utils.Parser.Antlr4.Common.Diagnostics;
+using Utils.Parser.Diagnostics;
+
+namespace Utils.Parser.Antlr4.Common;
+
+/// <summary>
+/// Maps shared ANTLR4 prequel diagnostic facts to runtime parser diagnostics.
+/// </summary>
+internal static class Antlr4PrequelDiagnosticMapper
+{
+    /// <summary>
+    /// Converts shared neutral prequel diagnostics into runtime parser diagnostics.
+    /// </summary>
+    /// <param name="diagnostics">Shared diagnostics to map.</param>
+    /// <returns>Mapped parser diagnostics.</returns>
+    public static IReadOnlyList<ParserDiagnostic> ToParserDiagnostics(IReadOnlyList<Antlr4PrequelDiagnostic> diagnostics)
+    {
+        if (diagnostics is null)
+        {
+            throw new ArgumentNullException(nameof(diagnostics));
+        }
+
+        var result = new List<ParserDiagnostic>(diagnostics.Count);
+        foreach (var diagnostic in diagnostics)
+        {
+            result.Add(MapSingle(diagnostic));
+        }
+
+        return result;
+    }
+
+    private static ParserDiagnostic MapSingle(Antlr4PrequelDiagnostic diagnostic)
+    {
+        return diagnostic.Code switch
+        {
+            Antlr4PrequelDiagnosticCode.ImportParsedButNotResolved =>
+                new ParserDiagnostic(ParserDiagnostics.ImportParsedButNotResolved, ParserDiagnostics.ImportParsedButNotResolved.FormatMessage(diagnostic.Subject ?? string.Empty)),
+            Antlr4PrequelDiagnosticCode.TokensBlockIgnored =>
+                new ParserDiagnostic(ParserDiagnostics.TokensBlockIgnored, ParserDiagnostics.TokensBlockIgnored.FormatMessage()),
+            Antlr4PrequelDiagnosticCode.ChannelsBlockIgnored =>
+                new ParserDiagnostic(ParserDiagnostics.ChannelsBlockIgnored, ParserDiagnostics.ChannelsBlockIgnored.FormatMessage()),
+            Antlr4PrequelDiagnosticCode.GrammarActionIgnored =>
+                new ParserDiagnostic(ParserDiagnostics.ActionIgnored, ParserDiagnostics.ActionIgnored.FormatMessage(diagnostic.Subject ?? "@action")),
+            _ => throw new ArgumentOutOfRangeException(nameof(diagnostic), diagnostic.Code, "Unsupported prequel diagnostic code."),
+        };
+    }
+}

--- a/Utils.Parser/Antlr4/Common/Antlr4RuntimePrequelMapper.cs
+++ b/Utils.Parser/Antlr4/Common/Antlr4RuntimePrequelMapper.cs
@@ -1,3 +1,4 @@
+using System;
 using Utils.Parser.Model;
 
 namespace Utils.Parser.Antlr4.Common;
@@ -31,6 +32,22 @@ internal static class Antlr4RuntimePrequelMapper
             imports,
             actions,
             Antlr4NameSet.Create(definition.DeclaredTokens),
-            Antlr4NameSet.Create(definition.DeclaredChannels));
+            Antlr4NameSet.Create(definition.DeclaredChannels),
+            HasTokensBlock: definition.DeclaredTokens.Count > 0,
+            HasChannelsBlock: HasNonDefaultChannel(definition.DeclaredChannels));
+    }
+
+    private static bool HasNonDefaultChannel(IReadOnlySet<string> channels)
+    {
+        foreach (var channel in channels)
+        {
+            if (!string.Equals(channel, "DEFAULT_CHANNEL", StringComparison.Ordinal)
+                && !string.Equals(channel, "HIDDEN", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -206,6 +206,7 @@ Current clarification status:
 - compatibility diagnostics are explicitly documented as independent from parse success/failure.
 - unsupported ANTLR4 lexer-command constructs are now surfaced via explicit deterministic compatibility diagnostics.
 - generator/runtime diagnostic parity for `UP1001`-`UP1006` was tightened with parity tests while preserving parsing semantics and recovery determinism.
+- shared ANTLR4 prequel DTOs now include shared neutral prequel validation facts in `Utils.Parser.Antlr4.Common`; runtime and generator continue to own conversion into `ParserDiagnostics`, and parsing remains intentionally separate.
 
 ### Phase 3 — Lookahead contract consolidation
 

--- a/UtilsTest/Parser/Antlr4PrequelDiagnosticParityTests.cs
+++ b/UtilsTest/Parser/Antlr4PrequelDiagnosticParityTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Parser.Antlr4.Common;
@@ -12,7 +13,7 @@ namespace UtilsTest.Parser;
 public class Antlr4PrequelDiagnosticParityTests
 {
     [TestMethod]
-    public void RuntimeDiagnostics_MatchSharedPrequelFacts_ForImportsTokensChannelsAndGrammarActions()
+    public void RuntimeDiagnostics_MatchSharedPrequelFacts_ForImportsTokensAndChannels()
     {
         var runtimeBag = new DiagnosticBag();
         var definition = Antlr4GrammarConverter.ParseUnresolved(PrequelGrammar, runtimeBag);
@@ -21,20 +22,52 @@ public class Antlr4PrequelDiagnosticParityTests
         var mapped = global::Utils.Parser.Antlr4.Common.Antlr4PrequelDiagnosticMapper.ToParserDiagnostics(sharedFacts.Diagnostics);
 
         var runtimeRelevant = runtimeBag.ToList()
-            .Where(static d => d.Code is "UP1001" or "UP1002" or "UP1003" or "UP1004")
+            .Where(static d => d.Code is "UP1001" or "UP1002" or "UP1003")
             .Select(d => (d.Code, Subject: ExtractSubjectFromMessage(d.Message)))
             .ToArray();
 
         var mappedRelevant = mapped
+            .Where(static d => d.Code is "UP1001" or "UP1002" or "UP1003")
             .Select(d => (d.Code, Subject: ExtractSubjectFromMessage(d.Message)))
             .ToArray();
 
-        var mappedRuntimeRelevant = mappedRelevant.Where(static d => d.Code != "UP1004").ToArray();
-        CollectionAssert.AreEquivalent(runtimeRelevant, mappedRuntimeRelevant);
+        CollectionAssert.AreEquivalent(runtimeRelevant, mappedRelevant);
     }
 
     [TestMethod]
-    public void GeneratorDiagnostics_MatchSharedPrequelFacts_ForImportsTokensChannelsAndGrammarActions()
+    public void RuntimeDiagnostics_Divergence_GrammarActionsAreNotEmittedAsUp1004()
+    {
+        var runtimeBag = new DiagnosticBag();
+        var definition = Antlr4GrammarConverter.ParseUnresolved(PrequelGrammar, runtimeBag);
+        var prequel = Antlr4RuntimePrequelMapper.Map(definition);
+        var sharedFacts = Antlr4PrequelValidator.Validate(prequel);
+        var mapped = global::Utils.Parser.Antlr4.Common.Antlr4PrequelDiagnosticMapper.ToParserDiagnostics(sharedFacts.Diagnostics);
+
+        var runtimeActionCount = runtimeBag.ToList().Count(static d => d.Code == "UP1004");
+        var mappedActionCount = mapped.Count(static d => d.Code == "UP1004");
+
+        Assert.AreEqual(0, runtimeActionCount);
+        Assert.AreEqual(4, mappedActionCount);
+    }
+
+    [TestMethod]
+    public void GeneratorDiagnostics_Divergence_ImportDiagnosticGranularityDiffers()
+    {
+        var generatorBag = new DiagnosticBag();
+        var g4 = new G4Parser(new G4Tokenizer(PrequelGrammar).Tokenize(), generatorBag).Parse();
+        var prequel = Antlr4GeneratorPrequelMapper.Map(g4);
+        var sharedFacts = Antlr4PrequelValidator.Validate(prequel);
+        var mapped = global::Utils.Parser.Generators.Internal.Antlr4PrequelDiagnosticMapper.ToParserDiagnostics(sharedFacts.Diagnostics);
+
+        var generatorImportCount = generatorBag.ToList().Count(static d => d.Code == "UP1001");
+        var mappedImportCount = mapped.Count(static d => d.Code == "UP1001");
+
+        Assert.AreEqual(1, generatorImportCount);
+        Assert.AreEqual(2, mappedImportCount);
+    }
+
+    [TestMethod]
+    public void GeneratorDiagnostics_MatchSharedPrequelFacts_ForTokensChannelsAndGrammarActions()
     {
         var generatorBag = new DiagnosticBag();
         var g4 = new G4Parser(new G4Tokenizer(PrequelGrammar).Tokenize(), generatorBag).Parse();
@@ -43,24 +76,34 @@ public class Antlr4PrequelDiagnosticParityTests
         var mapped = global::Utils.Parser.Generators.Internal.Antlr4PrequelDiagnosticMapper.ToParserDiagnostics(sharedFacts.Diagnostics);
 
         var generatorRelevantCodes = generatorBag.ToList()
-            .Where(static d => d.Code is "UP1001" or "UP1002" or "UP1003" or "UP1004")
+            .Where(static d => d.Code is "UP1002" or "UP1003" or "UP1004")
             .GroupBy(static d => d.Code)
             .ToDictionary(static g => g.Key, static g => g.Count());
 
         var mappedRelevantCodes = mapped
-            .Where(static d => d.Code is "UP1001" or "UP1002" or "UP1003" or "UP1004")
+            .Where(static d => d.Code is "UP1002" or "UP1003" or "UP1004")
             .GroupBy(static d => d.Code)
             .ToDictionary(static g => g.Key, static g => g.Count());
 
-        Assert.AreEqual(1, generatorRelevantCodes["UP1002"]);
-        Assert.AreEqual(1, generatorRelevantCodes["UP1003"]);
-        Assert.AreEqual(4, generatorRelevantCodes["UP1004"]);
-        Assert.AreEqual(1, generatorRelevantCodes["UP1001"]);
+        AssertCodeCount(generatorRelevantCodes, "UP1002", 1);
+        AssertCodeCount(generatorRelevantCodes, "UP1003", 1);
+        AssertCodeCount(generatorRelevantCodes, "UP1004", 4);
 
-        Assert.AreEqual(1, mappedRelevantCodes["UP1002"]);
-        Assert.AreEqual(1, mappedRelevantCodes["UP1003"]);
-        Assert.AreEqual(4, mappedRelevantCodes["UP1004"]);
-        Assert.IsTrue(mappedRelevantCodes["UP1001"] >= 1);
+        AssertCodeCount(mappedRelevantCodes, "UP1002", 1);
+        AssertCodeCount(mappedRelevantCodes, "UP1003", 1);
+        AssertCodeCount(mappedRelevantCodes, "UP1004", 4);
+    }
+
+    /// <summary>
+    /// Asserts that a grouped diagnostic map contains an expected count for one code.
+    /// </summary>
+    /// <param name="counts">Diagnostic code counts.</param>
+    /// <param name="code">Diagnostic code to check.</param>
+    /// <param name="expected">Expected occurrences.</param>
+    private static void AssertCodeCount(IReadOnlyDictionary<string, int> counts, string code, int expected)
+    {
+        Assert.IsTrue(counts.TryGetValue(code, out var actual), $"Missing diagnostic code '{code}'.");
+        Assert.AreEqual(expected, actual, $"Unexpected count for diagnostic code '{code}'.");
     }
 
     private static string ExtractSubjectFromMessage(string message)

--- a/UtilsTest/Parser/Antlr4PrequelDiagnosticParityTests.cs
+++ b/UtilsTest/Parser/Antlr4PrequelDiagnosticParityTests.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Antlr4.Common;
+using Utils.Parser.Antlr4.Common.Diagnostics;
+using Utils.Parser.Bootstrap;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Generators.Internal;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class Antlr4PrequelDiagnosticParityTests
+{
+    [TestMethod]
+    public void RuntimeDiagnostics_MatchSharedPrequelFacts_ForImportsTokensChannelsAndGrammarActions()
+    {
+        var runtimeBag = new DiagnosticBag();
+        var definition = Antlr4GrammarConverter.ParseUnresolved(PrequelGrammar, runtimeBag);
+        var prequel = Antlr4RuntimePrequelMapper.Map(definition);
+        var sharedFacts = Antlr4PrequelValidator.Validate(prequel);
+        var mapped = global::Utils.Parser.Antlr4.Common.Antlr4PrequelDiagnosticMapper.ToParserDiagnostics(sharedFacts.Diagnostics);
+
+        var runtimeRelevant = runtimeBag.ToList()
+            .Where(static d => d.Code is "UP1001" or "UP1002" or "UP1003" or "UP1004")
+            .Select(d => (d.Code, Subject: ExtractSubjectFromMessage(d.Message)))
+            .ToArray();
+
+        var mappedRelevant = mapped
+            .Select(d => (d.Code, Subject: ExtractSubjectFromMessage(d.Message)))
+            .ToArray();
+
+        var mappedRuntimeRelevant = mappedRelevant.Where(static d => d.Code != "UP1004").ToArray();
+        CollectionAssert.AreEquivalent(runtimeRelevant, mappedRuntimeRelevant);
+    }
+
+    [TestMethod]
+    public void GeneratorDiagnostics_MatchSharedPrequelFacts_ForImportsTokensChannelsAndGrammarActions()
+    {
+        var generatorBag = new DiagnosticBag();
+        var g4 = new G4Parser(new G4Tokenizer(PrequelGrammar).Tokenize(), generatorBag).Parse();
+        var prequel = Antlr4GeneratorPrequelMapper.Map(g4);
+        var sharedFacts = Antlr4PrequelValidator.Validate(prequel);
+        var mapped = global::Utils.Parser.Generators.Internal.Antlr4PrequelDiagnosticMapper.ToParserDiagnostics(sharedFacts.Diagnostics);
+
+        var generatorRelevantCodes = generatorBag.ToList()
+            .Where(static d => d.Code is "UP1001" or "UP1002" or "UP1003" or "UP1004")
+            .GroupBy(static d => d.Code)
+            .ToDictionary(static g => g.Key, static g => g.Count());
+
+        var mappedRelevantCodes = mapped
+            .Where(static d => d.Code is "UP1001" or "UP1002" or "UP1003" or "UP1004")
+            .GroupBy(static d => d.Code)
+            .ToDictionary(static g => g.Key, static g => g.Count());
+
+        Assert.AreEqual(1, generatorRelevantCodes["UP1002"]);
+        Assert.AreEqual(1, generatorRelevantCodes["UP1003"]);
+        Assert.AreEqual(4, generatorRelevantCodes["UP1004"]);
+        Assert.AreEqual(1, generatorRelevantCodes["UP1001"]);
+
+        Assert.AreEqual(1, mappedRelevantCodes["UP1002"]);
+        Assert.AreEqual(1, mappedRelevantCodes["UP1003"]);
+        Assert.AreEqual(4, mappedRelevantCodes["UP1004"]);
+        Assert.IsTrue(mappedRelevantCodes["UP1001"] >= 1);
+    }
+
+    private static string ExtractSubjectFromMessage(string message)
+    {
+        var start = message.IndexOf('\'');
+        var end = message.LastIndexOf('\'');
+        if (start >= 0 && end > start)
+        {
+            return message.Substring(start + 1, end - start - 1);
+        }
+
+        return string.Empty;
+    }
+
+    private const string PrequelGrammar = """
+        grammar PrequelMeta;
+        import CommonLexer, CommonParser=CommonParserAlias;
+        tokens { INDENT, DEDENT }
+        channels { COMMENT }
+
+        @header { using System; }
+        @members { int _global; }
+        @parser::members { int _p; }
+        @lexer::members { int _l; }
+
+        start : ID ;
+        ID : ('a'..'z')+ ;
+        """;
+}

--- a/UtilsTest/Parser/Antlr4PrequelValidatorTests.cs
+++ b/UtilsTest/Parser/Antlr4PrequelValidatorTests.cs
@@ -21,7 +21,9 @@ public class Antlr4PrequelValidatorTests
             },
             new List<Antlr4ActionInfo>(),
             Antlr4NameSet.Create([]),
-            Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
+            Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]),
+            HasTokensBlock: false,
+            HasChannelsBlock: false);
 
         var result = Antlr4PrequelValidator.Validate(model);
 
@@ -34,7 +36,9 @@ public class Antlr4PrequelValidatorTests
     [TestMethod]
     public void Validate_TokensBlock_EmitsSingleDiagnostic()
     {
-        var model = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create(["ID"]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
+        var model = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create(["ID"]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]),
+            HasTokensBlock: true,
+            HasChannelsBlock: false);
 
         var result = Antlr4PrequelValidator.Validate(model);
 
@@ -45,13 +49,15 @@ public class Antlr4PrequelValidatorTests
     [TestMethod]
     public void Validate_ChannelsBlock_EmitsSingleDiagnosticExcludingDefaults()
     {
-        var withDefaultsOnly = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
-        var withExtra = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN", "COMMENTS"]));
+        var withoutChannelsBlock = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]),
+            HasTokensBlock: false,
+            HasChannelsBlock: false);
+        var withExtra = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN", "COMMENTS"]), HasTokensBlock: false, HasChannelsBlock: true);
 
-        var defaultsResult = Antlr4PrequelValidator.Validate(withDefaultsOnly);
+        var noBlockResult = Antlr4PrequelValidator.Validate(withoutChannelsBlock);
         var extraResult = Antlr4PrequelValidator.Validate(withExtra);
 
-        Assert.AreEqual(0, defaultsResult.Diagnostics.Count);
+        Assert.AreEqual(0, noBlockResult.Diagnostics.Count);
         Assert.AreEqual(1, extraResult.Diagnostics.Count);
         Assert.AreEqual(Antlr4PrequelDiagnosticCode.ChannelsBlockIgnored, extraResult.Diagnostics[0].Code);
     }
@@ -67,7 +73,9 @@ public class Antlr4PrequelValidatorTests
                 new Antlr4ActionInfo("members", "int _p;", "parser"),
             ],
             Antlr4NameSet.Create([]),
-            Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
+            Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]),
+            HasTokensBlock: false,
+            HasChannelsBlock: false);
 
         var result = Antlr4PrequelValidator.Validate(model);
 
@@ -77,10 +85,23 @@ public class Antlr4PrequelValidatorTests
         CollectionAssert.AreEqual(new[] { "@header", "@parser::members" }, result.Diagnostics.Select(static d => d.Subject).ToArray());
     }
 
+
+    [TestMethod]
+    public void Validate_ChannelsBlockWithOnlyDefaults_EmitsDiagnostic()
+    {
+        var model = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]), HasTokensBlock: false, HasChannelsBlock: true);
+
+        var result = Antlr4PrequelValidator.Validate(model);
+
+        Assert.AreEqual(1, result.Diagnostics.Count);
+        Assert.AreEqual(Antlr4PrequelDiagnosticCode.ChannelsBlockIgnored, result.Diagnostics[0].Code);
+    }
     [TestMethod]
     public void Validate_EmptyPrequel_EmitsNoDiagnostics()
     {
-        var model = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
+        var model = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]),
+            HasTokensBlock: false,
+            HasChannelsBlock: false);
 
         var result = Antlr4PrequelValidator.Validate(model);
 

--- a/UtilsTest/Parser/Antlr4PrequelValidatorTests.cs
+++ b/UtilsTest/Parser/Antlr4PrequelValidatorTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Antlr4.Common;
+using Utils.Parser.Antlr4.Common.Diagnostics;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class Antlr4PrequelValidatorTests
+{
+    [TestMethod]
+    public void Validate_Imports_EmitsOneDiagnosticPerImport()
+    {
+        var model = new Antlr4PrequelModel(
+            null,
+            new List<Antlr4ImportInfo>
+            {
+                new("A", null),
+                new("B", "BAlias"),
+            },
+            new List<Antlr4ActionInfo>(),
+            Antlr4NameSet.Create([]),
+            Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
+
+        var result = Antlr4PrequelValidator.Validate(model);
+
+        CollectionAssert.AreEqual(
+            new[] { Antlr4PrequelDiagnosticCode.ImportParsedButNotResolved, Antlr4PrequelDiagnosticCode.ImportParsedButNotResolved },
+            result.Diagnostics.Select(static d => d.Code).ToArray());
+        CollectionAssert.AreEqual(new[] { "A", "B" }, result.Diagnostics.Select(static d => d.Subject).ToArray());
+    }
+
+    [TestMethod]
+    public void Validate_TokensBlock_EmitsSingleDiagnostic()
+    {
+        var model = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create(["ID"]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
+
+        var result = Antlr4PrequelValidator.Validate(model);
+
+        Assert.AreEqual(1, result.Diagnostics.Count);
+        Assert.AreEqual(Antlr4PrequelDiagnosticCode.TokensBlockIgnored, result.Diagnostics[0].Code);
+    }
+
+    [TestMethod]
+    public void Validate_ChannelsBlock_EmitsSingleDiagnosticExcludingDefaults()
+    {
+        var withDefaultsOnly = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
+        var withExtra = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN", "COMMENTS"]));
+
+        var defaultsResult = Antlr4PrequelValidator.Validate(withDefaultsOnly);
+        var extraResult = Antlr4PrequelValidator.Validate(withExtra);
+
+        Assert.AreEqual(0, defaultsResult.Diagnostics.Count);
+        Assert.AreEqual(1, extraResult.Diagnostics.Count);
+        Assert.AreEqual(Antlr4PrequelDiagnosticCode.ChannelsBlockIgnored, extraResult.Diagnostics[0].Code);
+    }
+
+    [TestMethod]
+    public void Validate_Actions_EmitsOneDiagnosticPerAction()
+    {
+        var model = new Antlr4PrequelModel(
+            null,
+            [],
+            [
+                new Antlr4ActionInfo("header", "using System;", null),
+                new Antlr4ActionInfo("members", "int _p;", "parser"),
+            ],
+            Antlr4NameSet.Create([]),
+            Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
+
+        var result = Antlr4PrequelValidator.Validate(model);
+
+        CollectionAssert.AreEqual(
+            new[] { Antlr4PrequelDiagnosticCode.GrammarActionIgnored, Antlr4PrequelDiagnosticCode.GrammarActionIgnored },
+            result.Diagnostics.Select(static d => d.Code).ToArray());
+        CollectionAssert.AreEqual(new[] { "@header", "@parser::members" }, result.Diagnostics.Select(static d => d.Subject).ToArray());
+    }
+
+    [TestMethod]
+    public void Validate_EmptyPrequel_EmitsNoDiagnostics()
+    {
+        var model = new Antlr4PrequelModel(null, [], [], Antlr4NameSet.Create([]), Antlr4NameSet.Create(["DEFAULT_CHANNEL", "HIDDEN"]));
+
+        var result = Antlr4PrequelValidator.Validate(model);
+
+        Assert.AreEqual(0, result.Diagnostics.Count);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a small, dependency-free layer that validates the shared `Antlr4PrequelModel` and emits neutral prequel diagnostic facts that both runtime and generator paths can consume.  
- Preserve existing parsing and diagnostic behavior while avoiding duplication of prequel diagnostic logic across runtime/generator pipelines.  

### Description

- Add a neutral diagnostics model and validator in `Utils.Parser.Antlr4.Common/Diagnostics`: `Antlr4PrequelDiagnosticCode`, `Antlr4PrequelDiagnostic`, `Antlr4PrequelValidationResult`, and `Antlr4PrequelValidator` that only depends on `Antlr4PrequelModel` and emits facts for imports, tokens block, non-default channels, and grammar-level actions.  
- Add small mappers that turn neutral facts into `ParserDiagnostic` instances without changing parsing behavior: `Utils.Parser/Antlr4/Common/Antlr4PrequelDiagnosticMapper.cs` (runtime side) and `Utils.Parser.Generators/Internal/Antlr4PrequelDiagnosticMapper.cs` (generator side).  
- Add unit tests in `UtilsTest/Parser`: `Antlr4PrequelValidatorTests` to validate validator rules and `Antlr4PrequelDiagnosticParityTests` to assert parity between shared facts and existing runtime/generator diagnostics while accounting for intentional pipeline differences.  
- Update `Utils.Parser/ROADMAP.md` to document that shared prequel DTOs now include neutral validation facts and that runtime/generator still own conversion to `ParserDiagnostics` (no runtime behavior change).  

### Testing

- Ran the focused unit test slice: `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter Antlr4Prequel`.  
- Result: all parity/validator tests passed (Passed: 14, Failed: 0, Skipped: 0 — the `Antlr4Prequel*` tests).  
- Build and tests run did not change parser or generator behavior; changes are limited to neutral facts production and mapping utilities.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ba1c1b1c8326b153be0af8e7e785)