### PR TITLE
docs: add comprehensive README examples for remaining packages

### DIFF
--- a/Utils.Collections/README.md
+++ b/Utils.Collections/README.md
@@ -1,30 +1,101 @@
 # omy.Utils.Collections
 
-`omy.Utils.Collections` packages the skip list implementation from the main utilities set into a dedicated library focused on ordered collections.
+`omy.Utils.Collections` provides `SkipList<T>` — a probabilistic sorted collection with O(log n) average-case insertion, removal, and lookup.
 
-## Installation
+## Install
 
 ```bash
 dotnet add package omy.Utils.Collections
 ```
 
-## Usage
+## Supported frameworks
+- net8.0
+
+## Features
+- `SkipList<T>` — sorted `ICollection<T>` backed by a probabilistic skip structure.
+- Configurable `threshold` to tune skip level density.
+- Custom `IComparer<T>` support.
+
+## Quick usage
 
 ```csharp
 using Utils.Collections;
 
-// Create a skip list with a custom threshold for balancing upper levels.
-var numbers = new SkipList<int>(threshold: 5);
-
+var numbers = new SkipList<int>();
 numbers.Add(3);
 numbers.Add(1);
 numbers.Add(2);
 
-// Elements are kept sorted during insertion.
-foreach (var number in numbers)
-{
-    Console.WriteLine(number);
-}
+// Iteration yields elements in ascending sorted order
+foreach (int n in numbers)
+    Console.WriteLine(n); // 1, 2, 3
 ```
 
-The `SkipList<T>` type provides `Add`, `Remove`, `Contains`, and enumeration capabilities while maintaining sorted order with logarithmic-time expectations.
+## SkipList examples
+
+### Custom threshold
+
+The threshold controls how densely the skip structure is built. Lower values create taller structures with faster lookups on large lists; higher values create flatter, more memory-efficient structures.
+
+```csharp
+using Utils.Collections;
+
+var list = new SkipList<int>(threshold: 5);
+list.Add(10);
+list.Add(5);
+list.Add(7);
+
+Console.WriteLine(list.Count);     // 3
+Console.WriteLine(list.Contains(7)); // true
+```
+
+### Custom comparer
+
+```csharp
+using System.Collections.Generic;
+using Utils.Collections;
+
+var words = new SkipList<string>(StringComparer.OrdinalIgnoreCase, threshold: 10);
+words.Add("Banana");
+words.Add("apple");
+words.Add("Cherry");
+
+foreach (string w in words)
+    Console.WriteLine(w); // apple, Banana, Cherry (case-insensitive order)
+```
+
+### Remove and Clear
+
+```csharp
+using Utils.Collections;
+
+var list = new SkipList<int>();
+list.Add(1);
+list.Add(2);
+list.Add(3);
+
+list.Remove(2);
+Console.WriteLine(list.Contains(2)); // false
+Console.WriteLine(list.Count);       // 2
+
+list.Clear();
+Console.WriteLine(list.Count);       // 0
+```
+
+### CopyTo
+
+```csharp
+using Utils.Collections;
+
+var list = new SkipList<int>();
+list.Add(30);
+list.Add(10);
+list.Add(20);
+
+var dest = new int[3];
+list.CopyTo(dest, 0);
+// dest = [10, 20, 30] (sorted)
+```
+
+## Related packages
+- `omy.Utils` – core utilities including `LRUCache<K,V>`, `IndexedList<K,V>`, and `EnumerableEx` extensions.

--- a/Utils.DependencyInjection.Generators/README.md
+++ b/Utils.DependencyInjection.Generators/README.md
@@ -1,8 +1,6 @@
-# Utils.DependencyInjection.Generators
+# omy.Utils.DependencyInjection.Generators
 
-`Utils.DependencyInjection.Generators` provides a Roslyn source generator that implements `IServiceConfigurator` classes marked
-with the `[StaticAuto]` attribute. It targets **.NET 9** and complements the `Utils.DependencyInjection` runtime library by wiring
-attribute-based registrations at build time.
+`omy.Utils.DependencyInjection.Generators` provides a Roslyn source generator that implements `IServiceConfigurator` classes marked with `[StaticAuto]`. It complements `omy.Utils.DependencyInjection` by wiring attribute-based registrations at compile time.
 
 ## Install
 ```bash
@@ -15,27 +13,23 @@ dotnet add package omy.Utils.DependencyInjection.Generators
 ## Features
 
 - Scans the compilation for `IServiceConfigurator` implementations decorated with `[StaticAuto]`.
-- Detects types annotated with `[Singleton]`, `[Scoped]`, or `[Transient]` and generates the matching registration calls.
-- Supports keyed registrations when a domain is supplied to the lifetime attributes.
+- Detects types annotated with `[Singleton]`, `[Scoped]`, or `[Transient]` and generates matching `AddSingleton`/`AddScoped`/`AddTransient` calls.
+- Supports keyed registrations when a domain string is passed to the lifetime attribute.
 - Registers interfaces marked with `[Injectable]` against their attributed implementations.
-- Emits partial class implementations that remain editable alongside generated code.
+- Emits a `partial` class so generated code coexists with hand-written logic.
 
 ## Getting started
 
-1. Add a project reference to **Utils.DependencyInjection.Generators** (as an analyzer) and to **Utils.DependencyInjection** (as a library).
-2. Decorate your services with lifetime attributes and mark exposed interfaces with `[Injectable]`.
-3. Create an `IServiceConfigurator` implementation and mark it with `[StaticAuto]`.
+1. Add `omy.Utils.DependencyInjection.Generators` as an analyzer reference.
+2. Add `omy.Utils.DependencyInjection` as a library reference.
+3. Decorate services with lifetime attributes and expose interfaces with `[Injectable]`.
+4. Create a `partial` `IServiceConfigurator` implementation and mark it `[StaticAuto]`.
 
 ## Examples
 
-The following scenarios highlight the generator's capabilities. They can be mixed and
-matched inside the same project because the generated partial classes never overwrite
-hand-written logic.
-
-### Basic registration example
+### Basic registration
 
 ```csharp
-using System;
 using Microsoft.Extensions.DependencyInjection;
 using Utils.DependencyInjection;
 
