### PR TITLE
Introduce embedded code preparation contracts

### DIFF
--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeContextSymbol.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeContextSymbol.cs
@@ -1,0 +1,19 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Identifies a contextual symbol that an embedded-code preparer may make available to source code.
+/// </summary>
+internal enum EmbeddedCodeContextSymbol
+{
+    /// <summary>Name of the parser rule that owns the embedded source block.</summary>
+    RuleName,
+
+    /// <summary>Current input position associated with the embedded source block.</summary>
+    InputPosition,
+
+    /// <summary>Zero-based alternative index associated with the embedded source block when known.</summary>
+    AlternativeIndex,
+
+    /// <summary>Zero-based element index associated with the embedded source block when known.</summary>
+    ElementIndex
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeKind.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeKind.cs
@@ -1,0 +1,22 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Identifies the ANTLR embedded-code construct that owns a raw source block.
+/// </summary>
+internal enum EmbeddedCodeKind
+{
+    /// <summary>Semantic predicate source from a parser construct such as <c>{ condition }?</c>.</summary>
+    SemanticPredicate,
+
+    /// <summary>Inline parser action source from a parser alternative construct such as <c>{ code }</c>.</summary>
+    ParserInlineAction,
+
+    /// <summary>Rule initialization action source from a rule prequel construct such as <c>@init { }</c>.</summary>
+    RuleInitAction,
+
+    /// <summary>Rule finalization action source from a rule prequel construct such as <c>@after { }</c>.</summary>
+    RuleAfterAction,
+
+    /// <summary>Grammar-level action source from a prequel construct such as <c>@members { }</c>.</summary>
+    GrammarAction
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodePreparationContext.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodePreparationContext.cs
@@ -1,0 +1,84 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Describes the explicit preparation environment for ANTLR embedded-code source.
+/// </summary>
+internal sealed record EmbeddedCodePreparationContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmbeddedCodePreparationContext"/> record.
+    /// </summary>
+    /// <param name="grammarName">Name of the grammar that owns the embedded source.</param>
+    /// <param name="target">Preparation path that will consume the embedded source.</param>
+    /// <param name="ruleName">Optional rule name associated with the embedded source.</param>
+    /// <param name="languageOrCompilerIdentity">Optional explicit language or compiler identity configured by the caller.</param>
+    /// <param name="symbolModelVersion">Version of the contextual symbol model understood by the preparer.</param>
+    /// <param name="supportedSymbols">Contextual symbols that are available to the preparer.</param>
+    public EmbeddedCodePreparationContext(
+        string grammarName,
+        EmbeddedCodeTarget target,
+        string? ruleName = null,
+        string? languageOrCompilerIdentity = null,
+        int symbolModelVersion = 1,
+        IReadOnlySet<EmbeddedCodeContextSymbol>? supportedSymbols = null)
+    {
+        if (string.IsNullOrWhiteSpace(grammarName))
+        {
+            throw new ArgumentException("Grammar name cannot be null, empty, or whitespace.", nameof(grammarName));
+        }
+
+        if (symbolModelVersion <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(symbolModelVersion), "Symbol model version must be strictly positive.");
+        }
+
+        GrammarName = grammarName;
+        Target = target;
+        RuleName = ruleName;
+        LanguageOrCompilerIdentity = languageOrCompilerIdentity;
+        SymbolModelVersion = symbolModelVersion;
+        SupportedSymbols = supportedSymbols?.ToHashSet() ?? CreateDefaultSupportedSymbols();
+    }
+
+    /// <summary>
+    /// Gets the name of the grammar that owns the embedded source.
+    /// </summary>
+    public string GrammarName { get; }
+
+    /// <summary>
+    /// Gets the preparation path that will consume the embedded source.
+    /// </summary>
+    public EmbeddedCodeTarget Target { get; }
+
+    /// <summary>
+    /// Gets the optional rule name associated with the embedded source.
+    /// </summary>
+    public string? RuleName { get; }
+
+    /// <summary>
+    /// Gets the optional explicit language or compiler identity configured by the caller.
+    /// </summary>
+    public string? LanguageOrCompilerIdentity { get; }
+
+    /// <summary>
+    /// Gets the version of the contextual symbol model understood by the preparer.
+    /// </summary>
+    public int SymbolModelVersion { get; }
+
+    /// <summary>
+    /// Gets the contextual symbols that are available to the preparer.
+    /// </summary>
+    public IReadOnlySet<EmbeddedCodeContextSymbol> SupportedSymbols { get; }
+
+    /// <summary>
+    /// Creates the default contextual symbol set shared by current parser embedded-code planning.
+    /// </summary>
+    /// <returns>The default immutable contextual symbol set.</returns>
+    private static IReadOnlySet<EmbeddedCodeContextSymbol> CreateDefaultSupportedSymbols() => new HashSet<EmbeddedCodeContextSymbol>
+    {
+        EmbeddedCodeContextSymbol.RuleName,
+        EmbeddedCodeContextSymbol.InputPosition,
+        EmbeddedCodeContextSymbol.AlternativeIndex,
+        EmbeddedCodeContextSymbol.ElementIndex
+    };
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodePreparationResult.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodePreparationResult.cs
@@ -1,0 +1,111 @@
+using Utils.Parser.Diagnostics;
+
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Represents the result of preparing ANTLR embedded-code source for a specific execution or generation path.
+/// </summary>
+/// <typeparam name="TArtifact">Type of the prepared artifact produced on success.</typeparam>
+internal sealed record EmbeddedCodePreparationResult<TArtifact>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmbeddedCodePreparationResult{TArtifact}"/> record.
+    /// </summary>
+    /// <param name="status">Preparation outcome category.</param>
+    /// <param name="artifact">Optional prepared artifact when preparation succeeded.</param>
+    /// <param name="diagnosticDescriptor">Optional diagnostic descriptor associated with the outcome.</param>
+    /// <param name="exception">Optional exception associated with a failed preparation attempt.</param>
+    /// <param name="diagnosticArguments">Optional diagnostic message arguments associated with the outcome.</param>
+    public EmbeddedCodePreparationResult(
+        EmbeddedCodePreparationStatus status,
+        TArtifact? artifact = default,
+        ParserDiagnosticDescriptor? diagnosticDescriptor = null,
+        Exception? exception = null,
+        IReadOnlyList<object?>? diagnosticArguments = null)
+    {
+        if (status == EmbeddedCodePreparationStatus.Succeeded && artifact is null)
+        {
+            throw new ArgumentException("A successful embedded-code preparation result must include an artifact.", nameof(artifact));
+        }
+
+        Status = status;
+        Artifact = artifact;
+        DiagnosticDescriptor = diagnosticDescriptor;
+        Exception = exception;
+        DiagnosticArguments = diagnosticArguments?.ToArray() ?? Array.Empty<object?>();
+    }
+
+    /// <summary>
+    /// Gets the preparation outcome category.
+    /// </summary>
+    public EmbeddedCodePreparationStatus Status { get; }
+
+    /// <summary>
+    /// Gets the optional prepared artifact when preparation succeeded.
+    /// </summary>
+    public TArtifact? Artifact { get; }
+
+    /// <summary>
+    /// Gets the optional diagnostic descriptor associated with the outcome.
+    /// </summary>
+    public ParserDiagnosticDescriptor? DiagnosticDescriptor { get; }
+
+    /// <summary>
+    /// Gets the optional exception associated with a failed preparation attempt.
+    /// </summary>
+    public Exception? Exception { get; }
+
+    /// <summary>
+    /// Gets the optional diagnostic message arguments associated with the outcome.
+    /// </summary>
+    public IReadOnlyList<object?> DiagnosticArguments { get; }
+
+    /// <summary>
+    /// Creates a successful preparation result with an artifact.
+    /// </summary>
+    /// <param name="artifact">Prepared artifact produced by the preparation path.</param>
+    /// <returns>A successful preparation result.</returns>
+    public static EmbeddedCodePreparationResult<TArtifact> Success(TArtifact artifact) =>
+        new(EmbeddedCodePreparationStatus.Succeeded, artifact);
+
+    /// <summary>
+    /// Creates an unsupported preparation result.
+    /// </summary>
+    /// <param name="diagnosticArguments">Optional diagnostic message arguments associated with the outcome.</param>
+    /// <returns>An unsupported preparation result.</returns>
+    public static EmbeddedCodePreparationResult<TArtifact> Unsupported(IEnumerable<object?>? diagnosticArguments = null) =>
+        new(EmbeddedCodePreparationStatus.Unsupported, diagnosticDescriptor: ParserDiagnostics.EmbeddedCodeLanguageUnsupported, diagnosticArguments: ToDiagnosticArgumentList(diagnosticArguments));
+
+    /// <summary>
+    /// Creates a compiler-not-configured preparation result.
+    /// </summary>
+    /// <param name="diagnosticArguments">Optional diagnostic message arguments associated with the outcome.</param>
+    /// <returns>A compiler-not-configured preparation result.</returns>
+    public static EmbeddedCodePreparationResult<TArtifact> CompilerNotConfigured(IEnumerable<object?>? diagnosticArguments = null) =>
+        new(EmbeddedCodePreparationStatus.CompilerNotConfigured, diagnosticDescriptor: ParserDiagnostics.EmbeddedCodeCompilerNotConfigured, diagnosticArguments: ToDiagnosticArgumentList(diagnosticArguments));
+
+    /// <summary>
+    /// Creates a failed compilation preparation result.
+    /// </summary>
+    /// <param name="exception">Optional exception associated with the failed compilation.</param>
+    /// <param name="diagnosticArguments">Optional diagnostic message arguments associated with the outcome.</param>
+    /// <returns>A failed compilation preparation result.</returns>
+    public static EmbeddedCodePreparationResult<TArtifact> CompilationFailed(Exception? exception = null, IEnumerable<object?>? diagnosticArguments = null) =>
+        new(EmbeddedCodePreparationStatus.CompilationFailed, diagnosticDescriptor: ParserDiagnostics.EmbeddedCodeCompilationFailed, exception: exception, diagnosticArguments: ToDiagnosticArgumentList(diagnosticArguments));
+
+    /// <summary>
+    /// Creates a preserved-without-compilation preparation result.
+    /// </summary>
+    /// <param name="diagnosticArguments">Optional diagnostic message arguments associated with the outcome.</param>
+    /// <returns>A preserved-without-compilation preparation result.</returns>
+    public static EmbeddedCodePreparationResult<TArtifact> PreservedNotCompiled(IEnumerable<object?>? diagnosticArguments = null) =>
+        new(EmbeddedCodePreparationStatus.PreservedNotCompiled, diagnosticDescriptor: ParserDiagnostics.EmbeddedCodePreservedNotCompiled, diagnosticArguments: ToDiagnosticArgumentList(diagnosticArguments));
+
+    /// <summary>
+    /// Materializes optional diagnostic arguments exactly once.
+    /// </summary>
+    /// <param name="diagnosticArguments">Optional diagnostic arguments to materialize.</param>
+    /// <returns>A read-only list of diagnostic arguments.</returns>
+    private static IReadOnlyList<object?> ToDiagnosticArgumentList(IEnumerable<object?>? diagnosticArguments) =>
+        diagnosticArguments?.ToArray() ?? Array.Empty<object?>();
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodePreparationStatus.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodePreparationStatus.cs
@@ -1,0 +1,22 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Identifies the outcome category returned by embedded-code preparation.
+/// </summary>
+internal enum EmbeddedCodePreparationStatus
+{
+    /// <summary>Preparation succeeded and produced an artifact.</summary>
+    Succeeded,
+
+    /// <summary>The embedded-code construct or requested preparation path is not supported.</summary>
+    Unsupported,
+
+    /// <summary>The requested preparation path requires a compiler that was not configured.</summary>
+    CompilerNotConfigured,
+
+    /// <summary>The configured preparation path attempted compilation and failed.</summary>
+    CompilationFailed,
+
+    /// <summary>The source was intentionally preserved as metadata without compilation.</summary>
+    PreservedNotCompiled
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeSource.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeSource.cs
@@ -1,0 +1,81 @@
+using Utils.Parser.Source;
+
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Describes a raw ANTLR embedded-code source block without assigning execution behavior to it.
+/// </summary>
+internal sealed record EmbeddedCodeSource
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmbeddedCodeSource"/> record.
+    /// </summary>
+    /// <param name="sourceText">Raw embedded-code source text without surrounding ANTLR delimiters.</param>
+    /// <param name="kind">Kind of ANTLR construct that owns the source text.</param>
+    /// <param name="ruleName">Optional rule name that owns the source text.</param>
+    /// <param name="alternativeIndex">Optional zero-based alternative index that owns the source text.</param>
+    /// <param name="elementIndex">Optional zero-based element index that owns the source text.</param>
+    /// <param name="location">Optional human-readable source location for diagnostics or tooling.</param>
+    public EmbeddedCodeSource(
+        string sourceText,
+        EmbeddedCodeKind kind,
+        string? ruleName = null,
+        int? alternativeIndex = null,
+        int? elementIndex = null,
+        SourceCodeLocation? location = null)
+    {
+        ArgumentNullException.ThrowIfNull(sourceText);
+        ValidateIndex(alternativeIndex, nameof(alternativeIndex));
+        ValidateIndex(elementIndex, nameof(elementIndex));
+
+        SourceText = sourceText;
+        Kind = kind;
+        RuleName = ruleName;
+        AlternativeIndex = alternativeIndex;
+        ElementIndex = elementIndex;
+        Location = location;
+    }
+
+    /// <summary>
+    /// Gets the raw embedded-code source text without surrounding ANTLR delimiters.
+    /// </summary>
+    public string SourceText { get; }
+
+    /// <summary>
+    /// Gets the kind of ANTLR construct that owns the source text.
+    /// </summary>
+    public EmbeddedCodeKind Kind { get; }
+
+    /// <summary>
+    /// Gets the optional rule name that owns the source text.
+    /// </summary>
+    public string? RuleName { get; }
+
+    /// <summary>
+    /// Gets the optional zero-based alternative index that owns the source text.
+    /// </summary>
+    public int? AlternativeIndex { get; }
+
+    /// <summary>
+    /// Gets the optional zero-based element index that owns the source text.
+    /// </summary>
+    public int? ElementIndex { get; }
+
+    /// <summary>
+    /// Gets the optional human-readable source location for diagnostics or tooling.
+    /// </summary>
+    public SourceCodeLocation? Location { get; }
+
+    /// <summary>
+    /// Validates that an optional source index is zero or greater when supplied.
+    /// </summary>
+    /// <param name="value">Optional index value to validate.</param>
+    /// <param name="parameterName">Parameter name used when throwing validation errors.</param>
+    private static void ValidateIndex(int? value, string parameterName)
+    {
+        if (value < 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "Embedded-code indexes must be greater than or equal to zero.");
+        }
+    }
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeTarget.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeTarget.cs
@@ -1,0 +1,13 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Identifies the preparation path that will consume embedded ANTLR source code.
+/// </summary>
+internal enum EmbeddedCodeTarget
+{
+    /// <summary>Prepare embedded code as C# source that a Roslyn source generator can emit.</summary>
+    SourceGeneratorCSharp,
+
+    /// <summary>Prepare embedded code through an explicitly configured runtime-inline expression compiler.</summary>
+    RuntimeInlineExpression
+}

--- a/Utils.Parser/EmbeddedCode/IEmbeddedCodePreparer.cs
+++ b/Utils.Parser/EmbeddedCode/IEmbeddedCodePreparer.cs
@@ -1,0 +1,29 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Defines the minimal preparation boundary for ANTLR parser embedded code.
+/// </summary>
+/// <typeparam name="TPredicateArtifact">Prepared artifact type produced for semantic predicates.</typeparam>
+/// <typeparam name="TActionArtifact">Prepared artifact type produced for inline parser actions.</typeparam>
+internal interface IEmbeddedCodePreparer<TPredicateArtifact, TActionArtifact>
+{
+    /// <summary>
+    /// Prepares semantic predicate source without evaluating it.
+    /// </summary>
+    /// <param name="source">Raw embedded-code source and metadata for a semantic predicate.</param>
+    /// <param name="context">Explicit preparation context selected by the caller.</param>
+    /// <returns>Preparation result containing an artifact or metadata that explains why no artifact was produced.</returns>
+    EmbeddedCodePreparationResult<TPredicateArtifact> PrepareSemanticPredicate(
+        EmbeddedCodeSource source,
+        EmbeddedCodePreparationContext context);
+
+    /// <summary>
+    /// Prepares inline parser action source without executing it.
+    /// </summary>
+    /// <param name="source">Raw embedded-code source and metadata for an inline parser action.</param>
+    /// <param name="context">Explicit preparation context selected by the caller.</param>
+    /// <returns>Preparation result containing an artifact or metadata that explains why no artifact was produced.</returns>
+    EmbeddedCodePreparationResult<TActionArtifact> PrepareParserAction(
+        EmbeddedCodeSource source,
+        EmbeddedCodePreparationContext context);
+}

--- a/Utils.Parser/EmbeddedCode/PreservingEmbeddedCodePreparer.cs
+++ b/Utils.Parser/EmbeddedCode/PreservingEmbeddedCodePreparer.cs
@@ -1,0 +1,52 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Neutral embedded-code preparer that preserves source metadata and never compiles or executes code.
+/// </summary>
+/// <typeparam name="TPredicateArtifact">Prepared artifact type that would be used for semantic predicates.</typeparam>
+/// <typeparam name="TActionArtifact">Prepared artifact type that would be used for inline parser actions.</typeparam>
+internal sealed class PreservingEmbeddedCodePreparer<TPredicateArtifact, TActionArtifact> : IEmbeddedCodePreparer<TPredicateArtifact, TActionArtifact>
+{
+    /// <inheritdoc />
+    public EmbeddedCodePreparationResult<TPredicateArtifact> PrepareSemanticPredicate(
+        EmbeddedCodeSource source,
+        EmbeddedCodePreparationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return source.Kind == EmbeddedCodeKind.SemanticPredicate
+            ? EmbeddedCodePreparationResult<TPredicateArtifact>.PreservedNotCompiled(CreateDiagnosticArguments(source, context))
+            : EmbeddedCodePreparationResult<TPredicateArtifact>.Unsupported(CreateDiagnosticArguments(source, context));
+    }
+
+    /// <inheritdoc />
+    public EmbeddedCodePreparationResult<TActionArtifact> PrepareParserAction(
+        EmbeddedCodeSource source,
+        EmbeddedCodePreparationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return source.Kind == EmbeddedCodeKind.ParserInlineAction
+            ? EmbeddedCodePreparationResult<TActionArtifact>.PreservedNotCompiled(CreateDiagnosticArguments(source, context))
+            : EmbeddedCodePreparationResult<TActionArtifact>.Unsupported(CreateDiagnosticArguments(source, context));
+    }
+
+    /// <summary>
+    /// Creates diagnostic arguments that identify the preserved or unsupported embedded-code construct.
+    /// </summary>
+    /// <param name="source">Embedded source metadata used to describe the construct.</param>
+    /// <param name="context">Preparation context used to describe the target path.</param>
+    /// <returns>Diagnostic arguments suitable for the shared embedded-code diagnostic descriptors.</returns>
+    private static IReadOnlyList<object?> CreateDiagnosticArguments(
+        EmbeddedCodeSource source,
+        EmbeddedCodePreparationContext context)
+    {
+        var constructName = source.RuleName is null
+            ? source.Kind.ToString()
+            : $"{source.RuleName}:{source.Kind}";
+
+        return new object?[] { constructName, context.Target.ToString() };
+    }
+}

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -382,6 +382,7 @@ Current clarification status:
 - a shared netstandard2.0 ANTLR prequel DTO project was introduced, while runtime and generator parsing remain intentionally separate.
 - runtime advanced-configuration public API was consolidated so `ParserRuntimeFeaturePolicy` is the single explicit runtime feature-entry point for semantic predicates, parser actions, and runtime observers.
 - current expression-backed predicate/action adapters are documented as useful intermediate runtime adapters with opportunistic compilation, not as the final prepare-before-parse architecture.
+- internal embedded-code preparation boundary contracts now model raw source, target path, contextual symbols, preparation status, diagnostics metadata, and path-specific artifacts without changing runtime behavior or enabling execution.
 
 Goal: progressively improve ANTLR4 grammar compatibility.
 
@@ -446,6 +447,7 @@ Forbidden work:
 Current clarification status:
 
 - tooling direction now explicitly distinguishes future C# source-generator embedded-code hooks from runtime-inline expression preparation; generator output must not be presented as current executable embedded-code support until implemented.
+- embedded-code preparation contracts provide a future source-generator/runtime-inline boundary only; C# hooks and runtime-inline prepared execution remain unimplemented.
 - runtime trace analysis abstractions are available as tooling-only, read-only, deterministic consumers of passive observations/exports,
 - analysis outputs are explicitly descriptive and non-authoritative (no replay, no runtime ownership transfer, no parser/diagnostics authority transfer).
 - end-to-end runtime-observation/export/analysis usage guidance is documented as illustrative tooling only, with explicit non-framework/non-authoritative boundaries.

--- a/UtilsTest/Parser/EmbeddedCodePreparationContractTests.cs
+++ b/UtilsTest/Parser/EmbeddedCodePreparationContractTests.cs
@@ -1,0 +1,191 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Diagnostics;
+using Utils.Parser.EmbeddedCode;
+using Utils.Parser.Source;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Tests for embedded-code preparation boundary contracts.
+/// </summary>
+[TestClass]
+public class EmbeddedCodePreparationContractTests
+{
+    /// <summary>
+    /// Verifies that embedded-code source metadata preserves raw source text and construct identity.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodeSource_StoresRawSourceAndConstructKind()
+    {
+        var location = new SourceCodeLocation("Grammar.g4", 3, 17);
+        var source = new EmbeddedCodeSource(
+            "inputPosition > 0",
+            EmbeddedCodeKind.SemanticPredicate,
+            ruleName: "expr",
+            alternativeIndex: 1,
+            elementIndex: 2,
+            location: location);
+
+        Assert.AreEqual("inputPosition > 0", source.SourceText);
+        Assert.AreEqual(EmbeddedCodeKind.SemanticPredicate, source.Kind);
+        Assert.AreEqual("expr", source.RuleName);
+        Assert.AreEqual(1, source.AlternativeIndex);
+        Assert.AreEqual(2, source.ElementIndex);
+        Assert.AreSame(location, source.Location);
+    }
+
+    /// <summary>
+    /// Verifies that preparation context metadata records the explicitly selected target path.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodePreparationContext_RepresentsExplicitTargetPath()
+    {
+        var context = new EmbeddedCodePreparationContext(
+            "ExprGrammar",
+            EmbeddedCodeTarget.RuntimeInlineExpression,
+            ruleName: "expr",
+            languageOrCompilerIdentity: "TestExpressionCompiler",
+            symbolModelVersion: 2,
+            supportedSymbols: new HashSet<EmbeddedCodeContextSymbol>
+            {
+                EmbeddedCodeContextSymbol.RuleName,
+                EmbeddedCodeContextSymbol.InputPosition
+            });
+
+        Assert.AreEqual("ExprGrammar", context.GrammarName);
+        Assert.AreEqual(EmbeddedCodeTarget.RuntimeInlineExpression, context.Target);
+        Assert.AreEqual("expr", context.RuleName);
+        Assert.AreEqual("TestExpressionCompiler", context.LanguageOrCompilerIdentity);
+        Assert.AreEqual(2, context.SymbolModelVersion);
+        Assert.IsTrue(context.SupportedSymbols.Contains(EmbeddedCodeContextSymbol.RuleName));
+        Assert.IsTrue(context.SupportedSymbols.Contains(EmbeddedCodeContextSymbol.InputPosition));
+        Assert.IsFalse(context.SupportedSymbols.Contains(EmbeddedCodeContextSymbol.AlternativeIndex));
+    }
+
+    /// <summary>
+    /// Verifies that preparation results can represent a successful artifact-producing outcome.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodePreparationResult_RepresentsSuccess()
+    {
+        var result = EmbeddedCodePreparationResult<string>.Success("prepared-predicate");
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.Succeeded, result.Status);
+        Assert.AreEqual("prepared-predicate", result.Artifact);
+        Assert.IsNull(result.DiagnosticDescriptor);
+        Assert.AreEqual(0, result.DiagnosticArguments.Count);
+    }
+
+    /// <summary>
+    /// Verifies that preparation results can represent an unsupported embedded-code path.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodePreparationResult_RepresentsUnsupported()
+    {
+        var result = EmbeddedCodePreparationResult<string>.Unsupported(new object?[] { "semantic predicate" });
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.Unsupported, result.Status);
+        Assert.IsNull(result.Artifact);
+        Assert.AreSame(ParserDiagnostics.EmbeddedCodeLanguageUnsupported, result.DiagnosticDescriptor);
+        Assert.AreEqual("semantic predicate", result.DiagnosticArguments[0]);
+    }
+
+
+    /// <summary>
+    /// Verifies that preparation results can represent a missing compiler configuration.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodePreparationResult_RepresentsCompilerNotConfigured()
+    {
+        var result = EmbeddedCodePreparationResult<string>.CompilerNotConfigured(new object?[] { "inline action" });
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.CompilerNotConfigured, result.Status);
+        Assert.IsNull(result.Artifact);
+        Assert.AreSame(ParserDiagnostics.EmbeddedCodeCompilerNotConfigured, result.DiagnosticDescriptor);
+        Assert.AreEqual("inline action", result.DiagnosticArguments[0]);
+    }
+
+    /// <summary>
+    /// Verifies that preparation results can represent a failed compilation attempt.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodePreparationResult_RepresentsCompilationFailed()
+    {
+        var exception = new InvalidOperationException("compiler failed");
+        var result = EmbeddedCodePreparationResult<string>.CompilationFailed(
+            exception,
+            new object?[] { "inline action", exception.Message });
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.CompilationFailed, result.Status);
+        Assert.IsNull(result.Artifact);
+        Assert.AreSame(ParserDiagnostics.EmbeddedCodeCompilationFailed, result.DiagnosticDescriptor);
+        Assert.AreSame(exception, result.Exception);
+        Assert.AreEqual("inline action", result.DiagnosticArguments[0]);
+        Assert.AreEqual("compiler failed", result.DiagnosticArguments[1]);
+    }
+
+    /// <summary>
+    /// Verifies that preparation results can represent source preserved without compilation.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodePreparationResult_RepresentsPreservedWithoutCompilation()
+    {
+        var result = EmbeddedCodePreparationResult<string>.PreservedNotCompiled(new object?[] { "expr:ParserInlineAction" });
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.PreservedNotCompiled, result.Status);
+        Assert.IsNull(result.Artifact);
+        Assert.AreSame(ParserDiagnostics.EmbeddedCodePreservedNotCompiled, result.DiagnosticDescriptor);
+        Assert.AreEqual("expr:ParserInlineAction", result.DiagnosticArguments[0]);
+    }
+
+    /// <summary>
+    /// Verifies that the neutral preparer preserves semantic predicates without compilation.
+    /// </summary>
+    [TestMethod]
+    public void PreservingEmbeddedCodePreparer_DoesNotCompileSemanticPredicate()
+    {
+        var preparer = new PreservingEmbeddedCodePreparer<string, string>();
+        var source = new EmbeddedCodeSource("inputPosition > 0", EmbeddedCodeKind.SemanticPredicate, ruleName: "expr");
+        var context = new EmbeddedCodePreparationContext("ExprGrammar", EmbeddedCodeTarget.SourceGeneratorCSharp, ruleName: "expr");
+
+        var result = preparer.PrepareSemanticPredicate(source, context);
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.PreservedNotCompiled, result.Status);
+        Assert.IsNull(result.Artifact);
+        Assert.AreSame(ParserDiagnostics.EmbeddedCodePreservedNotCompiled, result.DiagnosticDescriptor);
+    }
+
+    /// <summary>
+    /// Verifies that the neutral preparer preserves inline parser actions without compilation.
+    /// </summary>
+    [TestMethod]
+    public void PreservingEmbeddedCodePreparer_DoesNotCompileParserAction()
+    {
+        var preparer = new PreservingEmbeddedCodePreparer<string, string>();
+        var source = new EmbeddedCodeSource("count++;", EmbeddedCodeKind.ParserInlineAction, ruleName: "expr");
+        var context = new EmbeddedCodePreparationContext("ExprGrammar", EmbeddedCodeTarget.RuntimeInlineExpression, ruleName: "expr");
+
+        var result = preparer.PrepareParserAction(source, context);
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.PreservedNotCompiled, result.Status);
+        Assert.IsNull(result.Artifact);
+        Assert.AreSame(ParserDiagnostics.EmbeddedCodePreservedNotCompiled, result.DiagnosticDescriptor);
+    }
+
+    /// <summary>
+    /// Verifies that the neutral preparer rejects source kinds outside the requested preparation method.
+    /// </summary>
+    [TestMethod]
+    public void PreservingEmbeddedCodePreparer_ReturnsUnsupportedForWrongConstruct()
+    {
+        var preparer = new PreservingEmbeddedCodePreparer<string, string>();
+        var source = new EmbeddedCodeSource("count++;", EmbeddedCodeKind.RuleInitAction, ruleName: "expr");
+        var context = new EmbeddedCodePreparationContext("ExprGrammar", EmbeddedCodeTarget.RuntimeInlineExpression, ruleName: "expr");
+
+        var result = preparer.PrepareParserAction(source, context);
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.Unsupported, result.Status);
+        Assert.IsNull(result.Artifact);
+        Assert.AreSame(ParserDiagnostics.EmbeddedCodeLanguageUnsupported, result.DiagnosticDescriptor);
+    }
+}

