### PR TITLE
Introduce composed diagnostic value objects and adapt diagnostics to use structured spans and locations

### DIFF
--- a/Utils.Parser.Diagnostics/DiagnosticBag.cs
+++ b/Utils.Parser.Diagnostics/DiagnosticBag.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Utils.Parser.Source;
 
 namespace Utils.Parser.Diagnostics;
 
@@ -76,6 +77,40 @@ public sealed class DiagnosticBag : IReadOnlyCollection<ParserDiagnostic>
             ruleName,
             exception);
 
+        _items.Add(diagnostic);
+        return diagnostic;
+    }
+
+    /// <summary>
+    /// Creates and adds a diagnostic from a descriptor with composed context objects.
+    /// </summary>
+    /// <param name="descriptor">Diagnostic descriptor.</param>
+    /// <param name="span">Optional source span.</param>
+    /// <param name="location">Optional source location.</param>
+    /// <param name="ruleName">Optional rule context.</param>
+    /// <param name="exception">Optional related exception.</param>
+    /// <param name="arguments">Message format arguments.</param>
+    /// <returns>The added diagnostic.</returns>
+    public ParserDiagnostic AddWithStructuredContext(
+        ParserDiagnosticDescriptor descriptor,
+        DiagnosticSpan? span,
+        SourceCodeLocation? location,
+        string? ruleName,
+        Exception? exception,
+        params object?[] arguments)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        var details = new DiagnosticDetails(
+            descriptor,
+            descriptor.FormatMessage(arguments),
+            ruleName,
+            exception);
+
+        var diagnostic = new ParserDiagnostic(details, span, location);
         _items.Add(diagnostic);
         return diagnostic;
     }

--- a/Utils.Parser.Diagnostics/DiagnosticDetails.cs
+++ b/Utils.Parser.Diagnostics/DiagnosticDetails.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace Utils.Parser.Diagnostics;
+
+/// <summary>
+/// Represents immutable content for a parser diagnostic.
+/// </summary>
+public sealed record DiagnosticDetails
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagnosticDetails"/> record.
+    /// </summary>
+    /// <param name="descriptor">Diagnostic descriptor.</param>
+    /// <param name="message">Resolved diagnostic message.</param>
+    /// <param name="ruleName">Optional rule name context.</param>
+    /// <param name="exception">Optional related exception.</param>
+    public DiagnosticDetails(
+        ParserDiagnosticDescriptor descriptor,
+        string message,
+        string? ruleName = null,
+        Exception? exception = null)
+    {
+        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+        RuleName = ruleName;
+        Exception = exception;
+    }
+
+    /// <summary>
+    /// Gets the diagnostic descriptor.
+    /// </summary>
+    public ParserDiagnosticDescriptor Descriptor { get; }
+
+    /// <summary>
+    /// Gets the resolved diagnostic message.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>
+    /// Gets the optional rule name context.
+    /// </summary>
+    public string? RuleName { get; }
+
+    /// <summary>
+    /// Gets the optional related exception.
+    /// </summary>
+    public Exception? Exception { get; }
+}

--- a/Utils.Parser.Diagnostics/DiagnosticSpan.cs
+++ b/Utils.Parser.Diagnostics/DiagnosticSpan.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Utils.Parser.Diagnostics;
+
+/// <summary>
+/// Represents a zero-based source span for a diagnostic.
+/// </summary>
+public sealed record DiagnosticSpan
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagnosticSpan"/> record.
+    /// </summary>
+    /// <param name="start">Zero-based source start index.</param>
+    /// <param name="length">Source span length.</param>
+    public DiagnosticSpan(int start, int length)
+    {
+        if (start < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(start), "Start must be greater than or equal to zero.");
+        }
+
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Length must be greater than or equal to zero.");
+        }
+
+        Start = start;
+        Length = length;
+    }
+
+    /// <summary>
+    /// Gets the zero-based source start index.
+    /// </summary>
+    public int Start { get; }
+
+    /// <summary>
+    /// Gets the source span length.
+    /// </summary>
+    public int Length { get; }
+}

