### PR TITLE
Consolidate parser runtime configuration onto ParserRuntimeFeaturePolicy

### DIFF
--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -100,7 +100,13 @@ public sealed class Antlr4GrammarConverter
         ISemanticPredicateEvaluator semanticPredicateEvaluator,
         IParserActionExecutor parserActionExecutor,
         DiagnosticBag? diagnostics = null)
-        => new Runtime.CompiledGrammar(Parse(grammarText, diagnostics), semanticPredicateEvaluator, parserActionExecutor);
+        => new Runtime.CompiledGrammar(
+            Parse(grammarText, diagnostics),
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                SemanticPredicateEvaluator = semanticPredicateEvaluator,
+                ParserActionExecutor = parserActionExecutor
+            });
 
     /// <summary>
     /// Full pipeline: ANTLR4 grammar text → resolved <see cref="Utils.Parser.Model.ParserDefinition"/>.

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -374,6 +374,7 @@ Current clarification status:
 - generator-side AST now preserves rule lifecycle prequel metadata (`@init` / `@after`) for parity/audit visibility while keeping runtime behavior and emitted C# unchanged.
 - shared ANTLR prequel metadata model extraction is complete for options/imports/actions/tokens/channels through mapper-only DTO sharing; runtime and generator parsing remain intentionally duplicated.
 - a shared netstandard2.0 ANTLR prequel DTO project was introduced, while runtime and generator parsing remain intentionally separate.
+- runtime advanced-configuration public API was consolidated so `ParserRuntimeFeaturePolicy` is the single explicit runtime feature-entry point for semantic predicates, parser actions, and runtime observers.
 
 Goal: progressively improve ANTLR4 grammar compatibility.
 

--- a/Utils.Parser/Runtime/CompiledGrammar.cs
+++ b/Utils.Parser/Runtime/CompiledGrammar.cs
@@ -32,48 +32,6 @@ public sealed class CompiledGrammar
 
     /// <summary>
     /// Initialises a <see cref="CompiledGrammar"/> from a fully resolved
-    /// <see cref="ParserDefinition"/> and an explicit semantic predicate evaluation policy.
-    /// </summary>
-    /// <param name="definition">A resolved grammar definition.</param>
-    /// <param name="semanticPredicateEvaluator">
-    /// Evaluator used by the embedded <see cref="ParserEngine"/> for semantic predicates.
-    /// </param>
-    public CompiledGrammar(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator)
-        : this(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = semanticPredicateEvaluator })
-    {
-    }
-
-    /// <summary>
-    /// Initialises a <see cref="CompiledGrammar"/> from a fully resolved
-    /// <see cref="ParserDefinition"/> and an explicit parser action execution policy.
-    /// </summary>
-    /// <param name="definition">A resolved grammar definition.</param>
-    /// <param name="parserActionExecutor">Parser embedded action execution policy.</param>
-    public CompiledGrammar(ParserDefinition definition, IParserActionExecutor parserActionExecutor)
-        : this(definition, ParserRuntimeFeaturePolicy.Default with { ParserActionExecutor = parserActionExecutor })
-    {
-    }
-
-    /// <summary>
-    /// Initialises a <see cref="CompiledGrammar"/> from a fully resolved
-    /// <see cref="ParserDefinition"/> with explicit predicate and action policies.
-    /// </summary>
-    /// <param name="definition">A resolved grammar definition.</param>
-    /// <param name="semanticPredicateEvaluator">Semantic predicate evaluator policy.</param>
-    /// <param name="parserActionExecutor">Parser embedded action execution policy.</param>
-    public CompiledGrammar(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator, IParserActionExecutor parserActionExecutor)
-        : this(
-            definition,
-            ParserRuntimeFeaturePolicy.Default with
-            {
-                SemanticPredicateEvaluator = semanticPredicateEvaluator,
-                ParserActionExecutor = parserActionExecutor
-            })
-    {
-    }
-
-    /// <summary>
-    /// Initialises a <see cref="CompiledGrammar"/> from a fully resolved
     /// <see cref="ParserDefinition"/> with an explicit runtime feature policy.
     /// </summary>
     /// <param name="definition">A resolved grammar definition.</param>

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -99,49 +99,6 @@ public sealed class ParserEngine
     }
 
     /// <summary>