--- a/docs/parser/EmbeddedCodeExecutionModel.md
+++ b/docs/parser/EmbeddedCodeExecutionModel.md
@@ -79,6 +79,18 @@ The prepared output is intentionally path-specific:
 
 Adapters may differ by path, but model semantics must stay aligned.
 
+## 4.1 Minimal preparation boundary
+
+The repository now contains an internal minimal preparation boundary in `Utils.Parser` for future embedded-code preparation work. It models:
+
+- raw embedded source text and construct kind (`EmbeddedCodeSource`, `EmbeddedCodeKind`);
+- explicit target path metadata (`EmbeddedCodePreparationContext`, `EmbeddedCodeTarget`);
+- the contextual symbol model (`ruleName`, `inputPosition`, `alternativeIndex`, `elementIndex`);
+- preparation outcomes (`EmbeddedCodePreparationResult<TArtifact>`, `EmbeddedCodePreparationStatus`);
+- one narrow preparation interface for semantic predicates and inline parser actions (`IEmbeddedCodePreparer<TPredicateArtifact, TActionArtifact>`).
+
+This boundary is intentionally metadata/preparation-only in this step. It is not wired into `ParserEngine`, does not change scheduling or memoization, does not migrate the expression-backed adapters, and does not make `GrammarEmitter` generate executable embedded-code hooks. The neutral preserving preparer returns explicit preserved/unsupported metadata and never compiles or executes embedded source.
+
 ## 5. Source generator C# path
 
 Pipeline:
