### PR TITLE
Harden public collection contracts for Visual Studio syntax colorization DTOs

### DIFF
--- a/Utils.Parser.VisualStudio/SyntaxColorizationDescriptor.cs
+++ b/Utils.Parser.VisualStudio/SyntaxColorizationDescriptor.cs
@@ -7,20 +7,61 @@ namespace Utils.Parser.VisualStudio;
 /// </summary>
 public sealed class SyntaxColorizationDescriptor
 {
+    private readonly List<string> fileExtensions = [];
+    private readonly List<string> stringSyntaxExtensions = [];
+    private readonly List<SyntaxColorizationDescriptorEntry> entries = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SyntaxColorizationDescriptor"/> class.
+    /// </summary>
+    public SyntaxColorizationDescriptor()
+    {
+        FileExtensions = fileExtensions.AsReadOnly();
+        StringSyntaxExtensions = stringSyntaxExtensions.AsReadOnly();
+        Entries = entries.AsReadOnly();
+    }
+
     /// <summary>
     /// Gets the file extensions declared by the descriptor.
     /// </summary>
-    public List<string> FileExtensions { get; } = new List<string>();
+    public IReadOnlyList<string> FileExtensions { get; }
 
     /// <summary>
     /// Gets the StringSyntax extension names declared by the descriptor.
     /// </summary>
-    public List<string> StringSyntaxExtensions { get; } = new List<string>();
+    public IReadOnlyList<string> StringSyntaxExtensions { get; }
 
     /// <summary>
     /// Gets the mapping entries for classifications and rule names.
     /// </summary>
-    public List<SyntaxColorizationDescriptorEntry> Entries { get; } = new List<SyntaxColorizationDescriptorEntry>();
+    public IReadOnlyList<SyntaxColorizationDescriptorEntry> Entries { get; }
+
+    /// <summary>
+    /// Adds one file extension to the descriptor.
+    /// </summary>
+    /// <param name="fileExtension">File extension to add.</param>
+    internal void AddFileExtension(string fileExtension)
+    {
+        fileExtensions.Add(fileExtension);
+    }
+
+    /// <summary>
+    /// Adds one StringSyntax extension to the descriptor.
+    /// </summary>
+    /// <param name="stringSyntaxExtension">StringSyntax extension to add.</param>
+    internal void AddStringSyntaxExtension(string stringSyntaxExtension)
+    {
+        stringSyntaxExtensions.Add(stringSyntaxExtension);
+    }
+
+    /// <summary>
+    /// Adds one entry to the descriptor.
+    /// </summary>
+    /// <param name="entry">Entry to add.</param>
+    internal void AddEntry(SyntaxColorizationDescriptorEntry entry)
+    {
+        entries.Add(entry);
+    }
 }
 
 /// <summary>
@@ -28,6 +69,8 @@ public sealed class SyntaxColorizationDescriptor
 /// </summary>
 public sealed class SyntaxColorizationDescriptorEntry
 {
+    private readonly List<string> rules = [];
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SyntaxColorizationDescriptorEntry"/> class.
     /// </summary>
@@ -35,6 +78,7 @@ public sealed class SyntaxColorizationDescriptorEntry
     public SyntaxColorizationDescriptorEntry(string classification)
     {
         Classification = classification;
+        Rules = rules.AsReadOnly();
     }
 
     /// <summary>
@@ -45,5 +89,14 @@ public sealed class SyntaxColorizationDescriptorEntry
     /// <summary>
     /// Gets the rule names included in this section.
     /// </summary>
-    public List<string> Rules { get; } = new List<string>();
+    public IReadOnlyList<string> Rules { get; }
+
+    /// <summary>
+    /// Adds one rule name to this section.
+    /// </summary>
+    /// <param name="rule">Rule name to add.</param>
+    internal void AddRule(string rule)
+    {
+        rules.Add(rule);
+    }
 }

