### PR TITLE
docs(parser): fix stale internal references and align README TFM

### DIFF
--- a/Utils.Parser/README.md
+++ b/Utils.Parser/README.md
@@ -14,7 +14,7 @@ dotnet add package omy.Utils.Parser
 
 ## Supported frameworks
 
-- net9.0
+- net8.0
 
 ## `.g4` file support status
 

--- a/docs/parser/ParserMetadataAndRuntimeLimitations.md
+++ b/docs/parser/ParserMetadataAndRuntimeLimitations.md
@@ -11,7 +11,7 @@ Use this file for **what is not runtime-authoritative today** and what requires 
 - Canonical here: metadata-only semantics, unsupported semantics, compatibility boundaries, execution-sharing constraints, and activation preconditions.
 - Canonical in companion file: parse authority, diagnostics authority, parse-tree authority, scheduling ownership, and registry authority boundaries.
 - Companion: [`RuntimeStateOwnership.md`](./RuntimeStateOwnership.md).
-- Process obligations remain in [`AGENT.md`](../../AGENT.md); roadmap direction remains in [`ROADMAP.md`](../../ROADMAP.md).
+- Process obligations remain in [`Utils.Parser/AGENTS.md`](../../Utils.Parser/AGENTS.md); roadmap direction remains in [`Utils.Parser/ROADMAP.md`](../../Utils.Parser/ROADMAP.md).
 
 ## Topic ownership map (canonical + companion)
 

--- a/docs/parser/RuntimeStateOwnership.md
+++ b/docs/parser/RuntimeStateOwnership.md
@@ -10,7 +10,7 @@ Use this file for **authority boundaries**: which component owns which decision.
 - Canonical here: parse authority, diagnostics authority, parse-tree authority, scheduling ownership, registry ownership, and lifecycle ownership boundaries.
 - Canonical in companion file: metadata-only limitations, unsupported semantics, duplicated-work/execution-sharing constraints, and future activation preconditions.
 - Companion: [`ParserMetadataAndRuntimeLimitations.md`](./ParserMetadataAndRuntimeLimitations.md).
-- Contribution/process rules remain in [`AGENT.md`](../../AGENT.md); roadmap direction remains in [`ROADMAP.md`](../../ROADMAP.md).
+- Contribution/process rules remain in [`Utils.Parser/AGENTS.md`](../../Utils.Parser/AGENTS.md); roadmap direction remains in [`Utils.Parser/ROADMAP.md`](../../Utils.Parser/ROADMAP.md).
 
 ## Topic ownership map (canonical + companion)
 


### PR DESCRIPTION
### Motivation
- Repair stale documentation links that referenced the repository root `AGENT.md`/`ROADMAP.md` and remove a misleading README TFM so consumers and contributors see the correct parser-scoped references and supported framework.

### Description
- Update `docs/parser/RuntimeStateOwnership.md` and `docs/parser/ParserMetadataAndRuntimeLimitations.md` to reference `Utils.Parser/AGENTS.md` and `Utils.Parser/ROADMAP.md` instead of the stale root links.
- Update `Utils.Parser/README.md` supported framework from `net9.0` to `net8.0` to match `Utils.Parser/Utils.Parser.csproj`, and do not change any runtime code, diagnostics, ANTLR compatibility semantics, or public APIs.
- Documentation impact: `Utils.Parser/ROADMAP.md` requires no update, `docs/parser/ANTLRCompatibility.md` requires no update, and `docs/parser/INDEX.md` requires no update because no parser-doc files were added/removed/renamed.

### Testing
- Built the project with `dotnet build Utils.Parser/Utils.Parser.csproj` and the build completed successfully with only existing warnings and no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16acfd40388326960f469abc2632fb)