--- a/Utils.Parser.Diagnostics/ParserDiagnostic.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostic.cs
@@ -1,4 +1,5 @@
 using System;
+using Utils.Parser.Source;
 
 namespace Utils.Parser.Diagnostics;
 
@@ -24,18 +25,49 @@ public sealed class ParserDiagnostic
         string? ruleName = null,
         Exception? exception = null)
     {
-        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
-        Message = message ?? throw new ArgumentNullException(nameof(message));
-        SpanStart = spanStart;
-        SpanLength = spanLength;
-        RuleName = ruleName;
-        Exception = exception;
+        Details = new DiagnosticDetails(
+            descriptor ?? throw new ArgumentNullException(nameof(descriptor)),
+            message ?? throw new ArgumentNullException(nameof(message)),
+            ruleName,
+            exception);
+        Span = CreateSpan(spanStart, spanLength);
+    }
+
+    /// <summary>
+    /// Initializes a new diagnostic instance.
+    /// </summary>
+    /// <param name="details">Diagnostic details.</param>
+    /// <param name="span">Optional source span.</param>
+    /// <param name="location">Optional source location.</param>
+    public ParserDiagnostic(
+        DiagnosticDetails details,
+        DiagnosticSpan? span = null,
+        SourceCodeLocation? location = null)
+    {
+        Details = details ?? throw new ArgumentNullException(nameof(details));
+        Span = span;
+        Location = location;
     }
 
     /// <summary>
     /// Gets the descriptor.
     /// </summary>
-    public ParserDiagnosticDescriptor Descriptor { get; }
+    public DiagnosticDetails Details { get; }
+
+    /// <summary>
+    /// Gets the optional source span.
+    /// </summary>
+    public DiagnosticSpan? Span { get; }
+
+    /// <summary>
+    /// Gets the optional human-readable source location.
+    /// </summary>
+    public SourceCodeLocation? Location { get; }
+
+    /// <summary>
+    /// Gets the descriptor.
+    /// </summary>
+    public ParserDiagnosticDescriptor Descriptor => Details.Descriptor;
 
     /// <summary>
     /// Gets the diagnostic code.
@@ -50,48 +82,47 @@ public sealed class ParserDiagnostic
     /// <summary>
     /// Gets the resolved message.
     /// </summary>
-    public string Message { get; }
+    public string Message => Details.Message;
 
-    /// <summary>
-    /// Gets the optional source span start position.
-    /// </summary>
-    public int? SpanStart { get; }
-
-    /// <summary>
-    /// Gets the optional source span length.
-    /// </summary>
-    public int? SpanLength { get; }
-
-    /// <summary>Gets the optional source file path.</summary>
-    public string? FilePath { get; set; }
-
-    /// <summary>Gets the optional 1-based line.</summary>
-    public int? Line { get; set; }
-
-    /// <summary>Gets the optional 1-based column.</summary>
-    public int? Column { get; set; }
 
     /// <summary>
     /// Gets the optional rule name context.
     /// </summary>
-    public string? RuleName { get; }
+    public string? RuleName => Details.RuleName;
 
     /// <summary>
     /// Gets the optional related exception.
     /// </summary>
-    public Exception? Exception { get; }
+    public Exception? Exception => Details.Exception;
 
     /// <summary>
     /// Formats the diagnostic in file/line/column style.
     /// </summary>
     public string ToDisplayString()
     {
-        if (Line is null || Column is null)
+        if (Location is null)
         {
             return $"{Code}: {Message}";
         }
 
-        string path = string.IsNullOrWhiteSpace(FilePath) ? "<input>" : FilePath;
-        return $"{path}({Line},{Column}): {Severity.ToString().ToLowerInvariant()} {Code}: {Message}";
+        return $"{Location}: {Severity.ToString().ToLowerInvariant()} {Code}: {Message}";
+    }
+
+    /// <summary>
+    /// Creates a diagnostic span from legacy nullable start and length values.
+    /// </summary>
+    /// <param name="spanStart">Optional source span start position.</param>
+    /// <param name="spanLength">Optional source span length.</param>
+    /// <returns>The composed diagnostic span, or <see langword="null"/> when no span was provided.</returns>
+    private static DiagnosticSpan? CreateSpan(int? spanStart, int? spanLength)
+    {
+        if (spanStart.HasValue != spanLength.HasValue)
+        {
+            throw new ArgumentException("spanStart and spanLength must both be provided or both be null.");
+        }
+
+        return spanStart.HasValue
+            ? new DiagnosticSpan(spanStart.Value, spanLength!.Value)
+            : null;
     }
 }

