### PR TITLE
fix(converter): emit diagnostics for silently dropped ANTLR4 constructs

### DIFF
--- a/Utils.Parser.Diagnostics/ParserDiagnostics.cs
+++ b/Utils.Parser.Diagnostics/ParserDiagnostics.cs
@@ -194,6 +194,18 @@ public static class ParserDiagnostics
     public static readonly ParserDiagnosticDescriptor LabelOnNonRuleReferenceIgnored =
         new("UP1022", "Label ignored on non-rule reference", "Label '{0}' is recognized but ignored because it targets a non-rule-reference element.", DefaultCategory);
 
+    /// <summary>Element option on an alternative recognized but not applied by the current runtime model.</summary>
+    public static readonly ParserDiagnosticDescriptor ElementOptionIgnored =
+        new("UP1032", "Element option ignored", "Element option '{0}' is recognized but not applied by the current runtime model.", DefaultCategory);
+
+    /// <summary>Options block on a lexer rule recognized but ignored by the current runtime model.</summary>
+    public static readonly ParserDiagnosticDescriptor LexerRuleOptionsIgnored =
+        new("UP1033", "Lexer rule options ignored", "Options block on lexer rule '{0}' is recognized but ignored by the current runtime model.", DefaultCategory);
+
+    /// <summary>Options block on a parser rule recognized but ignored by the current runtime model.</summary>
+    public static readonly ParserDiagnosticDescriptor ParserRuleOptionsIgnored =
+        new("UP1034", "Parser rule options ignored", "Options block on parser rule '{0}' is recognized but ignored by the current runtime model.", DefaultCategory);
+
     // Warnings (UP5xxx)
     /// <summary>Best-effort recovery used.</summary>
     public static readonly ParserDiagnosticDescriptor BestEffortRecoveryUsed =
@@ -311,6 +323,9 @@ public static class ParserDiagnostics
             [UnsupportedLexerCommand.Code] = UnsupportedLexerCommand,
             [UnsupportedAntlrOptionIgnored.Code] = UnsupportedAntlrOptionIgnored,
             [LabelOnNonRuleReferenceIgnored.Code] = LabelOnNonRuleReferenceIgnored,
+            [ElementOptionIgnored.Code] = ElementOptionIgnored,
+            [LexerRuleOptionsIgnored.Code] = LexerRuleOptionsIgnored,
+            [ParserRuleOptionsIgnored.Code] = ParserRuleOptionsIgnored,
             [BestEffortRecoveryUsed.Code] = BestEffortRecoveryUsed,
             [ExpectedTokenMissing.Code] = ExpectedTokenMissing,
             [FallbackStrategyUsed.Code] = FallbackStrategyUsed,

--- a/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
+++ b/Utils.Parser/Bootstrap/Antlr4GrammarConverter.cs
@@ -493,6 +493,9 @@ public sealed class Antlr4GrammarConverter
         bool isFragment = HasToken(node, "FRAGMENT");
         var nameToken = Require(FirstToken(node, "TOKEN_REF"), "Missing TOKEN_REF in lexerRuleSpec");
 
+        if (First(node, "optionsSpec") != null)
+            _diagnostics?.AddWithContext(ParserDiagnostics.LexerRuleOptionsIgnored, null, null, nameToken.Text, null, nameToken.Text);
+
         var ruleBlock = Require(First(node, "lexerRuleBlock"), "Missing lexerRuleBlock");
         var content = ConvertLexerRuleBlock(ruleBlock);
 
