### PR TITLE
Move runtime source primitives into Utils.Parser.Source

### DIFF
--- a/Utils.Parser.Source/IsExternalInit.cs
+++ b/Utils.Parser.Source/IsExternalInit.cs
@@ -1,0 +1,8 @@
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Provides record initialization support when targeting frameworks that do not define the type.
+/// </summary>
+internal static class IsExternalInit
+{
+}

--- a/Utils.Parser.Source/README.md
+++ b/Utils.Parser.Source/README.md
@@ -6,8 +6,10 @@ The package is intentionally small and does not carry runtime parsing logic, dia
 
 ## Contracts
 
-- `SourceCodeLocation` represents a source file path with a 1-based line and 1-based column.
-- `SourceCodeRange` extends `SourceCodeLocation` with a length component for source ranges.
+- `SourceCodeLocation` represents a required source file path with a 1-based line and 1-based column for human-readable display.
+- `SourceCodeRange` extends `SourceCodeLocation` with a length component for human-readable source ranges.
+- `SourceLocation` represents a point in source text with an absolute offset plus optional file/display coordinates.
+- `SourceSpan` represents a runtime text span with an absolute offset and length, plus optional file/display coordinates for diagnostics formatting.
 
 ## Intended consumers
 

--- a/Utils.Parser.Source/SourceCodeLocation.cs
+++ b/Utils.Parser.Source/SourceCodeLocation.cs
@@ -3,14 +3,14 @@ using System;
 namespace Utils.Parser.Source;
 
 /// <summary>
-/// Represents a human-readable location in source code.
+/// Represents a human-readable location in source code with a required file path, line, and column.
 /// </summary>
 public class SourceCodeLocation
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SourceCodeLocation"/> class.
     /// </summary>
-    /// <param name="filePath">Source file path.</param>
+    /// <param name="filePath">Required source file path.</param>
     /// <param name="line">1-based line number.</param>
     /// <param name="column">1-based column number.</param>
     public SourceCodeLocation(string filePath, int line, int column)
@@ -36,7 +36,7 @@ public class SourceCodeLocation
     }
 
     /// <summary>
-    /// Gets the source file path.
+    /// Gets the required source file path.
     /// </summary>
     public string FilePath { get; }
 

--- a/Utils.Parser.Source/SourceCodeRange.cs
+++ b/Utils.Parser.Source/SourceCodeRange.cs
@@ -3,17 +3,17 @@ using System;
 namespace Utils.Parser.Source;
 
 /// <summary>
-/// Represents a human-readable source location with a length component.
+/// Represents a human-readable source location with a required file path and a length component.
 /// </summary>
 public sealed class SourceCodeRange : SourceCodeLocation
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SourceCodeRange"/> class.
     /// </summary>
-    /// <param name="filePath">Source file path.</param>
+    /// <param name="filePath">Required source file path.</param>
     /// <param name="line">1-based line number.</param>
     /// <param name="column">1-based column number.</param>
-    /// <param name="length">Range length.</param>
+    /// <param name="length">Number of display characters covered by the range.</param>
     public SourceCodeRange(string filePath, int line, int column, int length)
         : base(filePath, line, column)
     {
@@ -26,7 +26,7 @@ public sealed class SourceCodeRange : SourceCodeLocation
     }
 
     /// <summary>
-    /// Gets the range length.
+    /// Gets the number of display characters covered by the range.
     /// </summary>
     public int Length { get; }
 

--- a/Utils.Parser.Source/SourceLocation.cs
+++ b/Utils.Parser.Source/SourceLocation.cs
@@ -1,0 +1,14 @@
+namespace Utils.Parser.Source;
+
+/// <summary>
+/// Represents a point in a source text with both display coordinates and an absolute offset.
+/// </summary>
+/// <param name="FilePath">Optional path of the source file containing the location.</param>
+/// <param name="Line">1-based line number for human-readable display.</param>
+/// <param name="Column">1-based column number for human-readable display.</param>
+/// <param name="Position">Zero-based absolute offset from the start of the source text.</param>
+public sealed record SourceLocation(
+    string? FilePath,
+    int Line,
+    int Column,
+    int Position);