--- a/Utils.Parser.Diagnostics/Source/SourceCodeLocation.cs
+++ b/Utils.Parser.Diagnostics/Source/SourceCodeLocation.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Utils.Parser.Source;
+
+/// <summary>
+/// Represents a human-readable location in source code.
+/// </summary>
+public class SourceCodeLocation
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SourceCodeLocation"/> class.
+    /// </summary>
+    /// <param name="filePath">Source file path.</param>
+    /// <param name="line">1-based line number.</param>
+    /// <param name="column">1-based column number.</param>
+    public SourceCodeLocation(string filePath, int line, int column)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentException("File path cannot be null, empty, or whitespace.", nameof(filePath));
+        }
+
+        if (line <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(line), "Line must be strictly positive.");
+        }
+
+        if (column <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(column), "Column must be strictly positive.");
+        }
+
+        FilePath = filePath;
+        Line = line;
+        Column = column;
+    }
+
+    /// <summary>
+    /// Gets the source file path.
+    /// </summary>
+    public string FilePath { get; }
+
+    /// <summary>
+    /// Gets the 1-based line number.
+    /// </summary>
+    public int Line { get; }
+
+    /// <summary>
+    /// Gets the 1-based column number.
+    /// </summary>
+    public int Column { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => $"{FilePath}({Line},{Column})";
+}

--- a/Utils.Parser.Diagnostics/Source/SourceCodeRange.cs
+++ b/Utils.Parser.Diagnostics/Source/SourceCodeRange.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Utils.Parser.Source;
+
+/// <summary>
+/// Represents a human-readable source location with a length component.
+/// </summary>
+public sealed class SourceCodeRange : SourceCodeLocation
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SourceCodeRange"/> class.
+    /// </summary>
+    /// <param name="filePath">Source file path.</param>
+    /// <param name="line">1-based line number.</param>
+    /// <param name="column">1-based column number.</param>
+    /// <param name="length">Range length.</param>
+    public SourceCodeRange(string filePath, int line, int column, int length)
+        : base(filePath, line, column)
+    {
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Length must be greater than or equal to zero.");
+        }
+
+        Length = length;
+    }
+
+    /// <summary>
+    /// Gets the range length.
+    /// </summary>
+    public int Length { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => $"{FilePath}({Line},{Column},{Length})";
+}

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -240,6 +240,8 @@ Current clarification status:
 - unsupported ANTLR4 lexer-command constructs are now surfaced via explicit deterministic compatibility diagnostics.
 - generator/runtime diagnostic parity for `UP1001`-`UP1006` was tightened with parity tests while preserving parsing semantics and recovery determinism.
 - shared ANTLR4 prequel DTOs now include shared neutral prequel validation facts in `Utils.Parser.Antlr4.Common`; runtime and generator continue to own conversion into `ParserDiagnostics`, and parsing remains intentionally separate.
+- parser diagnostics now use immutable composed value objects (`DiagnosticDetails`, `DiagnosticSpan`, `SourceCodeLocation`, and `SourceCodeRange`) to separate diagnostic content, source offsets, and human-readable source locations while preserving diagnostic ownership and emission semantics.
+- `SourceCodeLocation` is intended to become the shared source-location contract for every parser surface that needs to carry a location in parsed source code, including future rule results, without changing those surfaces in this diagnostics-focused PR.
 
 ### Phase 3 — Lookahead contract consolidation
 