@@ -57,37 +51,34 @@ public partial class FormatterConfigurator : IServiceConfigurator { }
 var services = new ServiceCollection();
 new FormatterConfigurator().ConfigureServices(services);
 var provider = services.BuildServiceProvider();
-var formatter = provider.GetRequiredService<IMessageFormatter>();
-string result = formatter.Format("hello");
+
+string result = provider.GetRequiredService<IMessageFormatter>().Format("hello");
+// → "HELLO"
 ```
 
-The generated `ConfigureServices` method automatically registers `UppercaseFormatter` as the
-implementation for `IMessageFormatter`.
+The generator emits a `ConfigureServices` implementation that calls `services.AddSingleton<IMessageFormatter, UppercaseFormatter>()`.
 
-### Multi-tenant keyed registrations
+### Keyed registrations
 
-You can scope services to tenants or domains by supplying a key when decorating the service with lifetime attributes.
+Supply a domain key to the lifetime attribute for keyed (multi-tenant) scenarios:
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
 using Utils.DependencyInjection;
 
 [Injectable]
-public interface ICalculator
-{
-    int Add(int left, int right);
-}
+public interface ICalculator { int Add(int a, int b); }
 
 [Singleton("europe")]
 public class VatCalculator : ICalculator
 {
-    public int Add(int left, int right) => (int)Math.Round((left + right) * 1.2, MidpointRounding.AwayFromZero);
+    public int Add(int a, int b) => (int)Math.Round((a + b) * 1.2);
 }
 
 [Singleton("us")]
 public class SalesTaxCalculator : ICalculator
 {
-    public int Add(int left, int right) => (int)Math.Round((left + right) * 1.07, MidpointRounding.AwayFromZero);
+    public int Add(int a, int b) => (int)Math.Round((a + b) * 1.07);
 }
 
 [StaticAuto]
@@ -96,126 +87,42 @@ public partial class CalculatorConfigurator : IServiceConfigurator { }
 var services = new ServiceCollection();
 new CalculatorConfigurator().ConfigureServices(services);
 var provider = services.BuildServiceProvider();
-var europeanCalculator = provider.GetRequiredKeyedService<ICalculator>("europe");
-var usCalculator = provider.GetRequiredKeyedService<ICalculator>("us");
+
+var eu = provider.GetRequiredKeyedService<ICalculator>("europe");
+var us = provider.GetRequiredKeyedService<ICalculator>("us");
 ```
 
-The generator emits `AddKeyedSingleton` calls so that each calculator is registered with its
-domain. Consumers resolve the correct implementation by providing the key.
+The generator emits `AddKeyedSingleton<ICalculator, VatCalculator>("europe")` and the corresponding call for `SalesTaxCalculator`.
 
-### Partial methods for fine-grained control
+### Open-generic registrations
 
-Because the generator emits partial classes, you can extend the configurator with custom logic without losing the automatic registrations.
-
-```csharp
-using Microsoft.Extensions.DependencyInjection;
-
-[StaticAuto]
-public partial class AdvancedConfigurator : IServiceConfigurator
-{
-    partial void OnAfterConfigureServices(IServiceCollection services)
-    {
-        services.AddLogging();
-    }
-}
-```
-
-When the generator is executed it creates a matching partial class and invokes
-`OnAfterConfigureServices` after wiring the detected services, allowing manual tweaks.
-
-### Module-based composition
-
-Large solutions commonly split registrations into domain-specific modules. The generator can
-aggregate all of them without manual wiring.
-
-```csharp
-using Microsoft.Extensions.DependencyInjection;
-using Utils.DependencyInjection;
-
-[StaticAuto]
-public partial class AccountingModule : IServiceConfigurator { }
-
-[StaticAuto]
-public partial class NotificationsModule : IServiceConfigurator { }
-
-[StaticAuto]
-public partial class ApplicationConfigurator : IServiceConfigurator
-{
-    partial void OnAfterConfigureServices(IServiceCollection services)
-    {
-        services.AddLogging();
-    }
-}
-
-var services = new ServiceCollection();
-new ApplicationConfigurator().ConfigureServices(services);
-```
-
-Each generated partial class invokes the others through `IServiceConfigurator` so the final
-`ApplicationConfigurator` can remain focused on cross-cutting concerns such as logging or
-metrics.
-
-### Open generics and interfaces
-
-The generator handles open-generic registrations when the implementation type declares a
-generic constraint.
+The generator handles open-generic implementations:
 
 ```csharp
 using Utils.DependencyInjection;
 
 [Injectable]
-public interface IRepository<T>
-    where T : class
+public interface IRepository<T> where T : class
 {
-    ValueTask<T?> GetAsync(Guid id, CancellationToken cancellationToken = default);
+    ValueTask<T?> GetAsync(Guid id, CancellationToken ct = default);
 }
 
 [Scoped]
-public class SqlRepository<T> : IRepository<T>
-    where T : class
+public class SqlRepository<T> : IRepository<T> where T : class
 {
-    public ValueTask<T?> GetAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        // database lookup
-        return ValueTask.FromResult<T?>(default);
-    }
+    public ValueTask<T?> GetAsync(Guid id, CancellationToken ct = default)
+        => ValueTask.FromResult<T?>(default);
 }
 
 [StaticAuto]
 public partial class DataConfigurator : IServiceConfigurator { }
 ```
 
-At build time the generator emits `services.AddScoped(typeof(IRepository<>), typeof(SqlRepository<>));`
-while preserving the generic constraints.
+At build time the generator emits `services.AddScoped(typeof(IRepository<>), typeof(SqlRepository<>))`.
 
-### Conditional environments
+### Manual registrations alongside generated ones
 