--- a/Utils.Parser.Source/SourceSpan.cs
+++ b/Utils.Parser.Source/SourceSpan.cs
@@ -1,0 +1,21 @@
+namespace Utils.Parser.Source;
+
+/// <summary>
+/// Represents a span in a source text with an absolute offset and length.
+/// </summary>
+/// <param name="Position">Zero-based absolute offset from the start of the source text.</param>
+/// <param name="Length">Number of characters covered by this span.</param>
+/// <param name="Line">1-based line where the span starts, when display coordinates are available.</param>
+/// <param name="Column">1-based column where the span starts, when display coordinates are available.</param>
+/// <param name="FilePath">Optional source file path used for display or diagnostics formatting.</param>
+/// <remarks>
+/// This type is used by runtime tokens and parse nodes to preserve text offsets. Unlike
+/// <see cref="SourceCodeRange"/>, it keeps the absolute source position and allows the file path
+/// to be omitted when the source text is anonymous or in-memory.
+/// </remarks>
+public sealed record SourceSpan(
+    int Position,
+    int Length,
+    int Line = 1,
+    int Column = 1,
+    string? FilePath = null);

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -6,6 +6,7 @@ using Utils.Parser.Model;
 using Utils.Parser.Resolution;
 using Utils.Parser.Runtime;
 using System.IO;
+using Utils.Parser.Source;
 
 namespace Utils.Parser.Bootstrap;
 

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -85,6 +85,7 @@ Current capabilities and responsibilities:
 - Parser tests are organized to reflect runtime contracts.
 - Runtime observation and export contract is documented (`docs/parser/RuntimeObservationAndExportContract.md`).
 - Diagnostics/observation correlation boundaries are documented (`docs/parser/DiagnosticsObservationCorrelation.md`) as descriptive-only and non-authoritative.
+- Source-position contracts are centralized in the shared `Utils.Parser.Source` package: `SourceCodeLocation` / `SourceCodeRange` remain human-readable diagnostic/display locations, while `SourceLocation` / `SourceSpan` preserve runtime text offsets and spans for tokens and parse nodes.
 
 Clarifications that must remain true:
 
@@ -243,6 +244,7 @@ Current clarification status:
 - shared ANTLR4 prequel DTOs now include shared neutral prequel validation facts in `Utils.Parser.Antlr4.Common`; runtime and generator continue to own conversion into `ParserDiagnostics`, and parsing remains intentionally separate.
 - parser diagnostics now use immutable composed value objects (`DiagnosticDetails`, `DiagnosticSpan`, `SourceCodeLocation`, and `SourceCodeRange`) to separate diagnostic content, source offsets, and human-readable source locations while preserving diagnostic ownership and emission semantics.
 - `SourceCodeLocation` and `SourceCodeRange` are now hosted by a dedicated shared `Utils.Parser.Source` package so diagnostics, runtime, generators, and future tooling surfaces can share source-location contracts without depending on diagnostics.
+- `SourceLocation` and `SourceSpan` were moved into the shared `Utils.Parser.Source` package alongside `SourceCodeLocation` and `SourceCodeRange`, centralizing source-position contracts while keeping token/runtime behavior unchanged.
 
 ### Phase 3 — Lookahead contract consolidation
 

--- a/Utils.Parser/Runtime/AlternativeScheduler.cs
+++ b/Utils.Parser/Runtime/AlternativeScheduler.cs
@@ -1,5 +1,6 @@
 using Utils.Parser.Diagnostics;
 using Utils.Parser.Model;
+using Utils.Parser.Source;
 
 namespace Utils.Parser.Runtime;
 

--- a/Utils.Parser/Runtime/KeywordLookup.cs
+++ b/Utils.Parser/Runtime/KeywordLookup.cs
@@ -1,4 +1,5 @@
 using Utils.Parser.Model;
+using Utils.Parser.Source;
 
 namespace Utils.Parser.Runtime;
 

--- a/Utils.Parser/Runtime/LexerEngine.cs
+++ b/Utils.Parser/Runtime/LexerEngine.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text;
 using Utils.Parser.Diagnostics;
 using Utils.Parser.Model;
+using Utils.Parser.Source;
 
 namespace Utils.Parser.Runtime;
 

