### PR TITLE
fix(fonts): remove dead code, debug output and fix Math.Log/Pow hot paths

### DIFF
--- a/Utils.Fonts/TTF/Tables/BslnTable.cs
+++ b/Utils.Fonts/TTF/Tables/BslnTable.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using Utils.IO.Serialization;
 
 namespace Utils.Fonts.TTF.Tables;
@@ -343,8 +344,9 @@ public class BslnTable : TrueTypeTable
         const ushort unitSize = 4;
 
         // Binary-search header parameters (same formula as KernTable)
-        ushort searchRange   = (ushort)(Math.Pow(2, Math.Floor(Math.Log2(nUnits))) * unitSize);
-        ushort entrySelector = (ushort)Math.Floor(Math.Log2(nUnits));
+        int    log2          = BitOperations.Log2((uint)nUnits);
+        ushort searchRange   = (ushort)((1 << log2) * unitSize);
+        ushort entrySelector = (ushort)log2;
         ushort rangeShift    = (ushort)(nUnits * unitSize - searchRange);
 
         // binSrchHeader (12 bytes)

--- a/Utils.Fonts/TTF/Tables/Cmap/CMapFormat4.cs
+++ b/Utils.Fonts/TTF/Tables/Cmap/CMapFormat4.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using Utils.IO.Serialization;
 using Utils.Objects;
@@ -236,27 +237,14 @@ public class CMapFormat4 : CMapFormatBase
     /// <summary>
     /// Gets the search range used in the CMap header.
     /// </summary>
-    public virtual short SearchRange
-    {
-        get
-        {
-            double pow = Math.Floor(Math.Log(SegmentCount, 2));
-            double pow2 = Math.Pow(2, pow);
-            return (short)(2 * pow2);
-        }
-    }
+    public virtual short SearchRange =>
+        (short)(2 * (1 << BitOperations.Log2((uint)SegmentCount)));
 
     /// <summary>
     /// Gets the entry selector used in the CMap header.
     /// </summary>
-    public virtual short EntrySelector
-    {
-        get
-        {
-            int sr2 = SearchRange / 2;
-            return (short)Math.Log(sr2, 2);
-        }
-    }
+    public virtual short EntrySelector =>
+        (short)BitOperations.Log2((uint)SegmentCount);
 
     /// <summary>
     /// Gets the range shift used in the CMap header.
@@ -324,7 +312,7 @@ public class CMapFormat4 : CMapFormatBase
         for (int i = 0; i < segCount; i++)
         {
             idRangeOffsets[i] = data.Read<Int16>();
-            if (idRangeOffsets[i] <= 0)
+            if (idRangeOffsets[i] == 0)
             {
                 AddSegment((char)startCodes[i], (char)endCodes[i], idDeltas[i]);
                 continue;

--- a/Utils.Fonts/TTF/Tables/Glyf/GlyphBase.cs
+++ b/Utils.Fonts/TTF/Tables/Glyf/GlyphBase.cs
@@ -86,14 +86,9 @@ public class GlyphBase
         {
             glyf = new GlyphCompound();
         }
-        else if (numContours <= 0)
-        {
-            var message = $"Unknown glyf type: {numContours}";
-            throw new ArgumentException(message);
-        }
         else
         {
-            return null;
+            throw new ArgumentException($"Unknown glyf type: {numContours}");
         }
         glyf.GlyfTable = glyfTable;
         glyf.NumContours = numContours;

--- a/Utils.Fonts/TTF/Tables/KernTable.cs
+++ b/Utils.Fonts/TTF/Tables/KernTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Numerics;
 using Utils.IO.Serialization;
 
 namespace Utils.Fonts.TTF.Tables
@@ -94,9 +95,10 @@ namespace Utils.Fonts.TTF.Tables
 
             data.Write<UInt16>(nPairs);         // number of pairs
                                                 // For simplicity, compute searchRange, entrySelector, and rangeShift as follows:
-            ushort searchRange = (ushort)(Math.Pow(2, Math.Floor(Math.Log(nPairs, 2))) * KernPairSize);
-            ushort entrySelector = (ushort)Math.Log(Math.Pow(2, Math.Floor(Math.Log(nPairs, 2))), 2);
-            ushort rangeShift = (ushort)(nPairs * KernPairSize - searchRange);
+            int    log2         = BitOperations.Log2((uint)nPairs);
+            ushort searchRange  = (ushort)((1 << log2) * KernPairSize);
+            ushort entrySelector = (ushort)log2;
+            ushort rangeShift   = (ushort)(nPairs * KernPairSize - searchRange);
             data.Write<UInt16>(searchRange);
             data.Write<UInt16>(entrySelector);
             data.Write<UInt16>(rangeShift);

--- a/Utils.Fonts/TTF/Tables/PostTable.cs
+++ b/Utils.Fonts/TTF/Tables/PostTable.cs
@@ -372,7 +372,7 @@ public class PostTable : TrueTypeTable
         if (nameMap is null)
         {
             nameMap = new PostMap();
-            Console.WriteLine($"Unknown post map type: {Format:X2}");
+            System.Diagnostics.Debug.WriteLine($"Unknown post map type: {Format:X2}");
         }
         nameMap.ReadData(data);
     }

--- a/Utils.Fonts/TTF/TrueTypeFont.cs
+++ b/Utils.Fonts/TTF/TrueTypeFont.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Reflection;
 using System.Text;
 using Utils.Fonts.TTF.Tables;
@@ -215,7 +216,7 @@ public class TrueTypeFont : IFont
             var checkSum = ComputeChecksum(td.Tag, new ReaderWriter(td.Data));
             if (checkSum != td.CheckSum)
             {
-                Console.WriteLine($"Declared Checksum {td.CheckSum:X4} is different from {checkSum:X4}");
+                System.Diagnostics.Debug.WriteLine($"Declared Checksum {td.CheckSum:X4} is different from {checkSum:X4}");
             }
         }
 