-Partial methods are also ideal for environment-based tweaks. The generator still outputs the
-default registrations while giving developers an override point.
-
-```csharp
-using Microsoft.Extensions.DependencyInjection;
-
-[StaticAuto]
-public partial class EnvironmentConfigurator : IServiceConfigurator
-{
-    partial void OnBeforeConfigureServices(IServiceCollection services)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            services.AddSingleton<IPathService, WindowsPathService>();
-        }
-    }
-}
-```
-
-`OnBeforeConfigureServices` is emitted alongside `ConfigureServices`. It executes before the
-automatic registrations which allows conditional replacements without disabling generation.
-
-### Mixing manual and generated registrations
-
-Source generation remains opt-in for each configurator. Manual entries can remain untouched
-while the generator handles the repetitive parts.
+Because the generator only emits the `ConfigureServices` method body, you can add other members to the `partial` class freely:
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -223,13 +130,15 @@ using Microsoft.Extensions.DependencyInjection;
 [StaticAuto]
 public partial class MessagingConfigurator : IServiceConfigurator
 {
-    partial void OnAfterConfigureServices(IServiceCollection services)
+    public void RegisterExtraServices(IServiceCollection services)
     {
         services.AddSingleton<IMessageBus>(_ => new RabbitMqBus("amqp://localhost"));
     }
 }
 ```
 
-Because the generator never rewrites the partial file, developers can evolve their manual
-registrations at their own pace while still benefiting from automated discovery for routine
-services.
+Call both `ConfigureServices` (generated) and `RegisterExtraServices` (manual) during application startup.
+
+## Related packages
+- `omy.Utils.DependencyInjection` – runtime attributes, assembly scanning, and handler pipeline.
+- `omy.Utils` – shared helpers.

--- a/Utils.IO.Serialization.Generators/README.md
+++ b/Utils.IO.Serialization.Generators/README.md
@@ -1,6 +1,6 @@
-# Utils.IO.Serialization.Generators
+# omy.Utils.IO.Serialization.Generators
 
-`Utils.IO.Serialization.Generators` ships a Roslyn source generator that produces strongly typed reader and writer extension methods for DTOs annotated with `GenerateReaderWriterAttribute`. It targets **.NET 9** and extends the `Utils.IO.Serialization` primitives by removing repetitive serialization boilerplate.
+`omy.Utils.IO.Serialization.Generators` is a Roslyn source generator that produces strongly typed `Read{Type}` and `Write{Type}` extension methods for DTOs annotated with `[GenerateReaderWriter]`.
 
 ## Install
 ```bash
@@ -13,14 +13,14 @@ dotnet add package omy.Utils.IO.Serialization.Generators
 ## Features
 
 - Discovers classes, structs, and records decorated with `[GenerateReaderWriter]`.
-- Inspects members tagged with `[Field(order)]` to preserve wire ordering.
-- Emits `Read{Type}` and `Write{Type}` extension methods for `IReader` and `IWriter`.
-- Reuses custom serializers automatically when a member type already exposes matching extensions.
-- Generates partial, editor-friendly code with XML documentation.
+- Inspects members tagged with `[Field(order)]` to define binary wire ordering.
+- Emits `Read{Type}(this IReader)` and `Write{Type}(this IWriter, T value)` extension methods.
+- Automatically reuses custom serializers when a member type already exposes matching `Read{Member}` / `Write{Member}` extensions.
+- Generates XML-documented, editor-friendly code.
 
 ## Preparing a model
 
-Annotate each serializable field or property with the `FieldAttribute` specifying the binary order. The generator supports nested models and nullable members.
+Annotate each serializable field or property with `[Field(order)]`. The generator processes members in ascending order:
 
 ```csharp
 using Utils.IO.Serialization;
@@ -35,7 +35,7 @@ public partial class InventoryEntry
     public required string Name { get; set; }
 
     [Field(2)]
-    public PriceTag Price = new();
+    public PriceTag Price { get; set; } = new();
 }
 
 [GenerateReaderWriter]
@@ -54,112 +54,42 @@ public partial class PriceTag
 ```csharp
 using System.IO;
 using Utils.IO.Serialization;
-using Utils.IO.Serialization.Generators;
 
 var buffer = new MemoryStream();
-IWriter writer = new BinaryWriterAdapter(new BinaryWriter(buffer));
-IReader reader = new BinaryReaderAdapter(new BinaryReader(buffer));
-
-var entry = new InventoryEntry { Id = 7, Name = "Sprocket", Price = new PriceTag { Amount = 19.95m, Currency = "USD" } };
+var writer = new Writer(buffer);
+var entry  = new InventoryEntry { Id = 7, Name = "Sprocket", Price = new PriceTag { Amount = 19.95m, Currency = "USD" } };
 writer.WriteInventoryEntry(entry);
 
 buffer.Position = 0;
-InventoryEntry roundTrip = reader.ReadInventoryEntry();
+var reader       = new Reader(buffer);
+InventoryEntry   roundTrip = reader.ReadInventoryEntry();
 ```
 
-The generated extensions serialize the members in declaration order, nesting calls to generated serializers for `PriceTag`. When a member already exposes custom `Read{Member}` or `Write{Member}` extensions, the generator invokes them instead of emitting generic calls.
+`Writer` and `Reader` are the concrete `IWriter`/`IReader` implementations from `omy.Utils.IO`.
 
 ## Additional scenarios
 
-### Nested collections and dictionaries
+### Nested models
 
-Complex object graphs composed of collections are supported out of the box.
-
-```csharp
-[GenerateReaderWriter]
-public partial class Warehouse
-{
-    [Field(0)]
-    public List<InventoryEntry> Items { get; set; } = new();
-
-    [Field(1)]
-    public Dictionary<string, PriceTag> RegionalPrices { get; set; } = new();
-}
-
-var warehouse = new Warehouse
-{
-    Items =
-    [
-        new InventoryEntry { Id = 1, Name = "Widget", Price = new PriceTag { Amount = 9.99m } },
-        new InventoryEntry { Id = 2, Name = "Gadget", Price = new PriceTag { Amount = 14.5m } },
-    ],
-};
-warehouse.RegionalPrices["EU"] = new PriceTag { Amount = 8.99m, Currency = "EUR" };
-
-writer.WriteWarehouse(warehouse);
-```
-
-Enumerables are serialized using their existing element serializers, so nested graphs stay
-consistent with individual entity serialization logic.
-
-### Version tolerant models
-
-When new fields are appended with higher `Field` numbers the generator keeps backward
-compatibility by making them optional.
+When a member type is also annotated with `[GenerateReaderWriter]`, the generator nests calls to the generated serializer automatically:
 
 ```csharp
 [GenerateReaderWriter]
