### PR TITLE
Clarify embedded code generation boundary

### DIFF
--- a/Utils.Parser.Expressions/README.md
+++ b/Utils.Parser.Expressions/README.md
@@ -1,6 +1,6 @@
 # omy.Utils.Parser.Expressions
 
-`omy.Utils.Parser.Expressions` provides optional runtime adapters that connect `IExpressionCompiler` to parser runtime policy interfaces.
+`omy.Utils.Parser.Expressions` provides optional runtime adapters that connect `IExpressionCompiler` to parser runtime policy interfaces. These adapters are the current integration surface, not the final embedded-code preparation architecture.
 
 ## Purpose
 
@@ -14,6 +14,8 @@ Supported optional adapters:
 - Default parser behavior remains unchanged.
 - No compiler is selected automatically.
 - Lexer actions, lexer predicates, and grammar members are not executed by this package.
+- Current adapters compile opportunistically when evaluating/executing embedded code, with limited compilation caching.
+- The intended target is preparation before parsing: compile or generate an executable artifact during parser model preparation/generation, then execute that prepared artifact during parsing.
 
 ## Usage
 
@@ -27,20 +29,34 @@ var policy = ParserRuntimeFeaturePolicy.Default with
 var parser = new ParserEngine(definition, policy);
 ```
 
+## Current adapter behavior vs target model
+
+Current behavior:
+
+- `ExpressionSemanticPredicateEvaluator` adapts `IExpressionCompiler` to `ISemanticPredicateEvaluator`.
+- `ExpressionParserActionExecutor` adapts `IExpressionCompiler` to `IParserActionExecutor`.
+- The adapters compile from source text at predicate/action invocation time when needed.
+- Non-contextual expressions can reuse an opportunistically cached compiled delegate.
+- Expressions that reference contextual symbols (`ruleName`, `inputPosition`, `alternativeIndex`, `elementIndex`) are currently recompiled per invocation to avoid capturing the wrong runtime context.
+
+This behavior is intentionally preserved for now. It should not be described as the final target model. The target model is to compile or prepare expression-backed executable artifacts before parsing, during parser model generation/preparation, and then execute only the prepared artifact while parsing.
+
+`ParserEngine` should remain language-neutral. It should execute policy outcomes and emit diagnostics, not select an expression language or compile embedded source code.
+
 ## Scope and limitations
 
 ### Semantic predicates
 
 - Expects expression compilation to produce boolean-compatible expressions.
-- Predicates that do not reference contextual symbols are cached by predicate source code.
-- Predicates referencing `ruleName`, `inputPosition`, `alternativeIndex`, or `elementIndex` are recompiled per evaluation to avoid capturing runtime context.
+- Predicates that do not reference contextual symbols are cached by predicate source code in the current adapter.
+- Predicates referencing `ruleName`, `inputPosition`, `alternativeIndex`, or `elementIndex` are currently recompiled per evaluation to avoid capturing runtime context.
 - Compilation failures and delegate-shape adaptation failures are surfaced as structured `NotEvaluated` outcomes with `UP1026` metadata.
 
 ### Inline parser actions
 
 - Scope is parser inline actions only (no lexer actions/predicates, no `@members`).
 - Non-void expressions are evaluated and their result is discarded.
-- Cache scope is compilation-only for non-contextual actions; contextual actions (`ruleName`, `inputPosition`, `alternativeIndex`, `elementIndex`) are recompiled per execution to avoid first-context capture.
+- Cache scope is compilation-only for non-contextual actions in the current adapter; contextual actions (`ruleName`, `inputPosition`, `alternativeIndex`, `elementIndex`) are currently recompiled per execution to avoid first-context capture.
 - Compilation failures, delegate-shape adaptation failures, and runtime exceptions during compiled action execution return `NotExecuted` with `UP1026` metadata.
 
 `ParserEngine` remains the diagnostic owner and emits diagnostics when a `DiagnosticBag` is provided.

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -372,7 +372,7 @@ Current clarification status:
 - compatibility documentation is aligned with explicit parsed/normalized/rejected boundaries,
 - rule `locals [...]` clauses now emit deterministic explicit compatibility diagnostics (`UP1008 RuleLocalsIgnored`) instead of generic silent metadata discard.
 - semantic predicate default-policy behavior is explicitly documented as runtime-policy-driven (`ISemanticPredicateEvaluator`) with deterministic `UP1006` coverage, and precedence predicates are documented separately as non-generic predicate evaluation flow.
-- embedded ANTLR code execution model is documented as a future-safe boundary between source-generation C# and runtime expression-compilation paths, including multi-project responsibilities.
+- embedded ANTLR code execution model is documented as a future-safe boundary between source-generation C# and runtime-inline expression-compilation paths, including multi-project responsibilities and the shared target of preparing executable artifacts before parsing.
 - shared embedded-code diagnostic taxonomy is defined for future runtime, generator, and tooling paths without enabling execution.
 - parser action execution now returns structured outcomes so `ParserEngine` can emit fallback `UP1005` or detailed embedded-code diagnostics without giving executors direct `DiagnosticBag` access.
 - generator/runtime parity characterization tests now document shared supported grammar facts and known metadata divergences without changing runtime, diagnostics, parse-tree shape, or scheduler behavior.
@@ -381,6 +381,7 @@ Current clarification status:
 - shared ANTLR prequel metadata model extraction is complete for options/imports/actions/tokens/channels through mapper-only DTO sharing; runtime and generator parsing remain intentionally duplicated.
 - a shared netstandard2.0 ANTLR prequel DTO project was introduced, while runtime and generator parsing remain intentionally separate.
 - runtime advanced-configuration public API was consolidated so `ParserRuntimeFeaturePolicy` is the single explicit runtime feature-entry point for semantic predicates, parser actions, and runtime observers.
+- current expression-backed predicate/action adapters are documented as useful intermediate runtime adapters with opportunistic compilation, not as the final prepare-before-parse architecture.
 
 Goal: progressively improve ANTLR4 grammar compatibility.
 
@@ -402,6 +403,7 @@ Scope may include:
 Important constraint:
 
 - runtime support must stay clearly separated from metadata preservation.
+- the C# source-generator path and runtime-inline `IExpressionCompiler` path must remain separate; the runtime core must stay conservative and language-neutral.
 
 Allowed work:
 
@@ -443,6 +445,7 @@ Forbidden work:
 
 Current clarification status:
 
+- tooling direction now explicitly distinguishes future C# source-generator embedded-code hooks from runtime-inline expression preparation; generator output must not be presented as current executable embedded-code support until implemented.
 - runtime trace analysis abstractions are available as tooling-only, read-only, deterministic consumers of passive observations/exports,
 - analysis outputs are explicitly descriptive and non-authoritative (no replay, no runtime ownership transfer, no parser/diagnostics authority transfer).
 - end-to-end runtime-observation/export/analysis usage guidance is documented as illustrative tooling only, with explicit non-framework/non-authoritative boundaries.

--- a/docs/parser/ANTLRCompatibility.md
+++ b/docs/parser/ANTLRCompatibility.md
@@ -94,7 +94,7 @@ The shared embedded-code diagnostics taxonomy is documented in `EmbeddedCodeExec
 **Standard ANTLR4**: The predicate body is target-language code evaluated inline during parsing.
 
 **Utils.Parser**: Predicates are parsed and stored. Evaluation is delegated to an `ISemanticPredicateEvaluator` registered in `ParserRuntimeFeaturePolicy`. The default policy returns `NotEvaluated` without detailed diagnostic metadata, which does **not** reject the branch — it acts as if the predicate passed and `ParserEngine` emits `UP1006`.