@@ -241,6 +253,7 @@ Responsible for:
 - embedded-code recognition/classification;
 - raw source preservation in model metadata;
 - routing via runtime policy abstractions;
+- internal preparation boundary contracts for future executable or generable artifacts;
 - deterministic diagnostics;
 - preserving `ParserEngine` authority.
 
@@ -336,7 +349,7 @@ This model explicitly excludes:
 - hidden semantic runtime state;
 - parse-tree shape changes;
 - direct `Utils.Parser` dependency on `Utils.Expressions.CSyntax` or `Utils.Expressions.VBSyntax`;
-- implementation changes in this PR.
+- runtime behavior changes from the current preparation-boundary contracts.
 
 ## 13. Future PR plan
 
@@ -346,10 +359,16 @@ This model explicitly excludes:
 - document current expression-backed adapters as an intermediate runtime integration step;
 - no behavior change.
 
-### Future PR — Explicit preparation boundary
+### PR 2 — Explicit preparation boundary (current implementation step)
 
-- move runtime-inline expression compilation to parser model preparation/generation, or introduce an explicit boundary that produces executable artifacts before parsing;
+- introduce an internal minimal boundary that represents embedded-code source, preparation context, target path, preparation status, and path-specific artifacts;
+- keep the boundary disconnected from `ParserEngine`, `GrammarEmitter`, and the current expression-backed adapters;
 - preserve `ParserEngine` as an execution coordinator rather than a language compiler.