-public partial class InventoryEntry
+public partial class Shipment
 {
     [Field(0)]
-    public required int Id { get; set; }
+    public required int TrackingId { get; set; }
 
     [Field(1)]
-    public required string Name { get; set; }
-
-    [Field(2)]
-    public PriceTag Price = new();
-
-    [Field(3)]
-    public string? Description { get; set; }
+    public required InventoryEntry Item { get; set; }
 }
 ```
 
-Older readers that only know the first three fields still deserialize correctly because the
-generated code checks the buffer length before attempting to access new fields.
+`WriteShipment` calls `WriteInventoryEntry` internally; `ReadShipment` calls `ReadInventoryEntry`.
 
-### Working with spans and pooled buffers
+### Reusing manual serializers
 
-The generated extensions are regular methods that accept any `IWriter`/`IReader` implementation
-so they integrate with high-performance pipelines.
-
-```csharp
-using System.Buffers;
-using Utils.IO.Serialization;
-
-ArrayPool<byte> pool = ArrayPool<byte>.Shared;
-byte[] rented = pool.Rent(4096);
-
-try
-{
-    var writer = new SpanWriterAdapter(rented);
-    writer.WriteInventoryEntry(entry);
-
-    var reader = new SpanReaderAdapter(writer.WrittenSpan);
-    InventoryEntry clone = reader.ReadInventoryEntry();
-}
-finally
-{
-    pool.Return(rented);
-}
-```
-
-Adapters such as `SpanWriterAdapter` and `SpanReaderAdapter` allow serialization without heap
-allocations which is ideal for messaging systems.
-
-## Advanced scenario: reusing manual serializers
-
-You can mix generated serializers with hand-written ones to handle special data formats.
+If a member type already exposes hand-written `Write{Member}` / `Read{Member}` extensions, the generator defers to them:
 
 ```csharp
 using Utils.IO.Serialization;
@@ -168,18 +98,12 @@ public static class MoneySerializer
 {
     public static void WritePriceTag(this IWriter writer, PriceTag value)
     {
-        writer.WriteDecimal(value.Amount);
-        writer.WriteString(value.Currency);
+        writer.Write<decimal>(value.Amount);
+        writer.Write<string>(value.Currency);
     }
 
     public static PriceTag ReadPriceTag(this IReader reader)
-    {
-        return new PriceTag
-        {
-            Amount = reader.ReadDecimal(),
-            Currency = reader.ReadString(),
-        };
-    }
+        => new() { Amount = reader.Read<decimal>(), Currency = reader.Read<string>() };
 }
 
 [GenerateReaderWriter]
@@ -193,46 +117,23 @@ public partial class Invoice
 }
 ```
 
-Because `MoneySerializer` already exposes `WritePriceTag` and `ReadPriceTag`, the generator defers to them when producing the `WriteInvoice` and `ReadInvoice` implementations, ensuring bespoke formatting is preserved.
+Because `WritePriceTag` already exists, the generated `WriteInvoice` calls it instead of emitting a generic `Write<PriceTag>`.
 
-## Streaming large collections
+### Streaming large collections
 
-Generated extensions work nicely with streaming scenarios by combining them with buffered adapters.
+Generated extensions are regular methods that work with any `Stream`-backed `Writer`/`Reader`:
 
 ```csharp
 using System.IO;
 using Utils.IO.Serialization;
 
 await using var stream = File.OpenWrite("report.bin");
-await using var writer = new BinaryWriterAdapter(new BinaryWriter(stream));
+var writer = new Writer(stream);
 
 foreach (InventoryEntry item in inventory)
-{
     writer.WriteInventoryEntry(item);
-}
 ```
 
-Since the generator only emits member-level serialization logic, you can control buffering and chunk sizes directly on the `Stream` or adapter used during serialization.
-
-### Hybrid streaming with asynchronous writers
-
-The same generated extensions can be paired with asynchronous `PipeWriter` implementations for
-network streaming.
-
-```csharp
-using System.IO.Pipelines;
-using Utils.IO.Serialization;
-
-Pipe pipe = new();
-PipeWriter pipeWriter = pipe.Writer;
-
-await using var writer = new PipeWriterAdapter(pipeWriter);
-foreach (InventoryEntry item in inventory)
-{
-    writer.WriteInventoryEntry(item);
-    await writer.FlushAsync();
-}
-```
-
-Because flushing is under the caller's control you can batch messages, append framing headers,
-or interleave generated payloads with custom metadata before sending them over the network.
+## Related packages
+- `omy.Utils.IO` – provides `IReader`, `IWriter`, `Reader`, `Writer`, `[GenerateReaderWriter]`, and `[Field]`.
+- `omy.Utils` – shared helpers.

--- a/Utils.NumberToString/README.md
+++ b/Utils.NumberToString/README.md
@@ -1,6 +1,6 @@
 # omy.Utils.NumberToString
 
-`omy.Utils.NumberToString` provides localized number-to-text conversion APIs extracted from the broader `omy.Utils` library.
+`omy.Utils.NumberToString` provides pluggable language-specific finalization hooks consumed by `NumberToStringConverter` in `omy.Utils`.
 
 ## Install
 
@@ -8,53 +8,54 @@
 dotnet add package omy.Utils.NumberToString
 ```
 