--- a/Utils.Parser.VisualStudio/SyntaxColorizationDescriptorFileParser.cs
+++ b/Utils.Parser.VisualStudio/SyntaxColorizationDescriptorFileParser.cs
@@ -45,14 +45,25 @@ public sealed class SyntaxColorizationDescriptorFileParser
         SyntaxColorisationDocument parsedDocument = SyntaxColorisationGrammar.Parse(content);
         var descriptor = new SyntaxColorizationDescriptor();
 
-        descriptor.FileExtensions.AddRange(parsedDocument.FileExtensions);
-        descriptor.StringSyntaxExtensions.AddRange(parsedDocument.StringSyntaxExtensions);
+        foreach (string fileExtension in parsedDocument.FileExtensions)
+        {
+            descriptor.AddFileExtension(fileExtension);
+        }
+
+        foreach (string stringSyntaxExtension in parsedDocument.StringSyntaxExtensions)
+        {
+            descriptor.AddStringSyntaxExtension(stringSyntaxExtension);
+        }
 
         foreach (SyntaxColorisationSection section in parsedDocument.Sections)
         {
             var entry = new SyntaxColorizationDescriptorEntry(section.Classification);
-            entry.Rules.AddRange(section.Rules);
-            descriptor.Entries.Add(entry);
+            foreach (string rule in section.Rules)
+            {
+                entry.AddRule(rule);
+            }
+
+            descriptor.AddEntry(entry);
         }
 
         return descriptor;

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -78,6 +78,7 @@ Current capabilities and responsibilities:
 - Parser feature capabilities metadata is present.
 - ANTLR4 grammar bootstrap/conversion support is present.
 - Syntax colorisation descriptor DTO public contracts are hardened to read-only collection exposure (`IReadOnlyList<T>`), with mutation remaining internal to parser conversion flow.
+- Visual Studio syntax colorization descriptor DTO public contracts are hardened to read-only collection exposure (`IReadOnlyList<T>`), with descriptor-population mutation remaining internal to conversion flow.
 - Runtime invariant documentation exists.
 - Branch outcome documentation exists.
 - Parser tests are organized to reflect runtime contracts.

--- a/UtilsTest.Functional/Parser/VisualStudioSyntaxColorisationTests.cs
+++ b/UtilsTest.Functional/Parser/VisualStudioSyntaxColorisationTests.cs
@@ -29,10 +29,10 @@ public class VisualStudioSyntaxColorisationTests
             var parser = new SyntaxColorizationDescriptorFileParser();
             SyntaxColorizationDescriptor descriptor = parser.ParseFile(filePath);
 
-            CollectionAssert.AreEquivalent(new[] { ".demo" }, descriptor.FileExtensions);
-            CollectionAssert.AreEquivalent(new[] { "DEMO" }, descriptor.StringSyntaxExtensions);
+            CollectionAssert.AreEquivalent(new[] { ".demo" }, descriptor.FileExtensions.ToArray());
+            CollectionAssert.AreEquivalent(new[] { "DEMO" }, descriptor.StringSyntaxExtensions.ToArray());
             Assert.AreEqual("Keyword", descriptor.Entries[0].Classification);
