### PR TITLE
Make Rule.Kind immutable and add internal RuleResolutionBuilder for resolution

### DIFF
--- a/Utils.Parser/Bootstrap/SyntaxColorisationGrammar.cs
+++ b/Utils.Parser/Bootstrap/SyntaxColorisationGrammar.cs
@@ -379,15 +379,23 @@ public static class SyntaxColorisationGrammar
     /// Creates a lexer rule.
     /// </summary>
     private static Rule L(string name, RuleContent content)
-        => new(name, 0, false, new Alternation(new[] { new Alternative(0, Associativity.Left, content) }))
-        { Kind = RuleKind.Lexer };
+        => new(
+            name,
+            0,
+            false,
+            new Alternation(new[] { new Alternative(0, Associativity.Left, content) }),
+            Kind: RuleKind.Lexer);
 
     /// <summary>
     /// Creates a parser rule.
     /// </summary>
     private static Rule P(string name, RuleContent content)
-        => new(name, 0, false, new Alternation(new[] { new Alternative(0, Associativity.Left, content) }))
-        { Kind = RuleKind.Parser };
+        => new(
+            name,
+            0,
+            false,
+            new Alternation(new[] { new Alternative(0, Associativity.Left, content) }),
+            Kind: RuleKind.Parser);
 
     /// <summary>
     /// Creates one literal tokenizer node.

--- a/Utils.Parser/Model/Rule.cs
+++ b/Utils.Parser/Model/Rule.cs
@@ -73,13 +73,10 @@ public record Rule(
     /// <summary>Code executed before the rule body (<c>@init { }</c>), or <c>null</c>.</summary>
     EmbeddedAction? InitAction = null,
     /// <summary>Code executed after the rule body (<c>@after { }</c>), or <c>null</c>.</summary>
-    EmbeddedAction? AfterAction = null
-)
-{
+    EmbeddedAction? AfterAction = null,
     /// <summary>
     /// Whether this is a lexer or parser rule.
-    /// Set by <c>RuleResolver.Resolve</c> during the resolution pass;
-    /// initially <see cref="RuleKind.Unresolved"/>.
+    /// The default <see cref="RuleKind.Unresolved"/> value is valid before resolution.
     /// </summary>
-    public RuleKind Kind { get; internal set; } = RuleKind.Unresolved;
-}
+    RuleKind Kind = RuleKind.Unresolved
+);

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -79,6 +79,7 @@ Current capabilities and responsibilities:
 - ANTLR4 grammar bootstrap/conversion support is present.
 - Syntax colorisation descriptor DTO public contracts are hardened to read-only collection exposure (`IReadOnlyList<T>`), with mutation remaining internal to parser conversion flow.
 - Visual Studio syntax colorization descriptor DTO public contracts are hardened to read-only collection exposure (`IReadOnlyList<T>`), with descriptor-population mutation remaining internal to conversion flow.
+- `Rule.Kind` is now an immutable part of the public `Rule` record; mutable resolution state is kept inside internal `RuleResolutionBuilder` instances so `RuleResolver` produces final resolved rule projections without mutating public rule objects in place.
 - Runtime invariant documentation exists.
 - Branch outcome documentation exists.
 - Parser tests are organized to reflect runtime contracts.

--- a/Utils.Parser/Resolution/RuleResolutionBuilder.cs
+++ b/Utils.Parser/Resolution/RuleResolutionBuilder.cs
@@ -1,0 +1,65 @@
+using System;
+using Utils.Parser.Model;
+
+namespace Utils.Parser.Resolution;
+
+/// <summary>
+/// Holds mutable internal state while a rule kind is being resolved.
+/// </summary>
+internal sealed class RuleResolutionBuilder
+{
+    /// <summary>
+    /// Initializes a new builder from the public rule being resolved.
+    /// </summary>
+    /// <param name="source">Rule that provides the immutable public rule data.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> is <c>null</c>.</exception>
+    public RuleResolutionBuilder(Rule source)
+    {
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+        Kind = source.Kind;
+    }
+
+    /// <summary>
+    /// Gets the source rule whose immutable data is preserved during resolution.
+    /// </summary>
+    public Rule Source { get; }
+
+    /// <summary>
+    /// Gets the source rule name.
+    /// </summary>
+    public string Name => Source.Name;
+
+    /// <summary>
+    /// Gets the currently resolved or unresolved rule kind.
+    /// </summary>
+    public RuleKind Kind { get; private set; }
+
+    /// <summary>
+    /// Resolves the rule as the specified non-unresolved kind.
+    /// </summary>
+    /// <param name="kind">Final lexer or parser kind to assign.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="kind"/> is <see cref="RuleKind.Unresolved"/>.</exception>
+    /// <exception cref="GrammarValidationException">Thrown when a conflicting kind was already resolved.</exception>
+    public void ResolveAs(RuleKind kind)
+    {
+        if (kind == RuleKind.Unresolved)
+        {
+            throw new ArgumentException("A rule cannot be resolved as Unresolved.", nameof(kind));
+        }
+
+        if (Kind != RuleKind.Unresolved && Kind != kind)
+        {
+            throw new GrammarValidationException(
+                $"Rule '{Name}' was already resolved as {Kind} and cannot be resolved as {kind}.");
+        }
+
+        Kind = kind;
+    }
+
+    /// <summary>
+    /// Builds the final immutable rule with the resolved kind.
+    /// </summary>
+    /// <returns>A rule that preserves source data and exposes the final kind.</returns>
+    public Rule Build()
+        => Source with { Kind = Kind };
+}