-## Usage
+## Supported frameworks
+- net8.0
+
+## Features
+- `INumberToStringLanguageSpecifics` — interface for post-processing converted number text.
+- `DefaultNumberToStringLanguageSpecifics` — no-op implementation; returns the text unchanged.
+- `GermanNumberToStringLanguageSpecifics` — applies German grammar rules (e.g. `"eine Million"` instead of `"ein Million"`).
+
+## Using language specifics with NumberToStringConverter
+
+Language specifics are injected into `NumberToStringConverter` (from `omy.Utils`) to apply locale-aware text adjustments after number conversion. The built-in culture configurations in `omy.Utils` already wire them automatically:
 
 ```csharp
 using Utils.Mathematics;
 
-NumberToStringConverter converter = NumberToStringConverter.Default;
-string text = converter.Convert(12345);
-Console.WriteLine(text);
-```
-
-### Use a specific culture
-
-```csharp
-using Utils.Mathematics;
-
-NumberToStringConverter english = NumberToStringConverter.GetConverter("EN");
-string value = english.Convert(21001);
-Console.WriteLine(value);
-```
-
-### Convert decimal and fractional values
-
-```csharp
-using Utils.Mathematics;
-using Utils.Numerics;
-
-NumberToStringConverter french = NumberToStringConverter.GetConverter("FR-fr");
-
-string decimalText = french.Convert(12.34m);
-string fractionText = french.Convert(new Number(3, 2));
-
-Console.WriteLine(decimalText);
-Console.WriteLine(fractionText);
-```
-
-### Use language-specific finalization
-
-```csharp
-using Utils.Mathematics;
-
+// The "DE" converter uses GermanNumberToStringLanguageSpecifics internally
 NumberToStringConverter german = NumberToStringConverter.GetConverter("DE");
-string million = german.Convert(1_000_000);
-Console.WriteLine(million); // "eine Million" with German specifics
+string text = german.Convert(1_000_000);
+Console.WriteLine(text); // "eine Million"
 ```
 
-## Notes
+## Implementing a custom finalization
 
-- Targets stable frameworks for package consumers.
-- Versioning follows the `omy.Utils` package family.
-- For broader utility features, see the root package: `omy.Utils`.
+Implement `INumberToStringLanguageSpecifics` to apply your own post-processing step:
+
+```csharp
+using Utils.Mathematics;
+
+public class UpperCaseSpecifics : INumberToStringLanguageSpecifics
+{
+    public string FinalizeWriting(string languageIdentifier, string text)
+        => text.ToUpperInvariant();
+}
+```
+
+Pass an instance to the `NumberToStringConverter` constructor (declared in `omy.Utils`) via the `languageSpecifics` parameter.
+
+## DefaultNumberToStringLanguageSpecifics
+
+Used automatically when no language specifics are provided — it returns the input text unchanged:
+
+```csharp
+using Utils.Mathematics;
+
+var specifics = new DefaultNumberToStringLanguageSpecifics();
+string result = specifics.FinalizeWriting("EN", "twenty-one");
+// → "twenty-one" (no change)
+```
+
+## Related packages
+- `omy.Utils` — contains `NumberToStringConverter` and all built-in culture configurations.

--- a/Utils.OData.Generators/README.md
+++ b/Utils.OData.Generators/README.md
@@ -1,6 +1,6 @@
-# Utils.OData.Generators
+# omy.Utils.OData.Generators
 
-`Utils.OData.Generators` offers a Roslyn source generator that materializes entity classes and helpers for contexts derived from `Utils.OData.ODataContext`. It targets **.NET 9** and consumes EDMX metadata so OData payloads can be accessed through strongly typed models.
+`omy.Utils.OData.Generators` is a Roslyn source generator that reads EDMX metadata at build time and emits strongly typed entity classes nested inside your `ODataContext` derivative.
 
 ## Install
 ```bash
@@ -12,43 +12,53 @@ dotnet add package omy.Utils.OData.Generators
 
 ## Features
 
-- Locates partial classes inheriting from `ODataContext` and inspects their base constructor calls.
-- Loads EDMX definitions from relative paths or HTTP/HTTPS endpoints at build time.
-- Generates nested entity classes with nullable support, XML documentation, and `[Key]` attributes for primary keys.
-- Reports diagnostics when metadata cannot be found, downloaded, or deserialized (`ODATA001`–`ODATA003`).
-- Produces deterministic source files that play nicely with incremental builds and IDE navigation.
+- Locates `partial` classes inheriting from `ODataContext` and inspects their base constructor call.
+- Loads EDMX definitions from a relative file path or an HTTP/HTTPS endpoint at build time.
+- Generates nested entity classes with nullable properties, XML documentation, and `[Key]` attributes for primary-key columns.
+- Reports diagnostics when the metadata cannot be found, downloaded, or deserialized (`ODATA001`–`ODATA003`).
 
 ## Prerequisites
 
-1. Reference `Utils.OData` in your project.
-2. Add `Utils.OData.Generators` as an analyzer reference so MSBuild executes the generator.
-3. Create a partial context that calls an `ODataContext` base constructor with the EDMX location.
+1. Reference `omy.Utils.OData` as a library dependency.
+2. Add `omy.Utils.OData.Generators` as an analyzer reference so MSBuild executes the generator.
+3. Declare your context as a `partial` class and pass the EDMX path or URL to the base constructor.
 
 ## Usage example
 
 ```csharp
 using Utils.OData;
+using Utils.OData.Linq;
 
+// The generator reads Products.edmx and emits ProductContext.Product
 public partial class ProductContext : ODataContext
 {
     public ProductContext() : base("metadata/Products.edmx") { }
+
+    // Expose typed sets using the protected Query<T> helper
+    public ODataQueryable<Product> Products => Query<Product>("Products");
 }
 ```
 
-When the project is built, the generator reads `metadata/Products.edmx`, produces partial classes such as `ProductContext.Product`, and populates each property with the correct .NET type. The generated members can then be consumed through the LINQ provider:
+After build, `ProductContext.Product` is available as a generated nested partial class. Compose queries using LINQ and compile them to OData parameters:
 
 ```csharp
-var context = new ProductContext();
-var query = context.Products.Where(p => p.Price > 5).OrderBy(p => p.Name);
-```
+using Utils.OData.Linq;
 
-If the EDMX path is wrong or the file cannot be parsed, the generator raises diagnostics so the issue is caught during compilation instead of at runtime.
+var ctx = new ProductContext();
+var query = ctx.Products
+    .Where(p => p.Price > 5)
+    .OrderBy(p => p.Name);
+
+ODataQueryCompilation compiled = query.CompileToODataQuery();
+Console.WriteLine(compiled.ToUriString());
+// → Products?$filter=Price gt 5
+```
 
 ## Examples
 
 ### Extending generated entities
 
-Entities are emitted as partial classes, allowing domain-specific behavior to be added alongside the generated members.
+Generated entity classes are `partial`, so you can add domain logic alongside the generated properties:
 
 ```csharp
 public partial class ProductContext
@@ -60,97 +70,66 @@ public partial class ProductContext
 }
 ```
 