--- a/Utils.Parser/Runtime/ParseNode.cs
+++ b/Utils.Parser/Runtime/ParseNode.cs
@@ -1,4 +1,5 @@
 using Utils.Parser.Model;
+using Utils.Parser.Source;
 
 namespace Utils.Parser.Runtime;
 

--- a/Utils.Parser/Runtime/ParserEngine.cs
+++ b/Utils.Parser/Runtime/ParserEngine.cs
@@ -1,5 +1,6 @@
 using Utils.Parser.Model;
 using Utils.Parser.Diagnostics;
+using Utils.Parser.Source;
 
 namespace Utils.Parser.Runtime;
 

--- a/Utils.Parser/Runtime/Token.cs
+++ b/Utils.Parser/Runtime/Token.cs
@@ -1,47 +1,21 @@
+using Utils.Parser.Source;
+
 namespace Utils.Parser.Runtime;
-
-/// <summary>
-/// Represents a concrete location in a source file.
-/// </summary>
-public sealed record SourceLocation(
-    /// <summary>Optional path of the source file containing the location.</summary>
-    string? FilePath,
-    /// <summary>1-based line number.</summary>
-    int Line,
-    /// <summary>1-based column number.</summary>
-    int Column,
-    /// <summary>Zero-based absolute position from the start of the source.</summary>
-    int Position);
-
-/// <summary>
-/// An absolute position and length within a source text.
-/// </summary>
-public sealed record SourceSpan(
-    /// <summary>Zero-based character offset from the start of the source.</summary>
-    int Position,
-    /// <summary>Number of characters covered by this span.</summary>
-    int Length,
-    /// <summary>1-based line where the span starts.</summary>
-    int Line = 1,
-    /// <summary>1-based column where the span starts.</summary>
-    int Column = 1,
-    /// <summary>Optional source file path for diagnostics formatting.</summary>
-    string? FilePath = null);
 
 /// <summary>
 /// An atomic lexical unit produced by <see cref="LexerEngine"/>.
 /// Each token records its source position, the rule that matched it,
 /// the active lexer mode at the time of the match, and the matched text.
 /// </summary>
+/// <param name="Span">Position and length of the token in the source text.</param>
+/// <param name="RuleName">Name of the lexer rule that produced this token, for example <c>"ID"</c>.</param>
+/// <param name="ModeName">Name of the active lexer mode when this token was produced.</param>
+/// <param name="Channel">Channel name assigned to this token.</param>
+/// <param name="Text">Raw matched text.</param>
 public record Token(
-    /// <summary>Position and length of the token in the source text.</summary>
     SourceSpan Span,
-    /// <summary>Name of the lexer rule that produced this token (e.g. <c>"ID"</c>).</summary>
     string RuleName,
-    /// <summary>Name of the active lexer mode when this token was produced.</summary>
     string ModeName,
-    /// <summary>Channel name assigned to this token.</summary>
     string Channel,
-    /// <summary>Raw matched text.</summary>
     string Text
 );

--- a/Utils.Parser/Utils.Parser.csproj
+++ b/Utils.Parser/Utils.Parser.csproj
@@ -28,6 +28,7 @@
 
 
     <ItemGroup>
+        <ProjectReference Include="..\Utils.Parser.Source\Utils.Parser.Source.csproj" />
         <ProjectReference Include="..\Utils.Parser.Diagnostics\Utils.Parser.Diagnostics.csproj" />
         <ProjectReference Include="..\Utils.Parser.Antlr4.Common\Utils.Parser.Antlr4.Common.csproj" />
     </ItemGroup>

--- a/UtilsTest/Parser/GlobalUsings.cs
+++ b/UtilsTest/Parser/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Utils.Parser.Source;

--- a/UtilsTest/Parser/ParserSourceContractTests.cs
+++ b/UtilsTest/Parser/ParserSourceContractTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Verifies parser source-position contracts that are exposed through runtime tokens.
+/// </summary>
+[TestClass]
+public class ParserSourceContractTests
+{
+    /// <summary>
+    /// Ensures that a token keeps the exact runtime source span supplied by the caller.
+    /// </summary>
+    [TestMethod]
+    public void Token_PreservesRuntimeSourceSpanValues()
+    {
+        var span = new SourceSpan(12, 5, 3, 7, "sample.apu");
+        var token = new Token(span, "Identifier", "DEFAULT_MODE", "DEFAULT_CHANNEL", "value");
+
+        Assert.AreSame(span, token.Span);
+        Assert.AreEqual(12, token.Span.Position);
+        Assert.AreEqual(5, token.Span.Length);
+        Assert.AreEqual(3, token.Span.Line);
+        Assert.AreEqual(7, token.Span.Column);
+        Assert.AreEqual("sample.apu", token.Span.FilePath);
+    }
+}