--- a/Utils.Parser/Resolution/RuleResolver.cs
+++ b/Utils.Parser/Resolution/RuleResolver.cs
@@ -25,6 +25,7 @@ public static class RuleResolver
     /// <see cref="ParserDefinition.AllRules"/> dictionary.
     /// </summary>
     /// <param name="definition">The grammar definition to resolve.</param>
+    /// <param name="diagnostics">Optional diagnostics sink populated during validation.</param>
     /// <returns>The same definition with <see cref="ParserDefinition.AllRules"/> populated.</returns>
     /// <exception cref="GrammarValidationException">
     /// Thrown when duplicate rule names are detected, a rule references an unknown rule,
@@ -37,57 +38,46 @@ public static class RuleResolver
 
         ValidateGrammarTypeConstraints(definition, diagnostics);
 
-        // 1. Build AllRules, assigning known kinds at registration time.
-        var allRules = new Dictionary<string, Rule>();
+        // 1. Build mutable internal resolution builders, assigning known kinds at registration time.
+        var ruleBuilders = new Dictionary<string, RuleResolutionBuilder>(StringComparer.Ordinal);
 
         foreach (var mode in definition.Modes)
         {
             foreach (var rule in mode.Rules)
             {
-                if (!allRules.TryAdd(rule.Name, rule))
-                {
-                    diagnostics?.Add(ParserDiagnostics.InternalInconsistency, $"Duplicate rule name: {rule.Name}");
-                    throw new GrammarValidationException($"Duplicate rule name: {rule.Name}");
-                }
-                rule.Kind = RuleKind.Lexer;
+                var builder = RegisterRuleBuilder(ruleBuilders, rule, diagnostics);
+                builder.ResolveAs(RuleKind.Lexer);
             }
         }
 
         foreach (var rule in definition.ParserRules)
         {
-            if (!allRules.TryAdd(rule.Name, rule))
-            {
-                diagnostics?.Add(ParserDiagnostics.InternalInconsistency, $"Duplicate rule name: {rule.Name}");
-                throw new GrammarValidationException($"Duplicate rule name: {rule.Name}");
-            }
-            rule.Kind = RuleKind.Parser;
+            var builder = RegisterRuleBuilder(ruleBuilders, rule, diagnostics);
+            builder.ResolveAs(RuleKind.Parser);
         }
 
-        // Update AllRules on the definition.
-        definition = definition with { AllRules = allRules };
-
         // 2. Verify that all RuleRefs point to existing rules.
-        foreach (var rule in allRules.Values)
+        foreach (var builder in ruleBuilders.Values)
         {
-            ValidateRuleRefs(rule.Content, allRules, rule.Name, diagnostics);
+            ValidateRuleRefs(builder.Source.Content, ruleBuilders, builder.Name, diagnostics);
         }
 
         // 3. Infer RuleKind for any rules still marked Unresolved.
         //    Iterative resolution handles circular dependencies.
         bool changed = true;