-An optional expression-backed evaluator can be configured explicitly (for example through `omy.Utils.Parser.Expressions`) to enforce predicate outcomes when a consumer provides an `IExpressionCompiler`.
+An optional expression-backed evaluator can be configured explicitly (for example through `omy.Utils.Parser.Expressions`) to enforce predicate outcomes when a consumer provides an `IExpressionCompiler`. The current adapter may compile opportunistically during evaluation with compilation caching; this is documented as an intermediate implementation detail, not as the final prepare-before-parse target.
 
 **Usage** — implement `ISemanticPredicateEvaluator` and pass it via the policy:
 
@@ -152,7 +152,7 @@ See [`EmbeddedCodeExecutionModel.md`](./EmbeddedCodeExecutionModel.md) for expli
 **Standard ANTLR4**: Action code is target-language code executed as a side effect during parsing.
 
 **Utils.Parser**: Actions are parsed and stored. Execution is delegated to an `IParserActionExecutor` registered in `ParserRuntimeFeaturePolicy`. The default policy returns `NotExecuted`.
-An optional runtime expression-backed parser action executor can be configured explicitly; it is limited to the configured expression language and read-only contextual symbols, and currently surfaces compile/adaptation/compiled-execution failures as `UP1026` through `ParserEngine` diagnostics. `UP1028` remains reserved for explicit execution-disabled runtime policies, which the current expression-backed adapters do not expose.
+An optional runtime expression-backed parser action executor can be configured explicitly; it is limited to the configured expression language and read-only contextual symbols, and currently surfaces compile/adaptation/compiled-execution failures as `UP1026` through `ParserEngine` diagnostics. The current adapter may compile opportunistically during execution with compilation caching; this is documented as an intermediate implementation detail, not as the final prepare-before-parse target. `UP1028` remains reserved for explicit execution-disabled runtime policies, which the current expression-backed adapters do not expose.
 
 **Usage** — implement `IParserActionExecutor`:
 