--- a/UtilsTest/UtilsTest.Unit.csproj
+++ b/UtilsTest/UtilsTest.Unit.csproj
@@ -73,6 +73,7 @@
 		<ProjectReference Include="..\Utils.Parser.Diagnostics\Utils.Parser.Diagnostics.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Utils.OData.Generators\Utils.OData.Generators.csproj" />
 		<ProjectReference Include="..\Utils.OData\Utils.OData.csproj" />
+		<ProjectReference Include="..\Utils.Parser.Source\Utils.Parser.Source.csproj" />
 		<ProjectReference Include="..\Utils.Parser\Utils.Parser.csproj" />
 		<ProjectReference Include="..\Utils.Expressions.CSyntax\Utils.Expressions.CSyntax.csproj" />
 		<ProjectReference Include="..\Utils.Expressions.VBSyntax\Utils.Expressions.VBSyntax.csproj" />


### PR DESCRIPTION
### Motivation

- Remove a confusing boundary where runtime token primitives (`SourceLocation`, `SourceSpan`) lived in `Utils.Parser.Runtime` while human-readable source contracts (`SourceCodeLocation`, `SourceCodeRange`) were already in `Utils.Parser.Source`.
- Centralize source-position contracts so diagnostics, runtime, generators, and tooling can share the same small source package.
- Preserve the current conceptual distinction between:
  - human-readable source display contracts: `SourceCodeLocation` / `SourceCodeRange`;
  - runtime offset/span contracts: `SourceLocation` / `SourceSpan`.
- Keep lexer/parser behavior unchanged while accepting the API cleanup required to move source primitives out of the runtime namespace before API stabilization.

### Audit summary

- After PR #284, `SourceCodeLocation` and `SourceCodeRange` were hosted by the shared `Utils.Parser.Source` package.
- `SourceLocation` and `SourceSpan` were still declared in `Utils.Parser.Runtime/Token.cs`, even though they are generic source-position contracts rather than token-specific runtime behavior.
- `Token` exposes `SourceSpan`, and several runtime files consume `SourceSpan` or `SourceLocation` for offsets, parse nodes, and lexer/parser position handling.
- Moving these types into `Utils.Parser.Source` centralizes source-position contracts without merging or renaming the existing concepts.
- A later PR may audit whether `SourceCodeLocation` / `SourceCodeRange` should be merged with `SourceLocation` / `SourceSpan`, but that conceptual merge is intentionally not done here.

### Modifications

- Added `SourceLocation` to `Utils.Parser.Source`.
- Added `SourceSpan` to `Utils.Parser.Source`.
- Removed `SourceLocation` and `SourceSpan` declarations from `Utils.Parser.Runtime/Token.cs`.
- Simplified `Token.cs` so it declares only `Token` and imports `Utils.Parser.Source`.
- Added a direct project reference:
  - `Utils.Parser -> Utils.Parser.Source`
- Updated runtime files to import `Utils.Parser.Source` where needed.
- Added an `IsExternalInit` shim in `Utils.Parser.Source` to support records on `netstandard2.0`.
- Updated `Utils.Parser.Source/README.md` to document all four source contracts.
- Updated `Utils.Parser/ROADMAP.md` to record source-position centralization.
- Added `ParserSourceContractTests` to verify that `Token` preserves the exact `SourceSpan` values provided by the caller.

### Public API impact

Yes. This is an intentional pre-release breaking API change.

Moved public types:
- `SourceLocation`
- `SourceSpan`

Before:

```csharp
Utils.Parser.Runtime.SourceLocation
Utils.Parser.Runtime.SourceSpan
```

After:

```csharp
Utils.Parser.Source.SourceLocation
Utils.Parser.Source.SourceSpan
```