@@ -273,41 +274,21 @@ public class TrueTypeFont : IFont
     /// <summary>
     /// Gets the search range used in the font header.
     /// </summary>
-    public virtual short SearchRange
-    {
-        get
-        {
-            double num = Math.Floor(Math.Log(TablesCount, 2));
-            double num2 = Math.Pow(2.0, num);
-            return (short)(TableDirectoryEntrySize * num2);
-        }
-    }
+    public virtual short SearchRange =>
+        (short)(TableDirectoryEntrySize * (1 << BitOperations.Log2((uint)TablesCount)));
 
     /// <summary>
     /// Gets the entry selector used in the font header.
     /// </summary>
-    public virtual short EntrySelector
-    {
-        get
-        {
-            double num = Math.Floor(Math.Log(TablesCount, 2));
-            double num2 = Math.Pow(2.0, num);
-            return (short)Math.Log(num2, 2);
-        }
-    }
+    public virtual short EntrySelector =>
+        (short)BitOperations.Log2((uint)TablesCount);
 
     /// <summary>
     /// Gets the range shift used in the font header.
     /// </summary>
-    public virtual short RangeShift
-    {
-        get
-        {
-            double num = Math.Floor(Math.Log(TablesCount, 2));
-            short num2 = (short)Math.Pow(2.0, num);
-            return (short)(num2 * TableDirectoryEntrySize - SearchRange);
-        }
-    }
+    public virtual short RangeShift =>
+        // TTF spec: rangeShift = numTables * 16 - searchRange
+        (short)(TablesCount * TableDirectoryEntrySize - SearchRange);
 
     /// <summary>
     /// Computes the checksum for the data associated with the specified table tag.


### PR DESCRIPTION
## Summary

- **Bug fix -- `TrueTypeFont.RangeShift` (toujours 0)**: calculait `(2^log2(n) * EntrySize) - SearchRange`, or `SearchRange = 2^log2(n) * EntrySize`, donc le resultat etait toujours 0. La spec TTF dit `rangeShift = numTables * 16 - searchRange`. Corrige.
- **Bug fix -- `CMapFormat4` idRangeOffset `<= 0` -> `== 0`**: un offset stocke en `short` signe peut etre negatif (ex. 0x8000 = -32768) ; la condition `<= 0` le classifiait faussement en mode "use delta" au lieu de "use glyph array", corrompant la table cmap pour les polices avec de grands offsets.
- **Code mort -- `GlyphBase.CreateGlyf`**: branche `else { return null; }` apres une chaine `if/else-if` exhaustive qui couvre tous les entiers. Supprimee.
- **Debug -- `Console.WriteLine` en production**: deux appels dans `TrueTypeFont.cs` et `PostTable.cs` remplaces par `Debug.WriteLine` (elimine en Release).
- **Perf -- `Math.Pow(2, Math.Floor(Math.Log(n, 2)))` x5**: remplace par `1 << BitOperations.Log2((uint)n)` dans `TrueTypeFont`, `CMapFormat4`, `KernTable`, `BslnTable`. `EntrySelector` dans `TrueTypeFont` calculait `Math.Log(Math.Pow(2, x), 2) = x` -- cinq appels transcendants pour retourner une valeur deja connue.

## Test plan

- [ ] Build : 0 erreur
- [ ] 81 tests fonctionnels Fonts passent
- [ ] 1677 tests unitaires passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
