### PR TITLE
docs(Utils.Parser): add XML documentation to undocumented private members

### DIFF
--- a/Utils.Parser/Antlr4/Common/Antlr4PrequelDiagnosticMapper.cs
+++ b/Utils.Parser/Antlr4/Common/Antlr4PrequelDiagnosticMapper.cs
@@ -31,6 +31,7 @@ internal static class Antlr4PrequelDiagnosticMapper
         return result;
     }
 
+    /// <summary>Maps one <see cref="Antlr4PrequelDiagnostic"/> to the corresponding <see cref="ParserDiagnostic"/>.</summary>
     private static ParserDiagnostic MapSingle(Antlr4PrequelDiagnostic diagnostic)
     {
         return diagnostic.Code switch

--- a/Utils.Parser/Antlr4/Common/Antlr4RuntimePrequelMapper.cs
+++ b/Utils.Parser/Antlr4/Common/Antlr4RuntimePrequelMapper.cs
@@ -37,6 +37,7 @@ internal static class Antlr4RuntimePrequelMapper
             HasChannelsBlock: HasNonDefaultChannel(definition.DeclaredChannels));
     }
 
+    /// <summary>Returns <see langword="true"/> when <paramref name="channels"/> contains any channel other than <c>DEFAULT_CHANNEL</c> or <c>HIDDEN</c>.</summary>
     private static bool HasNonDefaultChannel(IReadOnlySet<string> channels)
     {
         foreach (var channel in channels)

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -29,6 +29,7 @@ public sealed class Antlr4GrammarConverter
 {
     /// <summary>Declaration-order counter incremented as rules are created during conversion.</summary>
     private int _order;
+    /// <summary>Optional diagnostics bag populated during conversion.</summary>
     private readonly DiagnosticBag? _diagnostics;
 
     /// <summary>Initialises a new converter instance. The <paramref name="sourceText"/> parameter is reserved for future use.</summary>

--- a/Utils.Parser/Metadata/ParserFeatureCapabilities.cs
+++ b/Utils.Parser/Metadata/ParserFeatureCapabilities.cs
@@ -11,6 +11,7 @@ namespace Utils.Parser.Metadata;
 /// </summary>
 public static class ParserFeatureCapabilities
 {
+    /// <summary>Immutable lookup from feature enum value to capability descriptor, used by <see cref="Get"/> and <see cref="All"/>.</summary>
     private static readonly IReadOnlyDictionary<ParserFeature, ParserFeatureCapability> CapabilityByFeature =
         new ReadOnlyDictionary<ParserFeature, ParserFeatureCapability>(
             BuildCapabilities().ToDictionary(static capability => capability.Feature));

--- a/Utils.Parser/ProjectCompilation/Antlr4GrammarProjectCompiler.cs
+++ b/Utils.Parser/ProjectCompilation/Antlr4GrammarProjectCompiler.cs
@@ -307,9 +307,13 @@ public static class Antlr4GrammarProjectCompiler
     /// </summary>
     private sealed class CompilationState
     {
+        /// <summary>Source resolver used to locate grammar files by name.</summary>
         private readonly IGrammarSourceResolver _resolver;
+        /// <summary>Optional diagnostics bag populated during compilation.</summary>
         private readonly DiagnosticBag? _diagnostics;
+        /// <summary>Loaded grammar definitions keyed by grammar name, populated as dependencies are visited.</summary>
         private readonly Dictionary<string, LoadedGrammarDefinition> _definitionsByName = new(StringComparer.OrdinalIgnoreCase);
+        /// <summary>Recursion guard stack of grammar names currently being visited, used to detect import cycles.</summary>
         private readonly List<string> _stack = [];
 
         /// <summary>

--- a/Utils.Parser/ProjectCompilation/FileSystemGrammarSourceResolver.cs
+++ b/Utils.Parser/ProjectCompilation/FileSystemGrammarSourceResolver.cs
@@ -9,6 +9,7 @@ namespace Utils.Parser.ProjectCompilation;
 /// </summary>
 public sealed class FileSystemGrammarSourceResolver : IGrammarSourceResolver
 {
+    /// <summary>Absolute path of the root directory used to locate grammar files.</summary>
     private readonly string _rootDirectory;
 
     /// <summary>

--- a/Utils.Parser/ProjectCompilation/InMemoryGrammarSourceResolver.cs
+++ b/Utils.Parser/ProjectCompilation/InMemoryGrammarSourceResolver.cs
@@ -9,6 +9,7 @@ namespace Utils.Parser.ProjectCompilation;
 /// </summary>
 public sealed class InMemoryGrammarSourceResolver : IGrammarSourceResolver
 {
+    /// <summary>Grammar sources indexed by name and by file base name for case-insensitive resolution.</summary>
     private readonly Dictionary<string, GrammarSource> _sources;
 
     /// <summary>

--- a/Utils.Parser/Resolution/LeftRecursionAnalyzer.cs
+++ b/Utils.Parser/Resolution/LeftRecursionAnalyzer.cs
@@ -81,6 +81,7 @@ internal static class LeftRecursionAnalyzer
         return map;
     }
 
+    /// <summary>Builds a first-reference graph and checks every non-directly-recursive rule for an indirect cycle back to itself.</summary>
     private static void DetectIndirectLeftRecursion(
         ParserDefinition definition,
         IReadOnlyDictionary<string, LeftRecursiveRuleInfo> directRules,
@@ -139,6 +140,7 @@ internal static class LeftRecursionAnalyzer
         }
     }
 
+    /// <summary>Performs a depth-first search in <paramref name="graph"/> and returns <see langword="true"/> when a path from <paramref name="start"/> to <paramref name="goal"/> exists.</summary>
     private static bool HasPath(
         IReadOnlyDictionary<string, HashSet<string>> graph,
         string start,
@@ -175,6 +177,7 @@ internal static class LeftRecursionAnalyzer
         return false;
     }
 
+    /// <summary>Returns the leading <see cref="RuleRef"/> from a content node when it directly or via sequence starts with one; otherwise <see langword="null"/>.</summary>
     private static RuleRef? GetLeadingRuleRef(RuleContent content)
     {
         return content switch

--- a/Utils.Parser/Resolution/RuleResolver.cs
+++ b/Utils.Parser/Resolution/RuleResolver.cs
@@ -186,6 +186,7 @@ public static class RuleResolver
         };
     }
 
+    /// <summary>Removes structurally identical duplicate alternatives from parser rules, keeping the lowest-priority copy and emitting a diagnostic for each removal.</summary>
     private static ParserDefinition NormalizeAlternatives(ParserDefinition definition, DiagnosticBag? diagnostics)
     {
         var updatedParserRules = new List<Rule>(definition.ParserRules.Count);
@@ -247,11 +248,13 @@ public static class RuleResolver
         };
     }
 
+    /// <summary>Returns a stable string fingerprint for an alternative including associativity, label, and structural content.</summary>
     private static string BuildAlternativeFingerprint(Alternative alternative)
     {
         return $"{alternative.Assoc}|{alternative.Label}|{BuildContentFingerprint(alternative.Content)}";
     }
 
+    /// <summary>Returns a stable recursive string fingerprint for a rule content node, used to detect structurally identical alternatives.</summary>
     private static string BuildContentFingerprint(RuleContent content)
     {
         return content switch

--- a/Utils.Parser/Runtime/AlternativeRuntimeObservation.cs
+++ b/Utils.Parser/Runtime/AlternativeRuntimeObservation.cs
@@ -41,6 +41,7 @@ public sealed record AlternativeRuntimeObservation(
     {
     }
 
+    /// <summary>Maps a legacy status string to the corresponding <see cref="ParserRuntimeObservationStatus"/> enum value, defaulting to <see cref="ParserRuntimeObservationStatus.Unknown"/> when unrecognized.</summary>
     private static ParserRuntimeObservationStatus ParseLegacyStatus(string status)
     {
         return Enum.TryParse<ParserRuntimeObservationStatus>(status, ignoreCase: true, out var normalized)
@@ -48,6 +49,7 @@ public sealed record AlternativeRuntimeObservation(
             : ParserRuntimeObservationStatus.Unknown;
     }
 
+    /// <summary>Infers the observation kind from a parsed legacy status value.</summary>
     private static ParserRuntimeObservationKind InferKindFromLegacyStatus(string status)
     {
         return ParseLegacyStatus(status) switch

--- a/Utils.Parser/Runtime/AlternativeStructuralPrefixExtractor.cs
+++ b/Utils.Parser/Runtime/AlternativeStructuralPrefixExtractor.cs
@@ -32,6 +32,7 @@ internal sealed class AlternativeStructuralPrefixExtractor
         return descriptors;
     }
 
+    /// <summary>Extracts the ordered leading structural token names from a single alternative's content.</summary>
     private static IReadOnlyList<string> ExtractStructuralTokens(RuleContent content)
     {
         if (content is Sequence sequence)
@@ -55,6 +56,7 @@ internal sealed class AlternativeStructuralPrefixExtractor
             : [];
     }
 
+    /// <summary>Extracts a single structural token name from a rule-content node that is a direct literal or rule reference; returns <see langword="false"/> for composite content.</summary>
     private static bool TryGetStructuralToken(RuleContent content, out string tokenName)
     {
         switch (content)

--- a/Utils.Parser/Runtime/ContinuationMetadataPreparation.cs
+++ b/Utils.Parser/Runtime/ContinuationMetadataPreparation.cs
@@ -8,7 +8,9 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class ContinuationMetadataPreparation
 {
+    /// <summary>Factory used to create typed continuation descriptors.</summary>
     private readonly ParserContinuationFactory _continuationFactory = new();
+    /// <summary>Extractor used to compute structural sequence positions for shared-prefix candidates.</summary>
     private readonly ContinuationStructuralPositionExtractor _positionExtractor = new();
 
     /// <summary>
@@ -45,6 +47,7 @@ internal sealed class ContinuationMetadataPreparation
         return continuations;
     }
 
+    /// <summary>Returns the shared token name for the specified alternative index when it participates in a shared-prefix candidate; otherwise <see langword="null"/>.</summary>
     private static string? ResolveSharedTokenName(
         IReadOnlyList<ParserLookaheadSharedPrefixCandidate> candidates,
         int alternativeIndex)

--- a/Utils.Parser/Runtime/ContinuationStructuralPositionExtractor.cs
+++ b/Utils.Parser/Runtime/ContinuationStructuralPositionExtractor.cs
@@ -39,6 +39,7 @@ internal sealed class ContinuationStructuralPositionExtractor
         return NormalizeMeaningfulSequencePosition(sequence, firstMeaningfulItemIndex + 1);
     }
 
+    /// <summary>Converts a raw sequence index to a meaningful-item count by excluding embedded actions and lexer commands.</summary>
     private static int NormalizeMeaningfulSequencePosition(Sequence sequence, int sequencePosition)
     {
         if (sequencePosition <= 0)
@@ -63,6 +64,7 @@ internal sealed class ContinuationStructuralPositionExtractor
         return meaningfulIndex;
     }
 
+    /// <summary>Returns <see langword="true"/> when the content is a literal or rule-reference whose value equals <paramref name="sharedTokenName"/>.</summary>
     private static bool IsSharedTokenMatchFromProbeMetadata(RuleContent content, string sharedTokenName)
     {
         return content switch

--- a/Utils.Parser/Runtime/ConventionSyntaxColorisation.cs
+++ b/Utils.Parser/Runtime/ConventionSyntaxColorisation.cs
@@ -9,8 +9,11 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 public sealed class ConventionSyntaxColorisation : ISyntaxColorisation
 {
+    /// <summary>Rule names classified as keywords.</summary>
     private readonly HashSet<string> keywords;
+    /// <summary>Rule names classified as numbers.</summary>
     private readonly HashSet<string> numbers;
+    /// <summary>Rule names classified as strings.</summary>
     private readonly HashSet<string> strings;
 
     /// <summary>

--- a/Utils.Parser/Runtime/G4SyntaxColorisation.cs
+++ b/Utils.Parser/Runtime/G4SyntaxColorisation.cs
@@ -9,6 +9,7 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 public sealed class G4SyntaxColorisation : ISyntaxColorisation
 {
+    /// <summary>ANTLR4 grammar keywords that receive keyword colorization.</summary>
     private static readonly HashSet<string> s_keywords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
         "grammar",
@@ -27,6 +28,7 @@ public sealed class G4SyntaxColorisation : ISyntaxColorisation
         "finally"
     };
 
+    /// <summary>Conventional ANTLR4 lexer rule names associated with numeric tokens.</summary>
     private static readonly HashSet<string> s_numberRules = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
         "NUMBER",

--- a/Utils.Parser/Runtime/LexerExtensionContext.cs
+++ b/Utils.Parser/Runtime/LexerExtensionContext.cs
@@ -7,6 +7,7 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 public sealed class LexerExtensionContext
 {
+    /// <summary>Token names declared in <c>tokens { ... }</c> blocks or backed by lexer rules, used by <see cref="IsTokenKnown"/>.</summary>
     private readonly HashSet<string> _knownTokenNames;
 
     /// <summary>

--- a/Utils.Parser/Runtime/ParseContext.cs
+++ b/Utils.Parser/Runtime/ParseContext.cs
@@ -8,6 +8,7 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class ParseContext(IReadOnlyList<Token> tokens)
 {
+    /// <summary>Zero-based index of the next token to be consumed.</summary>
     private int _position;
 
     /// <summary>Current zero-based index into the token list.</summary>

--- a/Utils.Parser/Runtime/ParserSharedPrefixExecutionEligibilityAnalyzer.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixExecutionEligibilityAnalyzer.cs
@@ -49,6 +49,7 @@ internal readonly record struct ParserSharedPrefixExecutionEligibilityResult(
 /// </summary>
 internal sealed class ParserSharedPrefixExecutionEligibilityAnalyzer
 {
+    /// <summary>Validator used to detect structural integrity issues before classifying eligibility.</summary>
     private readonly ParserSharedPrefixPlanValidator validator = new();
 
     /// <summary>

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanFactory.cs
@@ -174,6 +174,7 @@ internal sealed class ParserSharedPrefixPlanFactory
         return sharedPrefix.Count == 0 ? [candidate.TokenName] : sharedPrefix;
     }
 
+    /// <summary>Returns the longest common leading subsequence shared by all token sequences.</summary>
     private static IReadOnlyList<string> ComputeSharedPrefix(IReadOnlyList<IReadOnlyList<string>> sequences)
     {
         var minimumLength = sequences.Min(static sequence => sequence.Count);

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanFormatter.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanFormatter.cs
@@ -5,6 +5,7 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class ParserSharedPrefixPlanFormatter
 {
+    /// <summary>Analyzer used to compute eligibility and blockers for each formatted plan.</summary>
     private readonly ParserSharedPrefixExecutionEligibilityAnalyzer eligibilityAnalyzer = new();
 
     /// <summary>

--- a/Utils.Parser/Runtime/ParserStateRegistry.cs
+++ b/Utils.Parser/Runtime/ParserStateRegistry.cs
@@ -13,8 +13,11 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class ParserStateRegistry
 {
+    /// <summary>Set of state keys that have been entered during the current parse, used to prevent redundant re-entry.</summary>
     private readonly HashSet<ParserStateKey> _visitedStates = [];
+    /// <summary>Continuation keys grouped by rule invocation identity for post-completion replay metadata.</summary>
     private readonly Dictionary<RuleInvocationKey, HashSet<ContinuationKey>> _continuations = [];
+    /// <summary>Completed parse results grouped by rule invocation identity for local reuse.</summary>
     private readonly Dictionary<RuleInvocationKey, List<ParserRuleResult>> _completedResults = [];
 
     /// <summary>Resets all registry state for a new parse.</summary>

--- a/Utils.Parser/Runtime/RuntimeTraceAnalyzer.cs
+++ b/Utils.Parser/Runtime/RuntimeTraceAnalyzer.cs
@@ -54,6 +54,7 @@ public static class RuntimeTraceAnalyzer
             ComputeEventDelta(firstSummary.EventDistribution, secondSummary.EventDistribution));
     }
 
+    /// <summary>Returns <see langword="true"/> when two summaries have identical total counts and all distributions match.</summary>
     private static bool AreSummariesEquivalent(RuntimeTraceSummary first, RuntimeTraceSummary second)
     {
         return first.TotalObservations == second.TotalObservations
@@ -63,6 +64,7 @@ public static class RuntimeTraceAnalyzer
             && AreDictionariesEquivalent(first.AlternativeDistribution, second.AlternativeDistribution);
     }
 
+    /// <summary>Returns <see langword="true"/> when two count dictionaries have the same keys and identical values for every key.</summary>
     private static bool AreDictionariesEquivalent<TKey>(IReadOnlyDictionary<TKey, int> first, IReadOnlyDictionary<TKey, int> second)
         where TKey : notnull
     {
@@ -82,6 +84,7 @@ public static class RuntimeTraceAnalyzer
         return true;
     }
 
+    /// <summary>Groups observations by <paramref name="selector"/> and returns a dictionary of occurrence counts per key.</summary>
     private static IReadOnlyDictionary<T, int> CountBy<T>(
         IEnumerable<AlternativeRuntimeObservation> observations,
         Func<AlternativeRuntimeObservation, T> selector)
@@ -105,6 +108,7 @@ public static class RuntimeTraceAnalyzer
         return new ReadOnlyDictionary<T, int>(counts);
     }
 
+    /// <summary>Returns a per-kind signed delta showing how event counts differ between <paramref name="first"/> and <paramref name="second"/>.</summary>
     private static IReadOnlyDictionary<ParserRuntimeObservationKind, int> ComputeEventDelta(
         IReadOnlyDictionary<ParserRuntimeObservationKind, int> first,
         IReadOnlyDictionary<ParserRuntimeObservationKind, int> second)

--- a/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
+++ b/Utils.Parser/Runtime/ScheduledAlternativeExecutor.cs
@@ -19,8 +19,11 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class ScheduledAlternativeExecutor
 {
+    /// <summary>Registry for tracking visited states and invocation-local completion results.</summary>
     private readonly ParserStateRegistry _stateRegistry;
+    /// <summary>Cache of prior look-ahead probe outcomes reused to skip redundant probing.</summary>
     private readonly ParserLookaheadCache _lookaheadCache;
+    /// <summary>Probe used to evaluate shallow first-token look-ahead for an alternative.</summary>
     private readonly ParserLookaheadProbe _lookaheadProbe;
 
     /// <summary>

--- a/Utils.Parser/Runtime/SchedulingPreparation.cs
+++ b/Utils.Parser/Runtime/SchedulingPreparation.cs
@@ -8,11 +8,17 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class SchedulingPreparation
 {
+    /// <summary>Extracts per-alternative structural token prefixes from grammar definitions.</summary>
     private readonly AlternativeStructuralPrefixExtractor _structuralPrefixExtractor = new();
+    /// <summary>Detects shared-prefix candidates from look-ahead probe results.</summary>
     private readonly ParserLookaheadSharedPrefixDetector _sharedPrefixDetector = new();
+    /// <summary>Prepares continuation descriptors for scheduling orchestration.</summary>
     private readonly ContinuationMetadataPreparation _continuationMetadataPreparation = new();
+    /// <summary>Look-ahead probe used for shallow first-token analysis.</summary>
     private readonly ParserLookaheadProbe _lookaheadProbe;
+    /// <summary>Cache for look-ahead probe results to avoid redundant probing.</summary>
     private readonly ParserLookaheadCache _lookaheadCache;
+    /// <summary>Delegate used to resolve rule names to grammar rule objects.</summary>
     private readonly Func<string, Rule?> _resolveRule;
 
     /// <summary>

--- a/Utils.Parser/Runtime/TextReaderBuffer.cs
+++ b/Utils.Parser/Runtime/TextReaderBuffer.cs
@@ -8,12 +8,19 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class TextReaderBuffer(TextReader reader) : TextReaderLookahead
 {
+    /// <summary>Characters read ahead from the underlying reader.</summary>
     private readonly List<char> _buffer = [];
+    /// <summary>Index into <see cref="_buffer"/> of the current lookahead window start.</summary>
     private int _startIndex;
+    /// <summary>Absolute character position in the source stream.</summary>
     private int _position;
+    /// <summary>Current one-based line number.</summary>
     private int _line = 1;
+    /// <summary>Current one-based column number.</summary>
     private int _column = 1;
+    /// <summary><see langword="true"/> when the underlying reader has been exhausted.</summary>
     private bool _isEnd;
+    /// <summary><see langword="true"/> when the last consumed character was a carriage return, used to suppress the extra line increment for CRLF sequences.</summary>
     private bool _previousWasCarriageReturn;
 
     /// <inheritdoc />
@@ -111,6 +118,7 @@ internal sealed class TextReaderBuffer(TextReader reader) : TextReaderLookahead
         return builder.ToString();
     }
 
+    /// <summary>Reads from the underlying reader until at least <paramref name="count"/> characters are available in the buffer.</summary>
     private void EnsureBuffered(int count)
     {
         while (!_isEnd && _buffer.Count - _startIndex < count)
@@ -126,6 +134,7 @@ internal sealed class TextReaderBuffer(TextReader reader) : TextReaderLookahead
         }
     }
 
+    /// <summary>Advances line and column tracking after consuming <paramref name="value"/>.</summary>
     private void UpdateLineAndColumn(char value)
     {
         if (value == '\r')
@@ -152,6 +161,7 @@ internal sealed class TextReaderBuffer(TextReader reader) : TextReaderLookahead
         _previousWasCarriageReturn = false;
     }
 
+    /// <summary>Removes already-consumed characters from the front of the buffer when the consumed prefix is large enough.</summary>
     private void CompactBufferIfNeeded()
     {
         if (_startIndex == 0)

--- a/Utils.Parser/Runtime/TokenizerRuntime.cs
+++ b/Utils.Parser/Runtime/TokenizerRuntime.cs
@@ -47,14 +47,22 @@ public readonly record struct RuntimeTokenizerPosition(int Index, int Length);
 /// </summary>
 public sealed class TokenizerRuntime
 {
+    /// <summary>Source content being tokenized.</summary>
     private readonly string _content;
+    /// <summary>Characters treated as whitespace and skipped when requested.</summary>
     private readonly HashSet<char> _whiteSpaces;
+    /// <summary>Symbol strings tried when no custom reader matches, ordered longest-first.</summary>
     private readonly IReadOnlyList<string> _symbols;
+    /// <summary>Custom token readers applied before symbol matching.</summary>
     private readonly IReadOnlyList<RuntimeTryReadToken> _tokenReaders;
+    /// <summary>Transformers that map raw token text to a defined string value.</summary>
     private readonly IReadOnlyList<RuntimeStringTransformer> _stringTransformers;
+    /// <summary>Stack of saved positions for push/pop support.</summary>
     private readonly Stack<RuntimeTokenizerState> _savedStates = new();
 
+    /// <summary>Start index of the current token in <see cref="_content"/>.</summary>
     private int _index;
+    /// <summary>Length of the current token in <see cref="_content"/>.</summary>
     private int _length;
 
     /// <summary>
@@ -223,6 +231,7 @@ public sealed class TokenizerRuntime
         DefineString = string.Empty;
     }
 
+    /// <summary>Advances past the current token and positions the tokenizer on the next one, optionally skipping whitespace.</summary>
     private bool Read(bool ignoreWhiteSpace)
     {
         _index += _length;
@@ -271,5 +280,6 @@ public sealed class TokenizerRuntime
         throw new TokenizerRuntimeException(_content[_index].ToString(), _index);
     }
 
+    /// <summary>Snapshot of tokenizer cursor state used by push/pop operations.</summary>
     private readonly record struct RuntimeTokenizerState(int Index, int Length, string DefineString);
 }


### PR DESCRIPTION
## Summary

- Adds missing `/// <summary>` XML documentation to private fields, methods, and record structs across **26 files** in the `Utils.Parser` project.
- Covers: TextReaderBuffer, TokenizerRuntime, ParseContext, AlternativeStructuralPrefixExtractor, ParserSharedPrefixPlanFactory/Formatter, ParserSharedPrefixExecutionEligibilityAnalyzer, ContinuationMetadataPreparation, ContinuationStructuralPositionExtractor, SchedulingPreparation, ScheduledAlternativeExecutor, ParserStateRegistry, RuntimeTraceAnalyzer, AlternativeRuntimeObservation, LexerExtensionContext, ConventionSyntaxColorisation, G4SyntaxColorisation, FileSystemGrammarSourceResolver, InMemoryGrammarSourceResolver, Antlr4GrammarProjectCompiler (CompilationState), LeftRecursionAnalyzer, RuleResolver, ParserFeatureCapabilities, Antlr4RuntimePrequelMapper, Antlr4PrequelDiagnosticMapper, Antlr4GrammarConverter.
- No logic changed — documentation only.

## Test plan

- [x] `dotnet build Utils.Parser/Utils.Parser.csproj` — 0 errors
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter Parser` — 764/764 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)