### PR TITLE
Return read-only name set as IReadOnlyCollection and update model/tests

### DIFF
--- a/Utils.Parser.Antlr4.Common/Antlr4NameSet.cs
+++ b/Utils.Parser.Antlr4.Common/Antlr4NameSet.cs
@@ -10,34 +10,35 @@ public static class Antlr4NameSet
     /// </summary>
     /// <param name="names">Names to include in the set.</param>
     /// <returns>An ordinal, read-only set wrapper.</returns>
-    public static ISet<string> Create(IEnumerable<string> names)
+    public static IReadOnlyCollection<string> Create(IEnumerable<string> names)
     {
-        return new ReadOnlySet<string>(new HashSet<string>(names, StringComparer.Ordinal));
+        return new ReadOnlyNameSet(names);
     }
 
-    private sealed class ReadOnlySet<T>(HashSet<T> inner) : ISet<T>
+    private sealed class ReadOnlyNameSet : IReadOnlyCollection<string>
     {
-        public int Count => inner.Count;
-        public bool IsReadOnly => true;
+        private readonly HashSet<string> _inner;
 
-        public bool Contains(T item) => inner.Contains(item);
-        public IEnumerator<T> GetEnumerator() => inner.GetEnumerator();
-        public bool IsProperSubsetOf(IEnumerable<T> other) => inner.IsProperSubsetOf(other);
-        public bool IsProperSupersetOf(IEnumerable<T> other) => inner.IsProperSupersetOf(other);
-        public bool IsSubsetOf(IEnumerable<T> other) => inner.IsSubsetOf(other);
-        public bool IsSupersetOf(IEnumerable<T> other) => inner.IsSupersetOf(other);
-        public bool Overlaps(IEnumerable<T> other) => inner.Overlaps(other);
-        public bool SetEquals(IEnumerable<T> other) => inner.SetEquals(other);
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
-        public void CopyTo(T[] array, int arrayIndex) => inner.CopyTo(array, arrayIndex);
+        public ReadOnlyNameSet(IEnumerable<string> names)
+        {
+            _inner = new HashSet<string>(names, StringComparer.Ordinal);
+        }
 
-        public bool Add(T item) => throw new NotSupportedException("Set is read-only.");
-        void ICollection<T>.Add(T item) => throw new NotSupportedException("Set is read-only.");
-        public bool Remove(T item) => throw new NotSupportedException("Set is read-only.");
-        public void Clear() => throw new NotSupportedException("Set is read-only.");
-        public void ExceptWith(IEnumerable<T> other) => throw new NotSupportedException("Set is read-only.");
-        public void IntersectWith(IEnumerable<T> other) => throw new NotSupportedException("Set is read-only.");
-        public void SymmetricExceptWith(IEnumerable<T> other) => throw new NotSupportedException("Set is read-only.");
-        public void UnionWith(IEnumerable<T> other) => throw new NotSupportedException("Set is read-only.");
+        public int Count => _inner.Count;
+
+        public bool Contains(string name)
+        {
+            return _inner.Contains(name);
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return _inner.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/Utils.Parser.Antlr4.Common/Antlr4PrequelModel.cs
+++ b/Utils.Parser.Antlr4.Common/Antlr4PrequelModel.cs
@@ -14,7 +14,7 @@ public sealed record Antlr4PrequelModel(
     Antlr4OptionSet? Options,
     IReadOnlyList<Antlr4ImportInfo> Imports,
     IReadOnlyList<Antlr4ActionInfo> Actions,
-    ISet<string> DeclaredTokens,
-    ISet<string> DeclaredChannels,
+    IReadOnlyCollection<string> DeclaredTokens,
+    IReadOnlyCollection<string> DeclaredChannels,
     bool HasTokensBlock = false,
     bool HasChannelsBlock = false);

--- a/UtilsTest/Parser/Antlr4PrequelValidatorTests.cs
+++ b/UtilsTest/Parser/Antlr4PrequelValidatorTests.cs
@@ -86,6 +86,16 @@ public class Antlr4PrequelValidatorTests
     }
 
 
+
+    [TestMethod]
+    public void NameSetCreate_ReturnsReadOnlyCollectionContract()
+    {
+        IReadOnlyCollection<string> names = Antlr4NameSet.Create(["ID"]);
+
+        Assert.AreEqual(1, names.Count);
+        Assert.IsFalse(names is ISet<string>);
+    }
+
     [TestMethod]
     public void Validate_ChannelsBlockWithOnlyDefaults_EmitsDiagnostic()
     {


### PR DESCRIPTION
# Motivation

Utils.Parser.Antlr4.Common est encore en phase pré-release.
C’est le bon moment pour supprimer une ambiguïté de contrat public avant stabilisation API :

    Antlr4PrequelModel.DeclaredTokens et DeclaredChannels étaient exposés en ISet<string>, ce qui suggérait des opérations mutables (Add, Remove, Clear),

    alors que l’intention du module est un modèle neutre et en lecture seule.

Le changement réduit la dette API en rendant le contrat explicitement read-only.
# Modifications

    Antlr4PrequelModel :

        DeclaredTokens : ISet<string> → IReadOnlyCollection<string>

        DeclaredChannels : ISet<string> → IReadOnlyCollection<string>

    Antlr4NameSet.Create(...) :

        type de retour : ISet<string> → IReadOnlyCollection<string>

        suppression du wrapper ISet<T> et remplacement par un wrapper read-only concret.

    Tests :

        ajout d’un test qui vérifie que Create(...) expose bien un contrat read-only et n’expose plus ISet<string>.

# Public API impact

Oui, API-changing (pré-release, intentionnel) :

    signature de constructeur de Antlr4PrequelModel modifiée sur 2 paramètres ;

    signature de retour de Antlr4NameSet.Create(...) modifiée.

Aucun changement comportemental attendu : seulement un durcissement du contrat public (immutabilité d’interface).
# Migration

Cas de migration attendus :

    Appels existants qui passent un ISet<string>
    Aucun changement requis côté passage de paramètre (ISet<string> implémente IReadOnlyCollection<string>).

    Code consommateur qui utilisait le retour de Create(...) comme ISet<string>
    Remplacer l’usage des membres mutables (Add, Remove, Clear, etc.) par un usage read-only :

        énumération,

        Count,

        opérations LINQ.

# Diagnostics impact

Aucun.
Les faits diagnostics neutres produits par Antlr4PrequelValidator restent inchangés.
# Runtime impact

Aucun.
Aucune modification du runtime, du scheduling, ni de l’autorité parse/diagnostics.
# ANTLR compatibility impact

Aucun.
Aucune évolution des frontières de compatibilité ANTLR4.
# Documentation impact

    ROADMAP.md : pas de mise à jour nécessaire (pas de changement runtime/diagnostics/compatibilité).

    docs/parser/ANTLRCompatibility.md : pas de mise à jour nécessaire (frontières inchangées).

    docs/parser/INDEX.md : pas de mise à jour nécessaire (aucun document parser ajouté/supprimé/modifié matériellement).

# Tests

    Test ajouté : validation du contrat read-only (Create(...) n’expose plus ISet<string>).

    Les tests parser/prequel ciblés restent passants.
