### PR TITLE
Clarify parser source coordinate contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Clarified parser source-coordinate documentation across `omy.Utils.Parser.Source` and the parser roadmap, including the split between runtime offsets and human-readable diagnostic/tooling locations.
 - Updated the `omy.Utils` NuGet description to a concise consumer-facing summary aligned with the package README and discoverability goals.
 
 ### Added

--- a/Utils.Parser.Diagnostics/README.md
+++ b/Utils.Parser.Diagnostics/README.md
@@ -10,7 +10,7 @@ Use this package when you need a common set of diagnostic primitives across pars
 - diagnostic severities,
 - diagnostic aggregation utilities.
 
-Source-location contracts such as `SourceCodeLocation` and `SourceCodeRange` are provided by `omy.Utils.Parser.Source` so non-diagnostic surfaces can share them without depending on diagnostics.
+Human-readable source-location contracts such as `SourceCodeLocation` and `SourceCodeRange` are provided by `omy.Utils.Parser.Source` so non-diagnostic surfaces can share them without depending on diagnostics. Runtime offset contracts such as `SourceLocation` and `SourceSpan` remain separate in that package for token and parser operations.
 
 ## Typical usage
 

--- a/Utils.Parser.Source/README.md
+++ b/Utils.Parser.Source/README.md
@@ -2,15 +2,48 @@
 
 `omy.Utils.Parser.Source` contains shared source-location contracts for the `Utils.Parser` ecosystem.
 
-The package is intentionally small and does not carry runtime parsing logic, diagnostic emission logic, generators, or tooling behavior. It only provides reusable contracts that other parser packages can reference without depending on diagnostics.
+The package is intentionally small. It does not contain runtime parsing logic, parser logic, diagnostic emission logic, generator logic, or tooling behavior. It only provides reusable source-coordinate contracts that parser runtime components, diagnostics, generators, and tooling can reference without introducing artificial package coupling.
 
-## Contracts
+## Runtime source coordinates
 
-- `SourceCodeLocation` represents a required source file path with a 1-based line and 1-based column for human-readable display.
-- `SourceCodeRange` extends `SourceCodeLocation` with a length component for human-readable source ranges.
-- `SourceLocation` represents a point in source text with an absolute offset plus optional file/display coordinates.
-- `SourceSpan` represents a runtime text span with an absolute offset and length, plus optional file/display coordinates for diagnostics formatting.
+Runtime source coordinates describe technical positions in the source text consumed by lexer, parser, and runtime components.
+
+- `SourceLocation` represents a point in source text.
+- `SourceSpan` represents a range in source text.
+
+These contracts are intended for tokens, parse nodes, lexer/parser runtime observation, runtime analyses, and source-text slicing.
+
+For runtime coordinates:
+
+- `Position` is a zero-based absolute offset in the source string.
+- `Length` is a length in characters/runtime text units according to the source representation used by the runtime.
+- `Line` and `Column` are 1-based display coordinates associated with the same point or span start.
+- `FilePath` is optional because source text can be anonymous, generated, or held only in memory.
+
+## Human-readable source coordinates
+
+Human-readable source coordinates describe locations intended for diagnostics, display, import/export, and tooling surfaces.
+
+- `SourceCodeLocation` represents a required file path plus 1-based line and column.
+- `SourceCodeRange` extends `SourceCodeLocation` with a display/diagnostic length.
+
+These contracts are useful when a readable source location is known but no canonical runtime absolute position is available.
+
+For human-readable coordinates:
+
+- no absolute source offset is stored;
+- `FilePath` is required;
+- `Line` and `Column` are 1-based;
+- `Length`, when present, is intended for display or diagnostic ranges rather than runtime slicing authority.
+
+## Why both models exist
+
+An absolute position in a source string and a file/line/column location are not interchangeable without the source text and the counting conventions used to interpret it.
+
+Line endings, tab expansion, Unicode representation, and column-counting rules can all make conversion context-dependent. A runtime offset can be the correct contract for token and parse-node operations while still being insufficient to reconstruct a human-readable location without additional source context. Conversely, a human-readable file/line/column location can be enough for diagnostics or tooling while not identifying a canonical absolute offset in a particular runtime source buffer.
+
+For that reason, `SourceSpan` does not replace `SourceCodeRange`, and `SourceCodeLocation` does not replace `SourceLocation`. They model different contracts and should only be converted by code that explicitly owns the relevant source text and counting conventions.
 
 ## Intended consumers
 
