### PR TITLE
Expand embedded-code runtime and generator test coverage

### DIFF
--- a/UtilsTest/Parser/Antlr4GeneratedEmbeddedCodeTests.cs
+++ b/UtilsTest/Parser/Antlr4GeneratedEmbeddedCodeTests.cs
@@ -524,6 +524,125 @@ public class Antlr4GeneratedEmbeddedCodeTests
         Assert.IsTrue(result.Diagnostics.Any(static diagnostic => diagnostic.ToString().Contains("not", StringComparison.Ordinal)));
     }
 
+
+    /// <summary>
+    /// Ensures invalid inline action C# remains a Roslyn compilation error in the source-generator path.
+    /// </summary>
+    [TestMethod]
+    public void CompileGeneratedSource_InvalidActionCode_ReportsRoslynError()
+    {
+        const string grammar = """
+            grammar P;
+            start : { not valid ; } A ;
+            A : 'a' ;
+            """;
+
+        var result = CompileGeneratedSourceExpectingFailure(Emit(grammar));
+
+        Assert.IsTrue(result.Diagnostics.Any(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        Assert.IsTrue(result.Diagnostics.Any(static diagnostic => diagnostic.ToString().Contains("not", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// Ensures generated hook names remain aligned with shared runtime discovery metadata for representative parser shapes.
+    /// </summary>
+    [TestMethod]
+    public void Emit_GeneratedHooks_MatchSharedRuntimeDiscoveryIndexes_ForParserShapes()
+    {
+        var singlePredicate = new ValidatingPredicate("true");
+        var singleAction = new EmbeddedAction("OnAction(context);", ActionContext.Alternative, ActionPosition.Inline, []);
+        var sequenceAction = new EmbeddedAction("OnAction(context);", ActionContext.Alternative, ActionPosition.Inline, []);
+        var quantifierPredicate = new ValidatingPredicate("OnPredicate(context)");
+        var negationPredicate = new ValidatingPredicate("OnPredicate(context)");
+        var duplicateFirst = new EmbeddedAction("OnAction(context);", ActionContext.Alternative, ActionPosition.Inline, []);
+        var duplicateSecond = new EmbeddedAction("OnAction(context);", ActionContext.Alternative, ActionPosition.Inline, []);
+        var leftRecursiveBasePredicate = new ValidatingPredicate("false");
+        var leftRecursiveTailAction = new EmbeddedAction("OnAction(context);", ActionContext.Alternative, ActionPosition.Inline, []);
+
+        var cases = new[]
+        {
+            (
+                Grammar: """
+                    grammar P;
+                    start : { true }? ;
+                    A : 'a' ;
+                    """,
+                Definition: CreateGeneratedParityDefinition(new Rule("start", 0, false, new Alternation([new Alternative(0, Associativity.Left, singlePredicate)]), Kind: RuleKind.Parser))),
+            (
+                Grammar: """
+                    grammar P;
+                    start : { OnAction(context); } ;
+                    A : 'a' ;
+                    """,
+                Definition: CreateGeneratedParityDefinition(new Rule("start", 0, false, new Alternation([new Alternative(0, Associativity.Left, singleAction)]), Kind: RuleKind.Parser))),
+            (
+                Grammar: """
+                    grammar P;
+                    start : A { OnAction(context); } B ;
+                    A : 'a' ;
+                    B : 'b' ;
+                    """,
+                Definition: CreateGeneratedParityDefinition(new Rule("start", 0, false, new Alternation([new Alternative(0, Associativity.Left, new Sequence([new RuleRef("A"), sequenceAction, new RuleRef("B")]))]), Kind: RuleKind.Parser))),
+            (
+                Grammar: """
+                    grammar P;
+                    start : A ({ OnPredicate(context) }? B)* ;
+                    A : 'a' ;
+                    B : 'b' ;
+                    """,
+                Definition: CreateGeneratedParityDefinition(new Rule("start", 0, false, new Alternation([new Alternative(0, Associativity.Left, new Sequence([new RuleRef("A"), new Quantifier(new Sequence([quantifierPredicate, new RuleRef("B")]), 0, null)]))]), Kind: RuleKind.Parser))),
+            (
+                Grammar: """
+                    grammar P;
+                    start : ~({ OnPredicate(context) }? A) ;
+                    A : 'a' ;
+                    B : 'b' ;
+                    """,
+                Definition: CreateGeneratedParityDefinition(new Rule("start", 0, false, new Alternation([new Alternative(0, Associativity.Left, new Negation(new Sequence([negationPredicate, new RuleRef("A")])))]), Kind: RuleKind.Parser))),
+            (
+                Grammar: """
+                    grammar P;
+                    start
+                        : { OnAction(context); } A
+                        | { OnAction(context); } B
+                        ;
+                    A : 'a' ;
+                    B : 'b' ;
+                    """,
+                Definition: CreateGeneratedParityDefinition(new Rule("start", 0, false, new Alternation([
+                    new Alternative(0, Associativity.Left, new Sequence([duplicateFirst, new RuleRef("A")])),
+                    new Alternative(1, Associativity.Left, new Sequence([duplicateSecond, new RuleRef("B")]))
+                ]), Kind: RuleKind.Parser))),
+            (
+                Grammar: """
+                    grammar P;
+                    expr
+                        : expr PLUS INT
+                        | { false }? INT
+                        ;
+                    INT : [0-9]+ ;
+                    PLUS : '+' ;
+                    """,
+                Definition: CreateGeneratedParityLeftRecursiveBaseDefinition(leftRecursiveBasePredicate)),
+            (
+                Grammar: """
+                    grammar P;
+                    expr
+                        : INT
+                        | expr { OnAction(context); } PLUS INT
+                        ;
+                    INT : [0-9]+ ;
+                    PLUS : '+' ;
+                    """,
+                Definition: CreateGeneratedParityLeftRecursiveTailDefinition(leftRecursiveTailAction))
+        };
+
+        foreach (var testCase in cases)
+        {
+            AssertGeneratedHooksMatchDiscovery(testCase.Grammar, testCase.Definition);
+        }
+    }
+
     /// <summary>
     /// Ensures generated hook dispatch metadata remains aligned with shared ParserDefinition runtime discovery metadata.
     /// </summary>
@@ -557,6 +676,88 @@ public class Antlr4GeneratedEmbeddedCodeTests
         Assert.AreEqual(0, entry.ElementIndex);
         StringAssert.Contains(generatedSource, expectedHookName);
     }
+
+
+    /// <summary>
+    /// Asserts generated hook names for all runtime-executable entries discovered from a hand-built parser definition.
+    /// </summary>
+    /// <param name="grammarText">ANTLR grammar text emitted by the production generator.</param>
+    /// <param name="definition">Equivalent parser definition inspected by shared runtime discovery.</param>
+    private static void AssertGeneratedHooksMatchDiscovery(string grammarText, ParserDefinition definition)
+    {
+        string generatedSource = Emit(grammarText);
+        var entries = EmbeddedCodeRuntimeDiscovery.Discover(definition).ExecutableEntries;
+        var ordinalsByKind = new Dictionary<EmbeddedCodeKind, int>();
+
+        foreach (var entry in entries)
+        {
+            int ordinal = ordinalsByKind.TryGetValue(entry.Kind, out int current) ? current : 0;
+            ordinalsByKind[entry.Kind] = ordinal + 1;
+            string prefix = entry.Kind == EmbeddedCodeKind.SemanticPredicate ? "__Predicate" : "__Action";
+            string elementIndex = entry.ElementIndex?.ToString() ?? "m1";
+            string expectedHookName = $"{prefix}_{entry.RuleName}_{entry.AlternativeIndex}_{elementIndex}_{ordinal}";
+
+            StringAssert.Contains(generatedSource, expectedHookName);
+        }
+    }
+
+    /// <summary>
+    /// Creates a parser definition used by generated-hook parity tests.
+    /// </summary>
+    /// <param name="rootRule">Root parser rule.</param>
+    /// <returns>A parser definition containing the supplied root rule.</returns>
+    private static ParserDefinition CreateGeneratedParityDefinition(Rule rootRule) =>
+        new("P", GrammarType.Combined, null, [], [], [], [rootRule], rootRule);
+
+    /// <summary>
+    /// Creates a direct-left-recursive parser definition whose base alternative follows a recursive alternative.
+    /// </summary>
+    /// <param name="predicate">Predicate contained in the base alternative.</param>
+    /// <returns>A parser definition with left-recursive metadata.</returns>
+    private static ParserDefinition CreateGeneratedParityLeftRecursiveBaseDefinition(ValidatingPredicate predicate)
+    {
+        var recursiveAlternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("expr"), new RuleRef("PLUS"), new RuleRef("INT")]));
+        var baseAlternative = new Alternative(1, Associativity.Left, new Sequence([predicate, new RuleRef("INT")]));
+        var rule = new Rule("expr", 0, false, new Alternation([recursiveAlternative, baseAlternative]), Kind: RuleKind.Parser);
+        return CreateGeneratedParityLeftRecursiveDefinition(rule, [baseAlternative], [recursiveAlternative]);
+    }
+
+    /// <summary>
+    /// Creates a direct-left-recursive parser definition with an executable tail action.
+    /// </summary>
+    /// <param name="action">Action contained in the recursive tail.</param>
+    /// <returns>A parser definition with left-recursive metadata.</returns>
+    private static ParserDefinition CreateGeneratedParityLeftRecursiveTailDefinition(EmbeddedAction action)
+    {
+        var baseAlternative = new Alternative(0, Associativity.Left, new Sequence([new RuleRef("INT")]));
+        var recursiveAlternative = new Alternative(1, Associativity.Left, new Sequence([new RuleRef("expr"), action, new RuleRef("PLUS"), new RuleRef("INT")]));
+        var rule = new Rule("expr", 0, false, new Alternation([baseAlternative, recursiveAlternative]), Kind: RuleKind.Parser);
+        return CreateGeneratedParityLeftRecursiveDefinition(rule, [baseAlternative], [recursiveAlternative]);
+    }
+
+    /// <summary>
+    /// Creates a parser definition with direct-left-recursive metadata populated.
+    /// </summary>
+    /// <param name="rule">Left-recursive parser rule.</param>
+    /// <param name="baseAlternatives">Resolved base alternatives.</param>
+    /// <param name="recursiveAlternatives">Resolved recursive alternatives.</param>
+    /// <returns>A parser definition with left-recursive metadata.</returns>
+    private static ParserDefinition CreateGeneratedParityLeftRecursiveDefinition(
+        Rule rule,
+        IReadOnlyList<Alternative> baseAlternatives,
+        IReadOnlyList<Alternative> recursiveAlternatives) =>
+        new ParserDefinition("P", GrammarType.Combined, null, [], [], [], [rule], rule)
+        {
+            LeftRecursiveRules = new Dictionary<string, LeftRecursiveRuleInfo>
+            {
+                [rule.Name] = new()
+                {
+                    Rule = rule,
+                    BaseAlternatives = baseAlternatives,
+                    RecursiveAlternatives = recursiveAlternatives
+                }
+            }
+        };
 
     /// <summary>
     /// Emits generated C# for the supplied grammar using the production grammar emitter.

--- a/UtilsTest/Parser/EmbeddedCodePreparationContractTests.cs
+++ b/UtilsTest/Parser/EmbeddedCodePreparationContractTests.cs
@@ -62,6 +62,50 @@ public class EmbeddedCodePreparationContractTests
         Assert.IsFalse(context.SupportedSymbols.Contains(EmbeddedCodeContextSymbol.AlternativeIndex));
     }
 
+
+    /// <summary>
+    /// Verifies that the default preparation context exposes the complete current parser symbol model.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodePreparationContext_WhenSymbolsAreOmitted_ExposesDefaultRuntimeSymbols()
+    {
+        var context = new EmbeddedCodePreparationContext("ExprGrammar", EmbeddedCodeTarget.RuntimeInlineExpression);
+
+        CollectionAssert.AreEquivalent(
+            new object[]
+            {
+                EmbeddedCodeContextSymbol.RuleName,
+                EmbeddedCodeContextSymbol.InputPosition,
+                EmbeddedCodeContextSymbol.AlternativeIndex,
+                EmbeddedCodeContextSymbol.ElementIndex
+            },
+            context.SupportedSymbols.Cast<object>().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that success results cannot silently omit the prepared artifact contract.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodePreparationResult_WhenSuccessHasNoArtifact_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(() => new EmbeddedCodePreparationResult<string>(EmbeddedCodePreparationStatus.Succeeded));
+    }
+
+    /// <summary>
+    /// Verifies that diagnostic arguments are materialized and preserved even if the caller mutates the original collection.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodePreparationResult_MaterializesDiagnosticArguments()
+    {
+        var arguments = new List<object?> { "predicate", "runtime" };
+        var result = EmbeddedCodePreparationResult<string>.Unsupported(arguments);
+
+        arguments[0] = "changed";
+
+        Assert.AreEqual("predicate", result.DiagnosticArguments[0]);
+        Assert.AreEqual("runtime", result.DiagnosticArguments[1]);
+    }
+
     /// <summary>
     /// Verifies that preparation results can represent a successful artifact-producing outcome.
     /// </summary>

--- a/UtilsTest/Parser/EmbeddedCodeRuntimeDiscoveryTests.cs
+++ b/UtilsTest/Parser/EmbeddedCodeRuntimeDiscoveryTests.cs
@@ -196,6 +196,47 @@ public class EmbeddedCodeRuntimeDiscoveryTests
             unsupported.Select(static entry => (object)entry.UnsupportedReason).ToArray());
     }
 