-        int maxIterations = allRules.Count + 1;
+        int maxIterations = ruleBuilders.Count + 1;
         while (changed && maxIterations-- > 0)
         {
             changed = false;
-            foreach (var rule in allRules.Values)
+            foreach (var builder in ruleBuilders.Values)
             {
-                if (rule.Kind != RuleKind.Unresolved)
+                if (builder.Kind != RuleKind.Unresolved)
                     continue;
 
-                var inferred = InferKind(rule.Content, allRules);
+                var inferred = InferKindFromBuilders(builder.Source.Content, ruleBuilders);
                 if (inferred != RuleKind.Unresolved)
                 {
-                    rule.Kind = inferred;
+                    builder.ResolveAs(inferred);
                     changed = true;
                 }
             }
@@ -95,13 +85,16 @@ public static class RuleResolver
 
         // Apply the ANTLR4 naming convention to any remaining Unresolved rules:
         // upper-case start → lexer; lower-case start → parser.
-        foreach (var rule in allRules.Values)
+        foreach (var builder in ruleBuilders.Values)
         {
-            if (rule.Kind == RuleKind.Unresolved)
+            if (builder.Kind == RuleKind.Unresolved)
             {
-                rule.Kind = char.IsUpper(rule.Name[0]) ? RuleKind.Lexer : RuleKind.Parser;
+                builder.ResolveAs(char.IsUpper(builder.Name[0]) ? RuleKind.Lexer : RuleKind.Parser);
             }
         }
+
+        definition = BuildFinalDefinition(definition, ruleBuilders);
+        var allRules = definition.AllRules;
 
         // 4. Validate that lexer rules do not reference parser content.
         foreach (var rule in allRules.Values)
@@ -133,6 +126,64 @@ public static class RuleResolver
         definition = definition with { LeftRecursiveRules = leftRecursiveRules };
 
         return definition;
+    }
+
+    /// <summary>
+    /// Registers a rule in the resolution builder map.
+    /// </summary>
+    /// <param name="ruleBuilders">Mutable builder lookup keyed by rule name.</param>
+    /// <param name="rule">Rule to register.</param>
+    /// <param name="diagnostics">Optional diagnostics sink.</param>
+    /// <returns>The builder created for <paramref name="rule"/>.</returns>
+    /// <exception cref="GrammarValidationException">Thrown when a duplicate rule name is detected.</exception>
+    private static RuleResolutionBuilder RegisterRuleBuilder(
+        IDictionary<string, RuleResolutionBuilder> ruleBuilders,
+        Rule rule,
+        DiagnosticBag? diagnostics)
+    {
+        var builder = new RuleResolutionBuilder(rule);
+        if (!ruleBuilders.TryAdd(rule.Name, builder))
+        {
+            diagnostics?.Add(ParserDiagnostics.InternalInconsistency, $"Duplicate rule name: {rule.Name}");
+            throw new GrammarValidationException($"Duplicate rule name: {rule.Name}");
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Builds a parser definition whose projections all point to finalized immutable rules.
+    /// </summary>
+    /// <param name="definition">Definition that provided the source rule projections.</param>
+    /// <param name="ruleBuilders">Resolution builders containing final rule kinds.</param>
+    /// <returns>A definition with finalized modes, parser rules, root rule, and all-rules lookup.</returns>
+    private static ParserDefinition BuildFinalDefinition(
+        ParserDefinition definition,
+        IReadOnlyDictionary<string, RuleResolutionBuilder> ruleBuilders)
+    {
+        var allRules = ruleBuilders.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.Build(),
+            StringComparer.Ordinal);
+
+        var updatedModes = definition.Modes
+            .Select(mode => mode with
+            {
+                Rules = mode.Rules.Select(rule => allRules[rule.Name]).ToList()
+            })
+            .ToList();
+
+        var updatedParserRules = definition.ParserRules
+            .Select(rule => allRules[rule.Name])
+            .ToList();
+
+        return definition with
+        {
+            Modes = updatedModes,
+            ParserRules = updatedParserRules,
+            RootRule = definition.RootRule is null ? null : allRules[definition.RootRule.Name],
+            AllRules = allRules
+        };
     }
 
     private static ParserDefinition NormalizeAlternatives(ParserDefinition definition, DiagnosticBag? diagnostics)
@@ -173,7 +224,6 @@ public static class RuleResolver
             {
                 Content = new Alternation(normalized.OrderBy(a => a.Priority).ToList())
             };
-            updatedRule.Kind = rule.Kind;
             updatedParserRules.Add(updatedRule);
             changedAny = true;
         }
@@ -327,9 +377,10 @@ public static class RuleResolver
     /// <param name="content">Grammar element to inspect.</param>
     /// <param name="rules">All known rules, keyed by name.</param>
     /// <param name="contextRuleName">Owning rule name, used in exception messages.</param>