@@ -695,6 +698,12 @@ public sealed class Antlr4GrammarConverter
         bool hasRuleExceptionMetadata = false;
         foreach (var prequel in All(node, "rulePrequel"))
         {
+            if (First(prequel, "optionsSpec") != null)
+            {
+                _diagnostics?.AddWithContext(ParserDiagnostics.ParserRuleOptionsIgnored, null, null, name, null, name);
+                continue;
+            }
+
             if (First(prequel, "localsSpec") != null)
             {
                 hasIgnoredRuleMetadata = true;
@@ -787,31 +796,43 @@ public sealed class Antlr4GrammarConverter
     /// Resolves associativity from the <c>&lt;assoc=right&gt;</c> option that may appear at the
     /// start of an ANTLR4 <c>alternative</c> node as an <c>elementOptions</c> child.
     /// Navigates the parse tree: <c>alternative → elementOptions → elementOption → identifier / qualifiedIdentifier</c>.
+    /// Emits <see cref="ParserDiagnostics.ElementOptionIgnored"/> for any option other than <c>assoc</c>.
     /// </summary>
-    private static Associativity ResolveAlternativeAssociativity(ParserNode alternativeNode)
+    private Associativity ResolveAlternativeAssociativity(ParserNode alternativeNode)
     {
         var elementOptions = First(alternativeNode, "elementOptions");
         if (elementOptions is null)
             return Associativity.Left;
 
+        var result = Associativity.Left;
         foreach (var elementOption in All(elementOptions, "elementOption"))
         {
-            // Only the key=value form carries assoc: identifier ASSIGN qualifiedIdentifier
             if (!HasToken(elementOption, "ASSIGN"))
+            {
+                // Simple bare-identifier option — not assoc, emit diagnostic
+                var bareIdent = First(elementOption, "identifier");
+                _diagnostics?.Add(ParserDiagnostics.ElementOptionIgnored, TryGetIdentifierText(bareIdent!) ?? "?");
                 continue;
+            }
 
             var keyNode = First(elementOption, "identifier");
-            if (!string.Equals(TryGetIdentifierText(keyNode!), "assoc", StringComparison.Ordinal))
-                continue;
+            var keyText = TryGetIdentifierText(keyNode!);
 
-            // Value is a qualifiedIdentifier node whose first identifier child holds the text
-            var qualifiedId = First(elementOption, "qualifiedIdentifier");
-            var valueIdent = qualifiedId is not null ? First(qualifiedId, "identifier") : null;
-            if (string.Equals(TryGetIdentifierText(valueIdent!), "right", StringComparison.Ordinal))
-                return Associativity.Right;
+            if (string.Equals(keyText, "assoc", StringComparison.Ordinal))
+            {
+                // Value is a qualifiedIdentifier node whose first identifier child holds the text
+                var qualifiedId = First(elementOption, "qualifiedIdentifier");
+                var valueIdent = qualifiedId is not null ? First(qualifiedId, "identifier") : null;
+                if (string.Equals(TryGetIdentifierText(valueIdent!), "right", StringComparison.Ordinal))
+                    result = Associativity.Right;
+            }
+            else
+            {
+                _diagnostics?.Add(ParserDiagnostics.ElementOptionIgnored, keyText ?? "?");
+            }
         }
 
-        return Associativity.Left;
+        return result;
     }
 
     /// <summary>Converts an <c>alternative</c> node into a <see cref="RuleContent"/> (sequence or single element).</summary>

--- a/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarConverterTests.cs
@@ -785,6 +785,70 @@ public class Antlr4GrammarConverterTests
         Assert.IsTrue(def.AllRules.ContainsKey("start"));
     }
 
+    // ─── Silent-drop diagnostics ─────────────────────────────────────────────
+
+    [TestMethod]
+    public void Alternative_WithUnknownElementOption_EmitsDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            expr : <myOption=someValue> 'x' 'y' | 'z' ;
+            """, diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.ElementOptionIgnored.Code),
+            "Expected UP1032 for unknown element option <myOption=...>");
+        var diag = diagnostics.First(d => d.Code == ParserDiagnostics.ElementOptionIgnored.Code);
+        StringAssert.Contains(diag.Message, "myOption");
+    }
+
+    [TestMethod]
+    public void Alternative_WithAssocRight_DoesNotEmitElementOptionDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            expr : <assoc=right> expr '^' expr | INT ;
+            INT : ('0'..'9')+ ;
+            """, diagnostics);
+
+        Assert.IsFalse(diagnostics.Any(d => d.Code == ParserDiagnostics.ElementOptionIgnored.Code),
+            "assoc=right must not emit UP1032");
+    }
+
+    [TestMethod]
+    public void LexerRule_WithOptionsBlock_EmitsDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start : ID ;
+            ID options { caseInsensitive=true; } : ('a'..'z')+ ;
+            """, diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.LexerRuleOptionsIgnored.Code),
+            "Expected UP1033 for options block on lexer rule");
+        var diag = diagnostics.First(d => d.Code == ParserDiagnostics.LexerRuleOptionsIgnored.Code);
+        StringAssert.Contains(diag.Message, "ID");
+    }
+
+    [TestMethod]
+    public void ParserRule_WithOptionsBlock_EmitsDiagnostic()
+    {
+        var diagnostics = new DiagnosticBag();
+        _ = Antlr4GrammarConverter.Parse("""
+            grammar G;
+            start
+              options { caseInsensitive=true; }
+              : 'x' ;
+            """, diagnostics);
+
+        Assert.IsTrue(diagnostics.Any(d => d.Code == ParserDiagnostics.ParserRuleOptionsIgnored.Code),
+            "Expected UP1034 for options block on parser rule");
+        var diag = diagnostics.First(d => d.Code == ParserDiagnostics.ParserRuleOptionsIgnored.Code);
+        StringAssert.Contains(diag.Message, "start");
+    }
+
     // ─── Utilitaires ─────────────────────────────────────────────────────────
 
     private static bool ContainsLexerCommand(RuleContent content, LexerCommandType type)

--- a/docs/parser/Antlr4CompatibilityMatrix.md
+++ b/docs/parser/Antlr4CompatibilityMatrix.md
@@ -55,6 +55,7 @@ Rationale: execution of user code and semantic predicates is policy-controlled. 
 |---|---|---|---|---|---|
 | `{ condition }?` | Yes | Yes (`ValidatingPredicate`) | Yes, via `ISemanticPredicateEvaluator` in `ParserRuntimeFeaturePolicy` | `NotEvaluated` is treated as accepted; parse continues conservatively | `UP1006` (`SemanticPredicateNotEnforced`) when result is `NotEvaluated` |
 | `{ condition }=>` (if recognized) | Yes | Yes (`GatingPredicate`) | Yes, via `ISemanticPredicateEvaluator` in `ParserRuntimeFeaturePolicy` | `NotEvaluated` is treated as accepted; parse continues conservatively | `UP1006` (`SemanticPredicateNotEnforced`) when result is `NotEvaluated` |
+| Predicate options (`{ condition }?<fail=...>`) | No — causes parse failure | No | No | Grammar text fails to parse at meta-grammar level; `{ condition }?` without options is supported | None emitted (parse fails before converter) |
 | `precpred(_ctx, N)` | Yes | Yes (`PrecedencePredicate`) | No (not via semantic predicate evaluator) | Normalized into precedence checks (`CheckPrecedence`) | No `UP1006` emission for precedence predicates |
 
 ## Parsed but not fully resolved
@@ -82,6 +83,9 @@ Additional architectural context and explicit non-goals are documented in `docs/
 | Other grammar `options` entries | Parsed and preserved as metadata; unsupported options are reported explicitly with `UnsupportedAntlrOptionIgnored`. |
 | Left-recursive precedence parity | Implemented for current runtime model, but not equivalent to all ANTLR4 precedence scenarios; the runtime can emit `LeftRecursivePrecedencePartiallySupported` where applicable. |
 | Lexer command set | Supported commands are `skip`, `more`, `channel`, `type`, `pushMode`, `popMode`, `mode`. Any other command is rejected deterministically with `UnsupportedLexerCommand`. |
+| Element options other than `assoc` (`<type=...>`, etc.) | Parsed; `assoc=right` applied; all other options emitted as `UP1032` (`ElementOptionIgnored`) and ignored. |
+| Lexer rule options block (`TOKEN options { ... } : ...`) | Parsed; recognized and emitted as `UP1033` (`LexerRuleOptionsIgnored`); not applied. |
+| Parser rule options block (`rule options { ... } : ...`) | Parsed; recognized and emitted as `UP1034` (`ParserRuleOptionsIgnored`); not applied. |
 
 ## Runtime metadata boundary
 


### PR DESCRIPTION
## Summary

Three ANTLR4 constructs were recognized by the meta-grammar but silently dropped by `Antlr4GrammarConverter` with no diagnostic, making it impossible for users to know their grammar contained unsupported syntax.

This PR adds explicit diagnostics for each:

- **UP1032 `ElementOptionIgnored`** — element options other than `<assoc=right>` on parser alternatives (e.g. `<type=Token>`) are now reported. `assoc=right` handling is preserved unchanged.
- **UP1033 `LexerRuleOptionsIgnored`** — `options { ... }` block on a lexer rule (e.g. `TOKEN options { caseInsensitive=true; } : ...`) is now reported with the rule name.
- **UP1034 `ParserRuleOptionsIgnored`** — `options { ... }` block in a parser rule prequel (e.g. `rule options { ... } : ...`) is now reported with the rule name.

`ResolveAlternativeAssociativity` is changed from `private static` to `private` so it can write to `_diagnostics`.

Also documents in `Antlr4CompatibilityMatrix.md` that predicate options (`{ condition }?<fail=...>`) cause a meta-grammar parse failure (not a silent drop — separate issue), and adds the three newly diagnosed constructs to the "Partially supported" table.

## Test plan

- [ ] `Alternative_WithUnknownElementOption_EmitsDiagnostic` — UP1032 emitted for unknown element option
- [ ] `Alternative_WithAssocRight_DoesNotEmitElementOptionDiagnostic` — UP1032 not emitted for `assoc=right` (regression guard)
- [ ] `LexerRule_WithOptionsBlock_EmitsDiagnostic` — UP1033 emitted for lexer rule options block
- [ ] `ParserRule_WithOptionsBlock_EmitsDiagnostic` — UP1034 emitted for parser rule options block
- [ ] Full unit test suite: 1539 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