-This package is designed to be shared by diagnostics, parser runtime components, source generators, and future tooling surfaces that need source-location data without introducing an artificial dependency on `omy.Utils.Parser.Diagnostics`.
+This package is designed to be shared by diagnostics, parser runtime components, source generators, and future tooling surfaces that need source-location data without depending on `omy.Utils.Parser.Diagnostics`.

--- a/Utils.Parser.Source/SourceCodeLocation.cs
+++ b/Utils.Parser.Source/SourceCodeLocation.cs
@@ -3,16 +3,21 @@ using System;
 namespace Utils.Parser.Source;
 
 /// <summary>
-/// Represents a human-readable location in source code with a required file path, line, and column.
+/// Represents a human-readable source-code location for diagnostics, display, and tooling.
 /// </summary>
+/// <remarks>
+/// This contract requires a file path and 1-based line/column coordinates, but intentionally
+/// carries no absolute source offset. It must not be treated as equivalent to
+/// <see cref="SourceLocation" />, which is a runtime/source-buffer coordinate contract.
+/// </remarks>
 public class SourceCodeLocation
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SourceCodeLocation"/> class.
     /// </summary>
-    /// <param name="filePath">Required source file path.</param>
-    /// <param name="line">1-based line number.</param>
-    /// <param name="column">1-based column number.</param>
+    /// <param name="filePath">Required source file path for diagnostics, display, or tooling.</param>
+    /// <param name="line">1-based human-readable line number.</param>
+    /// <param name="column">1-based human-readable column number.</param>
     public SourceCodeLocation(string filePath, int line, int column)
     {
         if (string.IsNullOrWhiteSpace(filePath))
@@ -36,17 +41,17 @@ public class SourceCodeLocation
     }
 
     /// <summary>
-    /// Gets the required source file path.
+    /// Gets the required source file path for diagnostics, display, or tooling.
     /// </summary>
     public string FilePath { get; }
 
     /// <summary>
-    /// Gets the 1-based line number.
+    /// Gets the 1-based human-readable line number.
     /// </summary>
     public int Line { get; }
 
     /// <summary>
-    /// Gets the 1-based column number.
+    /// Gets the 1-based human-readable column number.
     /// </summary>
     public int Column { get; }
 

--- a/Utils.Parser.Source/SourceCodeRange.cs
+++ b/Utils.Parser.Source/SourceCodeRange.cs
@@ -3,8 +3,13 @@ using System;
 namespace Utils.Parser.Source;
 
 /// <summary>
-/// Represents a human-readable source location with a required file path and a length component.
+/// Represents a human-readable source-code range for diagnostics, display, and tooling.
 /// </summary>