-            CollectionAssert.AreEquivalent(new[] { "FOR", "IF" }, descriptor.Entries[0].Rules);
+            CollectionAssert.AreEquivalent(new[] { "FOR", "IF" }, descriptor.Entries[0].Rules.ToArray());
         }
         finally
         {

--- a/UtilsTest.Functional/Parser/VisualStudioSyntaxColorizationDescriptorApiTests.cs
+++ b/UtilsTest.Functional/Parser/VisualStudioSyntaxColorizationDescriptorApiTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.VisualStudio;
+
+namespace UtilsTest.Functional.Parser;
+
+[TestClass]
+public class VisualStudioSyntaxColorizationDescriptorApiTests
+{
+    [TestMethod]
+    public void Descriptor_CollectionsExposeReadOnlyContracts()
+    {
+        Assert.AreEqual(typeof(IReadOnlyList<string>), typeof(SyntaxColorizationDescriptor).GetProperty(nameof(SyntaxColorizationDescriptor.FileExtensions))!.PropertyType);
+        Assert.AreEqual(typeof(IReadOnlyList<string>), typeof(SyntaxColorizationDescriptor).GetProperty(nameof(SyntaxColorizationDescriptor.StringSyntaxExtensions))!.PropertyType);
+        Assert.AreEqual(typeof(IReadOnlyList<SyntaxColorizationDescriptorEntry>), typeof(SyntaxColorizationDescriptor).GetProperty(nameof(SyntaxColorizationDescriptor.Entries))!.PropertyType);
+        Assert.AreEqual(typeof(IReadOnlyList<string>), typeof(SyntaxColorizationDescriptorEntry).GetProperty(nameof(SyntaxColorizationDescriptorEntry.Rules))!.PropertyType);
+    }
+
+    [TestMethod]
+    public void Descriptor_CollectionsRejectConsumerMutation()
+    {
+        var descriptor = new SyntaxColorizationDescriptor();
+        var entry = new SyntaxColorizationDescriptorEntry("Keyword");
+
+        Assert.ThrowsException<NotSupportedException>(() => ((IList<string>)descriptor.FileExtensions).Add(".sql"));
+        Assert.ThrowsException<NotSupportedException>(() => ((IList<string>)descriptor.StringSyntaxExtensions).Add("SQL"));
+        Assert.ThrowsException<NotSupportedException>(() => ((IList<SyntaxColorizationDescriptorEntry>)descriptor.Entries).Add(entry));
+        Assert.ThrowsException<NotSupportedException>(() => ((IList<string>)entry.Rules).Add("RULE"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove misleading consumer-owned mutation from Visual Studio syntax colorization descriptor DTOs by exposing read-only collection contracts while keeping descriptor population parser-owned.

### Description
- Replace public `List<T>` properties with `IReadOnlyList<T>` on `SyntaxColorizationDescriptor.FileExtensions`, `SyntaxColorizationDescriptor.StringSyntaxExtensions`, `SyntaxColorizationDescriptor.Entries`, and `SyntaxColorizationDescriptorEntry.Rules`.
- Introduce private backing `List<T>` fields and internal mutation methods `AddFileExtension`, `AddStringSyntaxExtension`, `AddEntry`, and `AddRule`, and update `SyntaxColorizationDescriptorFileParser.ParseContent` to populate DTOs via these methods.
- Update existing functional tests to consume the read-only surfaces (use `.ToArray()` for `CollectionAssert`) and add a new functional test `VisualStudioSyntaxColorizationDescriptorApiTests` that asserts the public properties expose `IReadOnlyList<T>` and consumer mutation throws `NotSupportedException`.
- Add a short ROADMAP note clarifying the Visual Studio descriptor DTO contract hardening.

### Testing
- Ran `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --filter "VisualStudioSyntaxColorisationTests|VisualStudioSyntaxColorizationDescriptorApiTests"` and the targeted tests passed (Passed: 18, Failed: 0).
- An initial attempt to run the API test in `UtilsTest.Unit` failed because that test referenced `Utils.Parser.VisualStudio`; the test was moved to the Functional test project to match available references and then executed successfully.
- No runtime or parser behavior changes were introduced and no parser runtime tests regressed in the targeted run.

### Public API impact
Yes. Public DTO collections now expose IReadOnlyList<T> instead of List<T>.

### Migration
Consumers must stop mutating descriptor collections directly. Use enumeration, LINQ, or copy into a mutable list when needed.

### Compatibility impact
Source-breaking for callers that relied on List<T> members such as Add, AddRange, or direct mutation.
------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c90658008326a944d8c4fd9c9d8b)