### PR TITLE
Centralize embedded-code runtime indexing and diagnostics

### DIFF
--- a/Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuildEntry.cs
+++ b/Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuildEntry.cs
@@ -22,6 +22,7 @@ public sealed record PreparedExpressionEmbeddedCodeRegistryBuildEntry
     /// <param name="isDuplicate">Whether a successful preparation collided with an existing registry key.</param>
     /// <param name="isSkipped">Whether the item was intentionally skipped without invoking the preparer.</param>
     /// <param name="skipReason">Human-readable reason for skipped items.</param>
+    /// <param name="unsupportedReason">Common unsupported reason for skipped items.</param>
     public PreparedExpressionEmbeddedCodeRegistryBuildEntry(
         EmbeddedCodeSource source,
         PreparedExpressionEmbeddedCodeKey? key,
@@ -33,7 +34,8 @@ public sealed record PreparedExpressionEmbeddedCodeRegistryBuildEntry
         bool wasAddedToRegistry = false,
         bool isDuplicate = false,
         bool isSkipped = false,
-        string? skipReason = null)
+        string? skipReason = null,
+        EmbeddedCodeUnsupportedReason? unsupportedReason = null)
     {
         Source = source ?? throw new ArgumentNullException(nameof(source));
         Key = key;
@@ -46,6 +48,7 @@ public sealed record PreparedExpressionEmbeddedCodeRegistryBuildEntry
         IsDuplicate = isDuplicate;
         IsSkipped = isSkipped;
         SkipReason = skipReason;
+        UnsupportedReason = unsupportedReason;
     }
 
     /// <summary>
@@ -102,4 +105,9 @@ public sealed record PreparedExpressionEmbeddedCodeRegistryBuildEntry
     /// Gets the human-readable reason for skipped items.
     /// </summary>
     public string? SkipReason { get; }
+
+    /// <summary>
+    /// Gets the common unsupported reason for skipped items.
+    /// </summary>
+    public EmbeddedCodeUnsupportedReason? UnsupportedReason { get; }
 }

--- a/Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuilder.cs
+++ b/Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuilder.cs
@@ -1,3 +1,4 @@
+using Utils.Parser.Diagnostics;
 using Utils.Parser.EmbeddedCode;
 using Utils.Parser.Model;
 
@@ -32,31 +33,30 @@ public static class PreparedExpressionEmbeddedCodeRegistryBuilder
         var duplicateEntries = new List<PreparedExpressionEmbeddedCodeRegistryBuildEntry>();
         var skippedEntries = new List<PreparedExpressionEmbeddedCodeRegistryBuildEntry>();
         var allEntries = new List<PreparedExpressionEmbeddedCodeRegistryBuildEntry>();
+        var discovery = EmbeddedCodeRuntimeDiscovery.Discover(definition);
 
-        foreach (var action in definition.Actions)
+        foreach (var entry in discovery.Entries)
         {
-            AddSkippedEntry(
-                CreateSource(action.RawCode, EmbeddedCodeKind.GrammarAction, null, null, null),
-                null,
-                "Grammar-level actions are not prepared by the expression registry builder.",
-                skippedEntries,
-                allEntries);
-        }
+            if (!entry.IsRuntimeExecutable)
+            {
+                AddSkippedEntry(entry, skippedEntries, allEntries);
+                continue;
+            }
 
-        foreach (var rule in definition.ParserRules)
-        {
-            ScanRule(
-                definition,
-                rule,
-                preparer,
-                options,
-                registry,
-                successfulSemanticPredicates,
-                successfulParserActions,
-                nonSuccessEntries,
-                duplicateEntries,
-                skippedEntries,
-                allEntries);
+            var rule = GetParserRule(definition, entry.RuleName!);
+            if (entry.Kind == EmbeddedCodeKind.SemanticPredicate)
+            {
+                PrepareSemanticPredicate(definition, rule, entry.Source, preparer, options, registry, successfulSemanticPredicates, nonSuccessEntries, duplicateEntries, allEntries);
+                continue;
+            }
+
+            if (entry.Kind == EmbeddedCodeKind.ParserInlineAction)
+            {
+                PrepareParserAction(definition, rule, entry.Source, preparer, options, registry, successfulParserActions, nonSuccessEntries, duplicateEntries, allEntries);
+                continue;
+            }
+
+            AddSkippedEntry(entry, skippedEntries, allEntries);
         }
 
         return new PreparedExpressionEmbeddedCodeRegistryBuildResult(
@@ -70,389 +70,20 @@ public static class PreparedExpressionEmbeddedCodeRegistryBuilder
     }
 
     /// <summary>
-    /// Scans one parser rule and records any supported or intentionally skipped embedded-code items.
+    /// Finds a parser rule by name in the definition currently being scanned.
     /// </summary>