-    private static void ValidateRuleRefs(
+    /// <param name="diagnostics">Optional diagnostics sink populated when a reference is missing.</param>
+    private static void ValidateRuleRefs<TRuleState>(
         RuleContent content,
-        IDictionary<string, Rule> rules,
+        IReadOnlyDictionary<string, TRuleState> rules,
         string contextRuleName,
         DiagnosticBag? diagnostics)
     {
@@ -370,9 +421,10 @@ public static class RuleResolver
     /// <param name="content">Grammar element to inspect.</param>
     /// <param name="rules">All known rules, keyed by name.</param>
     /// <param name="contextRuleName">Owning rule name, used in exception messages.</param>
+    /// <param name="diagnostics">Optional diagnostics sink populated when a label target is missing.</param>
     private static void ValidateLabels(
         RuleContent content,
-        IDictionary<string, Rule> rules,
+        IReadOnlyDictionary<string, Rule> rules,
         string contextRuleName,
         DiagnosticBag? diagnostics)
     {
@@ -414,7 +466,7 @@ public static class RuleResolver
     /// </summary>
     /// <param name="rule">Rule to validate.</param>
     /// <param name="rules">All known rules, used to resolve references.</param>
-    private static void ValidateKindConsistency(Rule rule, IDictionary<string, Rule> rules)
+    private static void ValidateKindConsistency(Rule rule, IReadOnlyDictionary<string, Rule> rules)
     {
         // Only lexer rules are checked; parser rules may legitimately mix references.
         if (rule.Kind != RuleKind.Lexer)
@@ -470,6 +522,33 @@ public static class RuleResolver
     }
 
     /// <summary>
+    /// Infers the <see cref="RuleKind"/> of a grammar element using mutable resolution builders.
+    /// </summary>
+    /// <param name="content">Grammar element to analyse.</param>
+    /// <param name="rules">All known rule builders, used to look up reference kinds.</param>
+    /// <returns>The inferred kind, or <see cref="RuleKind.Unresolved"/>.</returns>
+    /// <exception cref="GrammarValidationException">Thrown when a rule element mixes lexer and parser content.</exception>
+    private static RuleKind InferKindFromBuilders(RuleContent content, IReadOnlyDictionary<string, RuleResolutionBuilder> rules)
+        => content switch
+        {
+            TokenizerContent          => RuleKind.Lexer,
+            ModeSwitch                => RuleKind.Lexer,
+            LexerCommand              => RuleKind.Lexer,
+            RuleRef r                 => rules.TryGetValue(r.RuleName, out var rule)
+                                         ? rule.Kind : RuleKind.Unresolved,
+            Sequence s                => ResolveUniform(s.Items.Select(i => InferKindFromBuilders(i, rules))),
+            Alternation a             => ResolveUniform(a.Alternatives.Select(alt => InferKindFromBuilders(alt.Content, rules))),
+            Quantifier q              => InferKindFromBuilders(q.Inner, rules),
+            Negation n                => InferKindFromBuilders(n.Inner, rules),
+            Alternative alt           => InferKindFromBuilders(alt.Content, rules),
+            ValidatingPredicate       => RuleKind.Parser,
+            PrecedencePredicate       => RuleKind.Parser,
+            GatingPredicate           => RuleKind.Parser,
+            EmbeddedAction            => RuleKind.Unresolved, // Neutral; inherits from context.
+            _ => throw new GrammarValidationException($"Unknown RuleContent: {content.GetType()}")
+        };
+
+    /// <summary>
     /// Infers the <see cref="RuleKind"/> of a grammar element based on the kinds of
     /// its constituent parts.
     /// Returns <see cref="RuleKind.Unresolved"/> when not enough information is
@@ -481,7 +560,7 @@ public static class RuleResolver
     /// <exception cref="GrammarValidationException">
     /// Thrown when a rule element mixes lexer and parser content.
     /// </exception>
-    internal static RuleKind InferKind(RuleContent content, IDictionary<string, Rule> rules)
+    internal static RuleKind InferKind(RuleContent content, IReadOnlyDictionary<string, Rule> rules)
         => content switch
         {
             TokenizerContent          => RuleKind.Lexer,

--- a/UtilsTest/Parser/ModelTests.cs
+++ b/UtilsTest/Parser/ModelTests.cs
@@ -158,7 +158,7 @@ public class ModelTests
     }
 
     [TestMethod]
-    public void Rule_DefaultKindIsUnresolved()
+    public void Rule_DefaultKind_IsUnresolved()
     {
         var rule = new Rule("test", 0, false,
             new Alternation(new[] {
@@ -166,6 +166,23 @@ public class ModelTests
             }));
 
         Assert.AreEqual(RuleKind.Unresolved, rule.Kind);
+    }
+
+    [TestMethod]
+    public void Rule_WithExpression_PreservesKind()
+    {
+        var originalContent = new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("a"))
+        ]);
+        var newContent = new Alternation([
+            new Alternative(0, Associativity.Left, new LiteralMatch("b"))
+        ]);
+        var rule = new Rule("expr", 0, false, originalContent, Kind: RuleKind.Parser);
+
+        var updated = rule with { Content = newContent };
+
+        Assert.AreEqual(RuleKind.Parser, updated.Kind);
+        Assert.AreSame(newContent, updated.Content);
     }
 
     [TestMethod]
