### PR TITLE
Stabilize SyntaxColorisation API: expose IReadOnlyList for parsed descriptor results

### DIFF
--- a/Utils.Parser/Bootstrap/SyntaxColorisationGrammar.cs
+++ b/Utils.Parser/Bootstrap/SyntaxColorisationGrammar.cs
@@ -14,6 +14,8 @@ namespace Utils.Parser.Bootstrap;
 /// </summary>
 public sealed class SyntaxColorisationSection
 {
+    private readonly List<string> rules = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SyntaxColorisationSection"/> class.
     /// </summary>
@@ -31,7 +33,16 @@ public sealed class SyntaxColorisationSection
     /// <summary>
     /// Gets descriptor rules associated with the classification.
     /// </summary>
-    public List<string> Rules { get; } = new();
+    public IReadOnlyList<string> Rules => rules;
+
+    /// <summary>
+    /// Adds one descriptor rule to the section.
+    /// </summary>
+    /// <param name="ruleName">Rule name to add.</param>
+    internal void AddRule(string ruleName)
+    {
+        rules.Add(ruleName);
+    }
 }
 
 /// <summary>
@@ -39,20 +50,51 @@ public sealed class SyntaxColorisationSection
 /// </summary>
 public sealed class SyntaxColorisationDocument
 {
+    private readonly List<string> fileExtensions = new();
+    private readonly List<string> stringSyntaxExtensions = new();
+    private readonly List<SyntaxColorisationSection> sections = new();
+
     /// <summary>
     /// Gets declared file extensions.
     /// </summary>
-    public List<string> FileExtensions { get; } = new();
+    public IReadOnlyList<string> FileExtensions => fileExtensions;
 
     /// <summary>
     /// Gets declared StringSyntax extensions.
     /// </summary>
-    public List<string> StringSyntaxExtensions { get; } = new();
+    public IReadOnlyList<string> StringSyntaxExtensions => stringSyntaxExtensions;
 
     /// <summary>
     /// Gets declared classification sections.
     /// </summary>
-    public List<SyntaxColorisationSection> Sections { get; } = new();
+    public IReadOnlyList<SyntaxColorisationSection> Sections => sections;
+
+    /// <summary>
+    /// Adds one declared file extension.
+    /// </summary>
+    /// <param name="fileExtension">File extension value.</param>
+    internal void AddFileExtension(string fileExtension)
+    {
+        fileExtensions.Add(fileExtension);
+    }
+
+    /// <summary>
+    /// Adds one declared StringSyntax extension.
+    /// </summary>
+    /// <param name="stringSyntaxExtension">StringSyntax extension value.</param>
+    internal void AddStringSyntaxExtension(string stringSyntaxExtension)
+    {
+        stringSyntaxExtensions.Add(stringSyntaxExtension);
+    }
+
+    /// <summary>
+    /// Adds one section to the parsed descriptor document.
+    /// </summary>
+    /// <param name="section">Section value.</param>
+    internal void AddSection(SyntaxColorisationSection section)
+    {
+        sections.Add(section);
+    }
 }
 
 /// <summary>
@@ -174,7 +216,7 @@ public static class SyntaxColorisationGrammar
             ParserNode? sectionNode = First(entry, "section");
             if (sectionNode != null)
             {
-                document.Sections.Add(ReadSection(sectionNode));
+                document.AddSection(ReadSection(sectionNode));
             }
         }
 
@@ -193,13 +235,13 @@ public static class SyntaxColorisationGrammar
 
         if (directiveName.Equals("FileExtension", StringComparison.OrdinalIgnoreCase))
         {
-            document.FileExtensions.Add(value);
+            document.AddFileExtension(value);
             return;
         }
 
         if (directiveName.Equals("StringSyntaxExtension", StringComparison.OrdinalIgnoreCase))
         {
-            document.StringSyntaxExtensions.Add(value);
+            document.AddStringSyntaxExtension(value);
             return;
         }
 
@@ -220,7 +262,7 @@ public static class SyntaxColorisationGrammar
         var section = new SyntaxColorisationSection(classification);
         foreach (ParserNode valueNode in Descendants(ruleList, "value"))
         {
-            section.Rules.Add(ReadValue(valueNode));
+            section.AddRule(ReadValue(valueNode));
         }
 
         return section;