+/// <remarks>
+/// This contract extends <see cref="SourceCodeLocation" /> with a display/diagnostic length,
+/// but intentionally carries no absolute source offset. It must not be treated as equivalent to
+/// <see cref="SourceSpan" />, which is a runtime/source-buffer range contract.
+/// </remarks>
 public sealed class SourceCodeRange : SourceCodeLocation
 {
     /// <summary>
@@ -13,7 +18,7 @@ public sealed class SourceCodeRange : SourceCodeLocation
     /// <param name="filePath">Required source file path.</param>
     /// <param name="line">1-based line number.</param>
     /// <param name="column">1-based column number.</param>
-    /// <param name="length">Number of display characters covered by the range.</param>
+    /// <param name="length">Length intended for display or diagnostics for the range.</param>
     public SourceCodeRange(string filePath, int line, int column, int length)
         : base(filePath, line, column)
     {
@@ -26,7 +31,7 @@ public sealed class SourceCodeRange : SourceCodeLocation
     }
 
     /// <summary>
-    /// Gets the number of display characters covered by the range.
+    /// Gets the length intended for display or diagnostics for the range.
     /// </summary>
     public int Length { get; }
 

--- a/Utils.Parser.Source/SourceLocation.cs
+++ b/Utils.Parser.Source/SourceLocation.cs
@@ -1,12 +1,17 @@
 namespace Utils.Parser.Source;
 
 /// <summary>
-/// Represents a point in a source text with both display coordinates and an absolute offset.
+/// Represents a technical point in a source text for lexer, parser, and runtime operations.
 /// </summary>
-/// <param name="FilePath">Optional path of the source file containing the location.</param>
-/// <param name="Line">1-based line number for human-readable display.</param>
-/// <param name="Column">1-based column number for human-readable display.</param>
+/// <param name="FilePath">Optional path of the source file containing the location, or <see langword="null" /> for anonymous or in-memory source text.</param>
+/// <param name="Line">1-based human-readable line number associated with the same point, when display coordinates are available.</param>
+/// <param name="Column">1-based human-readable column number associated with the same point, when display coordinates are available.</param>
 /// <param name="Position">Zero-based absolute offset from the start of the source text.</param>
+/// <remarks>
+/// <see cref="SourceLocation" /> is a runtime/source-buffer coordinate contract. It is not
+/// equivalent to <see cref="SourceCodeLocation" />, which intentionally carries no absolute
+/// source offset and requires a file path for diagnostic or tooling display.
+/// </remarks>
 public sealed record SourceLocation(
     string? FilePath,
     int Line,

--- a/Utils.Parser.Source/SourceSpan.cs
+++ b/Utils.Parser.Source/SourceSpan.cs
@@ -1,17 +1,18 @@
 namespace Utils.Parser.Source;
 
 /// <summary>
-/// Represents a span in a source text with an absolute offset and length.
+/// Represents a technical range in a source text for lexer, parser, and runtime operations.
 /// </summary>
 /// <param name="Position">Zero-based absolute offset from the start of the source text.</param>
-/// <param name="Length">Number of characters covered by this span.</param>
-/// <param name="Line">1-based line where the span starts, when display coordinates are available.</param>
-/// <param name="Column">1-based column where the span starts, when display coordinates are available.</param>
+/// <param name="Length">Length of the range in the runtime text units used by the source representation.</param>
+/// <param name="Line">1-based human-readable line where the range starts, when display coordinates are available.</param>
+/// <param name="Column">1-based human-readable column where the range starts, when display coordinates are available.</param>
 /// <param name="FilePath">Optional source file path used for display or diagnostics formatting.</param>
 /// <remarks>
-/// This type is used by runtime tokens and parse nodes to preserve text offsets. Unlike
-/// <see cref="SourceCodeRange"/>, it keeps the absolute source position and allows the file path
-/// to be omitted when the source text is anonymous or in-memory.
+/// This type is used by runtime tokens, parse nodes, and related runtime analysis surfaces to
+/// preserve absolute text offsets. Unlike <see cref="SourceCodeRange" />, it keeps the absolute
+/// source position and allows the file path to be omitted when the source text is anonymous or
+/// in-memory.
 /// </remarks>
 public sealed record SourceSpan(
     int Position,

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -86,6 +86,7 @@ Current capabilities and responsibilities:
 - Runtime observation and export contract is documented (`docs/parser/RuntimeObservationAndExportContract.md`).
 - Diagnostics/observation correlation boundaries are documented (`docs/parser/DiagnosticsObservationCorrelation.md`) as descriptive-only and non-authoritative.
 - Source-position contracts are centralized in the shared `Utils.Parser.Source` package: `SourceCodeLocation` / `SourceCodeRange` remain human-readable diagnostic/display locations, while `SourceLocation` / `SourceSpan` preserve runtime text offsets and spans for tokens and parse nodes.
+- Source-position contracts are intentionally split between runtime coordinates (`SourceLocation`, `SourceSpan`) and human-readable source coordinates (`SourceCodeLocation`, `SourceCodeRange`). Runtime coordinates carry absolute text offsets for tokens/parser operations, while human-readable coordinates are used for diagnostics/tooling when no canonical source offset is available. These contracts must not be merged without a dedicated design review.
 
 Clarifications that must remain true:
 


### PR DESCRIPTION
### Motivation

- The four source-coordinate types are now centralized in `Utils.Parser.Source` and must be documented as distinct contracts rather than interchangeable aliases.
- Converting absolute offsets to file/line/column, or the reverse, depends on the original source text and counting conventions such as line endings, tabs, Unicode representation, and column rules.
- `SourceLocation` / `SourceSpan` and `SourceCodeLocation` / `SourceCodeRange` therefore must not be merged without a dedicated design review.

### Audit summary

Reviewed and clarified the source-coordinate documentation after PRs #284 and #285 centralized the source contracts in `Utils.Parser.Source`.

Documents and files modified:
- `Utils.Parser.Source/README.md`
- `Utils.Parser.Source/SourceLocation.cs`
- `Utils.Parser.Source/SourceSpan.cs`
- `Utils.Parser.Source/SourceCodeLocation.cs`
- `Utils.Parser.Source/SourceCodeRange.cs`
- `Utils.Parser.Diagnostics/README.md`
- `Utils.Parser/ROADMAP.md`
- `CHANGELOG.md`

Documents checked but not modified:
- `docs/parser/INDEX.md`: no update required because no parser documentation file was added, moved, removed, renamed, or materially re-scoped.
- `docs/parser/ANTLRCompatibility.md`: no update required because ANTLR compatibility semantics, feature support, diagnostics, and divergences are unchanged.

### Modifications

- Rewrote `Utils.Parser.Source/README.md` to add clear sections:
  - `Runtime source coordinates`
  - `Human-readable source coordinates`
  - `Why both models exist`
- Strengthened XML documentation for:
  - `SourceLocation`
  - `SourceSpan`
  - `SourceCodeLocation`
  - `SourceCodeRange`
- Clarified in `Utils.Parser.Diagnostics/README.md` that diagnostics use human-readable source-location contracts, while runtime offset contracts remain separate in `Utils.Parser.Source`.
- Added a roadmap note stating that runtime coordinates and human-readable coordinates are intentionally split and must not be merged without a dedicated design review.
- Added a changelog entry for the documentation clarification.

### Public API impact

None.

This PR does not:
- change public signatures;
- rename types;
- move types;
- remove types;
- add new public types;
- merge `SourceLocation` / `SourceSpan` with `SourceCodeLocation` / `SourceCodeRange`.

### Runtime impact

None.

This PR does not change:
- lexer behavior;
- parser behavior;
- token construction;
- parse-node construction;
- scheduling;
- lookahead;
- memoization;
- source span values.

### Diagnostics impact

No diagnostic behavior change.

This PR does not change:
- diagnostic codes;
- diagnostic severities;
- diagnostic emission points;
- diagnostic ownership;
- `ParserDiagnostic` semantics.

It only clarifies documentation around which source-coordinate contracts are human-readable diagnostics/tooling contracts and which are runtime/source-buffer contracts.

### Parse-tree impact

None.

No parse-tree shape, ownership, construction, or observation behavior changes are introduced.

### ANTLR compatibility impact

None.

ANTLR feature support, grammar parsing behavior, runtime/generator parity semantics, compatibility diagnostics, and documented divergences are unchanged.

`docs/parser/ANTLRCompatibility.md` was checked and does not require an update.

### Documentation impact

Updated:
- `CHANGELOG.md`
- `Utils.Parser.Diagnostics/README.md`
- `Utils.Parser.Source/README.md`
- `Utils.Parser.Source/SourceCodeLocation.cs`
- `Utils.Parser.Source/SourceCodeRange.cs`
- `Utils.Parser.Source/SourceLocation.cs`
- `Utils.Parser.Source/SourceSpan.cs`
- `Utils.Parser/ROADMAP.md`

Checked but not modified:
- `docs/parser/INDEX.md`
- `docs/parser/ANTLRCompatibility.md`

### Tests

Validation reported by Codex:
- `dotnet test UtilsTest/UtilsTest.Unit.csproj`: Passed 1357, Failed 0, Skipped 5.

No runtime or diagnostics behavior changes were introduced. Observed build warnings are pre-existing and unrelated to these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0badca98832695a9d969a22cf00c)