@@ -277,6 +294,108 @@ public class ModelTests
     }
 
     [TestMethod]
+    public void RuleResolver_ParserRules_AreFinalizedWithParserKind()
+    {
+        var definition = CreateProjectionTestDefinition();
+
+        var resolved = RuleResolver.Resolve(definition);
+
+        Assert.IsTrue(resolved.ParserRules.Count > 0);
+        Assert.IsTrue(resolved.ParserRules.All(rule => rule.Kind == RuleKind.Parser));
+    }
+
+    [TestMethod]
+    public void RuleResolver_ModeRules_AreFinalizedWithLexerKind()
+    {
+        var definition = CreateProjectionTestDefinition();
+
+        var resolved = RuleResolver.Resolve(definition);
+
+        Assert.IsTrue(resolved.Modes.SelectMany(mode => mode.Rules).Any());
+        Assert.IsTrue(resolved.Modes.SelectMany(mode => mode.Rules).All(rule => rule.Kind == RuleKind.Lexer));
+    }
+
+    [TestMethod]
+    public void RuleResolver_AllRules_UsesFinalizedRules()
+    {
+        var definition = CreateProjectionTestDefinition();
+
+        var resolved = RuleResolver.Resolve(definition);
+        var parserRule = resolved.ParserRules.Single(rule => rule.Name == "expr");
+        var lexerRule = resolved.Modes.Single().Rules.Single(rule => rule.Name == "TOKEN");
+
+        Assert.AreSame(parserRule, resolved.AllRules["expr"]);
+        Assert.AreSame(lexerRule, resolved.AllRules["TOKEN"]);
+        Assert.AreEqual(RuleKind.Parser, resolved.AllRules["expr"].Kind);
+        Assert.AreEqual(RuleKind.Lexer, resolved.AllRules["TOKEN"].Kind);
+    }
+
+    [TestMethod]
+    public void RuleResolver_RootRule_UsesFinalizedRule()
+    {
+        var definition = CreateProjectionTestDefinition();
+
+        var resolved = RuleResolver.Resolve(definition);
+
+        Assert.IsNotNull(resolved.RootRule);
+        Assert.AreEqual(RuleKind.Parser, resolved.RootRule!.Kind);
+        Assert.AreSame(resolved.AllRules[resolved.RootRule.Name], resolved.RootRule);
+    }
+
+    [TestMethod]
+    public void RuleResolver_NormalizedAlternatives_PreserveRuleKind()
+    {
+        var duplicateAlternativeRule = new Rule(
+            "expr",
+            0,
+            false,
+            new Alternation([
+                new Alternative(1, Associativity.Left, new RuleRef("TOKEN")),
+                new Alternative(0, Associativity.Left, new RuleRef("TOKEN"))
+            ]));
+        var tokenRule = new Rule(
+            "TOKEN",
+            1,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new LiteralMatch("a"))
+            ]));
+        var definition = new ParserDefinition(
+            "Test",
+            GrammarType.Combined,
+            null,
+            [],
+            [],
+            [new LexerMode("DEFAULT_MODE", [tokenRule])],
+            [duplicateAlternativeRule],
+            duplicateAlternativeRule);
+
+        var resolved = RuleResolver.Resolve(definition);
+        var normalizedRule = resolved.ParserRules.Single(rule => rule.Name == "expr");
+
+        Assert.AreEqual(RuleKind.Parser, normalizedRule.Kind);
+        Assert.AreEqual(1, normalizedRule.Content.Alternatives.Count);
+        Assert.AreSame(normalizedRule, resolved.AllRules["expr"]);
+        Assert.AreSame(normalizedRule, resolved.RootRule);
+    }
+
+    [TestMethod]
+    public void RuleResolutionBuilder_RejectsConflictingKind()
+    {
+        var rule = new Rule(
+            "expr",
+            0,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new RuleRef("TOKEN"))
+            ]),
+            Kind: RuleKind.Parser);
+        var builder = new RuleResolutionBuilder(rule);
+
+        Assert.ThrowsException<GrammarValidationException>(() => builder.ResolveAs(RuleKind.Lexer));
+    }
+
+    [TestMethod]
     public void RuleResolver_DuplicateRuleThrows()
     {
         var rule1 = new Rule("SAME", 0, false,
@@ -341,4 +460,37 @@ public class ModelTests
         Assert.IsTrue(tokens.Count > 0, "Expected at least one ERROR token");
         Assert.IsTrue(tokens.All(t => t.RuleName == "ERROR"), "Expected all tokens to be ERROR");
     }
+
+    /// <summary>
+    /// Creates a minimal combined grammar used to verify finalized rule projections.
+    /// </summary>
+    /// <returns>A parser definition with one lexer rule and one parser rule.</returns>
+    private static ParserDefinition CreateProjectionTestDefinition()
+    {
+        var tokenRule = new Rule(
+            "TOKEN",
+            0,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new LiteralMatch("a"))
+            ]));
+        var parserRule = new Rule(
+            "expr",
+            1,
+            false,
+            new Alternation([
+                new Alternative(0, Associativity.Left, new RuleRef("TOKEN"))
+            ]));
+
+        return new ParserDefinition(
+            "Test",
+            GrammarType.Combined,
+            null,
+            [],
+            [],
+            [new LexerMode("DEFAULT_MODE", [tokenRule])],
+            [parserRule],
+            parserRule);
+    }
+
 }