--- a/docs/parser/EmbeddedCodeExecutionModel.md
+++ b/docs/parser/EmbeddedCodeExecutionModel.md
@@ -45,17 +45,37 @@ Current generator output preserves embedded code as model metadata strings (for 
 
 ## 4. Two-path target architecture
 
-The target architecture uses **two implementation paths** over **one shared parser model**:
+The target architecture uses **two distinct implementation paths** over **one shared parser model**:
 
-1. Source-generation path (compile-time `.g4` ingestion, C# code generation).
-2. Runtime-ingestion path (runtime `.g4` ingestion with explicit expression compilation adapters).
+1. Source-generation path (compile-time `.g4` ingestion, C# source generation).
+2. Runtime-inline path (runtime `.g4` ingestion with an explicitly provided `IExpressionCompiler`).
+
+These paths must not be conflated. They share the same intent:
+
+```text
+compile/generate during parser model generation or source generation
+execute during parsing
+```
+
+They must not converge on this weaker model as the architectural target:
+
+```text
+store source text
+compile opportunistically during predicate/action evaluation
+```
 
 Shared expectations across both paths:
 
 - same ANTLR construct classification;
 - same model concepts;
 - same deterministic diagnostic vocabulary;
-- same runtime authority boundaries.
+- same runtime authority boundaries;
+- prepared executable output before parsing begins when executable embedded code is enabled.
+
+The prepared output is intentionally path-specific:
+
+- `Utils.Parser.Generators` should eventually produce C# source hooks compiled by Roslyn in the consuming project;
+- runtime inline ingestion should eventually produce a compiled expression, delegate, or equivalent executable function through the configured `IExpressionCompiler`.
 
 Adapters may differ by path, but model semantics must stay aligned.
 
@@ -68,6 +88,19 @@ Pipeline:
 - C# emitted by `GrammarEmitter`;
 - final compilation performed by Roslyn.
 
+Current state:
+
+- generated model construction is implemented;
+- embedded predicates and actions are still emitted as metadata strings such as `ValidatingPredicate("...")` and `EmbeddedAction("...", ...)`;
+- specialized executable C# hooks for embedded ANTLR code are not generated yet.
+
+Target state:
+
+- embedded ANTLR code selected for execution in this path is treated as C# source;
+- the generator emits explicit C# hook code;
+- Roslyn compiles that generated C# as part of the consuming project;
+- parsing invokes the already-generated hook rather than asking `ParserEngine` to compile source text.
+
 Boundary rules:
 
 - executable target-language support in this path is **C#-only** initially;
@@ -79,72 +112,66 @@ Boundary rules:
 
 Natural ownership: build-time C# embedded-code execution support belongs to `Utils.Parser.Generators`, not `ParserEngine`.
 
-## 6. Runtime expression compiler path
+## 6. Runtime-inline expression compiler path
 
-Pipeline:
+Pipeline target:
 
 - `.g4` parsed at runtime;
-- embedded ANTLR code preserved as raw text;
-- explicit embedded-code compiler configured by policy;
-- compiler delegates to `IExpressionCompiler`;
-- expression/delegate executed through runtime policy interfaces.
+- embedded ANTLR code classified and preserved as raw text metadata;
+- an explicit expression compiler is selected by configuration, not by `ParserEngine`;
+- preparation/generation compiles embedded code through `IExpressionCompiler`;
+- the prepared expression/delegate/function is stored in the parsing model or in an adjacent executable artifact;
+- parsing executes that prepared artifact through runtime policy interfaces.
 
 Conceptual mapping:
 
-- semantic predicates map to `ISemanticPredicateEvaluator`;
-- parser inline actions map to `IParserActionExecutor`.
+- semantic predicates execute through `ISemanticPredicateEvaluator`;
+- parser inline actions execute through `IParserActionExecutor`.
+
+`ISemanticPredicateEvaluator` and `IParserActionExecutor` are runtime execution interfaces. They are not, by themselves, the complete generation/preparation boundary for embedded code. A future correction should either move expression compilation into parser model preparation/generation or introduce an explicit preparation boundary that produces executable artifacts before parsing starts.
 
 Strict rules:
 
 - no raw target-language execution;
 - no implicit language selection;
-- `IExpressionCompiler` must be explicitly injected;
+- `IExpressionCompiler` must be explicitly injected or otherwise explicitly selected by the caller;
+- `ParserEngine` must not know whether the embedded source was C#, VB-like syntax, or another expression language;
+- `ParserEngine` must not become responsible for compiling embedded source text;
 - `Utils.Parser` core must not reference `Utils.Expressions.CSyntax` or `Utils.Expressions.VBSyntax` directly.
 
+Current intermediate status:
 
-Prototype status update:
-
-- A first optional runtime adapter now exists to map `IExpressionCompiler` to `ISemanticPredicateEvaluator` for semantic predicates (`{ condition }?`).
-- Default parser runtime behavior is unchanged (`NotEvaluated` with `UP1006` when applicable). Expression-backed semantic predicate evaluation now returns a structured outcome so compilation failures and delegate-shape adaptation failures can carry `UP1026` metadata, while `ParserEngine` remains the only component that emits diagnostics.
-- Current adapter scope is limited to parser semantic predicates only.
-- A first optional runtime parser action adapter now exists: `IExpressionCompiler` can be adapted to `IParserActionExecutor` for inline parser actions only.
-- Default parser runtime behavior is unchanged; inline actions still do not control parse acceptance, parse-tree shape, or branch rejection.
+- `ExpressionSemanticPredicateEvaluator` maps `IExpressionCompiler` to `ISemanticPredicateEvaluator` for semantic predicates (`{ condition }?`).
+- `ExpressionParserActionExecutor` maps `IExpressionCompiler` to `IParserActionExecutor` for inline parser actions (`{ code }`).
+- These adapters are useful explicit runtime integration points, but they are an intermediate step rather than the final architectural boundary.
+- Default parser runtime behavior is unchanged (`NotEvaluated` with `UP1006` when applicable for predicates, `NotExecuted`/`UP1005` default behavior for actions).
+- Expression-backed semantic predicate evaluation returns a structured outcome so compilation failures and delegate-shape adaptation failures can carry `UP1026` metadata, while `ParserEngine` remains the only component that emits diagnostics.
+- Inline actions still do not control parse acceptance, parse-tree shape, or branch rejection.
 - `Executed` and `NotExecuted` outcomes both continue parsing; no context mutation, no `ContextDelta`, and no lexer action/predicate or grammar-members execution support are introduced.
 - The symbol model is intentionally minimal and read-only (`ruleName`, `inputPosition`, `alternativeIndex`, `elementIndex`).
-- Predicate adapter cache: compilation-only and not parse-result memoization. Predicates that do not reference contextual symbols can be cached by predicate source; predicates referencing `ruleName`, `inputPosition`, `alternativeIndex`, or `elementIndex` are recompiled per evaluation to avoid context capture.
-- Action adapter cache: compilation-only and not parse-result memoization. Non-contextual actions can be cached by action source; actions referencing `ruleName`, `inputPosition`, `alternativeIndex`, or `elementIndex` are recompiled per execution to avoid context capture.
+- Predicate adapter cache: compilation-only and not parse-result memoization. Predicates that do not reference contextual symbols can be cached by predicate source; predicates referencing `ruleName`, `inputPosition`, `alternativeIndex`, or `elementIndex` are currently recompiled per evaluation to avoid context capture.
+- Action adapter cache: compilation-only and not parse-result memoization. Non-contextual actions can be cached by action source; actions referencing `ruleName`, `inputPosition`, `alternativeIndex`, or `elementIndex` are currently recompiled per execution to avoid context capture.
+
+The last two bullets describe current behavior, not the target model. The target runtime-inline model is to prepare an executable artifact before parsing and execute that artifact during parsing without opportunistic source compilation on predicate/action invocation.
 
 ## 7. Interface boundary
 
-A future conceptual compiler boundary should be explicit and separated from runtime execution interfaces.
-
-Example conceptual interface:
-
-```csharp
-public interface IEmbeddedCodeCompiler
-{
-    CompiledSemanticPredicate CompileSemanticPredicate(
-        EmbeddedCodeSource source,
-        EmbeddedCodeCompilationContext context);
-
-    CompiledParserAction CompileParserAction(
-        EmbeddedCodeSource source,
-        EmbeddedCodeCompilationContext context);
-}
-```
+A future preparation boundary should be explicit and separated from runtime execution interfaces. This document does not introduce a new interface or prescribe its final name.
 
 Separation of concerns:
 
-- compilation/preparation boundary: `IEmbeddedCodeCompiler` (future);
+- preparation/generation boundary: receives embedded source plus compilation context and produces a path-specific executable artifact before parsing;
 - runtime evaluation boundary: `ISemanticPredicateEvaluator`;
 - runtime execution boundary: `IParserActionExecutor`.
 
+The execution interfaces consume runtime context and return runtime outcomes. They should not become responsible for selecting the embedded language, compiling raw source text as part of parsing, or owning parser diagnostics.
+
 ## 8. Cache boundary
 
-Allowed cache scope for future embedded-code compilation:
+Allowed cache scope for future embedded-code preparation:
 
 - key: raw embedded code + compilation context;
-- value: compiled expression/delegate artifact.
+- value: path-specific executable artifact, such as generated C# source/hook metadata for the generator path or a compiled expression/delegate/function for the runtime-inline path.
 
 Example conceptual key fields:
 
@@ -156,8 +183,9 @@ Example conceptual key fields:
 
 Non-goal boundary:
 
-- this compilation cache is **not** parse-result memoization;
-- no `(input position + rule) -> parse result` semantic memoization changes.
+- this preparation cache is **not** parse-result memoization;
+- no `(input position + rule) -> parse result` semantic memoization changes;
+- future caching should avoid recompiling source text during predicate/action invocation.
 
 ## 9. Predicate vs action mapping
 
@@ -281,7 +309,7 @@ Usage rules:
 
 No new diagnostics are introduced in this documentation PR.
 
-Future PRs should define shared diagnostics in `Utils.Parser.Diagnostics` so they can be used by:
+Future implementation PRs should define shared diagnostics in `Utils.Parser.Diagnostics` so they can be used by:
 
 - runtime ingestion;
 - source generator Roslyn reporting;
@@ -312,30 +340,18 @@ This model explicitly excludes:
 
 ## 13. Future PR plan
 
-### PR 1 — Documentation/design (current PR)
+### PR 1 — Documentation/design realignment (current PR)
 
-- document model, boundaries, and project responsibilities;
+- clarify the two execution paths and the prepare-before-parse target;
+- document current expression-backed adapters as an intermediate runtime integration step;
 - no behavior change.
 
-### PR 2 — Diagnostics taxonomy
+### Future PR — Explicit preparation boundary
 
-- add shared embedded-code diagnostics;
-- no execution behavior added.
+- move runtime-inline expression compilation to parser model preparation/generation, or introduce an explicit boundary that produces executable artifacts before parsing;
+- preserve `ParserEngine` as an execution coordinator rather than a language compiler.
 
-### PR 3 — Runtime predicate adapter prototype
-
-- map `IExpressionCompiler` into `ISemanticPredicateEvaluator` for `{ condition }?`;
-- outcomes:
-  - `true` -> `Satisfied`
-  - `false` -> `Rejected`
-  - failed/unsupported -> `NotEvaluated` + diagnostic.
-
-### PR 4 — Runtime parser inline action adapter
-
-- map `IExpressionCompiler` into `IParserActionExecutor` for `{ code }`;
-- define allowed side-effects, mutable context boundaries, idempotence expectations, and backtracking caveats.
-
-### PR 5 — Source generator C# path
+### Future PR — Source generator C# path
 
 - add explicit C# embedded-code hook support in generator path;
 - define language option handling;
@@ -343,7 +359,7 @@ This model explicitly excludes:
 - report Roslyn diagnostics for unsupported/invalid embedded code;
 - document generated hook shape.
 
-### PR 6 — Lexer actions/predicates
+### Future PR — Lexer actions/predicates
 
 - separate design and implementation;
 - account for tokenization and lexer state impact.

--- a/docs/parser/INDEX.md
+++ b/docs/parser/INDEX.md
@@ -17,7 +17,7 @@ This index consolidates the parser documentation set and gives a short summary o
 
 ## Compatibility and analysis
 
-- [`EmbeddedCodeExecutionModel.md`](./EmbeddedCodeExecutionModel.md): Architecture boundary for ANTLR embedded code, including current behavior, future two-path model (source generation C# vs runtime expression compilation), current semantic-predicate and parser-action runtime adapter prototypes, cache limits (predicate vs action), and multi-project responsibilities.
+- [`EmbeddedCodeExecutionModel.md`](./EmbeddedCodeExecutionModel.md): Architecture boundary for ANTLR embedded code, including current behavior, the target two-path model (C# source generation vs runtime-inline `IExpressionCompiler` preparation), current semantic-predicate and parser-action runtime adapters as intermediate opportunistic-compilation implementations, cache limits (predicate vs action), and multi-project responsibilities.
 - [`ANTLRCompatibility.md`](./ANTLRCompatibility.md): Canonical ANTLR compatibility reference including feature behavior, shared prequel metadata/diagnostic boundaries, runtime-generator parity notes, and usage guidance.
 - [`Antlr4CompatibilityMatrix.md`](./Antlr4CompatibilityMatrix.md): Current ANTLR4 feature support matrix with explicit levels (supported, partial, parsed-only, unsupported), including semantic-predicate vs precedence-predicate runtime-policy distinctions and continuation metadata support boundaries.
 - [`RuntimeTraceAnalysis.md`](./RuntimeTraceAnalysis.md): Tooling-oriented analysis model for runtime traces, focused on descriptive outputs rather than runtime control.


### PR DESCRIPTION
# Motivation

The initial runtime adapters for expression-backed predicates/actions are useful, but the previous documentation could be read as if those adapters were the final embedded-code architecture.

The intended target is a prepare-before-parse boundary:

- `Utils.Parser.Generators` should eventually produce C# source hooks compiled by Roslyn.
- Runtime-inline ingestion should eventually use an explicit `IExpressionCompiler` to prepare compiled expression/delegate/function artifacts before parsing.
- `ParserEngine` must remain language-neutral and must not become responsible for compiling embedded source text.

# Audit summary

Current state:

- `Utils.Parser.Generators` generates C# model-construction code, but embedded predicates/actions are still emitted as metadata strings such as `ValidatingPredicate("...")` and `EmbeddedAction("...", ...)`.
- `ExpressionSemanticPredicateEvaluator` and `ExpressionParserActionExecutor` currently adapt `IExpressionCompiler` to runtime policy interfaces.
- These adapters currently compile opportunistically during predicate/action invocation, with limited compilation caching.
- Contextual expressions using `ruleName`, `inputPosition`, `alternativeIndex`, or `elementIndex` may be recompiled per invocation to avoid capturing the wrong runtime context.

Target direction clarified by this PR:

- Embedded code should be compiled/generated during parser model preparation or source generation.
- Parsing should execute already prepared artifacts.
- Runtime execution interfaces remain distinct from the future preparation/generation boundary.

# Modifications

Updated documentation only:

- `docs/parser/EmbeddedCodeExecutionModel.md`
- `Utils.Parser.Expressions/README.md`
- `Utils.Parser/ROADMAP.md`
- `docs/parser/ANTLRCompatibility.md`
- `docs/parser/INDEX.md`

# Public API impact

None.

No public API is added, removed, or changed.

# Migration

None.

This PR is documentation-only and does not change user-facing runtime behavior.

# Compatibility impact

No behavior change.

This PR clarifies the intended embedded-code architecture but does not change parser compatibility, runtime execution, generated code, or diagnostics.

# Runtime impact

None.

No runtime code was changed.

# Diagnostics impact

None.

No diagnostic descriptor, diagnostic emission behavior, or diagnostic ownership rule was changed.

# Parse-tree impact

None.

No parser behavior or parse-tree shape is changed.

# ANTLR compatibility impact

Documentation-only clarification.

This PR does not increase ANTLR compatibility support. It clarifies that current expression-backed adapters are intermediate opportunistic-compilation implementations and that the final target is prepare-before-parse execution artifacts.

# Documentation impact

Updated:

- `docs/parser/EmbeddedCodeExecutionModel.md` to clarify the two-path target architecture and the prepare-before-parse boundary.
- `Utils.Parser.Expressions/README.md` to clarify current adapter behavior versus the target model.
- `Utils.Parser/ROADMAP.md` to reflect the clarified direction for embedded-code preparation.
- `docs/parser/ANTLRCompatibility.md` to align semantic predicate/action wording with the clarified model.
- `docs/parser/INDEX.md` because `EmbeddedCodeExecutionModel.md` was materially changed.

# Tests

No runtime or unit tests were required because this PR is documentation-only.

`git diff --check` was run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d6fd976f08326a926cb61c67727b7)