--- a/Utils.Parser/Runtime/LexerEngine.cs
+++ b/Utils.Parser/Runtime/LexerEngine.cs
@@ -676,13 +676,26 @@ public sealed class LexerEngine(ParserDefinition definition)
         string message)
     {
         string formatted = FormatError(filePath, line, column, code, message);
+        int? spanStart = IsValidDiagnosticSpan(span) ? span.Position : null;
+        int? spanLength = IsValidDiagnosticSpan(span) ? span.Length : null;
+
         diagnostics?.AddWithContext(
             ParserDiagnostics.ParseFailure,
-            span?.Position,
-            span?.Length,
+            spanStart,
+            spanLength,
             null,
             null,
             formatted);
         throw new LexerValidationException(formatted);
+    }
+
+    /// <summary>
+    /// Determines whether a lexer source span can be safely converted to a diagnostic span.
+    /// </summary>
+    /// <param name="span">Optional lexer source span to validate.</param>
+    /// <returns><see langword="true"/> when the span has non-negative offset and length values; otherwise, <see langword="false"/>.</returns>
+    private static bool IsValidDiagnosticSpan(SourceSpan? span)
+    {
+        return span is not null && span.Position >= 0 && span.Length >= 0;
     }
 }

--- a/UtilsTest/Parser/Antlr4GeneratorRuntimeParityTests.cs
+++ b/UtilsTest/Parser/Antlr4GeneratorRuntimeParityTests.cs
@@ -324,10 +324,10 @@ public class Antlr4GeneratorRuntimeParityTests
         => new(
             diagnostic.Code,
             diagnostic.Severity,
-            diagnostic.Line,
-            diagnostic.Column,
-            diagnostic.SpanStart,
-            diagnostic.SpanLength);
+            diagnostic.Location?.Line,
+            diagnostic.Location?.Column,
+            diagnostic.Span?.Start,
+            diagnostic.Span?.Length);
 
     private static bool IsCompatibilityParityDiagnostic(string code)
         => code is "UP1001" or "UP1002" or "UP1003" or "UP1004" or "UP1005" or "UP1006";

--- a/UtilsTest/Parser/LexerEngineTests.cs
+++ b/UtilsTest/Parser/LexerEngineTests.cs
@@ -565,8 +565,13 @@ public class LexerEngineTests
         };
         var lexer = new LexerEngine(grammar);
         var options = new LexerEngineOptions { Extensions = [new InvalidSpanExtension()] };
+        var diagnostics = new DiagnosticBag();
 
-        Assert.ThrowsExactly<LexerValidationException>(() => lexer.Tokenize(new StringReader("a"), options).ToList());
+        Assert.ThrowsExactly<LexerValidationException>(() => lexer.Tokenize(new StringReader("a"), options, diagnostics).ToList());
+        var diagnostic = diagnostics.Single();
+        Assert.AreEqual(ParserDiagnostics.ParseFailure.Code, diagnostic.Code);
+        Assert.IsNull(diagnostic.Span);
+        StringAssert.Contains(diagnostic.Message, "Invalid token span");
     }
 
     [TestMethod]