--- a/UtilsTest/Parser/ParserLookaheadProbeTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadProbeTests.cs
@@ -45,7 +45,7 @@ public class ParserLookaheadProbeTests
     [TestMethod]
     public void Probe_LexerRuleRef_MatchingTokenRule_ReturnsRequiresParse()
     {
-        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([])) { Kind = RuleKind.Lexer } : null;
+        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([]), Kind: RuleKind.Lexer) : null;
         var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("ID")), TokenWithRule("ID"), Resolve, false);
         Assert.AreEqual(ParserLookaheadProbeKind.RequiresParse, result.Kind);
     }
@@ -53,7 +53,7 @@ public class ParserLookaheadProbeTests
     [TestMethod]
     public void Probe_LexerRuleRef_NonMatchingTokenRule_ReturnsImmediateReject()
     {
-        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([])) { Kind = RuleKind.Lexer } : null;
+        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([]), Kind: RuleKind.Lexer) : null;
         var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("ID")), TokenWithRule("NUMBER"), Resolve, false);
         Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
     }
@@ -61,7 +61,7 @@ public class ParserLookaheadProbeTests
     [TestMethod]
     public void Probe_LexerRuleRef_ProvidesExpectedTokenNames()
     {
-        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([])) { Kind = RuleKind.Lexer } : null;
+        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([]), Kind: RuleKind.Lexer) : null;
         var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("ID")), TokenWithRule("ID"), Resolve, false);
         CollectionAssert.AreEqual(new[] { "ID" }, result.ExpectedTokenNames!.ToArray());
     }
@@ -69,7 +69,7 @@ public class ParserLookaheadProbeTests
     [TestMethod]
     public void Probe_ParserRuleRef_ReturnsUnknown()
     {
-        Rule? Resolve(string name) => name == "expr" ? new Rule("expr", 0, false, new Alternation([])) { Kind = RuleKind.Parser } : null;
+        Rule? Resolve(string name) => name == "expr" ? new Rule("expr", 0, false, new Alternation([]), Kind: RuleKind.Parser) : null;
         var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("expr")), TokenWithRule("ID"), Resolve, false);
         Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
     }
@@ -78,7 +78,7 @@ public class ParserLookaheadProbeTests
     public void Probe_ParserRuleRef_NullToken_ReturnsUnknown()
     {
         // Parser rules may accept empty input, so a null token must not produce ImmediateReject.
-        Rule? Resolve(string name) => name == "opt" ? new Rule("opt", 0, false, new Alternation([])) { Kind = RuleKind.Parser } : null;
+        Rule? Resolve(string name) => name == "opt" ? new Rule("opt", 0, false, new Alternation([]), Kind: RuleKind.Parser) : null;
         var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("opt")), null, Resolve, false);
         Assert.AreEqual(ParserLookaheadProbeKind.Unknown, result.Kind);
     }
@@ -87,7 +87,7 @@ public class ParserLookaheadProbeTests
     public void Probe_LexerRuleRef_NullToken_ReturnsImmediateReject()
     {
         // A lexer rule always requires a token; EOF is a definitive reject.
-        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([])) { Kind = RuleKind.Lexer } : null;
+        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([]), Kind: RuleKind.Lexer) : null;
         var result = new ParserLookaheadProbe().Probe(CreateAlternative(new RuleRef("ID")), null, Resolve, false);
         Assert.AreEqual(ParserLookaheadProbeKind.ImmediateReject, result.Kind);
     }