+
+### Future PR — Runtime-inline preparation migration
+
+- move runtime-inline expression compilation to parser model preparation/generation through the explicit boundary;
+- execute prepared artifacts during parsing instead of compiling source text during predicate/action invocation.
 
 ### Future PR — Source generator C# path
 

--- a/docs/parser/INDEX.md
+++ b/docs/parser/INDEX.md
@@ -17,7 +17,7 @@ This index consolidates the parser documentation set and gives a short summary o
 
 ## Compatibility and analysis
 
-- [`EmbeddedCodeExecutionModel.md`](./EmbeddedCodeExecutionModel.md): Architecture boundary for ANTLR embedded code, including current behavior, the target two-path model (C# source generation vs runtime-inline `IExpressionCompiler` preparation), current semantic-predicate and parser-action runtime adapters as intermediate opportunistic-compilation implementations, cache limits (predicate vs action), and multi-project responsibilities.
+- [`EmbeddedCodeExecutionModel.md`](./EmbeddedCodeExecutionModel.md): Architecture boundary for ANTLR embedded code, including current behavior, the target two-path model (C# source generation vs runtime-inline `IExpressionCompiler` preparation), current semantic-predicate and parser-action runtime adapters as intermediate opportunistic-compilation implementations, cache limits (predicate vs action), the internal minimal preparation boundary, and multi-project responsibilities.
 - [`ANTLRCompatibility.md`](./ANTLRCompatibility.md): Canonical ANTLR compatibility reference including feature behavior, shared prequel metadata/diagnostic boundaries, runtime-generator parity notes, and usage guidance.
 - [`Antlr4CompatibilityMatrix.md`](./Antlr4CompatibilityMatrix.md): Current ANTLR4 feature support matrix with explicit levels (supported, partial, parsed-only, unsupported), including semantic-predicate vs precedence-predicate runtime-policy distinctions and continuation metadata support boundaries.
 - [`RuntimeTraceAnalysis.md`](./RuntimeTraceAnalysis.md): Tooling-oriented analysis model for runtime traces, focused on descriptive outputs rather than runtime control.


### PR DESCRIPTION
# Motivation

PR #287 clarified the target embedded-code architecture: a two-path model where embedded ANTLR code is prepared before parsing rather than compiled opportunistically during predicate/action invocation.

This PR introduces the minimal internal preparation/generation boundary needed for future work while keeping `ParserEngine`, `GrammarEmitter`, and the current expression-backed adapters unchanged.

# Audit summary

Current state before this PR:

- `Utils.Parser.Generators` generates C# model-construction code, but embedded predicates/actions are still emitted as metadata strings such as `ValidatingPredicate("...")` and `EmbeddedAction("...", ...)`.
- `ExpressionSemanticPredicateEvaluator` and `ExpressionParserActionExecutor` currently adapt `IExpressionCompiler` to runtime policy interfaces.
- Those adapters currently compile opportunistically during predicate/action invocation, with limited compilation caching.
- No concrete preparation/generation contract existed to represent raw embedded source, target path, contextual symbols, preparation status, and path-specific prepared artifacts.

This PR introduces only that minimal internal contract layer. It does not wire the contracts into runtime or generator execution.

# Modifications

Added internal embedded-code preparation contracts under `Utils.Parser/EmbeddedCode`:

- `EmbeddedCodeSource`
- `EmbeddedCodeKind`
- `EmbeddedCodeTarget`
- `EmbeddedCodeContextSymbol`
- `EmbeddedCodePreparationContext`
- `EmbeddedCodePreparationStatus`
- `EmbeddedCodePreparationResult<TArtifact>`
- `IEmbeddedCodePreparer<TPredicateArtifact, TActionArtifact>`
- `PreservingEmbeddedCodePreparer<TPredicateArtifact, TActionArtifact>`

Added tests:

- `UtilsTest/Parser/EmbeddedCodePreparationContractTests.cs`

Updated documentation:

- `docs/parser/EmbeddedCodeExecutionModel.md`
- `Utils.Parser/ROADMAP.md`
- `docs/parser/INDEX.md`

# Public API impact

None.

All new embedded-code preparation contracts are internal. No public API was added, removed, or changed.

# Migration

None.

This PR does not change runtime behavior, generator output, parser configuration, or user-facing APIs.

# Compatibility impact

No behavior change.

The PR introduces internal preparation contracts only and does not alter parser compatibility, generated code, runtime execution, or diagnostics emission.

# Runtime impact

None.

`ParserEngine`, scheduling, memoization, runtime policies, semantic predicate execution, and parser action execution are unchanged.

# Diagnostics impact

No diagnostic emission behavior changed.

The new result model can carry existing embedded-code diagnostic descriptors as metadata, but this PR does not change when or how diagnostics are emitted.

# Parse-tree impact

None.

No parser behavior or parse-tree shape is changed.

# ANTLR compatibility impact

No change in ANTLR feature support.

This PR does not increase support for semantic predicates, parser actions, rule lifecycle actions, grammar actions, lexer actions, or lexer predicates. It only adds internal contracts for future preparation work.

# Documentation impact

Updated:

- `docs/parser/EmbeddedCodeExecutionModel.md` to document the new internal minimal preparation boundary and clarify that it is not wired into runtime or generator behavior.
- `Utils.Parser/ROADMAP.md` to record the boundary contracts while explicitly preserving current runtime/generator limitations.
- `docs/parser/INDEX.md` because `EmbeddedCodeExecutionModel.md` was materially changed.

Not updated:

- `docs/parser/ANTLRCompatibility.md`, because no ANTLR support level or behavior changed.

# Tests

Added deterministic unit tests for the new internal contracts:

- `EmbeddedCodePreparationContractTests`

Reported validation:

- `dotnet test UtilsTest/UtilsTest.Unit.csproj`
- `dotnet test UtilsTest/UtilsTest.Unit.csproj --no-restore --filter EmbeddedCodePreparationContractTests`
- `dotnet build Utils.Parser/Utils.Parser.csproj --no-restore`
- `dotnet pack Utils.Parser/Utils.Parser.csproj --configuration Debug --no-restore`