-Because `Product` is a partial class, additional properties and helper methods seamlessly coexist with generated properties while keeping custom logic separate from tooling output.
-
 ### Consuming remote metadata
 
-You can point the base constructor to a remote EDMX URL; the generator downloads and caches the metadata during build.
+Point the base constructor to a remote EDMX endpoint; the generator downloads and caches the metadata at build time:
 
 ```csharp
 public partial class RemoteContext : ODataContext
 {
     public RemoteContext() : base("https://example.com/$metadata") { }
+
+    public ODataQueryable<Order> Orders => Query<Order>("Orders");
 }
 ```
 
-When network retrieval fails, diagnostic `ODATA002` highlights the HTTP issue, while malformed payloads trigger `ODATA003`, making problems explicit to developers before deployment.
+When network retrieval fails, diagnostic `ODATA002` is raised. Malformed payloads trigger `ODATA003`, surfacing problems at compile time rather than at runtime.
 
-### Handling multiple models
+### Multiple contexts in one assembly
 
-Large solutions often require multiple contexts. Simply declare additional partial classes, each referencing a different EDMX location, and the generator will emit isolated entity hierarchies per context.
+Each `partial` class referencing a different EDMX produces an isolated set of entity types:
 
 ```csharp
 public partial class SalesContext : ODataContext
 {
     public SalesContext() : base("metadata/Sales.edmx") { }
+
+    public ODataQueryable<Invoice> Invoices => Query<Invoice>("Invoices");
 }
 
 public partial class SupportContext : ODataContext
 {
     public SupportContext() : base("metadata/Support.edmx") { }
+
+    public ODataQueryable<Ticket> Tickets => Query<Ticket>("Tickets");
 }
 ```
 
-Each context receives its own `ODataQueryable<T>` properties and entity types, ensuring models stay isolated even when they share the same assembly.
+### Expand navigation properties
 
-### Navigation properties and expansions
-
-Generated entities include navigation properties mapped from the EDMX metadata.
+Use `Expand(params string[])` to request eager loading of related entities:
 
 ```csharp
-using System.Linq;
-using Utils.OData;
+using Utils.OData.Linq;
 
-public partial class ProductContext : ODataContext
-{
-    public ProductContext() : base("metadata/Products.edmx") { }
-}
+var ctx = new ProductContext();
+var query = ctx.Products
+    .Where(p => p.Price > 5)
+    .Expand("Supplier", "Category");
 
-var context = new ProductContext();
-var query = context.Products
-    .Where(p => p.Supplier.City == "Paris")
-    .Expand(p => p.Supplier)
-    .Select(p => new { p.Name, Supplier = p.Supplier.Name });
+ODataQueryCompilation compiled = query.CompileToODataQuery();
+Console.WriteLine(compiled.ToUriString());
+// → Products?$expand=Supplier,Category&$filter=Price gt 5
 ```
-
-The LINQ provider recognizes the generated navigation properties and emits `$expand` segments
-automatically when needed.
-
-### Partial classes for validation
-
-Because entities are partial classes, domain validation rules can live alongside generated
-members without being lost during rebuilds.
-
-```csharp
-using System;
-
-public partial class ProductContext
-{
-    public partial class Product
-    {
-        partial void OnNameChanging(string? value)
-        {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                throw new ArgumentException("A product requires a non-empty name.");
-            }
-        }
-    }
-}
-```
-
-The generator respects existing partial methods and only emits missing declarations, so custom
-validation hooks run whenever the entity property changes.
 
 ### Diagnostics reference
 
-Diagnostics surfaced by the generator can be acted upon quickly during development:
+| Id       | Cause                                                         | Resolution                                                    |
+|----------|---------------------------------------------------------------|---------------------------------------------------------------|
+| ODATA001 | Derived context is not declared `partial`.                    | Add the `partial` modifier to the class declaration.          |
+| ODATA002 | Base constructor argument could not be resolved at build time.| Use a string literal for the EDMX path or URL.                |
+| ODATA003 | EDMX file or URL could not be loaded or parsed.               | Check the path, network connectivity, and document structure. |
 
-| Id        | Message                                                            | Resolution hint                                         |
-|-----------|--------------------------------------------------------------------|---------------------------------------------------------|
-| ODATA001  | `ODataContext` constructor did not specify a metadata source.      | Ensure the base call references a local file or URL.    |
-| ODATA002  | Metadata file or endpoint could not be reached.                    | Verify network connectivity and credentials.            |
-| ODATA003  | Metadata content could not be parsed into EDMX structures.         | Validate that the EDMX document is well-formed XML.     |
-| ODATA004  | Duplicate entity names detected across merged EDMX documents.      | Rename the entities or split them into distinct models. |
-
-Keeping this table handy speeds up troubleshooting when metadata moves or services change.
+## Related packages
+- `omy.Utils.OData` – runtime client and LINQ provider.
+- `omy.Utils` – shared helpers used by the OData components.

--- a/Utils.OData/README.md
+++ b/Utils.OData/README.md
@@ -1,6 +1,6 @@
 # omy.Utils.OData (OData client helpers)
 
-`omy.Utils.OData` delivers HTTP client helpers, a LINQ provider, and metadata utilities to simplify consuming OData services.
+`omy.Utils.OData` delivers an HTTP client, a LINQ expression compiler, and metadata utilities for consuming OData services.
 
 ## Install
 ```bash
@@ -11,31 +11,198 @@ dotnet add package omy.Utils.OData
 - net9.0
 
 ## Features
-- `QueryOData` HTTP client with cookie forwarding, credential support, and automatic paging.
-- `ODataQueryBuilder` for constructing compliant query strings from an `IQuery` description.
-- `ODataContext` base class that loads EDMX metadata and exposes typed/untyped queryables.
-- Metadata converters that map raw responses to CLR values.
+- `QueryOData` — HTTP client with automatic paging, cookie forwarding, and credential support.
+- `Query` / `IQuery` — query definition with `Table`, `Filters`, `Select`, `Top`, `Skip`, `OrderBy`, `Search`, `Count`.
+- `ODataContext` — abstract base class that loads EDMX metadata and exposes typed/untyped LINQ queryables.
+- `ODataQueryable<T>` + `CompileToODataQuery()` — LINQ expression compiler that translates expressions into OData query parameters.
+- `Expand(params string[])` — appends `$expand` navigation property segments to a query.
 
 ## Quick usage
+
 ```csharp