@@ -107,7 +107,7 @@ public class ParserLookaheadProbeTests
     [TestMethod]
     public void Probe_AlternationOfSimpleTokens_ProvidesExpectedTokenNames()
     {
-        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([])) { Kind = RuleKind.Lexer } : null;
+        Rule? Resolve(string name) => name == "ID" ? new Rule("ID", 0, false, new Alternation([]), Kind: RuleKind.Lexer) : null;
         var alternation = new Alternation([
             CreateAlternative(new LiteralMatch("if")),
             CreateAlternative(new LiteralMatch("for")),
@@ -120,7 +120,7 @@ public class ParserLookaheadProbeTests
     [TestMethod]
     public void Probe_AlternationWithUnsupportedBranch_ReturnsNullExpectedNames()
     {
-        Rule? Resolve(string name) => name == "expr" ? new Rule("expr", 0, false, new Alternation([])) { Kind = RuleKind.Parser } : null;
+        Rule? Resolve(string name) => name == "expr" ? new Rule("expr", 0, false, new Alternation([]), Kind: RuleKind.Parser) : null;
         var alternation = new Alternation([
             CreateAlternative(new LiteralMatch("if")),
             CreateAlternative(new RuleRef("expr"))
@@ -208,7 +208,7 @@ public class ParserLookaheadProbeTests
     [TestMethod]
     public void Probe_Sequence_UnknownStopsAnalysis()
     {
-        Rule? Resolve(string name) => name == "expr" ? new Rule("expr", 0, false, new Alternation([])) { Kind = RuleKind.Parser } : null;
+        Rule? Resolve(string name) => name == "expr" ? new Rule("expr", 0, false, new Alternation([]), Kind: RuleKind.Parser) : null;
         var sequence = new Sequence([
             new RuleRef("expr"),
             new LiteralMatch("go")

--- a/UtilsTest/Parser/ParserLookaheadSharedPrefixDetectorTests.cs
+++ b/UtilsTest/Parser/ParserLookaheadSharedPrefixDetectorTests.cs
@@ -107,8 +107,8 @@ public class ParserLookaheadSharedPrefixDetectorTests
     [TestMethod]
     public void Detect_FromProbeResults_GroupsSharedFirstToken()
     {
-        var idRule = new Rule("ID", 0, false, new Alternation([])) { Kind = RuleKind.Lexer };
-        var exprRule = new Rule("expr", 1, false, new Alternation([])) { Kind = RuleKind.Parser };
+        var idRule = new Rule("ID", 0, false, new Alternation([]), Kind: RuleKind.Lexer);
+        var exprRule = new Rule("expr", 1, false, new Alternation([]), Kind: RuleKind.Parser);
         var alternatives = new[]
         {
             new Alternative(0, Associativity.Left, new Sequence([new RuleRef("ID"), new LiteralMatch("+"), new RuleRef("expr")]), null),

--- a/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
+++ b/UtilsTest/Parser/ParserSharedPrefixMetadataScenarioTests.cs
@@ -337,10 +337,10 @@ public class ParserSharedPrefixMetadataScenarioTests
     {
         if (name is "ID" or "NUMBER")
         {
-            return new Rule(name, 0, false, new Alternation([])) { Kind = RuleKind.Lexer };
+            return new Rule(name, 0, false, new Alternation([]), Kind: RuleKind.Lexer);
         }
 
-        return new Rule(name, 0, false, new Alternation([])) { Kind = RuleKind.Parser };
+        return new Rule(name, 0, false, new Alternation([]), Kind: RuleKind.Parser);
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation

- Eliminate the mixed-responsibility mutation of public `Rule` instances during resolution.
- Make `Rule` a final immutable consumer-visible model once resolution has completed.
- Move transient mutable resolution state into an internal `RuleResolutionBuilder` so `RuleResolver` can continue to resolve rule kinds incrementally without mutating public rule objects in place.
- Preserve runtime behavior while clarifying ownership boundaries between the resolution process and the resolved model.

### Audit summary

- Previous in-place `Kind` mutations were concentrated in `RuleResolver.Resolve(...)`, where rules from lexer modes and parser-rule lists were registered and then mutated via `rule.Kind = ...`.
- `NormalizeAlternatives(...)` also had to manually preserve `Kind` after a `with` copy because `Kind` was not part of the record state.
- Bootstrap declarations and several tests constructed rules and then assigned `Kind` via object-initializer or internal mutation patterns.
- Consumers that read `Kind` include runtime components such as `ParserEngine`, `LexerExtensionContext`, `ParserLookaheadProbe`, left-recursion/lookahead metadata paths, and unit tests.
- No `ResolvedRule`, `RawRule`, `RuleDeclaration`, or new public rule type was introduced. The public model remains a single `Rule` record.

### Modifications

- Moved `Rule.Kind` into the `Rule` record primary constructor as an immutable value with default `RuleKind.Unresolved`.
- Removed the previous `public RuleKind Kind { get; internal set; }` property.
- Added internal `RuleResolutionBuilder` in `Utils.Parser.Resolution` to hold mutable rule-kind state during resolution.
- Reworked `RuleResolver.Resolve(...)` to:
  - register rules into `RuleResolutionBuilder` instances;
  - resolve known lexer/parser kinds through the builder;
  - infer unresolved kinds through builder state;
  - build final immutable `Rule` instances;
  - reconstruct `Modes`, `ParserRules`, `RootRule`, and `AllRules` from finalized rule instances.
- Updated `NormalizeAlternatives(...)` so `with` copies naturally preserve `Kind` as part of the record state.
- Updated bootstrap/test helpers to pass `Kind` at construction time instead of assigning it afterward.
- Updated `Utils.Parser/ROADMAP.md` to record the public API and resolution-boundary cleanup.

### Public API impact

Yes. This is an intentional pre-release breaking API change.

Changed public API:
- `Rule.Kind` is now an immutable positional member of the public `Rule` record.
- The previous `internal set` mutability has been removed.
- The public `Rule` constructor / positional record shape now includes `Kind` with default value `RuleKind.Unresolved`.
- The synthesized record deconstruction shape changes accordingly.

Unchanged public semantics:
- `Rule.Kind` remains publicly readable.
- `RuleKind.Unresolved` remains the default state before resolution.
- Consumers should use `RuleResolver.Resolve(...)` to obtain finalized rules.

Internal-only API:
- `RuleResolutionBuilder` is `internal` and is not part of the public API.

Codex noted that adding `Kind` to the positional record constructor changes the constructor ABI and synthesized `Deconstruct` shape. This is accepted intentionally because the project is pre-release, has no current external users, and the change removes an accidental mutable contract before API stabilization.

### Migration

Before, internal code could mutate `Kind` after constructing a rule:

```csharp
var rule = new Rule(name, order, isFragment, content);
rule.Kind = RuleKind.Lexer;
```

After, construct the rule with a known kind:

```csharp
var rule = new Rule(name, order, isFragment, content, Kind: RuleKind.Lexer);
```

or use a `with` expression:

```csharp
var finalized = rule with { Kind = RuleKind.Parser };
```

Consumers should not rely on mutating `Rule.Kind`. To obtain finalized rules, use:

```csharp
var resolved = RuleResolver.Resolve(definition);
var kind = resolved.AllRules[ruleName].Kind;
```

### Compatibility impact

Source-breaking and binary-breaking for callers compiled against the previous positional `Rule` record constructor/deconstruction shape.

This is accepted as part of the pre-release API cleanup policy.

The change reduces the risk of partially resolved public `Rule` instances and clarifies that mutable rule-kind state belongs to the resolution process, not to the final public model.

### Runtime impact

No runtime behavior change expected.

This PR does not change parsing algorithms, lexer/parser matching behavior, scheduling, lookahead semantics, parser acceptance, memoization, or parse-tree construction.

### Diagnostics impact

None expected.

This PR does not change diagnostic codes, diagnostic severities, diagnostic emission points, or diagnostic ownership.

### Parse-tree impact

None.

### ANTLR compatibility impact

None.

ANTLR feature support, runtime/generator compatibility semantics, grammar parsing behavior, and compatibility diagnostics are unchanged. `docs/parser/ANTLRCompatibility.md` was checked and does not require an update because no ANTLR support status or divergence changed.

### Documentation impact

- `Utils.Parser/ROADMAP.md`: updated because this PR changes public API shape and clarifies the rule-resolution ownership boundary.
- `docs/parser/ANTLRCompatibility.md`: not updated because ANTLR feature support and compatibility diagnostics are unchanged.
- `docs/parser/INDEX.md`: not updated because no parser documentation file was added, removed, moved, renamed, or materially re-scoped.

### Tests

Added/updated tests covering:
- default `Rule.Kind == RuleKind.Unresolved`;
- `with` expressions preserve `Kind`;
- parser rules are finalized with `RuleKind.Parser`;
- lexer mode rules are finalized with `RuleKind.Lexer`;
- `AllRules` uses the same finalized rule instances as `ParserRules` / `Modes`;
- `RootRule` uses the finalized rule instance;
- normalized alternatives preserve `Kind`;
- `RuleResolutionBuilder` rejects conflicting kind resolution.

Validation reported by Codex:
- `dotnet test UtilsTest/UtilsTest.Unit.csproj`: Passed 1356, Failed 0, Skipped 5, Total 1361.
- `dotnet build` and `dotnet pack` for `Utils.Parser` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1942b48ef083269d055c98d9b11a36)