--- a/UtilsTest/Parser/ParserDiagnosticCompositionTests.cs
+++ b/UtilsTest/Parser/ParserDiagnosticCompositionTests.cs
@@ -1,0 +1,151 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.Source;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Tests immutable composed parser diagnostic source/location contracts.
+/// </summary>
+[TestClass]
+public class ParserDiagnosticCompositionTests
+{
+    [TestMethod]
+    public void SourceCodeLocation_ValidatesConstructorArguments_AndFormatsDisplayText()
+    {
+        Assert.ThrowsException<ArgumentException>(() => new SourceCodeLocation(" ", 1, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new SourceCodeLocation("file.ext", 0, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new SourceCodeLocation("file.ext", 1, 0));
+
+        var location = new SourceCodeLocation("file.ext", 12, 5);
+        Assert.AreEqual("file.ext", location.FilePath);
+        Assert.AreEqual(12, location.Line);
+        Assert.AreEqual(5, location.Column);
+        Assert.AreEqual("file.ext(12,5)", location.ToString());
+    }
+
+    [TestMethod]
+    public void SourceCodeRange_InheritsLocation_ValidatesLength_AndFormatsDisplayText()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new SourceCodeRange("file.ext", 1, 1, -1));
+
+        SourceCodeLocation rangeAsLocation = new SourceCodeRange("file.ext", 12, 5, 3);
+        var range = (SourceCodeRange)rangeAsLocation;
+        Assert.AreEqual("file.ext", range.FilePath);
+        Assert.AreEqual(12, range.Line);
+        Assert.AreEqual(5, range.Column);
+        Assert.AreEqual(3, range.Length);
+        Assert.AreEqual("file.ext(12,5,3)", range.ToString());
+    }
+
+    [TestMethod]
+    public void DiagnosticSpan_ValidatesStartAndLength()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DiagnosticSpan(-1, 0));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DiagnosticSpan(0, -1));
+
+        var span = new DiagnosticSpan(10, 4);
+        Assert.AreEqual(10, span.Start);
+        Assert.AreEqual(4, span.Length);
+    }
+
+    [TestMethod]
+    public void ParserDiagnostic_UsesComposedDetailsSpanAndLocation_WithReadOnlyFacadeProperties()
+    {
+        var descriptor = ParserDiagnostics.SemanticPredicateNotEnforced;
+        var details = new DiagnosticDetails(descriptor, "Message", "rule", new InvalidOperationException("boom"));
+        var span = new DiagnosticSpan(8, 2);
+        var location = new SourceCodeRange("file.ext", 3, 9, 2);
+
+        var diagnostic = new ParserDiagnostic(details, span, location);
+
+        Assert.AreSame(details, diagnostic.Details);
+        Assert.AreSame(span, diagnostic.Span);
+        Assert.AreSame(location, diagnostic.Location);
+        Assert.AreEqual(descriptor, diagnostic.Descriptor);
+        Assert.AreEqual(descriptor.Code, diagnostic.Code);
+        Assert.AreEqual(descriptor.Severity, diagnostic.Severity);
+        Assert.AreEqual("Message", diagnostic.Message);
+        Assert.AreEqual(8, diagnostic.Span?.Start);
+        Assert.AreEqual(2, diagnostic.Span?.Length);
+        Assert.AreEqual("rule", diagnostic.RuleName);
+        Assert.IsInstanceOfType<InvalidOperationException>(diagnostic.Exception);
+
+        Assert.AreEqual("file.ext", diagnostic.Location?.FilePath);
+        Assert.AreEqual(3, diagnostic.Location?.Line);
+        Assert.AreEqual(9, diagnostic.Location?.Column);
+
+        Assert.IsNull(typeof(ParserDiagnostic).GetProperty("SpanStart"));
+        Assert.IsNull(typeof(ParserDiagnostic).GetProperty("SpanLength"));
+        Assert.IsNull(typeof(ParserDiagnostic).GetProperty("FilePath"));
+        Assert.IsNull(typeof(ParserDiagnostic).GetProperty("Line"));
+        Assert.IsNull(typeof(ParserDiagnostic).GetProperty("Column"));
+    }
+
+    [TestMethod]
+    public void ParserDiagnostic_ToDisplayString_UsesLocationWhenAvailable()
+    {
+        var descriptor = ParserDiagnostics.SemanticPredicateNotEnforced;
+        var withoutLocation = new ParserDiagnostic(descriptor, "Message");
+        var withLocation = new ParserDiagnostic(
+            new DiagnosticDetails(descriptor, "Message"),
+            new DiagnosticSpan(0, 0),
+            new SourceCodeLocation("file.ext", 12, 5));
+
+        Assert.AreEqual($"{descriptor.Code}: Message", withoutLocation.ToDisplayString());
+        Assert.AreEqual($"file.ext(12,5): warning {descriptor.Code}: Message", withLocation.ToDisplayString());
+    }
+
+    [TestMethod]
+    public void ParserDiagnostic_LegacyConstructor_RejectsSpanStartWithoutSpanLength()
+    {
+        Assert.ThrowsException<ArgumentException>(() =>
+            new ParserDiagnostic(
+                ParserDiagnostics.SemanticPredicateNotEnforced,
+                "Message",
+                spanStart: 5,
+                spanLength: null));
+    }
+
+    [TestMethod]
+    public void ParserDiagnostic_LegacyConstructor_RejectsSpanLengthWithoutSpanStart()
+    {
+        Assert.ThrowsException<ArgumentException>(() =>
+            new ParserDiagnostic(
+                ParserDiagnostics.SemanticPredicateNotEnforced,
+                "Message",
+                spanStart: null,
+                spanLength: 2));
+    }
+
+    [TestMethod]
+    public void DiagnosticBag_AddWithContext_WithLegacySpanParameters_BuildsDiagnosticSpan()
+    {
+        var bag = new DiagnosticBag();
+        var descriptor = ParserDiagnostics.SemanticPredicateNotEnforced;
+
+        var diagnostic = bag.AddWithContext(descriptor, 4, 2, "rule", null);
+
+        Assert.AreEqual(1, bag.Count);
+        Assert.IsNotNull(diagnostic.Span);
+        Assert.AreEqual(4, diagnostic.Span?.Start);
+        Assert.AreEqual(2, diagnostic.Span?.Length);
+        Assert.IsNull(diagnostic.Location);
+        Assert.AreEqual(descriptor.Code, diagnostic.Code);
+    }
+
+    [TestMethod]
+    public void DiagnosticBag_AddWithContext_RejectsPartialLegacySpan()
+    {
+        var bag = new DiagnosticBag();
+
+        Assert.ThrowsException<ArgumentException>(() =>
+            bag.AddWithContext(
+                ParserDiagnostics.SemanticPredicateNotEnforced,
+                spanStart: 5,
+                spanLength: null,
+                ruleName: null,
+                exception: null));
+    }
+}