+
+    /// <summary>
+    /// Verifies that skipped embedded-code entries are non-executable and never expose runtime dispatch keys.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenUnsupportedConstructsExist_MarksEntriesAsNonExecutableWithoutRuntimeKeys()
+    {
+        var init = new EmbeddedAction("init", ActionContext.Rule, ActionPosition.Before, []);
+        var after = new EmbeddedAction("after", ActionContext.Rule, ActionPosition.After, []);
+        var nonInline = new EmbeddedAction("before", ActionContext.Alternative, ActionPosition.Before, []);
+        var parserRule = CreateParserRule("start", new Sequence([nonInline]), init, after);
+        var lexerAction = new EmbeddedAction("lexer", ActionContext.Alternative, ActionPosition.Inline, []);
+        var lexerPredicate = new ValidatingPredicate("lexerPredicate");
+        var lexerRule = CreateLexerRule("A", new Sequence([lexerAction, lexerPredicate]));
+        var grammarAction = new GrammarAction("members", "int value;");
+
+        var unsupported = EmbeddedCodeRuntimeDiscovery.Discover(CreateDefinition(parserRule, [grammarAction], [lexerRule])).UnsupportedEntries;
+
+        Assert.AreEqual(6, unsupported.Count);
+        foreach (var entry in unsupported)
+        {
+            Assert.IsFalse(entry.IsRuntimeExecutable);
+            Assert.IsNull(entry.RuntimeKey);
+            Assert.AreNotEqual(EmbeddedCodeUnsupportedReason.None, entry.UnsupportedReason);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that parser actions inside negation probes use shared runtime probe indexes.
+    /// </summary>
+    [TestMethod]
+    public void Discover_WhenActionIsInsideNegation_UsesRuntimeProbeIndex()
+    {
+        var action = new EmbeddedAction("insideNegationAction", ActionContext.Alternative, ActionPosition.Inline, []);
+        var rule = CreateParserRule("start", new Sequence([new LiteralMatch("a"), new Negation(action)]));
+
+        var entry = DiscoverSingle(CreateDefinition(rule));
+
+        AssertExecutable(entry, EmbeddedCodeKind.ParserInlineAction, "start", "insideNegationAction", 0, 0);
+    }
+
     /// <summary>
     /// Returns the single discovered executable entry for a test definition.
     /// </summary>

--- a/UtilsTest/Parser/PreparedExpressionEmbeddedCodeRegistryTests.cs
+++ b/UtilsTest/Parser/PreparedExpressionEmbeddedCodeRegistryTests.cs
@@ -156,6 +156,75 @@ public class PreparedExpressionEmbeddedCodeRegistryTests
         Assert.AreEqual(1, actionCalls);
     }
 
+
+    /// <summary>
+    /// Verifies that registry keys preserve source metadata, including unavailable alternative and element indexes.
+    /// </summary>
+    [TestMethod]
+    public void PreparedExpressionEmbeddedCodeKey_FromSource_PreservesNullableRuntimeIndexes()
+    {
+        var source = new EmbeddedCodeSource(
+            "single",
+            EmbeddedCodeKind.SemanticPredicate,
+            ruleName: "start",
+            alternativeIndex: null,
+            elementIndex: null);
+
+        var key = PreparedExpressionEmbeddedCodeKey.FromSource(source);
+
+        Assert.AreEqual(EmbeddedCodeKind.SemanticPredicate, key.Kind);
+        Assert.AreEqual("start", key.RuleName);
+        Assert.AreEqual("single", key.SourceText);
+        Assert.IsNull(key.AlternativeIndex);
+        Assert.IsNull(key.ElementIndex);
+    }
+
+    /// <summary>
+    /// Verifies that runtime contexts using unavailable indexes can resolve artifacts prepared with nullable indexes.
+    /// </summary>
+    [TestMethod]
+    public void TryGetSemanticPredicate_WhenSingleItemIndexesAreUnavailable_UsesNullableKey()
+    {
+        var registry = new PreparedExpressionEmbeddedCodeRegistry();
+        var artifact = new PreparedExpressionSemanticPredicate(
+            new EmbeddedCodeSource("single", EmbeddedCodeKind.SemanticPredicate, "start", null, null),
+            CreatePreparationContext("start"),
+            _ => true);
+
+        Assert.IsTrue(registry.TryAddSemanticPredicate(artifact));
+        var found = registry.TryGetSemanticPredicate(CreatePredicateContext("start", "single", -1, -1), out var resolved);
+
+        Assert.IsTrue(found);
+        Assert.AreSame(artifact, resolved);
+    }
+
+    /// <summary>
+    /// Verifies that prepared predicate lookup keys distinguish source text, alternative indexes, and element indexes independently.
+    /// </summary>
+    [TestMethod]
+    public void TryGetSemanticPredicate_WhenKeysDifferByTextAlternativeOrElement_DoesNotCollide()
+    {
+        var registry = new PreparedExpressionEmbeddedCodeRegistry();
+        var byText = CreatePredicateArtifact("start", "text-a", 0, 0, _ => true);
+        var byAlternative = CreatePredicateArtifact("start", "shared", 0, 0, _ => true);
+        var otherAlternative = CreatePredicateArtifact("start", "shared", 1, 0, _ => false);
+        var otherElement = CreatePredicateArtifact("start", "shared", 1, 2, _ => true);
+
+        Assert.IsTrue(registry.TryAddSemanticPredicate(byText));
+        Assert.IsTrue(registry.TryAddSemanticPredicate(byAlternative));
+        Assert.IsTrue(registry.TryAddSemanticPredicate(otherAlternative));
+        Assert.IsTrue(registry.TryAddSemanticPredicate(otherElement));
+
+        Assert.IsTrue(registry.TryGetSemanticPredicate(CreatePredicateContext("start", "text-a", 0, 0), out var resolvedByText));
+        Assert.IsTrue(registry.TryGetSemanticPredicate(CreatePredicateContext("start", "shared", 0, 0), out var resolvedByAlternative));
+        Assert.IsTrue(registry.TryGetSemanticPredicate(CreatePredicateContext("start", "shared", 1, 0), out var resolvedOtherAlternative));
+        Assert.IsTrue(registry.TryGetSemanticPredicate(CreatePredicateContext("start", "shared", 1, 2), out var resolvedOtherElement));
+        Assert.AreSame(byText, resolvedByText);
+        Assert.AreSame(byAlternative, resolvedByAlternative);
+        Assert.AreSame(otherAlternative, resolvedOtherAlternative);
+        Assert.AreSame(otherElement, resolvedOtherElement);
+    }
+
     /// <summary>
     /// Creates a prepared semantic predicate artifact around an already-available delegate.
     /// </summary>


### PR DESCRIPTION
# Motivation

The prepared runtime-inline path and the generated C# source-generator path are now both functional. Recent PRs added preparation contracts, prepared expression artifacts, prepared registries and adapters, a registry builder, an opt-in runtime policy builder, generated C# hooks, generated hook dispatch hardening, and shared runtime discovery metadata.

This PR adds regression coverage across those pieces so future changes do not accidentally diverge runtime metadata, registry lookup, prepared execution, or generated hook dispatch behavior.

The PR is intentionally test-only.

# Audit summary

This PR strengthens coverage for code introduced across PR #288 through PR #295:

- embedded-code preparation contracts;
- preparation result invariants;
- diagnostic argument materialization;
- prepared-expression registry keys and lookups;
- nullable/unavailable runtime indexes;
- shared runtime discovery metadata;
- unsupported/skipped entry invariants;
- generated C# hook dispatch names;
- generated C# / shared discovery parity;
- Roslyn error behavior for invalid generated hook bodies.

It does not add new runtime behavior, new parser features, new generated APIs, new executable ANTLR constructs, or broader C# syntax support.

# Modifications

Modified tests only:

- `UtilsTest/Parser/EmbeddedCodePreparationContractTests.cs`
- `UtilsTest/Parser/PreparedExpressionEmbeddedCodeRegistryTests.cs`
- `UtilsTest/Parser/EmbeddedCodeRuntimeDiscoveryTests.cs`
- `UtilsTest/Parser/Antlr4GeneratedEmbeddedCodeTests.cs`

No production code files are changed.

# Public API impact

None.

No public types, methods, generated helper APIs, or signatures are changed.

# Migration

No migration is required.

This PR only adds tests around existing behavior.

# Compatibility impact

No compatibility impact.

The PR does not change parser defaults, generated default `Parse(...)` behavior, registry behavior, source-generation behavior, or runtime policy defaults.

# Runtime impact

None.

`ParserEngine` is not modified, and no runtime execution path is changed.

# Generator impact

None functionally.

The generated C# path is exercised more thoroughly by tests, including generated hook naming parity against shared runtime discovery metadata, but `GrammarEmitter` and generated output logic are not changed.

# Diagnostics impact

No new diagnostics are introduced.

The PR adds tests proving existing diagnostic-related behavior:

- diagnostic arguments in preparation results are materialized and preserved;
- invalid inline action C# in generated hooks remains a Roslyn compilation error;
- unsupported runtime discovery entries are non-executable, have no runtime key, and expose explicit unsupported reasons.

# Parse-tree impact

None.

No parsing behavior or parse-tree construction code is changed.

# ANTLR compatibility impact

No new ANTLR construct is supported.

The PR only adds regression coverage for already-supported or already-classified behavior in the prepared runtime-inline and generated C# paths.

# Documentation impact

None.

No documentation files are modified.

# Tests

Added or strengthened tests in `EmbeddedCodePreparationContractTests` covering:

- default preparation-context runtime symbols;
- success result invariant requiring an artifact;
- materialization and preservation of diagnostic arguments.

Added tests in `PreparedExpressionEmbeddedCodeRegistryTests` covering:

- nullable/unavailable runtime indexes in prepared keys;
- lookup parity between nullable prepared keys and runtime contexts using unavailable indexes;
- key disambiguation by source text, alternative index, and element index.

Added tests in `EmbeddedCodeRuntimeDiscoveryTests` covering:

- unsupported entries are non-executable;
- unsupported entries do not expose runtime dispatch keys;
- unsupported entries expose explicit `EmbeddedCodeUnsupportedReason` values;
- parser actions inside negation probes use the runtime probe index.

Added tests in `Antlr4GeneratedEmbeddedCodeTests` covering:

- invalid inline action C# remains a Roslyn compilation error;
- generated hook names match `EmbeddedCodeRuntimeDiscovery` indexes for representative parser shapes:
  - single predicate alternative;
  - single action alternative;
  - sequence;
  - quantifier;
  - negation;
  - duplicate source text across alternatives;
  - direct-left-recursive base alternative;
  - direct-left-recursive tail.

Reported validation:

- Targeted test run passed for `EmbeddedCodePreparationContractTests`, `PreparedExpressionEmbeddedCodeRegistryTests`, `EmbeddedCodeRuntimeDiscoveryTests`, and `Antlr4GeneratedEmbeddedCodeTests`: `57 passed`.
- Full unit suite passed: `1462 passed`, `0 failed`, `5 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1edae7f9188326ba1d91d66169ef79)