-    /// <param name="definition">Owning parser definition.</param>
-    /// <param name="rule">Parser rule to scan.</param>
-    /// <param name="preparer">Preparer used for supported embedded-code items.</param>
-    /// <param name="options">Builder options.</param>
-    /// <param name="registry">Registry being populated.</param>
-    /// <param name="successfulSemanticPredicates">Successful semantic predicate entries.</param>
-    /// <param name="successfulParserActions">Successful parser action entries.</param>
-    /// <param name="nonSuccessEntries">Non-success preparation entries.</param>
-    /// <param name="duplicateEntries">Duplicate key entries.</param>
-    /// <param name="skippedEntries">Skipped entries.</param>
-    /// <param name="allEntries">All entries in traversal order.</param>
-    private static void ScanRule(
-        ParserDefinition definition,
-        Rule rule,
-        IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
-        PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
-        PreparedExpressionEmbeddedCodeRegistry registry,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulSemanticPredicates,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulParserActions,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> nonSuccessEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
-    {
-        if (rule.InitAction is not null)
-        {
-            AddSkippedEntry(
-                CreateSource(rule.InitAction.RawCode, EmbeddedCodeKind.RuleInitAction, rule.Name, null, null),
-                rule.Name,
-                "Rule initialization actions are not prepared by the expression registry builder.",
-                skippedEntries,
-                allEntries);
-        }
-
-        if (definition.LeftRecursiveRules.TryGetValue(rule.Name, out var leftRecursiveInfo))
-        {
-            ScanLeftRecursiveRule(
-                definition,
-                leftRecursiveInfo,
-                preparer,
-                options,
-                registry,
-                successfulSemanticPredicates,
-                successfulParserActions,
-                nonSuccessEntries,
-                duplicateEntries,
-                skippedEntries,
-                allEntries);
-        }
-        else
-        {
-            ScanContent(
-                definition,
-                rule,
-                rule.Content,
-                null,
-                null,
-                preparer,
-                options,
-                registry,
-                successfulSemanticPredicates,
-                successfulParserActions,
-                nonSuccessEntries,
-                duplicateEntries,
-                skippedEntries,
-                allEntries);
-        }
-
-        if (rule.AfterAction is not null)
-        {
-            AddSkippedEntry(
-                CreateSource(rule.AfterAction.RawCode, EmbeddedCodeKind.RuleAfterAction, rule.Name, null, null),
-                rule.Name,
-                "Rule finalization actions are not prepared by the expression registry builder.",
-                skippedEntries,
-                allEntries);
-        }
-    }
+    /// <param name="definition">Parser definition that owns the rule.</param>
+    /// <param name="ruleName">Rule name to locate.</param>
+    /// <returns>The matching parser rule.</returns>
+    private static Rule GetParserRule(ParserDefinition definition, string ruleName) =>
+        definition.ParserRules.First(rule => string.Equals(rule.Name, ruleName, StringComparison.Ordinal));
 
     /// <summary>
-    /// Recursively scans rule content using the same local alternative and sequence indexes supplied by the parser runtime.
+    /// Prepares and registers one validating semantic predicate discovered by shared runtime metadata.
     /// </summary>
     /// <param name="definition">Owning parser definition.</param>
     /// <param name="rule">Owning parser rule.</param>
-    /// <param name="content">Content node to scan.</param>
-    /// <param name="alternativeIndex">Current local alternative index, or <c>null</c> when unavailable.</param>
-    /// <param name="elementIndex">Current sequence element index, or <c>null</c> when unavailable.</param>
-    /// <param name="preparer">Preparer used for supported embedded-code items.</param>
-    /// <param name="options">Builder options.</param>
-    /// <param name="registry">Registry being populated.</param>
-    /// <param name="successfulSemanticPredicates">Successful semantic predicate entries.</param>
-    /// <param name="successfulParserActions">Successful parser action entries.</param>
-    /// <param name="nonSuccessEntries">Non-success preparation entries.</param>
-    /// <param name="duplicateEntries">Duplicate key entries.</param>
-    /// <param name="skippedEntries">Skipped entries.</param>
-    /// <param name="allEntries">All entries in traversal order.</param>
-    private static void ScanContent(
-        ParserDefinition definition,
-        Rule rule,
-        RuleContent content,
-        int? alternativeIndex,
-        int? elementIndex,
-        IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
-        PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
-        PreparedExpressionEmbeddedCodeRegistry registry,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulSemanticPredicates,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulParserActions,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> nonSuccessEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
-    {
-        switch (content)
-        {
-            case Alternation alternation:
-                ScanAlternation(definition, rule, alternation, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-                break;
-            case Alternative alternative:
-                ScanContent(definition, rule, alternative.Content, alternativeIndex, elementIndex, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-                break;
-            case Sequence sequence:
-                ScanSequence(definition, rule, sequence, alternativeIndex, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-                break;
-            case Quantifier quantifier:
-                ScanQuantifier(definition, rule, quantifier, alternativeIndex, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-                break;
-            case Negation negation:
-                ScanNegation(definition, rule, negation, alternativeIndex, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-                break;
-            case ValidatingPredicate predicate:
-                PrepareSemanticPredicate(definition, rule, predicate, alternativeIndex, elementIndex, preparer, options, registry, successfulSemanticPredicates, nonSuccessEntries, duplicateEntries, allEntries);
-                break;
-            case EmbeddedAction action:
-                PrepareOrSkipParserAction(definition, rule, action, alternativeIndex, elementIndex, preparer, options, registry, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-                break;
-        }
-    }
-
-    /// <summary>
-    /// Scans an alternation in runtime priority order so local indexes match scheduler contexts.
-    /// </summary>
-    /// <param name="definition">Owning parser definition.</param>
-    /// <param name="rule">Owning parser rule.</param>
-    /// <param name="alternation">Alternation to scan.</param>
-    /// <param name="preparer">Preparer used for supported embedded-code items.</param>
-    /// <param name="options">Builder options.</param>
-    /// <param name="registry">Registry being populated.</param>
-    /// <param name="successfulSemanticPredicates">Successful semantic predicate entries.</param>
-    /// <param name="successfulParserActions">Successful parser action entries.</param>
-    /// <param name="nonSuccessEntries">Non-success preparation entries.</param>
-    /// <param name="duplicateEntries">Duplicate key entries.</param>
-    /// <param name="skippedEntries">Skipped entries.</param>
-    /// <param name="allEntries">All entries in traversal order.</param>
-    private static void ScanAlternation(
-        ParserDefinition definition,
-        Rule rule,
-        Alternation alternation,
-        IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
-        PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
-        PreparedExpressionEmbeddedCodeRegistry registry,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulSemanticPredicates,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulParserActions,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> nonSuccessEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
-    {
-        var ordered = alternation.Alternatives.OrderBy(static alternative => alternative.Priority).ToList();
-        for (var index = 0; index < ordered.Count; index++)
-        {
-            ScanContent(definition, rule, ordered[index].Content, index, null, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-        }
-    }
-
-    /// <summary>
-    /// Scans a direct-left-recursive rule using the runtime seed and recursive-tail views.
-    /// </summary>
-    /// <param name="definition">Owning parser definition.</param>
-    /// <param name="info">Left-recursive rule split metadata.</param>
-    /// <param name="preparer">Preparer used for supported embedded-code items.</param>
-    /// <param name="options">Builder options.</param>
-    /// <param name="registry">Registry being populated.</param>
-    /// <param name="successfulSemanticPredicates">Successful semantic predicate entries.</param>
-    /// <param name="successfulParserActions">Successful parser action entries.</param>
-    /// <param name="nonSuccessEntries">Non-success preparation entries.</param>
-    /// <param name="duplicateEntries">Duplicate key entries.</param>
-    /// <param name="skippedEntries">Skipped entries.</param>
-    /// <param name="allEntries">All entries in traversal order.</param>
-    private static void ScanLeftRecursiveRule(
-        ParserDefinition definition,
-        LeftRecursiveRuleInfo info,
-        IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
-        PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
-        PreparedExpressionEmbeddedCodeRegistry registry,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulSemanticPredicates,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulParserActions,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> nonSuccessEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
-    {
-        var baseAlternatives = info.BaseAlternatives.OrderBy(static alternative => alternative.Priority).ToList();
-        for (var index = 0; index < baseAlternatives.Count; index++)
-        {
-            ScanContent(definition, info.Rule, baseAlternatives[index].Content, index, null, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-        }
-
-        var recursiveAlternatives = info.RecursiveAlternatives.OrderBy(static alternative => alternative.Priority).ToList();
-        for (var index = 0; index < recursiveAlternatives.Count; index++)
-        {
-            var tailContent = RemoveLeadingSelfReference(info.Rule.Name, recursiveAlternatives[index].Content);
-            if (tailContent is not null)
-            {
-                ScanLeftRecursiveTail(definition, info.Rule, tailContent, index, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Scans recursive-tail content after applying the same leading self-reference removal used by the runtime.
-    /// </summary>
-    /// <param name="definition">Owning parser definition.</param>
-    /// <param name="rule">Owning left-recursive rule.</param>
-    /// <param name="tailContent">Effective tail content parsed by the runtime.</param>
-    /// <param name="alternativeIndex">Runtime recursive alternative index.</param>
-    /// <param name="preparer">Preparer used for supported embedded-code items.</param>
-    /// <param name="options">Builder options.</param>
-    /// <param name="registry">Registry being populated.</param>
-    /// <param name="successfulSemanticPredicates">Successful semantic predicate entries.</param>
-    /// <param name="successfulParserActions">Successful parser action entries.</param>
-    /// <param name="nonSuccessEntries">Non-success preparation entries.</param>
-    /// <param name="duplicateEntries">Duplicate key entries.</param>
-    /// <param name="skippedEntries">Skipped entries.</param>
-    /// <param name="allEntries">All entries in traversal order.</param>
-    private static void ScanLeftRecursiveTail(
-        ParserDefinition definition,
-        Rule rule,
-        RuleContent tailContent,
-        int alternativeIndex,
-        IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
-        PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
-        PreparedExpressionEmbeddedCodeRegistry registry,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulSemanticPredicates,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulParserActions,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> nonSuccessEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
-    {
-        if (tailContent is Sequence sequence)
-        {
-            for (var index = 0; index < sequence.Items.Count; index++)
-            {
-                var item = sequence.Items[index];
-                if (item is RuleRef ruleRef && string.Equals(ruleRef.RuleName, rule.Name, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                ScanContent(definition, rule, item, alternativeIndex, index, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-            }
-
-            return;
-        }
-
-        ScanContent(definition, rule, tailContent, alternativeIndex, alternativeIndex, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-    }
-
-    /// <summary>
-    /// Scans sequence items with stable zero-based element indexes matching runtime contexts.
-    /// </summary>
-    /// <param name="definition">Owning parser definition.</param>
-    /// <param name="rule">Owning parser rule.</param>
-    /// <param name="sequence">Sequence to scan.</param>
-    /// <param name="alternativeIndex">Current local alternative index.</param>
-    /// <param name="preparer">Preparer used for supported embedded-code items.</param>
-    /// <param name="options">Builder options.</param>
-    /// <param name="registry">Registry being populated.</param>
-    /// <param name="successfulSemanticPredicates">Successful semantic predicate entries.</param>
-    /// <param name="successfulParserActions">Successful parser action entries.</param>
-    /// <param name="nonSuccessEntries">Non-success preparation entries.</param>
-    /// <param name="duplicateEntries">Duplicate key entries.</param>
-    /// <param name="skippedEntries">Skipped entries.</param>
-    /// <param name="allEntries">All entries in traversal order.</param>
-    private static void ScanSequence(
-        ParserDefinition definition,
-        Rule rule,
-        Sequence sequence,
-        int? alternativeIndex,
-        IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
-        PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
-        PreparedExpressionEmbeddedCodeRegistry registry,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulSemanticPredicates,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulParserActions,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> nonSuccessEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
-    {
-        for (var index = 0; index < sequence.Items.Count; index++)
-        {
-            ScanContent(definition, rule, sequence.Items[index], alternativeIndex, index, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-        }
-    }
-
-    /// <summary>
-    /// Scans quantified content with the runtime element-index strategy for quantifier inner parsing.
-    /// </summary>
-    /// <param name="definition">Owning parser definition.</param>
-    /// <param name="rule">Owning parser rule.</param>
-    /// <param name="quantifier">Quantifier model node.</param>
-    /// <param name="alternativeIndex">Current local alternative index.</param>
-    /// <param name="preparer">Preparer used for supported embedded-code items.</param>
-    /// <param name="options">Builder options.</param>
-    /// <param name="registry">Registry being populated.</param>
-    /// <param name="successfulSemanticPredicates">Successful semantic predicate entries.</param>
-    /// <param name="successfulParserActions">Successful parser action entries.</param>
-    /// <param name="nonSuccessEntries">Non-success preparation entries.</param>
-    /// <param name="duplicateEntries">Duplicate key entries.</param>
-    /// <param name="skippedEntries">Skipped entries.</param>
-    /// <param name="allEntries">All entries in traversal order.</param>
-    private static void ScanQuantifier(
-        ParserDefinition definition,
-        Rule rule,
-        Quantifier quantifier,
-        int? alternativeIndex,
-        IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
-        PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
-        PreparedExpressionEmbeddedCodeRegistry registry,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulSemanticPredicates,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulParserActions,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> nonSuccessEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
-    {
-        ScanContent(definition, rule, quantifier.Inner, alternativeIndex, alternativeIndex, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-    }
-
-    /// <summary>
-    /// Scans negated content with the runtime element-index strategy for negation inner probing.
-    /// </summary>
-    /// <param name="definition">Owning parser definition.</param>
-    /// <param name="rule">Owning parser rule.</param>
-    /// <param name="negation">Negation model node.</param>
-    /// <param name="alternativeIndex">Current local alternative index.</param>
-    /// <param name="preparer">Preparer used for supported embedded-code items.</param>
-    /// <param name="options">Builder options.</param>
-    /// <param name="registry">Registry being populated.</param>
-    /// <param name="successfulSemanticPredicates">Successful semantic predicate entries.</param>
-    /// <param name="successfulParserActions">Successful parser action entries.</param>
-    /// <param name="nonSuccessEntries">Non-success preparation entries.</param>
-    /// <param name="duplicateEntries">Duplicate key entries.</param>
-    /// <param name="skippedEntries">Skipped entries.</param>
-    /// <param name="allEntries">All entries in traversal order.</param>
-    private static void ScanNegation(
-        ParserDefinition definition,
-        Rule rule,
-        Negation negation,
-        int? alternativeIndex,
-        IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
-        PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
-        PreparedExpressionEmbeddedCodeRegistry registry,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulSemanticPredicates,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulParserActions,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> nonSuccessEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
-    {
-        ScanContent(definition, rule, negation.Inner, alternativeIndex, alternativeIndex, preparer, options, registry, successfulSemanticPredicates, successfulParserActions, nonSuccessEntries, duplicateEntries, skippedEntries, allEntries);
-    }
-
-    /// <summary>
-    /// Prepares and registers one validating semantic predicate.
-    /// </summary>
-    /// <param name="definition">Owning parser definition.</param>
-    /// <param name="rule">Owning parser rule.</param>
-    /// <param name="predicate">Predicate model node.</param>
-    /// <param name="alternativeIndex">Current local alternative index.</param>
-    /// <param name="elementIndex">Current sequence element index.</param>
+    /// <param name="source">Runtime-indexed source metadata.</param>
     /// <param name="preparer">Preparer used for supported embedded-code items.</param>
     /// <param name="options">Builder options.</param>
     /// <param name="registry">Registry being populated.</param>
@@ -463,9 +94,7 @@ public static class PreparedExpressionEmbeddedCodeRegistryBuilder
     private static void PrepareSemanticPredicate(
         ParserDefinition definition,
         Rule rule,
-        ValidatingPredicate predicate,
-        int? alternativeIndex,
-        int? elementIndex,
+        EmbeddedCodeSource source,
         IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
         PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
         PreparedExpressionEmbeddedCodeRegistry registry,
@@ -474,106 +103,48 @@ public static class PreparedExpressionEmbeddedCodeRegistryBuilder
         List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
         List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
     {
-        var source = CreateSource(predicate.Code, EmbeddedCodeKind.SemanticPredicate, rule.Name, alternativeIndex, elementIndex);
         var context = CreatePreparationContext(definition, rule, options);
         var result = preparer.PrepareSemanticPredicate(source, context);
         var key = result.Artifact is null ? null : PreparedExpressionEmbeddedCodeKey.FromSource(result.Artifact.Source, result.Artifact.PreparationContext.RuleName);
         var wasAdded = result.Artifact is not null && registry.TryAddSemanticPredicate(result.Artifact);
-        var entry = CreateEntry(source, key, rule.Name, result.Status, result.DiagnosticDescriptor, result.Exception, result.DiagnosticArguments, wasAdded, result.Artifact is not null && !wasAdded);
+        var buildEntry = CreateEntry(source, key, rule.Name, result.Status, result.DiagnosticDescriptor, result.Exception, result.DiagnosticArguments, wasAdded, result.Artifact is not null && !wasAdded);
 
-        AddPreparationEntry(entry, result.Artifact is not null && wasAdded, successfulEntries, nonSuccessEntries, duplicateEntries, allEntries);
+        AddPreparationEntry(buildEntry, result.Artifact is not null && wasAdded, successfulEntries, nonSuccessEntries, duplicateEntries, allEntries);
     }
 
     /// <summary>
-    /// Prepares and registers one inline parser action, or records unsupported action positions as skipped.
+    /// Prepares and registers one inline parser action discovered by shared runtime metadata.
     /// </summary>
     /// <param name="definition">Owning parser definition.</param>
     /// <param name="rule">Owning parser rule.</param>
-    /// <param name="action">Action model node.</param>
-    /// <param name="alternativeIndex">Current local alternative index.</param>
-    /// <param name="elementIndex">Current sequence element index.</param>
+    /// <param name="source">Runtime-indexed source metadata.</param>
     /// <param name="preparer">Preparer used for supported embedded-code items.</param>
     /// <param name="options">Builder options.</param>
     /// <param name="registry">Registry being populated.</param>
     /// <param name="successfulEntries">Successful parser action entries.</param>
     /// <param name="nonSuccessEntries">Non-success preparation entries.</param>
     /// <param name="duplicateEntries">Duplicate key entries.</param>
-    /// <param name="skippedEntries">Skipped entries.</param>
     /// <param name="allEntries">All entries in traversal order.</param>
-    private static void PrepareOrSkipParserAction(
+    private static void PrepareParserAction(
         ParserDefinition definition,
         Rule rule,
-        EmbeddedAction action,
-        int? alternativeIndex,
-        int? elementIndex,
+        EmbeddedCodeSource source,
         IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction> preparer,
         PreparedExpressionEmbeddedCodeRegistryBuilderOptions options,
         PreparedExpressionEmbeddedCodeRegistry registry,
         List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> successfulEntries,
         List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> nonSuccessEntries,
         List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> duplicateEntries,
-        List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
         List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
     {
-        var source = CreateSource(action.RawCode, EmbeddedCodeKind.ParserInlineAction, rule.Name, alternativeIndex, elementIndex);
-        if (action.Context != ActionContext.Alternative || action.Position != ActionPosition.Inline)
-        {
-            AddSkippedEntry(
-                source,
-                rule.Name,
-                "Only inline parser actions declared inside alternatives are prepared by the expression registry builder.",
-                skippedEntries,
-                allEntries);
-            return;
-        }
-
         var context = CreatePreparationContext(definition, rule, options);
         var result = preparer.PrepareParserAction(source, context);
         var key = result.Artifact is null ? null : PreparedExpressionEmbeddedCodeKey.FromSource(result.Artifact.Source, result.Artifact.PreparationContext.RuleName);
         var wasAdded = result.Artifact is not null && registry.TryAddParserAction(result.Artifact);
-        var entry = CreateEntry(source, key, rule.Name, result.Status, result.DiagnosticDescriptor, result.Exception, result.DiagnosticArguments, wasAdded, result.Artifact is not null && !wasAdded);
+        var buildEntry = CreateEntry(source, key, rule.Name, result.Status, result.DiagnosticDescriptor, result.Exception, result.DiagnosticArguments, wasAdded, result.Artifact is not null && !wasAdded);
 
-        AddPreparationEntry(entry, result.Artifact is not null && wasAdded, successfulEntries, nonSuccessEntries, duplicateEntries, allEntries);
+        AddPreparationEntry(buildEntry, result.Artifact is not null && wasAdded, successfulEntries, nonSuccessEntries, duplicateEntries, allEntries);
     }
-
-    /// <summary>
-    /// Removes the leading direct self-reference exactly as the parser runtime does for left-recursive tails.
-    /// </summary>
-    /// <param name="ruleName">Name of the left-recursive rule.</param>
-    /// <param name="content">Recursive alternative content.</param>
-    /// <returns>The effective tail content parsed by the runtime, or <c>null</c> when no leading self-reference exists.</returns>
-    private static RuleContent? RemoveLeadingSelfReference(string ruleName, RuleContent content)
-    {
-        switch (content)
-        {
-            case RuleRef ruleRef when string.Equals(ruleRef.RuleName, ruleName, StringComparison.Ordinal):
-                return new Sequence([]);
-            case Sequence sequence when sequence.Items.Count > 0:
-            {
-                if (sequence.Items[0] is RuleRef leading &&
-                    string.Equals(leading.RuleName, ruleName, StringComparison.Ordinal))
-                {
-                    return new Sequence(sequence.Items.Skip(1).ToList());
-                }
-
-                return null;
-            }
-            default:
-                return null;
-        }
-    }
-
-    /// <summary>
-    /// Creates source metadata for a discovered embedded-code item.
-    /// </summary>
-    /// <param name="sourceText">Raw embedded-code source text.</param>
-    /// <param name="kind">Embedded-code kind.</param>
-    /// <param name="ruleName">Owning rule name.</param>
-    /// <param name="alternativeIndex">Current local alternative index.</param>
-    /// <param name="elementIndex">Current sequence element index.</param>
-    /// <returns>Source metadata suitable for preparation and key creation.</returns>
-    private static EmbeddedCodeSource CreateSource(string sourceText, EmbeddedCodeKind kind, string? ruleName, int? alternativeIndex, int? elementIndex) =>
-        new(sourceText, kind, ruleName, alternativeIndex, elementIndex);
 
     /// <summary>
     /// Creates the preparation context supplied to the configured preparer.
@@ -611,7 +182,7 @@ public static class PreparedExpressionEmbeddedCodeRegistryBuilder
         PreparedExpressionEmbeddedCodeKey? key,
         string? ruleName,
         EmbeddedCodePreparationStatus status,
-        Utils.Parser.Diagnostics.ParserDiagnosticDescriptor? diagnosticDescriptor,
+        ParserDiagnosticDescriptor? diagnosticDescriptor,
         Exception? exception,
         IReadOnlyList<object?> diagnosticArguments,
         bool wasAdded,
@@ -655,28 +226,44 @@ public static class PreparedExpressionEmbeddedCodeRegistryBuilder
     /// <summary>
     /// Records an embedded-code item that is intentionally not prepared by this builder.
     /// </summary>
-    /// <param name="source">Embedded-code source metadata.</param>
-    /// <param name="ruleName">Owning rule name, or <c>null</c> for grammar-level items.</param>
-    /// <param name="reason">Reason why the item was skipped.</param>
+    /// <param name="runtimeEntry">Runtime discovery entry to record as skipped.</param>
     /// <param name="skippedEntries">Skipped entries bucket.</param>
     /// <param name="allEntries">All entries in traversal order.</param>
     private static void AddSkippedEntry(
-        EmbeddedCodeSource source,
-        string? ruleName,
-        string reason,
+        EmbeddedCodeRuntimeEntry runtimeEntry,
         List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> skippedEntries,
         List<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
     {
         var entry = new PreparedExpressionEmbeddedCodeRegistryBuildEntry(
-            source,
+            runtimeEntry.Source,
             null,
-            ruleName,
+            runtimeEntry.RuleName,
             EmbeddedCodePreparationStatus.Unsupported,
             wasAddedToRegistry: false,
             isSkipped: true,
-            skipReason: reason);
+            skipReason: GetSkipReason(runtimeEntry.UnsupportedReason),
+            unsupportedReason: runtimeEntry.UnsupportedReason);
 
         skippedEntries.Add(entry);
         allEntries.Add(entry);
     }
+
+    /// <summary>
+    /// Converts a common unsupported reason into the legacy human-readable skip reason text.
+    /// </summary>
+    /// <param name="reason">Common unsupported reason.</param>
+    /// <returns>Human-readable skip reason.</returns>
+    private static string GetSkipReason(EmbeddedCodeUnsupportedReason reason) => reason switch
+    {
+        EmbeddedCodeUnsupportedReason.GrammarAction => "Grammar-level actions are not prepared by the expression registry builder.",
+        EmbeddedCodeUnsupportedReason.RuleInitAction => "Rule initialization actions are not prepared by the expression registry builder.",
+        EmbeddedCodeUnsupportedReason.RuleAfterAction => "Rule finalization actions are not prepared by the expression registry builder.",
+        EmbeddedCodeUnsupportedReason.UnsupportedActionContext or EmbeddedCodeUnsupportedReason.UnsupportedActionPosition or EmbeddedCodeUnsupportedReason.NonInlineParserAction => "Only inline parser actions declared inside alternatives are prepared by the expression registry builder.",
+        EmbeddedCodeUnsupportedReason.LexerAction => "Lexer actions are not prepared by the expression registry builder.",
+        EmbeddedCodeUnsupportedReason.LexerPredicate => "Lexer predicates are not prepared by the expression registry builder.",
+        EmbeddedCodeUnsupportedReason.UnsupportedEmbeddedCodeKind => "This embedded-code kind is not prepared by the expression registry builder.",
+        EmbeddedCodeUnsupportedReason.MissingRuntimeIndex => "The embedded code is missing runtime dispatch indexes required by the expression registry builder.",
+        EmbeddedCodeUnsupportedReason.UnsupportedRuntimeShape => "The embedded code appears in a runtime shape that is not prepared by the expression registry builder.",
+        _ => "The embedded code is not prepared by the expression registry builder."
+    };
 }

--- a/Utils.Parser.Expressions/README.md
+++ b/Utils.Parser.Expressions/README.md
@@ -164,3 +164,9 @@ The target model remains to prepare executable artifacts before parsing and then
 - Runtime exceptions from a prepared action are converted to `ParserActionExecutionOutcome.NotExecuted` with `UP1026` metadata when the artifact is executed explicitly.
 
 Lexer actions, lexer predicates, grammar members, `@init`, and `@after` execution are not implemented by this package.
+### Shared runtime indexing metadata
+
+Parser embedded-code discovery now has a shared metadata model in `Utils.Parser.EmbeddedCode`. `EmbeddedCodeRuntimeDiscovery` walks a `ParserDefinition` and emits `EmbeddedCodeRuntimeEntry` values with the raw source, `EmbeddedCodeKind`, owning rule name, runtime-compatible alternative and element indexes, a runtime key for executable entries, and an explicit `EmbeddedCodeUnsupportedReason` for skipped entries. The metadata mirrors the existing parser runtime indexing rules for priority-ordered alternatives, single-item alternatives, sequences, quantifier inner parsing, negation probes, and direct-left-recursive base/tail alternatives. It is metadata only: it does not compile source, generate C#, execute actions, or change `ParserEngine` behavior.
+
+The expression-backed prepared registry consumes this shared discovery result before invoking its preparer. Unsupported constructs such as grammar actions, `@init`, `@after`, lexer actions/predicates, and non-inline parser actions remain non-executable, but they now carry explicit skip reasons. Invalid C# in a source-generator-supported hook remains a Roslyn compilation error rather than a custom parser diagnostic.
+

--- a/Utils.Parser.Generators/README.md
+++ b/Utils.Parser.Generators/README.md
@@ -185,3 +185,10 @@ A : 'a' ;
 ```
 
 The generated class exposes `CreateRuntimePolicy(ParserRuntimeFeaturePolicy? basePolicy = null)` and `ParseWithEmbeddedCode(string input)` for explicit opt-in execution. The existing generated `Parse(string input)` helper continues to use the default conservative runtime policy and does not execute generated embedded-code hooks. Action code can call members supplied by another declaration of the generated partial class. Invalid embedded C# is reported as a normal C# compilation error. Hook dispatch keys are aligned with the runtime `ParserEngine` indexes for single-item alternatives, sequences, quantified content, negation predicate probes, equal source text in multiple alternatives, and direct-left-recursive tail views because generated helpers resolve the generated definition before parsing with the generated policy. Lexer actions, lexer predicates, grammar actions, `@members`, `@init`, and `@after` are not executed by this support.
+
+## Shared runtime metadata alignment
+
+Generated C# hooks for parser semantic predicates and inline parser actions continue to be collected from the generator's `G4Grammar` AST because the analyzer package targets `netstandard2.0` and does not reference the `net8.0` runtime model assembly. The hook collector is intentionally kept aligned with `Utils.Parser.EmbeddedCode.EmbeddedCodeRuntimeDiscovery`: it uses the same runtime index rules for priority-ordered alternatives, single-item alternatives, sequences, quantifier inner parsing, negation probes, duplicate source text, and direct-left-recursive base/tail alternatives. Unit tests compare generated hook names against shared `ParserDefinition` discovery metadata for sensitive dispatch cases.
+
+Unsupported constructs are not promoted to executable generated hooks. Invalid C# inside a supported hook remains a Roslyn compilation error. This alignment does not add new supported C# constructs and does not change `ParserEngine` or the default `Parse(...)` behavior.
+

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeKind.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeKind.cs
@@ -17,6 +17,12 @@ public enum EmbeddedCodeKind
     /// <summary>Rule finalization action source from a rule prequel construct such as <c>@after { }</c>.</summary>
     RuleAfterAction,
 
-    /// <summary>Grammar-level action source from a prequel construct such as <c>@members { }</c>.</summary>
-    GrammarAction
+    /// <summary>Grammar-level action source from a prequel construct such as <c>@members</c>.</summary>
+    GrammarAction,
+
+    /// <summary>Opaque lexer action source from a lexer rule alternative.</summary>
+    LexerAction,
+
+    /// <summary>Lexer predicate source from a lexer rule alternative.</summary>
+    LexerPredicate
 }

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeDiscovery.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeDiscovery.cs
@@ -1,0 +1,332 @@
+using Utils.Parser.Model;
+
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Discovers embedded-code items from a resolved parser definition using indexes compatible with parser runtime contexts.
+/// </summary>
+public static class EmbeddedCodeRuntimeDiscovery
+{
+    /// <summary>
+    /// Discovers embedded-code entries from the supplied parser definition.
+    /// </summary>
+    /// <param name="definition">Parser definition to inspect without modification.</param>
+    /// <returns>Discovery entries in deterministic traversal order.</returns>
+    public static EmbeddedCodeRuntimeDiscoveryResult Discover(ParserDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var entries = new List<EmbeddedCodeRuntimeEntry>();
+        foreach (var action in definition.Actions)
+        {
+            entries.Add(CreateUnsupported(action.RawCode, EmbeddedCodeKind.GrammarAction, null, null, null, EmbeddedCodeUnsupportedReason.GrammarAction));
+        }
+
+        foreach (var rule in definition.ParserRules)
+        {
+            DiscoverParserRule(definition, rule, entries);
+        }
+
+        foreach (var mode in definition.Modes)
+        {
+            foreach (var rule in mode.Rules)
+            {
+                DiscoverLexerRule(rule, entries);
+            }
+        }
+
+        return new EmbeddedCodeRuntimeDiscoveryResult(entries);
+    }
+
+    /// <summary>
+    /// Discovers embedded-code entries in a parser rule, including lifecycle actions and left-recursive metadata.
+    /// </summary>
+    /// <param name="definition">Owning parser definition.</param>
+    /// <param name="rule">Parser rule to inspect.</param>
+    /// <param name="entries">Destination entry list.</param>
+    private static void DiscoverParserRule(ParserDefinition definition, Rule rule, List<EmbeddedCodeRuntimeEntry> entries)
+    {
+        if (rule.InitAction is not null)
+        {
+            entries.Add(CreateUnsupported(rule.InitAction.RawCode, EmbeddedCodeKind.RuleInitAction, rule.Name, null, null, EmbeddedCodeUnsupportedReason.RuleInitAction));
+        }
+
+        if (definition.LeftRecursiveRules.TryGetValue(rule.Name, out var leftRecursiveInfo))
+        {
+            DiscoverLeftRecursiveRule(leftRecursiveInfo, entries);
+        }
+        else
+        {
+            DiscoverContent(rule.Name, rule.Content, null, null, entries);
+        }
+
+        if (rule.AfterAction is not null)
+        {
+            entries.Add(CreateUnsupported(rule.AfterAction.RawCode, EmbeddedCodeKind.RuleAfterAction, rule.Name, null, null, EmbeddedCodeUnsupportedReason.RuleAfterAction));
+        }
+    }
+
+    /// <summary>
+    /// Discovers embedded-code entries in a lexer rule as unsupported parser runtime hooks.
+    /// </summary>
+    /// <param name="rule">Lexer rule to inspect.</param>
+    /// <param name="entries">Destination entry list.</param>
+    private static void DiscoverLexerRule(Rule rule, List<EmbeddedCodeRuntimeEntry> entries)
+    {
+        DiscoverLexerContent(rule.Name, rule.Content, null, null, entries);
+    }
+
+    /// <summary>
+    /// Recursively discovers embedded-code entries from parser content using runtime-compatible indexes.
+    /// </summary>
+    /// <param name="ruleName">Owning parser rule name.</param>
+    /// <param name="content">Parser content to inspect.</param>
+    /// <param name="alternativeIndex">Current runtime alternative index.</param>
+    /// <param name="elementIndex">Current runtime element index.</param>
+    /// <param name="entries">Destination entry list.</param>
+    private static void DiscoverContent(string ruleName, RuleContent content, int? alternativeIndex, int? elementIndex, List<EmbeddedCodeRuntimeEntry> entries)
+    {
+        switch (content)
+        {
+            case Alternation alternation:
+                DiscoverAlternation(ruleName, alternation, entries);
+                break;
+            case Alternative alternative:
+                DiscoverContent(ruleName, alternative.Content, alternativeIndex, elementIndex, entries);
+                break;
+            case Sequence sequence:
+                DiscoverSequence(ruleName, sequence.Items, alternativeIndex, entries);
+                break;
+            case Quantifier quantifier:
+                DiscoverContent(ruleName, quantifier.Inner, alternativeIndex, alternativeIndex, entries);
+                break;
+            case Negation negation:
+                DiscoverContent(ruleName, negation.Inner, alternativeIndex, alternativeIndex, entries);
+                break;
+            case ValidatingPredicate predicate:
+                entries.Add(CreateExecutable(predicate.Code, EmbeddedCodeKind.SemanticPredicate, ruleName, alternativeIndex, elementIndex));
+                break;
+            case GatingPredicate predicate:
+                entries.Add(CreateUnsupported(predicate.Code, EmbeddedCodeKind.SemanticPredicate, ruleName, alternativeIndex, elementIndex, EmbeddedCodeUnsupportedReason.UnsupportedEmbeddedCodeKind));
+                break;
+            case EmbeddedAction action:
+                DiscoverParserAction(ruleName, action, alternativeIndex, elementIndex, entries);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Discovers embedded-code entries from an alternation in runtime priority order.
+    /// </summary>
+    /// <param name="ruleName">Owning parser rule name.</param>
+    /// <param name="alternation">Alternation to inspect.</param>
+    /// <param name="entries">Destination entry list.</param>
+    private static void DiscoverAlternation(string ruleName, Alternation alternation, List<EmbeddedCodeRuntimeEntry> entries)
+    {
+        var ordered = alternation.Alternatives.OrderBy(static alternative => alternative.Priority).ToList();
+        for (var index = 0; index < ordered.Count; index++)
+        {
+            DiscoverContent(ruleName, ordered[index].Content, index, null, entries);
+        }
+    }
+
+    /// <summary>
+    /// Discovers embedded-code entries from sequence items with zero-based runtime element indexes.
+    /// </summary>
+    /// <param name="ruleName">Owning parser rule name.</param>
+    /// <param name="items">Sequence items to inspect.</param>
+    /// <param name="alternativeIndex">Current runtime alternative index.</param>
+    /// <param name="entries">Destination entry list.</param>
+    private static void DiscoverSequence(string ruleName, IReadOnlyList<RuleContent> items, int? alternativeIndex, List<EmbeddedCodeRuntimeEntry> entries)
+    {
+        for (var index = 0; index < items.Count; index++)
+        {
+            DiscoverContent(ruleName, items[index], alternativeIndex, index, entries);
+        }
+    }
+
+    /// <summary>
+    /// Discovers entries from direct-left-recursive metadata after the resolver has split base and recursive alternatives.
+    /// </summary>
+    /// <param name="info">Left-recursive rule metadata.</param>
+    /// <param name="entries">Destination entry list.</param>
+    private static void DiscoverLeftRecursiveRule(LeftRecursiveRuleInfo info, List<EmbeddedCodeRuntimeEntry> entries)
+    {
+        var baseAlternatives = info.BaseAlternatives.OrderBy(static alternative => alternative.Priority).ToList();
+        for (var index = 0; index < baseAlternatives.Count; index++)
+        {
+            DiscoverContent(info.Rule.Name, baseAlternatives[index].Content, index, null, entries);
+        }
+
+        var recursiveAlternatives = info.RecursiveAlternatives.OrderBy(static alternative => alternative.Priority).ToList();
+        for (var index = 0; index < recursiveAlternatives.Count; index++)
+        {
+            var tailContent = RemoveLeadingSelfReference(info.Rule.Name, recursiveAlternatives[index].Content);
+            if (tailContent is not null)
+            {
+                DiscoverLeftRecursiveTail(info.Rule.Name, tailContent, index, entries);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Discovers entries from direct-left-recursive tail content after leading self-reference removal.
+    /// </summary>
+    /// <param name="ruleName">Owning left-recursive rule name.</param>
+    /// <param name="tailContent">Effective tail content used by runtime parsing.</param>
+    /// <param name="alternativeIndex">Runtime recursive alternative index.</param>
+    /// <param name="entries">Destination entry list.</param>
+    private static void DiscoverLeftRecursiveTail(string ruleName, RuleContent tailContent, int alternativeIndex, List<EmbeddedCodeRuntimeEntry> entries)
+    {
+        if (tailContent is Sequence sequence)
+        {
+            for (var index = 0; index < sequence.Items.Count; index++)
+            {
+                if (sequence.Items[index] is RuleRef ruleRef && string.Equals(ruleRef.RuleName, ruleName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                DiscoverContent(ruleName, sequence.Items[index], alternativeIndex, index, entries);
+            }
+
+            return;
+        }
+
+        DiscoverContent(ruleName, tailContent, alternativeIndex, alternativeIndex, entries);
+    }
+
+    /// <summary>
+    /// Discovers and classifies a parser action according to parser runtime hook support.
+    /// </summary>
+    /// <param name="ruleName">Owning parser rule name.</param>
+    /// <param name="action">Embedded parser action.</param>
+    /// <param name="alternativeIndex">Current runtime alternative index.</param>
+    /// <param name="elementIndex">Current runtime element index.</param>
+    /// <param name="entries">Destination entry list.</param>
+    private static void DiscoverParserAction(string ruleName, EmbeddedAction action, int? alternativeIndex, int? elementIndex, List<EmbeddedCodeRuntimeEntry> entries)
+    {
+        if (action.Context == ActionContext.Alternative && action.Position == ActionPosition.Inline)
+        {
+            entries.Add(CreateExecutable(action.RawCode, EmbeddedCodeKind.ParserInlineAction, ruleName, alternativeIndex, elementIndex));
+            return;
+        }
+
+        var reason = action.Context != ActionContext.Alternative
+            ? EmbeddedCodeUnsupportedReason.UnsupportedActionContext
+            : EmbeddedCodeUnsupportedReason.UnsupportedActionPosition;
+        entries.Add(CreateUnsupported(action.RawCode, EmbeddedCodeKind.ParserInlineAction, ruleName, alternativeIndex, elementIndex, reason));
+    }
+
+    /// <summary>
+    /// Recursively discovers lexer embedded code and classifies it as unsupported for parser runtime hooks.
+    /// </summary>
+    /// <param name="ruleName">Owning lexer rule name.</param>
+    /// <param name="content">Lexer content to inspect.</param>
+    /// <param name="alternativeIndex">Current local alternative index.</param>
+    /// <param name="elementIndex">Current local element index.</param>
+    /// <param name="entries">Destination entry list.</param>
+    private static void DiscoverLexerContent(string ruleName, RuleContent content, int? alternativeIndex, int? elementIndex, List<EmbeddedCodeRuntimeEntry> entries)
+    {
+        switch (content)
+        {
+            case Alternation alternation:
+                var ordered = alternation.Alternatives.OrderBy(static alternative => alternative.Priority).ToList();
+                for (var index = 0; index < ordered.Count; index++)
+                {
+                    DiscoverLexerContent(ruleName, ordered[index].Content, index, null, entries);
+                }
+                break;
+            case Alternative alternative:
+                DiscoverLexerContent(ruleName, alternative.Content, alternativeIndex, elementIndex, entries);
+                break;
+            case Sequence sequence:
+                for (var index = 0; index < sequence.Items.Count; index++)
+                {
+                    DiscoverLexerContent(ruleName, sequence.Items[index], alternativeIndex, index, entries);
+                }
+                break;
+            case Quantifier quantifier:
+                DiscoverLexerContent(ruleName, quantifier.Inner, alternativeIndex, alternativeIndex, entries);
+                break;
+            case Negation negation:
+                DiscoverLexerContent(ruleName, negation.Inner, alternativeIndex, alternativeIndex, entries);
+                break;
+            case ValidatingPredicate predicate:
+                entries.Add(CreateUnsupported(predicate.Code, EmbeddedCodeKind.LexerPredicate, ruleName, alternativeIndex, elementIndex, EmbeddedCodeUnsupportedReason.LexerPredicate));
+                break;
+            case GatingPredicate predicate:
+                entries.Add(CreateUnsupported(predicate.Code, EmbeddedCodeKind.LexerPredicate, ruleName, alternativeIndex, elementIndex, EmbeddedCodeUnsupportedReason.LexerPredicate));
+                break;
+            case EmbeddedAction action:
+                entries.Add(CreateUnsupported(action.RawCode, EmbeddedCodeKind.LexerAction, ruleName, alternativeIndex, elementIndex, EmbeddedCodeUnsupportedReason.LexerAction));
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Removes a leading direct self-reference from left-recursive alternatives.
+    /// </summary>
+    /// <param name="ruleName">Name of the left-recursive rule.</param>
+    /// <param name="content">Recursive alternative content.</param>
+    /// <returns>The effective tail content, or <c>null</c> when no leading self-reference exists.</returns>
+    private static RuleContent? RemoveLeadingSelfReference(string ruleName, RuleContent content)
+    {
+        switch (content)
+        {
+            case RuleRef ruleRef when string.Equals(ruleRef.RuleName, ruleName, StringComparison.Ordinal):
+                return new Sequence([]);
+            case Sequence sequence when sequence.Items.Count > 0:
+                return TryRemoveLeadingSelfReference(ruleName, sequence);
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Removes a leading self-reference from a sequence when present.
+    /// </summary>
+    /// <param name="ruleName">Name of the left-recursive rule.</param>
+    /// <param name="sequence">Sequence to inspect.</param>
+    /// <returns>The sequence tail, or <c>null</c> when the sequence does not start with the rule.</returns>
+    private static RuleContent? TryRemoveLeadingSelfReference(string ruleName, Sequence sequence)
+    {
+        if (sequence.Items[0] is RuleRef leading && string.Equals(leading.RuleName, ruleName, StringComparison.Ordinal))
+        {
+            return new Sequence(sequence.Items.Skip(1).ToList());
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Creates an executable runtime entry.
+    /// </summary>
+    /// <param name="sourceText">Raw embedded-code source text.</param>
+    /// <param name="kind">Embedded-code kind.</param>
+    /// <param name="ruleName">Owning parser rule name.</param>
+    /// <param name="alternativeIndex">Runtime alternative index.</param>
+    /// <param name="elementIndex">Runtime element index.</param>
+    /// <returns>An executable runtime discovery entry.</returns>
+    private static EmbeddedCodeRuntimeEntry CreateExecutable(string sourceText, EmbeddedCodeKind kind, string ruleName, int? alternativeIndex, int? elementIndex) =>
+        new(new EmbeddedCodeSource(sourceText, kind, ruleName, alternativeIndex, elementIndex), true);
+
+    /// <summary>
+    /// Creates an unsupported runtime entry.
+    /// </summary>
+    /// <param name="sourceText">Raw embedded-code source text.</param>
+    /// <param name="kind">Embedded-code kind.</param>
+    /// <param name="ruleName">Optional owning rule name.</param>
+    /// <param name="alternativeIndex">Optional runtime alternative index.</param>
+    /// <param name="elementIndex">Optional runtime element index.</param>
+    /// <param name="reason">Unsupported reason.</param>
+    /// <returns>An unsupported runtime discovery entry.</returns>
+    private static EmbeddedCodeRuntimeEntry CreateUnsupported(
+        string sourceText,
+        EmbeddedCodeKind kind,
+        string? ruleName,
+        int? alternativeIndex,
+        int? elementIndex,
+        EmbeddedCodeUnsupportedReason reason) =>
+        new(new EmbeddedCodeSource(sourceText, kind, ruleName, alternativeIndex, elementIndex), false, reason);
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeDiscoveryResult.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeDiscoveryResult.cs
@@ -1,0 +1,27 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Contains embedded-code runtime discovery entries and filtered views for executable and unsupported items.
+/// </summary>
+public sealed record EmbeddedCodeRuntimeDiscoveryResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmbeddedCodeRuntimeDiscoveryResult"/> record.
+    /// </summary>
+    /// <param name="entries">All discovery entries in deterministic traversal order.</param>
+    public EmbeddedCodeRuntimeDiscoveryResult(IReadOnlyList<EmbeddedCodeRuntimeEntry> entries)
+    {
+        Entries = entries?.ToArray() ?? throw new ArgumentNullException(nameof(entries));
+        ExecutableEntries = Entries.Where(static entry => entry.IsRuntimeExecutable).ToArray();
+        UnsupportedEntries = Entries.Where(static entry => !entry.IsRuntimeExecutable).ToArray();
+    }
+
+    /// <summary>Gets all discovery entries in deterministic traversal order.</summary>
+    public IReadOnlyList<EmbeddedCodeRuntimeEntry> Entries { get; }
+
+    /// <summary>Gets entries that are executable by parser runtime hooks.</summary>
+    public IReadOnlyList<EmbeddedCodeRuntimeEntry> ExecutableEntries { get; }
+
+    /// <summary>Gets entries that were discovered but are outside parser runtime hook support.</summary>
+    public IReadOnlyList<EmbeddedCodeRuntimeEntry> UnsupportedEntries { get; }
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeEntry.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeEntry.cs
@@ -1,0 +1,48 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Describes one embedded-code item discovered with parser-runtime-compatible indexing metadata.
+/// </summary>
+public sealed record EmbeddedCodeRuntimeEntry
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmbeddedCodeRuntimeEntry"/> record.
+    /// </summary>
+    /// <param name="source">Raw source metadata, including runtime-compatible indexes when available.</param>
+    /// <param name="isRuntimeExecutable">Whether the embedded-code item is executable by parser runtime hooks.</param>
+    /// <param name="unsupportedReason">Reason why the item is not executable, or <c>null</c>/<see cref="EmbeddedCodeUnsupportedReason.None"/> when executable.</param>
+    public EmbeddedCodeRuntimeEntry(
+        EmbeddedCodeSource source,
+        bool isRuntimeExecutable,
+        EmbeddedCodeUnsupportedReason? unsupportedReason = null)
+    {
+        Source = source ?? throw new ArgumentNullException(nameof(source));
+        IsRuntimeExecutable = isRuntimeExecutable;
+        UnsupportedReason = isRuntimeExecutable ? EmbeddedCodeUnsupportedReason.None : unsupportedReason ?? EmbeddedCodeUnsupportedReason.UnsupportedEmbeddedCodeKind;
+        RuntimeKey = isRuntimeExecutable ? EmbeddedCodeRuntimeKey.FromSource(source) : null;
+    }
+
+    /// <summary>Gets the raw source metadata, including runtime-compatible indexes when available.</summary>
+    public EmbeddedCodeSource Source { get; }
+
+    /// <summary>Gets the embedded-code kind.</summary>
+    public EmbeddedCodeKind Kind => Source.Kind;
+
+    /// <summary>Gets the optional owning parser rule name.</summary>
+    public string? RuleName => Source.RuleName;
+
+    /// <summary>Gets the optional runtime alternative index.</summary>
+    public int? AlternativeIndex => Source.AlternativeIndex;
+
+    /// <summary>Gets the optional runtime element index.</summary>
+    public int? ElementIndex => Source.ElementIndex;
+
+    /// <summary>Gets parser-runtime dispatch metadata for executable entries.</summary>
+    public EmbeddedCodeRuntimeKey? RuntimeKey { get; }
+
+    /// <summary>Gets a value indicating whether the embedded-code item is executable by parser runtime hooks.</summary>
+    public bool IsRuntimeExecutable { get; }
+
+    /// <summary>Gets the unsupported reason for skipped entries, or <see cref="EmbeddedCodeUnsupportedReason.None"/> for executable entries.</summary>
+    public EmbeddedCodeUnsupportedReason UnsupportedReason { get; }
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeKey.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeKey.cs
@@ -1,0 +1,63 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Describes the runtime dispatch identity shared by parser embedded-code execution paths.
+/// </summary>
+public sealed record EmbeddedCodeRuntimeKey
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmbeddedCodeRuntimeKey"/> record.
+    /// </summary>
+    /// <param name="kind">Embedded-code kind used by runtime dispatch.</param>
+    /// <param name="ruleName">Owning parser rule name.</param>
+    /// <param name="sourceText">Raw embedded-code source text.</param>
+    /// <param name="alternativeIndex">Optional runtime alternative index.</param>
+    /// <param name="elementIndex">Optional runtime element index.</param>
+    public EmbeddedCodeRuntimeKey(
+        EmbeddedCodeKind kind,
+        string ruleName,
+        string sourceText,
+        int? alternativeIndex,
+        int? elementIndex)
+    {
+        ArgumentNullException.ThrowIfNull(ruleName);
+        ArgumentNullException.ThrowIfNull(sourceText);
+
+        Kind = kind;
+        RuleName = ruleName;
+        SourceText = sourceText;
+        AlternativeIndex = alternativeIndex;
+        ElementIndex = elementIndex;
+    }
+
+    /// <summary>Gets the embedded-code kind used by runtime dispatch.</summary>
+    public EmbeddedCodeKind Kind { get; }
+
+    /// <summary>Gets the owning parser rule name.</summary>
+    public string RuleName { get; }
+
+    /// <summary>Gets the raw embedded-code source text.</summary>
+    public string SourceText { get; }
+
+    /// <summary>Gets the optional runtime alternative index.</summary>
+    public int? AlternativeIndex { get; }
+
+    /// <summary>Gets the optional runtime element index.</summary>
+    public int? ElementIndex { get; }
+
+    /// <summary>
+    /// Creates a runtime key from source metadata when it has an owning parser rule.
+    /// </summary>
+    /// <param name="source">Embedded-code source metadata.</param>
+    /// <returns>A runtime key for executable parser embedded code.</returns>
+    public static EmbeddedCodeRuntimeKey FromSource(EmbeddedCodeSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (source.RuleName is null)
+        {
+            throw new ArgumentException("Runtime embedded-code keys require an owning parser rule.", nameof(source));
+        }
+
+        return new EmbeddedCodeRuntimeKey(source.Kind, source.RuleName, source.SourceText, source.AlternativeIndex, source.ElementIndex);
+    }
+}

--- a/Utils.Parser/EmbeddedCode/EmbeddedCodeUnsupportedReason.cs
+++ b/Utils.Parser/EmbeddedCode/EmbeddedCodeUnsupportedReason.cs
@@ -1,0 +1,43 @@
+namespace Utils.Parser.EmbeddedCode;
+
+/// <summary>
+/// Identifies why an embedded-code item is outside a runtime execution path's supported scope.
+/// </summary>
+public enum EmbeddedCodeUnsupportedReason
+{
+    /// <summary>The embedded code is supported by the selected runtime path.</summary>
+    None,
+
+    /// <summary>The embedded code is a grammar-level action such as <c>@members</c>.</summary>
+    GrammarAction,
+
+    /// <summary>The embedded code is a rule initialization action such as <c>@init</c>.</summary>
+    RuleInitAction,
+
+    /// <summary>The embedded code is a rule finalization action such as <c>@after</c>.</summary>
+    RuleAfterAction,
+
+    /// <summary>The embedded code is an opaque lexer action and is not executed by parser runtime hooks.</summary>
+    LexerAction,
+
+    /// <summary>The embedded code is a lexer predicate and is not executed by parser runtime hooks.</summary>
+    LexerPredicate,
+
+    /// <summary>The embedded code is a parser action that is not declared inline inside an alternative.</summary>
+    NonInlineParserAction,
+
+    /// <summary>The embedded action context is not supported by the selected runtime path.</summary>
+    UnsupportedActionContext,
+
+    /// <summary>The embedded action position is not supported by the selected runtime path.</summary>
+    UnsupportedActionPosition,
+
+    /// <summary>The embedded-code kind is not supported by the selected runtime path.</summary>
+    UnsupportedEmbeddedCodeKind,
+
+    /// <summary>The runtime alternative or element index required for dispatch could not be determined.</summary>
+    MissingRuntimeIndex,
+
+    /// <summary>The containing runtime shape cannot be mapped safely to parser dispatch metadata.</summary>
+    UnsupportedRuntimeShape
+}

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -67,6 +67,7 @@ Current capabilities and responsibilities:
 - `ActiveParseState` provides local descriptive branch state.
 - `ParserLookaheadProbe` and `ParserLookaheadCache` provide conservative shallow lookahead.
 - Runtime feature policies are present.
+- Shared embedded-code runtime discovery metadata is present for parser semantic predicates and inline parser actions, including explicit unsupported reasons for out-of-scope embedded code.
 - Passive runtime observation hooks are available via policy configuration and remain non-authoritative.
 - Semantic predicate evaluator abstraction is present.
 - Runtime expression-backed semantic predicate evaluator is available as an explicit optional adapter without changing default parser behavior.

--- a/UtilsTest/Parser/Antlr4GeneratedEmbeddedCodeTests.cs
+++ b/UtilsTest/Parser/Antlr4GeneratedEmbeddedCodeTests.cs
@@ -3,7 +3,9 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;
 using System.Runtime.Loader;
+using Utils.Parser.EmbeddedCode;
 using Utils.Parser.Generators.Internal;
+using Utils.Parser.Model;
 using Utils.Parser.Runtime;
 
 namespace UtilsTest.Parser;
@@ -520,6 +522,40 @@ public class Antlr4GeneratedEmbeddedCodeTests
 
         Assert.IsTrue(result.Diagnostics.Any(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
         Assert.IsTrue(result.Diagnostics.Any(static diagnostic => diagnostic.ToString().Contains("not", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// Ensures generated hook dispatch metadata remains aligned with shared ParserDefinition runtime discovery metadata.
+    /// </summary>
+    [TestMethod]
+    public void Emit_InlineActionHook_UsesSharedRuntimeDiscoveryIndexes()
+    {
+        const string grammar = """
+            grammar P;
+            start : A ({ OnAction(context); } B)* ;
+            A : 'a' ;
+            B : 'b' ;
+            """;
+        var action = new EmbeddedAction("OnAction(context);", ActionContext.Alternative, ActionPosition.Inline, []);
+        var parserRule = new Rule(
+            "start",
+            0,
+            false,
+            new Alternation([new Alternative(0, Associativity.Left, new Sequence([
+                new RuleRef("A"),
+                new Quantifier(new Sequence([action, new RuleRef("B")]), 0, null)
+            ]))]),
+            Kind: RuleKind.Parser);
+        var definition = new ParserDefinition("P", GrammarType.Combined, null, [], [], [], [parserRule], parserRule);
+
+        var entry = EmbeddedCodeRuntimeDiscovery.Discover(definition).ExecutableEntries.Single();
+        string generatedSource = Emit(grammar);
+        string expectedHookName = $"__Action_{entry.RuleName}_{entry.AlternativeIndex}_{entry.ElementIndex}_0";
+
+        Assert.AreEqual(EmbeddedCodeKind.ParserInlineAction, entry.Kind);
+        Assert.AreEqual(0, entry.AlternativeIndex);
+        Assert.AreEqual(0, entry.ElementIndex);
+        StringAssert.Contains(generatedSource, expectedHookName);
     }
 
     /// <summary>

--- a/UtilsTest/Parser/EmbeddedCodeRuntimeDiscoveryTests.cs
+++ b/UtilsTest/Parser/EmbeddedCodeRuntimeDiscoveryTests.cs
@@ -1,0 +1,281 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.EmbeddedCode;
+using Utils.Parser.Model;
+
+namespace UtilsTest.Parser;
+
+/// <summary>
+/// Validates shared embedded-code runtime discovery metadata used by parser execution paths.
+/// </summary>
+[TestClass]
+public class EmbeddedCodeRuntimeDiscoveryTests
+{
+    /// <summary>
+    /// Verifies that validating predicates receive parser runtime rule, alternative, and element indexes.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenValidatingPredicateExists_ReturnsExecutableRuntimeEntry()
+    {
+        var predicate = new ValidatingPredicate("inputPosition == 0");
+        var rule = CreateParserRule("start", new Sequence([predicate]));
+
+        var entry = DiscoverSingle(CreateDefinition(rule));
+
+        AssertExecutable(entry, EmbeddedCodeKind.SemanticPredicate, "start", "inputPosition == 0", 0, 0);
+    }
+
+    /// <summary>
+    /// Verifies that inline parser actions receive parser runtime rule, alternative, and element indexes.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenInlineParserActionExists_ReturnsExecutableRuntimeEntry()
+    {
+        var action = new EmbeddedAction("record();", ActionContext.Alternative, ActionPosition.Inline, []);
+        var rule = CreateParserRule("start", new Sequence([new LiteralMatch("a"), action]));
+
+        var entry = DiscoverSingle(CreateDefinition(rule));
+
+        AssertExecutable(entry, EmbeddedCodeKind.ParserInlineAction, "start", "record();", 0, 1);
+    }
+
+    /// <summary>
+    /// Verifies that single-item alternatives keep an unavailable element index, matching runtime dispatch.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenAlternativeHasSingleItem_UsesUnavailableElementIndex()
+    {
+        var action = new EmbeddedAction("single();", ActionContext.Alternative, ActionPosition.Inline, []);
+        var rule = CreateParserRule("start", new Alternation([new Alternative(0, Associativity.Left, action)]));
+
+        var entry = DiscoverSingle(CreateDefinition(rule));
+
+        AssertExecutable(entry, EmbeddedCodeKind.ParserInlineAction, "start", "single();", 0, null);
+    }
+
+    /// <summary>
+    /// Verifies that sequence items use zero-based runtime element indexes.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenActionIsInSequence_UsesSequenceElementIndex()
+    {
+        var action = new EmbeddedAction("sequence();", ActionContext.Alternative, ActionPosition.Inline, []);
+        var rule = CreateParserRule("start", new Sequence([new LiteralMatch("a"), action, new LiteralMatch("b")]));
+
+        var entry = DiscoverSingle(CreateDefinition(rule));
+
+        AssertExecutable(entry, EmbeddedCodeKind.ParserInlineAction, "start", "sequence();", 0, 1);
+    }
+
+    /// <summary>
+    /// Verifies that quantified content uses the runtime inner element index strategy.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenPredicateIsInsideQuantifier_UsesRuntimeInnerIndex()
+    {
+        var predicate = new ValidatingPredicate("insideQuantifier");
+        var rule = CreateParserRule("start", new Sequence([new LiteralMatch("a"), new Quantifier(predicate, 0, null)]));
+
+        var entry = DiscoverSingle(CreateDefinition(rule));
+
+        AssertExecutable(entry, EmbeddedCodeKind.SemanticPredicate, "start", "insideQuantifier", 0, 0);
+    }
+
+    /// <summary>
+    /// Verifies that negation probes use the runtime inner element index strategy.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenPredicateIsInsideNegation_UsesRuntimeProbeIndex()
+    {
+        var predicate = new ValidatingPredicate("insideNegation");
+        var rule = CreateParserRule("start", new Sequence([new LiteralMatch("a"), new Negation(predicate)]));
+
+        var entry = DiscoverSingle(CreateDefinition(rule));
+
+        AssertExecutable(entry, EmbeddedCodeKind.SemanticPredicate, "start", "insideNegation", 0, 0);
+    }
+
+    /// <summary>
+    /// Verifies that direct-left-recursive base alternatives are re-indexed after recursive alternatives are split out.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenLeftRecursiveBaseFollowsRecursiveAlternative_UsesResolvedBaseIndex()
+    {
+        var predicate = new ValidatingPredicate("base");
+        var recursiveAlternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("expr"), new LiteralMatch("+"), new RuleRef("expr")]));
+        var baseAlternative = new Alternative(1, Associativity.Left, new Sequence([predicate, new LiteralMatch("id")]));
+        var rule = CreateParserRule("expr", new Alternation([recursiveAlternative, baseAlternative]));
+        var definition = CreateDefinition(rule, leftRecursiveRules: new Dictionary<string, LeftRecursiveRuleInfo>
+        {
+            [rule.Name] = new LeftRecursiveRuleInfo
+            {
+                Rule = rule,
+                BaseAlternatives = [baseAlternative],
+                RecursiveAlternatives = [recursiveAlternative]
+            }
+        });
+
+        var entry = DiscoverSingle(definition);
+
+        AssertExecutable(entry, EmbeddedCodeKind.SemanticPredicate, "expr", "base", 0, 0);
+    }
+
+    /// <summary>
+    /// Verifies that direct-left-recursive tail indexing uses the effective tail after self-reference removal.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenActionIsInLeftRecursiveTail_UsesTailElementIndex()
+    {
+        var action = new EmbeddedAction("tail();", ActionContext.Alternative, ActionPosition.Inline, []);
+        var baseAlternative = new Alternative(0, Associativity.Left, new Sequence([new LiteralMatch("id")]));
+        var recursiveAlternative = new Alternative(1, Associativity.Left, new Sequence([new RuleRef("expr"), new LiteralMatch("+"), action, new RuleRef("expr")]));
+        var rule = CreateParserRule("expr", new Alternation([baseAlternative, recursiveAlternative]));
+        var definition = CreateDefinition(rule, leftRecursiveRules: new Dictionary<string, LeftRecursiveRuleInfo>
+        {
+            [rule.Name] = new LeftRecursiveRuleInfo
+            {
+                Rule = rule,
+                BaseAlternatives = [baseAlternative],
+                RecursiveAlternatives = [recursiveAlternative]
+            }
+        });
+
+        var entry = DiscoverSingle(definition);
+
+        AssertExecutable(entry, EmbeddedCodeKind.ParserInlineAction, "expr", "tail();", 0, 1);
+    }
+
+    /// <summary>
+    /// Verifies that duplicate source text in different alternatives remains represented as distinct runtime entries.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenSourceTextIsDuplicated_ReturnsDistinctRuntimeEntries()
+    {
+        var rule = CreateParserRule(
+            "start",
+            new Alternation([
+                new Alternative(0, Associativity.Left, new Sequence([new ValidatingPredicate("same")])),
+                new Alternative(1, Associativity.Left, new Sequence([new ValidatingPredicate("same")]))
+            ]));
+
+        var entries = EmbeddedCodeRuntimeDiscovery.Discover(CreateDefinition(rule)).ExecutableEntries;
+
+        Assert.AreEqual(2, entries.Count);
+        Assert.AreEqual(0, entries[0].AlternativeIndex);
+        Assert.AreEqual(1, entries[1].AlternativeIndex);
+        Assert.AreEqual("same", entries[0].Source.SourceText);
+        Assert.AreEqual("same", entries[1].Source.SourceText);
+    }
+
+    /// <summary>
+    /// Verifies that unsupported embedded-code scopes expose explicit common reasons.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenUnsupportedConstructsExist_ReturnsExplicitReasons()
+    {
+        var init = new EmbeddedAction("init", ActionContext.Rule, ActionPosition.Before, []);
+        var after = new EmbeddedAction("after", ActionContext.Rule, ActionPosition.After, []);
+        var nonInline = new EmbeddedAction("before", ActionContext.Alternative, ActionPosition.Before, []);
+        var parserRule = CreateParserRule("start", new Sequence([nonInline]), init, after);
+        var lexerAction = new EmbeddedAction("lexer", ActionContext.Alternative, ActionPosition.Inline, []);
+        var lexerPredicate = new ValidatingPredicate("lexerPredicate");
+        var lexerRule = CreateLexerRule("A", new Sequence([lexerAction, lexerPredicate]));
+        var grammarAction = new GrammarAction("members", "int value;");
+
+        var unsupported = EmbeddedCodeRuntimeDiscovery.Discover(CreateDefinition(parserRule, [grammarAction], [lexerRule])).UnsupportedEntries;
+
+        CollectionAssert.AreEquivalent(
+            new object[]
+            {
+                EmbeddedCodeUnsupportedReason.GrammarAction,
+                EmbeddedCodeUnsupportedReason.RuleInitAction,
+                EmbeddedCodeUnsupportedReason.UnsupportedActionPosition,
+                EmbeddedCodeUnsupportedReason.RuleAfterAction,
+                EmbeddedCodeUnsupportedReason.LexerAction,
+                EmbeddedCodeUnsupportedReason.LexerPredicate
+            },
+            unsupported.Select(static entry => (object)entry.UnsupportedReason).ToArray());
+    }
+
+    /// <summary>
+    /// Returns the single discovered executable entry for a test definition.
+    /// </summary>
+    /// <param name="definition">Parser definition to inspect.</param>
+    /// <returns>The only executable discovery entry.</returns>
+    private static EmbeddedCodeRuntimeEntry DiscoverSingle(ParserDefinition definition) =>
+        EmbeddedCodeRuntimeDiscovery.Discover(definition).ExecutableEntries.Single();
+
+    /// <summary>
+    /// Asserts the common executable runtime metadata for an entry.
+    /// </summary>
+    /// <param name="entry">Entry to inspect.</param>
+    /// <param name="kind">Expected embedded-code kind.</param>
+    /// <param name="ruleName">Expected rule name.</param>
+    /// <param name="sourceText">Expected source text.</param>
+    /// <param name="alternativeIndex">Expected alternative index.</param>
+    /// <param name="elementIndex">Expected element index.</param>
+    private static void AssertExecutable(EmbeddedCodeRuntimeEntry entry, EmbeddedCodeKind kind, string ruleName, string sourceText, int? alternativeIndex, int? elementIndex)
+    {
+        Assert.IsTrue(entry.IsRuntimeExecutable);
+        Assert.AreEqual(EmbeddedCodeUnsupportedReason.None, entry.UnsupportedReason);
+        Assert.AreEqual(kind, entry.Kind);
+        Assert.AreEqual(ruleName, entry.RuleName);
+        Assert.AreEqual(sourceText, entry.Source.SourceText);
+        Assert.AreEqual(alternativeIndex, entry.AlternativeIndex);
+        Assert.AreEqual(elementIndex, entry.ElementIndex);
+        Assert.IsNotNull(entry.RuntimeKey);
+        Assert.AreEqual(kind, entry.RuntimeKey.Kind);
+        Assert.AreEqual(ruleName, entry.RuntimeKey.RuleName);
+    }
+
+    /// <summary>
+    /// Creates a parser definition for discovery tests.
+    /// </summary>
+    /// <param name="parserRule">Parser rule to include.</param>
+    /// <param name="actions">Optional grammar-level actions.</param>
+    /// <param name="lexerRules">Optional lexer rules.</param>
+    /// <param name="leftRecursiveRules">Optional left-recursive rule metadata.</param>
+    /// <returns>A parser definition containing supplied metadata.</returns>
+    private static ParserDefinition CreateDefinition(
+        Rule parserRule,
+        IReadOnlyList<GrammarAction>? actions = null,
+        IReadOnlyList<Rule>? lexerRules = null,
+        IReadOnlyDictionary<string, LeftRecursiveRuleInfo>? leftRecursiveRules = null) =>
+        new ParserDefinition(
+            "G",
+            GrammarType.Combined,
+            null,
+            actions ?? [],
+            [],
+            lexerRules is null ? [] : [new LexerMode("DEFAULT_MODE", lexerRules)],
+            [parserRule],
+            parserRule)
+        {
+            LeftRecursiveRules = leftRecursiveRules ?? new Dictionary<string, LeftRecursiveRuleInfo>()
+        };
+
+    /// <summary>
+    /// Creates a parser rule around supplied content.
+    /// </summary>
+    /// <param name="name">Rule name.</param>
+    /// <param name="content">Rule content or full alternation.</param>
+    /// <param name="initAction">Optional rule initialization action.</param>
+    /// <param name="afterAction">Optional rule finalization action.</param>
+    /// <returns>A parser rule.</returns>
+    private static Rule CreateParserRule(string name, RuleContent content, EmbeddedAction? initAction = null, EmbeddedAction? afterAction = null)
+    {
+        var alternation = content as Alternation ?? new Alternation([new Alternative(0, Associativity.Left, content)]);
+        return new Rule(name, 0, false, alternation, InitAction: initAction, AfterAction: afterAction, Kind: RuleKind.Parser);
+    }
+
+    /// <summary>
+    /// Creates a lexer rule around supplied content.
+    /// </summary>
+    /// <param name="name">Rule name.</param>
+    /// <param name="content">Rule content or full alternation.</param>
+    /// <returns>A lexer rule.</returns>
+    private static Rule CreateLexerRule(string name, RuleContent content)
+    {
+        var alternation = content as Alternation ?? new Alternation([new Alternative(0, Associativity.Left, content)]);
+        return new Rule(name, 0, false, alternation, Kind: RuleKind.Lexer);
+    }
+}

--- a/UtilsTest/Parser/PreparedExpressionEmbeddedCodeRegistryBuilderTests.cs
+++ b/UtilsTest/Parser/PreparedExpressionEmbeddedCodeRegistryBuilderTests.cs
@@ -218,10 +218,10 @@ public class PreparedExpressionEmbeddedCodeRegistryBuilderTests
         Assert.AreEqual(4, result.SkippedEntries.Count);
         Assert.AreEqual(0, preparer.SemanticPredicateCalls.Count);
         Assert.AreEqual(0, preparer.ParserActionCalls.Count);
-        Assert.IsTrue(result.SkippedEntries.Any(static entry => entry.Source.Kind == EmbeddedCodeKind.GrammarAction));
-        Assert.IsTrue(result.SkippedEntries.Any(static entry => entry.Source.Kind == EmbeddedCodeKind.RuleInitAction));
-        Assert.IsTrue(result.SkippedEntries.Any(static entry => entry.Source.Kind == EmbeddedCodeKind.RuleAfterAction));
-        Assert.IsTrue(result.SkippedEntries.Any(static entry => entry.Source.Kind == EmbeddedCodeKind.ParserInlineAction));
+        Assert.IsTrue(result.SkippedEntries.Any(static entry => entry.Source.Kind == EmbeddedCodeKind.GrammarAction && entry.UnsupportedReason == EmbeddedCodeUnsupportedReason.GrammarAction));
+        Assert.IsTrue(result.SkippedEntries.Any(static entry => entry.Source.Kind == EmbeddedCodeKind.RuleInitAction && entry.UnsupportedReason == EmbeddedCodeUnsupportedReason.RuleInitAction));
+        Assert.IsTrue(result.SkippedEntries.Any(static entry => entry.Source.Kind == EmbeddedCodeKind.RuleAfterAction && entry.UnsupportedReason == EmbeddedCodeUnsupportedReason.RuleAfterAction));
+        Assert.IsTrue(result.SkippedEntries.Any(static entry => entry.Source.Kind == EmbeddedCodeKind.ParserInlineAction && entry.UnsupportedReason == EmbeddedCodeUnsupportedReason.UnsupportedActionPosition));
     }
 
     /// <summary>

--- a/docs/parser/ANTLRCompatibility.md
+++ b/docs/parser/ANTLRCompatibility.md
@@ -323,3 +323,9 @@ Additional intentional test-documented difference: malformed prequel inputs curr
 | `APU0xxx` | Error/Warning | Source-generator diagnostics (Roslyn pipeline) |
 
 Full descriptor table: `ParserDiagnostics.All`.
+### Shared runtime indexing metadata
+
+Parser embedded-code discovery now has a shared metadata model in `Utils.Parser.EmbeddedCode`. `EmbeddedCodeRuntimeDiscovery` walks a `ParserDefinition` and emits `EmbeddedCodeRuntimeEntry` values with the raw source, `EmbeddedCodeKind`, owning rule name, runtime-compatible alternative and element indexes, a runtime key for executable entries, and an explicit `EmbeddedCodeUnsupportedReason` for skipped entries. The metadata mirrors the existing parser runtime indexing rules for priority-ordered alternatives, single-item alternatives, sequences, quantifier inner parsing, negation probes, and direct-left-recursive base/tail alternatives. It is metadata only: it does not compile source, generate C#, execute actions, or change `ParserEngine` behavior.
+
+The expression-backed prepared registry consumes this shared discovery result before invoking its preparer. Unsupported constructs such as grammar actions, `@init`, `@after`, lexer actions/predicates, and non-inline parser actions remain non-executable, but they now carry explicit skip reasons. Invalid C# in a source-generator-supported hook remains a Roslyn compilation error rather than a custom parser diagnostic.
+

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -156,3 +156,8 @@ Custom policies should therefore avoid invocation-count-dependent decisions and 
 
 
 > Embedded-code execution paths use or document their diagnostics against the shared taxonomy in `EmbeddedCodeExecutionModel.md`; generated C# hook syntax errors surface as Roslyn compilation errors.
+
+## Embedded-code runtime indexing metadata
+
+Parser semantic predicates and inline parser actions use shared runtime-indexing metadata for `ParserDefinition` discovery. This improves parity between prepared runtime-inline expression registries and source-generated C# hook dispatch without adding support for grammar actions, lexer actions, lexer predicates, `@init`, or `@after` execution. Unsupported constructs remain out of scope and are classified with explicit reasons.
+

--- a/docs/parser/EmbeddedCodeExecutionModel.md
+++ b/docs/parser/EmbeddedCodeExecutionModel.md
@@ -413,3 +413,9 @@ Runtime policy architecture rule:
 - ParserEngine remains responsible for applying effects and emitting diagnostics.
 
 Parser action execution now uses structured `ParserActionExecutionOutcome`, aligned with semantic predicate outcomes. Executors return a status plus optional diagnostic metadata. Inline parser actions still do not influence parse acceptance: `Executed` and `NotExecuted` both continue parsing.
+### Shared runtime indexing metadata
+
+Parser embedded-code discovery now has a shared metadata model in `Utils.Parser.EmbeddedCode`. `EmbeddedCodeRuntimeDiscovery` walks a `ParserDefinition` and emits `EmbeddedCodeRuntimeEntry` values with the raw source, `EmbeddedCodeKind`, owning rule name, runtime-compatible alternative and element indexes, a runtime key for executable entries, and an explicit `EmbeddedCodeUnsupportedReason` for skipped entries. The metadata mirrors the existing parser runtime indexing rules for priority-ordered alternatives, single-item alternatives, sequences, quantifier inner parsing, negation probes, and direct-left-recursive base/tail alternatives. It is metadata only: it does not compile source, generate C#, execute actions, or change `ParserEngine` behavior.
+
+The expression-backed prepared registry consumes this shared discovery result before invoking its preparer. Unsupported constructs such as grammar actions, `@init`, `@after`, lexer actions/predicates, and non-inline parser actions remain non-executable, but they now carry explicit skip reasons. Invalid C# in a source-generator-supported hook remains a Roslyn compilation error rather than a custom parser diagnostic.
+

--- a/docs/parser/INDEX.md
+++ b/docs/parser/INDEX.md
@@ -25,3 +25,8 @@ This index consolidates the parser documentation set and gives a short summary o
 ## Maintenance rule for contributors and agents
 
 When adding, removing, or materially changing any file in `docs/parser/`, update this index in the same change so summaries stay accurate.
+
+## Recent metadata note
+
+`EmbeddedCodeExecutionModel.md` and `ANTLRCompatibility.md` document the shared embedded-code runtime indexing metadata and explicit unsupported reasons used to keep runtime-inline preparation and source-generated hooks aligned.
+


### PR DESCRIPTION
# Motivation

The runtime-inline prepared path and the generated C# path are now both functional, but they were still carrying closely related runtime-indexing and scope-classification logic in separate places.

This PR introduces shared embedded-code runtime metadata so the parser expression path and the generated C# path can stay aligned on where embedded code lives, which runtime key it uses, and why unsupported constructs are skipped.

The goal is consolidation and diagnostics clarity, not new executable ANTLR constructs or broader C# syntax support.

# Audit summary

Before this PR:

- `PreparedExpressionEmbeddedCodeRegistryBuilder` traversed `ParserDefinition` directly to calculate runtime-compatible indexes for prepared expression artifacts.
- `GrammarEmitter` collected generated C# hooks from its `G4Grammar` model using a separate but similar indexing strategy.
- Skipped or unsupported embedded-code constructs were represented mainly by ad hoc text reasons in the expression builder.

This PR adds a shared model in `Utils.Parser.EmbeddedCode`:

- `EmbeddedCodeRuntimeDiscovery`
- `EmbeddedCodeRuntimeDiscoveryResult`
- `EmbeddedCodeRuntimeEntry`
- `EmbeddedCodeRuntimeKey`
- `EmbeddedCodeUnsupportedReason`

The shared discovery currently works from resolved `ParserDefinition` metadata. It covers parser predicates/actions, grammar-level actions, rule lifecycle actions, lexer actions/predicates, quantifier and negation probe indexes, direct-left-recursive base alternatives, and direct-left-recursive recursive tails.

`PreparedExpressionEmbeddedCodeRegistryBuilder` now consumes `EmbeddedCodeRuntimeDiscovery` instead of re-traversing `ParserDefinition` for runtime indexes.

`GrammarEmitter` still collects hooks from `G4Grammar`, because the generator works before the same resolved `ParserDefinition` shape is directly available. The PR keeps the generator-specific collector but adds explicit parity coverage against the shared metadata model.

# Modifications

Added shared embedded-code runtime metadata in `Utils.Parser`:

- `Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeDiscovery.cs`
- `Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeDiscoveryResult.cs`
- `Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeEntry.cs`
- `Utils.Parser/EmbeddedCode/EmbeddedCodeRuntimeKey.cs`
- `Utils.Parser/EmbeddedCode/EmbeddedCodeUnsupportedReason.cs`

Updated existing embedded-code classification:

- `Utils.Parser/EmbeddedCode/EmbeddedCodeKind.cs`

Refactored expression registry building:

- `Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuilder.cs`
- `Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuildEntry.cs`

Updated tests:

- `UtilsTest/Parser/EmbeddedCodeRuntimeDiscoveryTests.cs`
- `UtilsTest/Parser/PreparedExpressionEmbeddedCodeRegistryBuilderTests.cs`
- `UtilsTest/Parser/Antlr4GeneratedEmbeddedCodeTests.cs`

Updated documentation:

- `Utils.Parser.Expressions/README.md`
- `Utils.Parser.Generators/README.md`
- `docs/parser/EmbeddedCodeExecutionModel.md`
- `docs/parser/ANTLRCompatibility.md`
- `docs/parser/Antlr4CompatibilityMatrix.md`
- `Utils.Parser/ROADMAP.md`
- `docs/parser/INDEX.md`

# Public API impact

Yes.

New public types are added in `Utils.Parser.EmbeddedCode`:

- `EmbeddedCodeRuntimeDiscovery`
- `EmbeddedCodeRuntimeDiscoveryResult`
- `EmbeddedCodeRuntimeEntry`
- `EmbeddedCodeRuntimeKey`
- `EmbeddedCodeUnsupportedReason`

`EmbeddedCodeKind` is extended with:

- `LexerAction`
- `LexerPredicate`

`PreparedExpressionEmbeddedCodeRegistryBuildEntry` now exposes:

- `UnsupportedReason`

These additions expose runtime-index metadata and skip classification for consumers that want to audit embedded-code preparation/generation behavior. This remains acceptable while the parser APIs are still evolving.

# Migration

No migration is required.

Existing prepared-expression and generated-C# usage continues to work. Existing callers of `PreparedExpressionEmbeddedCodeRegistryBuilder` receive the same categories of build entries, with additional `UnsupportedReason` metadata on skipped entries.

# Compatibility impact

No behavior change by default.

The PR does not change parser scheduling, memoization, runtime policies, generated default `Parse(...)` behavior, or generated embedded-code execution semantics.

# Runtime impact

No `ParserEngine` behavior change.

The shared discovery mirrors existing runtime indexing rules for audit and preparation purposes. It does not execute embedded code and does not alter runtime dispatch.

# Generator impact

`GrammarEmitter` remains on its `G4Grammar` collector for now, because direct reuse of `ParserDefinition` discovery would be a larger generator refactor.

The PR documents this split and adds a generator parity test so generated hook names stay aligned with the shared runtime metadata for covered shapes.

No new generated runtime API is introduced.

# Diagnostics impact

Unsupported/skipped embedded-code constructs now have explicit common reasons through `EmbeddedCodeUnsupportedReason`.

The expression registry builder carries those reasons into skipped build entries while preserving the legacy human-readable skip reason text.

This PR does not replace Roslyn diagnostics for invalid generated C# hooks and does not add new runtime diagnostics.

# Parse-tree impact

None.

No parse-tree shape or parser behavior changes are expected.

# ANTLR compatibility impact

No new ANTLR construct becomes executable in this PR.

The PR improves classification and documentation for existing supported and unsupported scopes:

- parser semantic predicates and parser inline actions remain the executable parser-runtime-hook constructs;
- grammar actions, rule lifecycle actions, lexer actions, lexer predicates, and non-inline parser actions remain unsupported by these runtime-policy paths.

# Documentation impact

Updated documentation describes the shared runtime metadata model, the explicit unsupported reasons, and the fact that the generated C# path still maintains a generator-specific collector with parity tests:

- `Utils.Parser.Expressions/README.md`
- `Utils.Parser.Generators/README.md`
- `docs/parser/EmbeddedCodeExecutionModel.md`
- `docs/parser/ANTLRCompatibility.md`
- `docs/parser/Antlr4CompatibilityMatrix.md`
- `Utils.Parser/ROADMAP.md`
- `docs/parser/INDEX.md`

# Tests

Added `EmbeddedCodeRuntimeDiscoveryTests` covering:

- executable semantic predicate discovery;
- executable parser inline action discovery;
- single-item alternative indexes;
- sequence element indexes;
- quantifier inner indexes;
- negation probe indexes;
- direct-left-recursive base alternative indexes after split;
- direct-left-recursive tail indexes;
- duplicate source text as distinct runtime entries;
- unsupported constructs with explicit reasons.

Updated `PreparedExpressionEmbeddedCodeRegistryBuilderTests` to verify skipped entries expose `UnsupportedReason` values.

Updated `Antlr4GeneratedEmbeddedCodeTests` with a parity test between shared runtime discovery metadata and generated hook naming for a quantifier inline action.

Reported validation:

- Targeted tests passed for `EmbeddedCodeRuntimeDiscoveryTests`, `PreparedExpressionEmbeddedCodeRegistryBuilderTests`, and `Antlr4GeneratedEmbeddedCodeTests`.
- Full unit suite passed: `1452 passed`, `0 failed`, `5 skipped`.
- Affected projects built/packed successfully in Debug validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ec178b9148326bf2688a60f04bea3)