+using Utils.OData;
+
 var query = new Query
 {
-    Table = "Products",
-    Select = "Id,Name,Price",
+    Table   = "Products",
+    Select  = "Id,Name,Price",
     Filters = "Price gt 10",
     OrderBy = "Name",
-    Top = 50,
+    Top     = 50,
 };
 
-var client = new QueryOData("https://example.com/odata");
-using HttpResponseMessage? response = await client.SimpleQuery(query, cancellationToken: CancellationToken.None);
+using var client = new QueryOData("https://example.com/odata");
+HttpResponseMessage? response = await client.SimpleQuery(query);
 if (response is not null && response.IsSuccessStatusCode)
 {
     string json = await response.Content.ReadAsStringAsync();
-    // deserialize or process the payload
+    // deserialize or process the OData JSON payload
 }
 ```
 
+## QueryOData examples
+
+### Aggregated JSON with automatic paging
+
+`QueryToJSon` transparently fetches subsequent pages and returns all matching rows as a single `JsonArray`.
+
+```csharp
+using System.Text.Json.Nodes;
+using Utils.OData;
+
+using var client = new QueryOData("https://example.com/odata");
+
+var query = new Query { Table = "Orders", Filters = "Status eq 'Open'" };
+var result = await client.QueryToJSon(query, maxPerRequest: 100);
+
+if (!result.IsError)
+{
+    JsonArray? rows = result.Value.Datas;
+    Console.WriteLine($"Retrieved {rows?.Count} orders.");
+}
+```
+
+### Streaming rows as IDataReader
+
+`QueryToDataReader` returns an `IDataReader` that downloads subsequent pages in the background, suitable for large datasets.
+
+```csharp
+using System.Data;
+using Utils.OData;
+
+using var client = new QueryOData("https://example.com/odata");
+
+var query = new Query { Table = "Transactions", Select = "Id,Amount,Date", Top = 10_000 };
+var readerResult = await client.QueryToDataReader(query, maxPerRequest: 500);
+
+if (!readerResult.IsError)
+{
+    using IDataReader reader = readerResult.Value;
+    while (reader.Read())
+    {
+        int    id     = reader.GetInt32(0);
+        decimal amount = reader.GetDecimal(1);
+        Console.WriteLine($"{id}: {amount:C}");
+    }
+}
+```
+
+### Forwarding session context
+
+Pass an incoming `HttpRequestMessage` to copy its headers and cookies to the outgoing OData request:
+
+```csharp
+using Utils.OData;
+
+using var client = new QueryOData("https://example.com/odata");
+var query = new Query { Table = "UserData" };
+HttpResponseMessage? response = await client.SimpleQuery(query, sourceRequest: incomingRequest);
+```
+
+### Custom HttpClient
+
+Provide your own `HttpClient` when you need custom message handlers or certificate validation:
+
+```csharp
+using System.Net.Http;
+using Utils.OData;
+
+var httpClient = new HttpClient();  // managed externally — not disposed by QueryOData
+using var client = new QueryOData("https://example.com/odata", httpClient);
+```
+
+### Credentials
+
+```csharp
+using System.Net;
+using Utils.OData;
+
+using var client = new QueryOData("https://example.com/odata");
+client.Credentials = new NetworkCredential("user", "password");
+```
+
+## ODataContext examples
+
+Derive from `ODataContext` to load EDMX metadata once and expose typed and untyped entity sets.
+
+```csharp
+using Utils.OData;
+using Utils.OData.Linq;
+
+public partial class NorthwindContext : ODataContext
+{
+    public NorthwindContext() : base("northwind.edmx") { }
+
+    // Expose a typed entity set via the protected Query<T> method
+    public ODataQueryable<Product> Products => Query<Product>("Products");
+
+    // Expose an untyped entity set for dynamic access
+    public ODataQueryable<ODataUntypedRow> RawCategories => Table("Categories");
+}
+
+public class Product
+{
+    public int    Id    { get; set; }
+    public string Name  { get; set; }
+    public decimal Price { get; set; }
+}
+```
+
+### LINQ expression compiler
+
+The LINQ provider translates expressions into OData query parameters. Use `CompileToODataQuery()` to obtain the compiled parameters and `ToUriString()` to build the URL fragment.
+
+```csharp
+using Utils.OData;
+using Utils.OData.Linq;
+
+var ctx = new NorthwindContext();
+
+var query = ctx.Products
+    .Where(p => p.Price > 10)
+    .OrderBy(p => p.Name)
+    .Take(20);
+
+ODataQueryCompilation compiled = query.CompileToODataQuery();
+// compiled.EntitySetName → "Products"
+// compiled.Filters       → ["Price gt 10"]
+Console.WriteLine(compiled.ToUriString());
+// → Products?$filter=Price gt 10
+```
+
+### Expand navigation properties
+
+Use `Expand(params string[])` to request eager loading of navigation properties:
+
+```csharp
+using Utils.OData;
+using Utils.OData.Linq;
+
+var ctx = new NorthwindContext();
+var query = ctx.Products
+    .Where(p => p.Price > 5)
+    .Expand("Supplier", "Category");
+
+ODataQueryCompilation compiled = query.CompileToODataQuery();
+Console.WriteLine(compiled.ToUriString());
+// → Products?$expand=Supplier,Category&$filter=Price gt 5
+```
+
+### Untyped row access
+
+Use `Table(entitySetName)` when no CLR type maps to the entity. Access field values through `GetValue<T>` inside a LINQ expression:
+
+```csharp
+using Utils.OData;
+using Utils.OData.Linq;
+
+var ctx = new NorthwindContext();
+var query = ctx.RawCategories
+    .Where(r => r.GetValue<string>("Country") == "France");
+
+ODataQueryCompilation compiled = query.CompileToODataQuery();
+```
+
 ## Related packages
-- `omy.Utils.OData.Generators` – source generator for strongly typed contexts.
+- `omy.Utils.OData.Generators` – source generator for strongly typed OData contexts.
 - `omy.Utils` – foundational helpers shared across the family.

--- a/Utils.VirtualMachine/README.md
+++ b/Utils.VirtualMachine/README.md
@@ -11,29 +11,98 @@ dotnet add package omy.Utils.VirtualMachine
 - net8.0
 
 ## Features
-- Byte-code processor supporting little- and big-endian formats.
-- Attribute-based opcode declarations for concise instruction definitions.
-- Facilities to plug in stacks, registers, and memory models.
+- `VirtualProcessor<T>` — abstract base class; derive and annotate methods with `[Instruction]` to register opcodes.
+- `[Instruction(name, params byte[] opcode)]` — maps a method to a single- or multi-byte opcode.
+- `Context` — abstract execution context carrying the byte-code array and instruction pointer.
+- `DefaultContext` — concrete context with a `Stack<object>` for stack-based machines.
+- Supports little-endian (default) and big-endian operand reading.
 
 ## Quick usage
+
 ```csharp
 using Utils.VirtualMachine;
 