`Token.Span` still exposes a `SourceSpan`, but the type is now `Utils.Parser.Source.SourceSpan` instead of `Utils.Parser.Runtime.SourceSpan`.

Removed from `Utils.Parser.Runtime`:
- `SourceLocation`
- `SourceSpan`

Preserved:
- type names;
- constructor parameters;
- property names;
- `Token.Span` semantics;
- lexer/parser runtime behavior.

Codex noted that this breaks consumers compiled against `Utils.Parser.Runtime.SourceSpan` / `SourceLocation` and the previous `Token` constructor signature. This is accepted because the project is pre-release, has no current external users, and the change removes an accidental runtime ownership boundary before API stabilization.

### Migration

Before:

```csharp
using Utils.Parser.Runtime;

var span = new SourceSpan(position, length, line, column, filePath);
var token = new Token(span, ruleName, modeName, channel, text);
```

After:

```csharp
using Utils.Parser.Runtime;
using Utils.Parser.Source;

var span = new SourceSpan(position, length, line, column, filePath);
var token = new Token(span, ruleName, modeName, channel, text);
```

Fully qualified name migration:

```csharp
Utils.Parser.Runtime.SourceSpan
```

becomes:

```csharp
Utils.Parser.Source.SourceSpan
```

and:

```csharp
Utils.Parser.Runtime.SourceLocation
```

becomes:

```csharp
Utils.Parser.Source.SourceLocation
```

### Compatibility impact

Source-breaking and binary-breaking for consumers that referenced:
- `Utils.Parser.Runtime.SourceSpan`
- `Utils.Parser.Runtime.SourceLocation`
- `Token` constructor signatures compiled against the previous runtime-owned `SourceSpan` type.

This is an accepted pre-release breaking change.

No compatibility shim or wrapper is intentionally kept in `Utils.Parser.Runtime`, because doing so would preserve the duplicate boundary that this PR removes.

### Runtime impact

No runtime behavior change expected.

This PR does not change:
- lexer matching;
- parser matching;
- scheduling;
- lookahead semantics;
- memoization;
- parser acceptance;
- parse-tree construction;
- token span values.

### Diagnostics impact

No diagnostic behavior change expected.

This PR does not change:
- diagnostic codes;
- diagnostic severities;
- diagnostic emission points;
- diagnostic ownership;
- `ParserDiagnostic` semantics.

`DiagnosticSpan` remains a diagnostics-specific offset span. `SourceSpan` remains a runtime/source-position contract.

### Parse-tree impact

No parse-tree shape or behavior change expected.

Parse nodes may now refer to `Utils.Parser.Source.SourceSpan` through imports, but source position values and parse-tree construction semantics are unchanged.

### ANTLR compatibility impact

None.

ANTLR feature support, grammar parsing behavior, runtime/generator parity semantics, compatibility diagnostics, and documented divergences are unchanged.

`docs/parser/ANTLRCompatibility.md` was checked and does not require an update.

### Documentation impact

- `Utils.Parser/ROADMAP.md`: updated because this PR centralizes source-position contracts in the shared source package.
- `Utils.Parser.Source/README.md`: updated to document `SourceLocation` and `SourceSpan` alongside `SourceCodeLocation` and `SourceCodeRange`.
- `docs/parser/ANTLRCompatibility.md`: not updated because no ANTLR support status, compatibility diagnostic, or behavior changed.
- `docs/parser/INDEX.md`: not updated because no parser documentation file was added, removed, renamed, moved, or materially re-scoped.

### Tests

Validation reported by Codex:
- `dotnet test UtilsTest/UtilsTest.Unit.csproj`: Passed 1357, Failed 0, Skipped 5.
- `dotnet build Utils.Parser/Utils.Parser.csproj -c Release`: succeeded.
- `dotnet pack Utils.Parser.Source/Utils.Parser.Source.csproj`: succeeded.
- `dotnet pack Utils.Parser/Utils.Parser.csproj`: succeeded.

Added/updated tests:
- `ParserSourceContractTests.Token_PreservesRuntimeSourceSpanValues` verifies that `Token` keeps the exact `SourceSpan` instance and values supplied by the caller.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b591b88688326a1c8c09df376e530)