--- a/UtilsTest/Parser/SyntaxColorisationGrammarPublicApiTests.cs
+++ b/UtilsTest/Parser/SyntaxColorisationGrammarPublicApiTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Bootstrap;
+
+namespace UtilsTest.Parser;
+
+[TestClass]
+public class SyntaxColorisationGrammarPublicApiTests
+{
+    [TestMethod]
+    public void Parse_ReturnsReadOnlyCollectionContracts()
+    {
+        const string descriptor = """
+            @FileExtension: .g4
+            @StringSyntaxExtension: ANTLR4
+            Keyword: grammar|parserRuleSpec
+            """;
+
+        SyntaxColorisationDocument document = SyntaxColorisationGrammar.Parse(descriptor);
+
+        Assert.AreEqual(typeof(IReadOnlyList<string>), typeof(SyntaxColorisationDocument).GetProperty(nameof(SyntaxColorisationDocument.FileExtensions))!.PropertyType);
+        Assert.AreEqual(typeof(IReadOnlyList<string>), typeof(SyntaxColorisationDocument).GetProperty(nameof(SyntaxColorisationDocument.StringSyntaxExtensions))!.PropertyType);
+        Assert.AreEqual(typeof(IReadOnlyList<SyntaxColorisationSection>), typeof(SyntaxColorisationDocument).GetProperty(nameof(SyntaxColorisationDocument.Sections))!.PropertyType);
+        Assert.AreEqual(typeof(IReadOnlyList<string>), typeof(SyntaxColorisationSection).GetProperty(nameof(SyntaxColorisationSection.Rules))!.PropertyType);
+    }
+
+    [TestMethod]
+    public void Parse_PreservesDocumentContentWithReadOnlyContracts()
+    {
+        const string descriptor = """
+            @FileExtension: .g4
+            @StringSyntaxExtension: ANTLR4
+            Keyword: grammar|parserRuleSpec
+            """;
+
+        SyntaxColorisationDocument document = SyntaxColorisationGrammar.Parse(descriptor);
+
+        CollectionAssert.AreEqual(new[] { ".g4" }, document.FileExtensions.ToArray());
+        CollectionAssert.AreEqual(new[] { "ANTLR4" }, document.StringSyntaxExtensions.ToArray());
+        Assert.AreEqual(1, document.Sections.Count);
+        Assert.AreEqual("Keyword", document.Sections[0].Classification);
+        CollectionAssert.AreEqual(new[] { "grammar", "parserRuleSpec" }, document.Sections[0].Rules.ToArray());
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce public API debt by preventing external mutation of parser-produced descriptor objects and clarify ownership boundaries for `SyntaxColorisation` outputs. 
- This is a small, pre-release API hardening change aimed at making contracts explicit without altering runtime behavior or parse semantics.

### Description
- Replaced mutable public `List<T>` properties with `IReadOnlyList<T>` on `SyntaxColorisationDocument.FileExtensions`, `SyntaxColorisationDocument.StringSyntaxExtensions`, `SyntaxColorisationDocument.Sections`, and `SyntaxColorisationSection.Rules` in `Utils.Parser/Bootstrap/SyntaxColorisationGrammar.cs`.
- Introduced internal mutation helpers: `AddFileExtension`, `AddStringSyntaxExtension`, `AddSection`, and `AddRule` and updated the conversion flow to use these helpers instead of mutating public lists.
- Added targeted unit tests in `UtilsTest/Parser/SyntaxColorisationGrammarPublicApiTests.cs` to assert the new read-only property types and to validate parsed content is preserved.
- Modified files: `Utils.Parser/Bootstrap/SyntaxColorisationGrammar.cs` and `UtilsTest/Parser/SyntaxColorisationGrammarPublicApiTests.cs`.
- Documentation impact: no updates to `Utils.Parser/ROADMAP.md`, `docs/parser/ANTLRCompatibility.md`, or `docs/parser/INDEX.md` are required because this change only hardens API contracts and does not affect runtime behavior, diagnostics, ANTLR compatibility, or parser semantics.

### Testing
- Ran `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter SyntaxColorisationGrammarPublicApiTests`; the two new tests passed successfully.
- Full project build emitted unrelated warnings but no errors; the change is covered by deterministic unit tests and introduces no runtime behavioral changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16bbed85388326ad33d31978b46430)