-class SampleMachine : VirtualProcessor<DefaultContext>
+class StackMachine : VirtualProcessor<DefaultContext>
 {
-    [Instruction("PUSH", 0x01, 0x01)]
+    [Instruction("PUSH", 0x01)]
     void Push(DefaultContext ctx, byte value) => ctx.Stack.Push(value);
 
-    [Instruction("ADD", 0x10, 0x01)]
+    [Instruction("ADD", 0x10)]
     void Add(DefaultContext ctx)
     {
-        var b = (byte)ctx.Stack.Pop();
-        var a = (byte)ctx.Stack.Pop();
+        byte b = (byte)ctx.Stack.Pop();
+        byte a = (byte)ctx.Stack.Pop();
         ctx.Stack.Push((byte)(a + b));
     }
+}
+
+byte[] program = [0x01, 3, 0x01, 4, 0x10]; // PUSH 3, PUSH 4, ADD
+var machine = new StackMachine();
+var context = new DefaultContext(program);
+machine.Execute(context);
+
+Console.WriteLine((byte)context.Stack.Peek()); // 7
+```
+
+## Multi-byte opcodes
+
+When different instruction variants share a common prefix, use a multi-byte opcode to disambiguate:
+
+```csharp
+using Utils.VirtualMachine;
+
+class ExtendedMachine : VirtualProcessor<DefaultContext>
+{
+    [Instruction("PUSH_INT", 0x01, 0x01)]
+    void PushInt(DefaultContext ctx, int value) => ctx.Stack.Push(value);
+
+    [Instruction("PUSH_BYTE", 0x01, 0x02)]
+    void PushByte(DefaultContext ctx, byte value) => ctx.Stack.Push(value);
+}
+```
+
+## Custom context
+
+Derive from `Context` to add registers, memory, or other execution state:
+
+```csharp
+using Utils.VirtualMachine;
+
+class CpuContext : Context
+{
+    public CpuContext(byte[] program) : base(program) { }
+
+    public int[] Registers { get; } = new int[8];
+}
+
+class Cpu : VirtualProcessor<CpuContext>
+{
+    [Instruction("LOAD", 0x20)]
+    void Load(CpuContext ctx, byte reg, int value)
+        => ctx.Registers[reg] = value;
+
+    [Instruction("ADD_REG", 0x21)]
+    void AddReg(CpuContext ctx, byte dest, byte src)
+        => ctx.Registers[dest] += ctx.Registers[src];
+}
+```
+
+## Big-endian mode
+
+Pass `littleEndian: false` to interpret multi-byte operands as big-endian:
+
+```csharp
+using Utils.VirtualMachine;
+
+class BigEndianMachine : VirtualProcessor<DefaultContext>
+{
+    protected BigEndianMachine() : base(littleEndian: false) { }
+
+    [Instruction("PUSH16", 0x03)]
+    void Push16(DefaultContext ctx, short value) => ctx.Stack.Push(value);
 }
 ```
 
 ## Related packages
-- `omy.Utils.IO` – for binary parsing helpers.
+- `omy.Utils.IO` – binary parsing helpers used by the VM framework.
 - `omy.Utils.Fonts` – uses the VM framework for font table parsing.


### PR DESCRIPTION
## Summary

Completes the README documentation pass for all remaining `omy.Utils.*` packages. Each README was written against the real public API verified from source.

### Packages updated

| Package | Changes |
|---|---|
| `Utils.Collections` | Expand minimal README with SkipList constructors, threshold tuning, custom comparer, Remove/Clear/CopyTo examples |
| `Utils.NumberToString` | **Corrected**: previous README referenced `NumberToStringConverter.Default` which lives in `omy.Utils`, not this package. README now documents the actual exports: `INumberToStringLanguageSpecifics`, `DefaultNumberToStringLanguageSpecifics`, `GermanNumberToStringLanguageSpecifics` |
| `Utils.VirtualMachine` | Expand with multi-byte opcodes, custom context, big-endian mode examples |
| `Utils.OData` | Full rewrite: `QueryToJSon` paging, `QueryToDataReader` streaming, session forwarding, `ODataContext` derivation, LINQ `CompileToODataQuery`, `Expand` |
| `Utils.OData.Generators` | **Corrected**: replaced `context.Products` (not auto-generated) with `Query<T>()` pattern; fixed `Expand(lambda)` → `Expand(params string[])`; removed non-existent `ODATA004` and `partial void OnNameChanging` |
| `Utils.DependencyInjection.Generators` | **Corrected**: removed `partial void OnAfterConfigureServices` / `OnBeforeConfigureServices` examples — these partial methods are not emitted by the generator |
| `Utils.IO.Serialization.Generators` | **Corrected**: replaced `BinaryWriterAdapter`, `SpanWriterAdapter`, `PipeWriterAdapter` (do not exist) with `Reader(stream)` and `Writer(stream)` from `omy.Utils.IO` |

### Skipped
- `Utils.Parser` and all sub-packages — still in active development.

## Test plan
- [ ] All code examples compile against the verified source API
- [ ] No references to non-existent classes, properties, or methods
- [ ] Markdown renders cleanly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)