### PR DESCRIPTION
### Motivation

- Separate diagnostic content, source offsets, and human-readable source locations into immutable composed value objects to improve clarity and reuse across parser surfaces.
- Preserve existing diagnostic emission semantics while enabling a shared `SourceCodeLocation` contract for future surface types without changing those surfaces now.
- Remove the remaining public flat diagnostic location/span accessors while the project is still pre-release and has no public compatibility constraints.

### Audit summary

- `ParserDiagnostic` previously mixed immutable diagnostic data with mutable or flat source-position fields.
- `SpanStart` / `SpanLength` and `FilePath` / `Line` / `Column` represented logical pairs/groups but were exposed as independent properties.
- Partial legacy spans (`spanStart` without `spanLength`, or the reverse) should not exist; they now fail explicitly instead of being silently converted.

### Modifications

- Added immutable value objects:
  - `DiagnosticDetails`
  - `DiagnosticSpan`
  - `SourceCodeLocation`
  - `SourceCodeRange`
- Refactored `ParserDiagnostic` to expose:
  - `Details`
  - `Span`
  - `Location`
- Kept high-level convenience accessors only:
  - `Descriptor`
  - `Code`
  - `Severity`
  - `Message`
  - `RuleName`
  - `Exception`
- Removed the old flat accessors:
  - `SpanStart`
  - `SpanLength`
  - `FilePath`
  - `Line`
  - `Column`
- Added `DiagnosticBag.AddWithStructuredContext(...)` for composed diagnostics.
- Kept `DiagnosticBag.AddWithContext(...)` for legacy call sites, with strict validation of partial spans.
- Updated roadmap notes and tests to reflect the new composed diagnostic contracts.

### Public API impact

Yes. This is an intentional pre-release breaking API change.

New public types:
- `Utils.Parser.Diagnostics.DiagnosticDetails`
- `Utils.Parser.Diagnostics.DiagnosticSpan`
- `Utils.Parser.Source.SourceCodeLocation`
- `Utils.Parser.Source.SourceCodeRange`

New/updated `ParserDiagnostic` public API:
- `ParserDiagnostic.Details`
- `ParserDiagnostic.Span`
- `ParserDiagnostic.Location`