-    /// Initializes a parser engine with an explicit semantic predicate evaluation policy.
-    /// </summary>
-    /// <param name="definition">Resolved parser definition.</param>
-    /// <param name="semanticPredicateEvaluator">
-    /// Strategy used to evaluate semantic predicates without executing arbitrary source code.
-    /// </param>
-    public ParserEngine(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator)
-        : this(
-            definition,
-            ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = semanticPredicateEvaluator })
-    {
-    }
-
-    /// <summary>
-    /// Initializes a parser engine with an explicit parser action execution policy.
-    /// </summary>
-    /// <param name="definition">Resolved parser definition.</param>
-    /// <param name="parserActionExecutor">Policy used to handle parser embedded actions.</param>
-    public ParserEngine(ParserDefinition definition, IParserActionExecutor parserActionExecutor)
-        : this(
-            definition,
-            ParserRuntimeFeaturePolicy.Default with { ParserActionExecutor = parserActionExecutor })
-    {
-    }
-
-    /// <summary>
-    /// Initializes a parser engine with explicit semantic predicate and action execution policies.
-    /// </summary>
-    /// <param name="definition">Resolved parser definition.</param>
-    /// <param name="semanticPredicateEvaluator">Policy used to evaluate semantic predicates.</param>
-    /// <param name="parserActionExecutor">Policy used to handle parser embedded actions.</param>
-    public ParserEngine(ParserDefinition definition, ISemanticPredicateEvaluator semanticPredicateEvaluator, IParserActionExecutor parserActionExecutor)
-        : this(
-            definition,
-            ParserRuntimeFeaturePolicy.Default with
-            {
-                SemanticPredicateEvaluator = semanticPredicateEvaluator,
-                ParserActionExecutor = parserActionExecutor
-            })
-    {
-    }
-
-    /// <summary>
     /// Initializes a parser engine with an explicit runtime feature policy.
     /// </summary>
     /// <param name="definition">Resolved parser definition.</param>

--- a/UtilsTest/Parser/ParserEngineActionExecutorTests.cs
+++ b/UtilsTest/Parser/ParserEngineActionExecutorTests.cs
@@ -35,7 +35,7 @@ public class ParserEngineActionExecutorTests
         var tokenRuleA = CreateTokenRuleA();
         var definition = CreateDefinition(startRule, tokenRuleA);
         var observer = new ObservingParserActionExecutor(ParserActionExecutionOutcome.NotExecuted());
-        var parser = new ParserEngine(definition, new DefaultSemanticPredicateEvaluator(), observer);
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new DefaultSemanticPredicateEvaluator(), ParserActionExecutor = observer });
 
         var result = parser.Parse([new Token(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
 
@@ -52,7 +52,7 @@ public class ParserEngineActionExecutorTests
         var startRule = CreateStartRuleWithInlineAction("run();");
         var tokenRuleA = CreateTokenRuleA();
         var definition = CreateDefinition(startRule, tokenRuleA);
-        var parser = new ParserEngine(definition, new DefaultSemanticPredicateEvaluator(), new ObservingParserActionExecutor(ParserActionExecutionOutcome.Executed));
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new DefaultSemanticPredicateEvaluator(), ParserActionExecutor = new ObservingParserActionExecutor(ParserActionExecutionOutcome.Executed) });
 
         var result = parser.Parse([new Token(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")]);
 
@@ -64,7 +64,7 @@ public class ParserEngineActionExecutorTests
     {
         var definition = CreateDefinition(CreateStartRuleWithInlineAction("run();"), CreateTokenRuleA());
         var diagnostics = new DiagnosticBag();
-        var parser = new ParserEngine(definition, new DefaultSemanticPredicateEvaluator(), new ObservingParserActionExecutor(ParserActionExecutionOutcome.Executed));
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new DefaultSemanticPredicateEvaluator(), ParserActionExecutor = new ObservingParserActionExecutor(ParserActionExecutionOutcome.Executed) });
 
         var result = parser.Parse([new Token(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
 
@@ -77,7 +77,7 @@ public class ParserEngineActionExecutorTests
     {
         var definition = CreateDefinition(CreateStartRuleWithInlineAction("skip();"), CreateTokenRuleA());
         var diagnostics = new DiagnosticBag();
-        var parser = new ParserEngine(definition, new DefaultSemanticPredicateEvaluator(), new ObservingParserActionExecutor(ParserActionExecutionOutcome.NotExecuted()));
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new DefaultSemanticPredicateEvaluator(), ParserActionExecutor = new ObservingParserActionExecutor(ParserActionExecutionOutcome.NotExecuted()) });
 
         var result = parser.Parse([new Token(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
 
@@ -92,8 +92,11 @@ public class ParserEngineActionExecutorTests
         var diagnostics = new DiagnosticBag();
         var parser = new ParserEngine(
             definition,
-            new DefaultSemanticPredicateEvaluator(),
-            new ObservingParserActionExecutor(ParserActionExecutionOutcome.NotExecuted(ParserDiagnostics.EmbeddedCodeExecutionDisabled, null, "parser action")));
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                SemanticPredicateEvaluator = new DefaultSemanticPredicateEvaluator(),
+                ParserActionExecutor = new ObservingParserActionExecutor(ParserActionExecutionOutcome.NotExecuted(ParserDiagnostics.EmbeddedCodeExecutionDisabled, null, "parser action"))
+            });
 
         var result = parser.Parse([new Token(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
 
@@ -110,12 +113,15 @@ public class ParserEngineActionExecutorTests
         var exception = new InvalidOperationException("compilation failed");
         var parser = new ParserEngine(
             definition,
-            new DefaultSemanticPredicateEvaluator(),
-            new ObservingParserActionExecutor(ParserActionExecutionOutcome.NotExecuted(
-                ParserDiagnostics.EmbeddedCodeCompilationFailed,
-                exception,
-                "parser action",
-                exception.Message)));
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                SemanticPredicateEvaluator = new DefaultSemanticPredicateEvaluator(),
+                ParserActionExecutor = new ObservingParserActionExecutor(ParserActionExecutionOutcome.NotExecuted(
+                    ParserDiagnostics.EmbeddedCodeCompilationFailed,
+                    exception,
+                    "parser action",
+                    exception.Message))
+            });
 
         _ = parser.Parse([new Token(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")], diagnostics: diagnostics);
 

--- a/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
+++ b/UtilsTest/Parser/ParserEngineSemanticPredicateEvaluatorTests.cs
@@ -22,7 +22,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     {
         var startRule = CreateStartRuleWithPredicate(new ValidatingPredicate("canProceed"));
         var definition = CreateDefinition(startRule);
-        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected));
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected) });
 
         var result = parser.Parse([]);
 
@@ -34,7 +34,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     {
         var startRule = CreateStartRuleWithPredicate(new GatingPredicate("canProceed"));
         var definition = CreateDefinition(startRule);
-        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied));
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied) });
 
         var result = parser.Parse([]);
 
@@ -46,7 +46,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     {
         var startRule = CreateStartRuleWithPredicate(new ValidatingPredicate("canProceed"));
         var definition = CreateDefinition(startRule);
-        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.NotEvaluated()));
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.NotEvaluated()) });
         var diagnostics = new DiagnosticBag();
 
         parser.Parse([], diagnostics: diagnostics);