Removed `ParserDiagnostic` public API:
- `SpanStart`
- `SpanLength`
- `FilePath`
- `Line`
- `Column`

The removed properties are intentionally not preserved as façade properties because they would keep the old flat model visible and could mask issues during pre-release cleanup.

### Migration

Before:

```csharp
var start = diagnostic.SpanStart;
var length = diagnostic.SpanLength;
var filePath = diagnostic.FilePath;
var line = diagnostic.Line;
var column = diagnostic.Column;
```

After:

```csharp
var start = diagnostic.Span?.Start;
var length = diagnostic.Span?.Length;
var filePath = diagnostic.Location?.FilePath;
var line = diagnostic.Location?.Line;
var column = diagnostic.Location?.Column;
```

Before, location-like data could be assigned after diagnostic creation:

```csharp
diagnostic.FilePath = filePath;
diagnostic.Line = line;
diagnostic.Column = column;
```

After, the location must be supplied as part of diagnostic construction:

```csharp
var diagnostic = new ParserDiagnostic(
    details,
    span,
    new SourceCodeLocation(filePath, line, column));
```

Legacy constructor calls using `spanStart` / `spanLength` remain supported when both values are provided together or both are null.

Partial spans are now rejected:

```csharp
new ParserDiagnostic(descriptor, message, spanStart: 5, spanLength: null); // throws
new ParserDiagnostic(descriptor, message, spanStart: null, spanLength: 2); // throws
```

### Compatibility impact

Source-breaking for consumers that accessed:
- `ParserDiagnostic.SpanStart`
- `ParserDiagnostic.SpanLength`
- `ParserDiagnostic.FilePath`
- `ParserDiagnostic.Line`
- `ParserDiagnostic.Column`

Source-breaking for consumers that mutated diagnostic location fields after creation.

Behavioral compatibility is preserved for valid diagnostics:
- diagnostic codes are unchanged;
- severities are unchanged;
- emission points are unchanged;
- display formatting remains equivalent when a location is available.

Invalid partial legacy spans now fail explicitly.

### Runtime impact

No parser runtime behavior change expected.

This PR does not change parser execution, scheduling, memoization, parse acceptance, tokenization behavior, or parse-tree construction.

### Diagnostics impact

Diagnostic model shape changes, but diagnostic semantics do not.

Unchanged:
- diagnostic codes;
- diagnostic severities;
- diagnostic emission points;
- diagnostic ownership;
- diagnostic parity expectations.

Changed:
- diagnostics are now composed from immutable value objects;
- source offsets are represented by `DiagnosticSpan`;
- human-readable source locations are represented by `SourceCodeLocation` / `SourceCodeRange`;
- partial legacy spans are rejected explicitly.

### Parse-tree impact

None.

### ANTLR compatibility impact

None.

ANTLR compatibility feature support, compatibility diagnostics, runtime/generator parity semantics, and grammar parsing behavior are unchanged.

### Documentation impact

- `Utils.Parser/ROADMAP.md`: updated because this PR changes the public diagnostics API shape and documents `SourceCodeLocation` as the future shared source-location contract.
- `docs/parser/ANTLRCompatibility.md`: not updated because ANTLR compatibility semantics and diagnostic codes are unchanged.
- `docs/parser/INDEX.md`: not updated because no parser documentation file was added, removed, moved, or materially re-scoped.

### Tests

- Added `ParserDiagnosticCompositionTests` covering:
  - `SourceCodeLocation` validation and formatting;
  - `SourceCodeRange` validation and formatting;
  - `DiagnosticSpan` validation;
  - `ParserDiagnostic` composition;
  - removal of old flat accessors;
  - `ToDisplayString()` behavior;
  - rejection of partial legacy spans;
  - `DiagnosticBag.AddWithContext(...)` mapping and validation.
- Updated `Antlr4GeneratorRuntimeParityTests` to consume `Location` and `Span` instead of the removed flat accessors.
- Ran `dotnet test`, including the new composition tests and updated parity tests, successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183f8ae7088326896dcad38829141b)