@@ -93,7 +93,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
             """,
             diagnostics: null);
 
-        var parser = new ParserEngine(definition, new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected));
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected) });
         var lexer = new LexerEngine(definition);
         var result = parser.Parse(lexer.Tokenize(new StringReader("a")));
 
@@ -105,7 +105,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     public void Parser_ExpressionEvaluator_WhenCompilationThrows_EmitsUP1026WithoutUP1006()
     {
         var definition = CreateSemanticPredicateGrammarDefinition();
-        var parser = new ParserEngine(definition, new ExpressionSemanticPredicateEvaluator(new ThrowingExpressionCompiler()));
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new ExpressionSemanticPredicateEvaluator(new ThrowingExpressionCompiler()) });
         var lexer = new LexerEngine(definition);
         var diagnostics = new DiagnosticBag();
 
@@ -120,7 +120,7 @@ public class ParserEngineSemanticPredicateEvaluatorTests
     public void Parser_ExpressionEvaluator_WhenExpressionIsNotBoolean_EmitsUP1026WithoutUP1006()
     {
         var definition = CreateSemanticPredicateGrammarDefinition();
-        var parser = new ParserEngine(definition, new ExpressionSemanticPredicateEvaluator(new NonBooleanExpressionCompiler()));
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new ExpressionSemanticPredicateEvaluator(new NonBooleanExpressionCompiler()) });
         var lexer = new LexerEngine(definition);
         var diagnostics = new DiagnosticBag();
 
@@ -178,7 +178,9 @@ public class ParserEngineSemanticPredicateEvaluatorTests
         {
             new(new SourceSpan(0, 1, 1, 1), "A", "DEFAULT_MODE", "DEFAULT_CHANNEL", "a")
         };
-        var parser = new ParserEngine(definition, observer);
+        var parser = new ParserEngine(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = observer });
 
         var result = parser.Parse(tokens);
 
@@ -201,7 +203,10 @@ public class ParserEngineSemanticPredicateEvaluatorTests
 
         var grammar = new CompiledGrammar(
             definition,
-            new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected));
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                SemanticPredicateEvaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected)
+            });
 
         var result = grammar.Parse("a");
 

--- a/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
@@ -24,10 +24,10 @@ public class ParserRuntimeFeaturePolicyTests
     }
 
     /// <summary>
-    /// Verifies that existing constructor overloads map runtime strategies exactly as before.
+    /// Verifies that runtime feature policy configuration maps runtime strategies exactly as expected.
     /// </summary>
     [TestMethod]
-    public void ParserEngine_ExistingOverloads_ProduceEquivalentPolicies()
+    public void ParserEngine_RuntimeFeaturePolicy_ProducesEquivalentPolicies()
     {
         var definition = CreateMinimalDefinition();
         var evaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied);

--- a/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeFeaturePolicyTests.cs
@@ -33,9 +33,9 @@ public class ParserRuntimeFeaturePolicyTests
         var evaluator = new ConstantSemanticPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied);
         var executor = new ConstantParserActionExecutor(ParserActionExecutionOutcome.Executed);
 
-        var evaluatorOnly = new ParserEngine(definition, evaluator);
-        var executorOnly = new ParserEngine(definition, executor);
-        var combined = new ParserEngine(definition, evaluator, executor);
+        var evaluatorOnly = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = evaluator });
+        var executorOnly = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { ParserActionExecutor = executor });
+        var combined = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = evaluator, ParserActionExecutor = executor });
 
         Assert.AreSame(evaluator, GetSemanticPredicateEvaluator(evaluatorOnly));
         Assert.IsInstanceOfType<DefaultParserActionExecutor>(GetParserActionExecutor(evaluatorOnly));

--- a/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
+++ b/UtilsTest/Parser/ParserRuntimeInvariantTests.cs
@@ -38,7 +38,13 @@ public class ParserRuntimeInvariantTests
             ]));
         var definition = CreateDefinition(startRule, [subRule], LexerRule("A", "a"), LexerRule("B", "b"));
         var evaluator = new CountingPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied);
-        var parser = new ParserEngine(definition, evaluator, new CountingActionExecutor(ParserActionExecutionOutcome.NotExecuted()));
+        var parser = new ParserEngine(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                SemanticPredicateEvaluator = evaluator,
+                ParserActionExecutor = new CountingActionExecutor(ParserActionExecutionOutcome.NotExecuted())
+            });
 
         var result = parser.Parse([Token("A", "a")]);
 
@@ -63,7 +69,7 @@ public class ParserRuntimeInvariantTests
             ]));
         var definition = CreateDefinition(startRule, LexerRule("A", "a"), LexerRule("B", "b"));
         var actions = new CountingActionExecutor(ParserActionExecutionOutcome.Executed);
-        var parser = new ParserEngine(definition, new DefaultSemanticPredicateEvaluator(), actions);
+        var parser = new ParserEngine(definition, ParserRuntimeFeaturePolicy.Default with { SemanticPredicateEvaluator = new DefaultSemanticPredicateEvaluator(), ParserActionExecutor = actions });
 
         var result = parser.Parse([Token("A", "a")]);
 
@@ -88,7 +94,13 @@ public class ParserRuntimeInvariantTests
             ]));
         var definition = CreateDefinition(startRule, LexerRule("A", "a"), LexerRule("B", "b"));
         var evaluator = new CountingPredicateEvaluator(SemanticPredicateEvaluationOutcome.Satisfied);
-        var parser = new ParserEngine(definition, evaluator, new CountingActionExecutor(ParserActionExecutionOutcome.NotExecuted()));
+        var parser = new ParserEngine(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                SemanticPredicateEvaluator = evaluator,
+                ParserActionExecutor = new CountingActionExecutor(ParserActionExecutionOutcome.NotExecuted())
+            });
         var diagnostics = new DiagnosticBag();
 
         var result = parser.Parse([Token("A", "a"), Token("B", "b")], diagnostics: diagnostics);
@@ -116,7 +128,13 @@ public class ParserRuntimeInvariantTests
             ]));
         var definition = CreateDefinition(startRule, LexerRule("A", "a"), LexerRule("B", "b"));
         var evaluator = new CountingPredicateEvaluator(SemanticPredicateEvaluationOutcome.Rejected);
-        var parser = new ParserEngine(definition, evaluator, new CountingActionExecutor(ParserActionExecutionOutcome.NotExecuted()));
+        var parser = new ParserEngine(
+            definition,
+            ParserRuntimeFeaturePolicy.Default with
+            {
+                SemanticPredicateEvaluator = evaluator,
+                ParserActionExecutor = new CountingActionExecutor(ParserActionExecutionOutcome.NotExecuted())
+            });
         var diagnostics = new DiagnosticBag();
 
         var result = parser.Parse([Token("A", "a"), Token("B", "b")], diagnostics: diagnostics);


### PR DESCRIPTION
### Motivation
- Reduce public API debt by removing redundant runtime-configuration constructors.
- Make `ParserRuntimeFeaturePolicy` the single explicit entry point for advanced runtime options.
- Clarify responsibility boundaries for semantic predicates, parser actions, and runtime observers while keeping default conservative behavior unchanged.

### Audit summary
- Audited public `ParserEngine` and `CompiledGrammar` construction paths.
- Identified redundant public overloads that configured individual runtime strategies directly.
- Confirmed `ParserRuntimeFeaturePolicy` already models all advanced runtime configuration points: semantic predicates, parser actions, and passive runtime observation.

### Modifications
- Removed redundant public constructors from `ParserEngine` so only these remain:
  - `ParserEngine(ParserDefinition)`
  - `ParserEngine(ParserDefinition, ParserRuntimeFeaturePolicy)`
- Removed redundant public constructors from `CompiledGrammar` so only these remain:
  - `CompiledGrammar(ParserDefinition)`
  - `CompiledGrammar(ParserDefinition, ParserRuntimeFeaturePolicy)`
- Rewrote internal call sites and tests to use `ParserRuntimeFeaturePolicy.Default with { ... }`.
- Updated `Antlr4GrammarConverter.Compile(...)` to pass evaluator/action configuration through `ParserRuntimeFeaturePolicy`.
- Updated `Utils.Parser/ROADMAP.md` with a short note about runtime advanced-configuration API consolidation.

### Public API impact
Yes. This is an intentional pre-release breaking API change.

Removed from `ParserEngine`:
- `ParserEngine(ParserDefinition, ISemanticPredicateEvaluator)`
- `ParserEngine(ParserDefinition, IParserActionExecutor)`
- `ParserEngine(ParserDefinition, ISemanticPredicateEvaluator, IParserActionExecutor)`

Removed from `CompiledGrammar`:
- `CompiledGrammar(ParserDefinition, ISemanticPredicateEvaluator)`
- `CompiledGrammar(ParserDefinition, IParserActionExecutor)`
- `CompiledGrammar(ParserDefinition, ISemanticPredicateEvaluator, IParserActionExecutor)`

Kept:
- default conservative constructors;
- explicit `ParserRuntimeFeaturePolicy` constructors.

### Migration
Before:

```csharp
var parser = new ParserEngine(definition, evaluator);
```

After:

```csharp
var parser = new ParserEngine(
    definition,
    ParserRuntimeFeaturePolicy.Default with
    {
        SemanticPredicateEvaluator = evaluator
    });
```

Before:

```csharp
var grammar = new CompiledGrammar(definition, evaluator, executor);
```

After:

```csharp
var grammar = new CompiledGrammar(
    definition,
    ParserRuntimeFeaturePolicy.Default with
    {
        SemanticPredicateEvaluator = evaluator,
        ParserActionExecutor = executor
    });
```

### Compatibility impact
Source-breaking only for callers using the removed convenience constructors.

The equivalent behavior remains available through `ParserRuntimeFeaturePolicy`.

### Runtime impact
No runtime behavior change expected.

This PR does not change parser execution, scheduling, memoization, parse acceptance, parse-tree shape, semantic predicate semantics, parser action semantics, or observer behavior.

### Diagnostics impact
None. Diagnostic codes, diagnostic format, emission points, and ownership remain unchanged.

### Parse-tree impact
None.

### ANTLR compatibility impact
None. No ANTLR feature support level, compatibility diagnostic, runtime/generator parity rule, or grammar parsing behavior is changed.

### Documentation impact
- `Utils.Parser/ROADMAP.md`: updated to record the runtime advanced-configuration API consolidation.
- `docs/parser/ANTLRCompatibility.md`: no update required because ANTLR feature behavior and compatibility semantics are unchanged.
- `docs/parser/INDEX.md`: no update required because no parser documentation file was added, removed, moved, or materially re-scoped.
- Other parser docs/READMEs: no examples requiring the removed constructors were changed in this PR.

### Tests
- Updated impacted unit tests to construct `ParserEngine` / `CompiledGrammar` via `ParserRuntimeFeaturePolicy`.
- Renamed the policy-equivalence test so it no longer refers to removed overloads.
- Ran `dotnet test UtilsTest/UtilsTest.Unit.csproj`: 1340 passed, 5 skipped.
- Built the solution with `dotnet build` and fixed compile errors introduced by the constructor removals before running tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1704101bd08326bb89e6f74ac5bdf8)