### PR TITLE
perf(collections/io/geography): eliminate per-call allocations in 4 hot paths

### DIFF
--- a/Utils.Geography/Geography/Model/GeoPoint.cs
+++ b/Utils.Geography/Geography/Model/GeoPoint.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -427,21 +428,29 @@ namespace Utils.Geography.Model
 
         #region Utility
 
+        // Regex instances are expensive to compile; cache one per unique (nativeDigits, decimalSeparator) pair.
+        private static readonly ConcurrentDictionary<string, Regex> _regexCache = new();
+
         /// <summary>
-        /// Builds the regex used to parse coordinate values from strings.
+        /// Builds or retrieves from cache the regex used to parse coordinate values from strings.
         /// </summary>
         protected static Regex BuildRegexCoordinates(CultureInfo culture)
         {
-            // Build a pattern that accommodates the culture's digits and decimal separator
-            // This pattern picks up optional modifiers (W/E/N/S/+/-), degrees, optional minutes, optional seconds.
-            string digits = $"[{string.Join("", culture.NumberFormat.NativeDigits)}]+";
+            string nativeDigits = string.Join("", culture.NumberFormat.NativeDigits);
             string decimalSeparator = culture.NumberFormat.NumberDecimalSeparator;
-            string number = $"{digits}({Regex.Escape(decimalSeparator)}{digits})?";
+            string cacheKey = $"{nativeDigits}|{decimalSeparator}";
 
-            return new Regex(
-                @$"(?<modifier>W|E|N|S|\-|\+)?(?<degrees>{number})(°(?<minutes>{number}))?('(?<seconds>{number}))?",
-                RegexOptions.Compiled | RegexOptions.IgnoreCase
-            );
+            return _regexCache.GetOrAdd(cacheKey, static key =>
+            {
+                int sep = key.IndexOf('|');
+                string digits = $"[{key[..sep]}]+";
+                string dec = key[(sep + 1)..];
+                string number = $"{digits}({Regex.Escape(dec)}{digits})?";
+                return new Regex(
+                    @$"(?<modifier>W|E|N|S|\-|\+)?(?<degrees>{number})(°(?<minutes>{number}))?('(?<seconds>{number}))?",
+                    RegexOptions.Compiled | RegexOptions.IgnoreCase
+                );
+            });
         }
 
         #endregion

--- a/Utils.IO/IO/BaseEncoding/BaseEncoderStream.cs
+++ b/Utils.IO/IO/BaseEncoding/BaseEncoderStream.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 
 namespace Utils.IO.BaseEncoding;
 
@@ -112,8 +111,10 @@ public class BaseEncoderStream : Stream
     /// <param name="count">Number of bytes to read.</param>
     public override void Write(byte[] buffer, int offset, int count)
     {
-        foreach (var b in buffer.Skip(offset).Take(count))
+        int end = offset + count;
+        for (int idx = offset; idx < end; idx++)
         {
+            byte b = buffer[idx];
             position++;
             value = (value << 8) | b;
             shift += 8;

--- a/Utils.IO/IO/StreamUtils.cs
+++ b/Utils.IO/IO/StreamUtils.cs
@@ -214,35 +214,30 @@ public static class StreamUtils
         // We'll store the data in a MemoryStream as we read it.
         // We'll also keep track of the last bytes read to detect the separator.
         using var ms = new MemoryStream();
-        var separatorQueue = new Queue<byte>(blockSeparator.Length);
+        // Circular buffer: avoids Queue enumerator allocation on every byte read.
+        int sepLen = blockSeparator.Length;
+        byte[] window = new byte[sepLen];
+        int writePos = 0;   // next slot to write into
+        int filled   = 0;   // number of valid bytes currently in window
 
         while (true)
         {
             int readByte = s.ReadByte();
             if (readByte == -1)
-            {
-                // Reached end of stream => return whatever we have so far
                 return ms.ToArray();
-            }
 
-            // Write the current byte to the memory stream
             ms.WriteByte((byte)readByte);
 
-            // Keep track of up to the last 'blockSeparator.Length' bytes
-            separatorQueue.Enqueue((byte)readByte);
-            if (separatorQueue.Count > blockSeparator.Length)
-            {
-                separatorQueue.Dequeue();
-            }
+            window[writePos] = (byte)readByte;
+            writePos = (writePos + 1) % sepLen;
+            if (filled < sepLen) filled++;
 
-            // If the queue holds exactly the separator length, check for match
-            if (separatorQueue.Count == blockSeparator.Length)
+            if (filled == sepLen)
             {
                 bool matched = true;
-                int i = 0;
-                foreach (byte b in separatorQueue)
+                for (int i = 0; i < sepLen; i++)
                 {
-                    if (blockSeparator[i++] != b)
+                    if (window[(writePos + i) % sepLen] != blockSeparator[i])
                     {
                         matched = false;
                         break;
@@ -251,11 +246,8 @@ public static class StreamUtils
 
                 if (matched)
                 {
-                    // The block ends right before the block separator
-                    // => remove the separator from the MemoryStream content
-                    long newLength = ms.Length - blockSeparator.Length;
-                    if (newLength < 0) newLength = 0; // Safety check
-
+                    long newLength = ms.Length - sepLen;
+                    if (newLength < 0) newLength = 0;
                     ms.SetLength(newLength);
                     return ms.ToArray();
                 }

--- a/Utils/Collections/EnumerableEx.Zip.cs
+++ b/Utils/Collections/EnumerableEx.Zip.cs
@@ -88,7 +88,12 @@ public static partial class EnumerableEx
     /// <param name="enumerations"><see cref="IEnumerable"/> to be read</param>
     /// <returns>Array of objects</returns>
     public static IEnumerable<object[]> Zip(bool continueAfterShortestListEnds, params (IEnumerable enumeration, object defaultValue)[] enumerations)
-        => Zip(continueAfterShortestListEnds, enumerations.Select(e => e.enumeration).ToArray(), enumerations.Select((e) => e.defaultValue).ToArray());
+    {
+        var enums     = new IEnumerable[enumerations.Length];
+        var defaults  = new object[enumerations.Length];
+        for (int i = 0; i < enumerations.Length; i++) { enums[i] = enumerations[i].enumeration; defaults[i] = enumerations[i].defaultValue; }
+        return Zip(continueAfterShortestListEnds, enums, defaults);
+    }
 
     /// <summary>
     /// Read several <see cref="IEnumerable"/> in parallel and returns an array of object of elments from the same indexes
@@ -98,7 +103,12 @@ public static partial class EnumerableEx
     /// <param name="transform">transformation function of input object to output object</param>
     /// <returns>Array of objects</returns>
     public static IEnumerable<TResult> Zip<TResult>(bool continueAfterShortestListEnds, Func<object[], TResult> transform, params (IEnumerable enumeration, object defaultValue)[] enumerations)
-        => Zip(continueAfterShortestListEnds, enumerations.Select(e => e.enumeration).ToArray(), enumerations.Select((e) => e.defaultValue)).Select(o => transform(o));
+    {
+        var enums    = new IEnumerable[enumerations.Length];
+        var defaults = new object[enumerations.Length];
+        for (int i = 0; i < enumerations.Length; i++) { enums[i] = enumerations[i].enumeration; defaults[i] = enumerations[i].defaultValue; }
+        return Zip(continueAfterShortestListEnds, enums, defaults).Select(o => transform(o));
+    }
 
     private static IEnumerable<object[]> Zip(bool continueAfterShortestListEnds, IEnumerable[] enumerations, object[] defaultValues)
     {

--- a/Utils/Collections/EnumerableEx.cs
+++ b/Utils/Collections/EnumerableEx.cs
@@ -123,7 +123,50 @@ public static partial class EnumerableEx
     }
 
     /// <summary>
-    /// Enumerates all elements in <paramref name="enumerable"/> followed by 
+    /// Returns a slice of <paramref name="source"/> starting at <paramref name="skip"/> and
+    /// yielding at most <paramref name="take"/> elements, using a single enumerator.
+    /// This is equivalent to <c>Skip(skip).Take(take)</c> but avoids the two LINQ
+    /// enumerator allocations that the chained form incurs.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the sequence.</typeparam>
+    /// <param name="source">The sequence to slice.</param>
+    /// <param name="skip">Number of elements to skip from the start.</param>
+    /// <param name="take">Maximum number of elements to return.</param>
+    /// <returns>The requested slice of <paramref name="source"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> is <see langword="null"/>.</exception>
+    public static IEnumerable<T> SkipTake<T>(this IEnumerable<T> source, int skip, int take)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (take <= 0) yield break;
+
+        // Fast path for arrays — avoid the enumerator entirely.
+        if (source is T[] array)
+        {
+            int end = Math.Min(skip + take, array.Length);
+            for (int i = skip; i < end; i++) yield return array[i];
+            yield break;
+        }
+
+        // Fast path for IList<T> — direct index access, no enumerator overhead.
+        if (source is IList<T> list)
+        {
+            int end = Math.Min(skip + take, list.Count);
+            for (int i = skip; i < end; i++) yield return list[i];
+            yield break;
+        }
+
+        // General case: advance past the skipped elements with a single enumerator.
+        using var e = source.GetEnumerator();
+        for (int i = 0; i < skip; i++)
+            if (!e.MoveNext()) yield break;
+
+        int remaining = take;
+        while (remaining-- > 0 && e.MoveNext())
+            yield return e.Current;
+    }
+
+    /// <summary>
+    /// Enumerates all elements in <paramref name="enumerable"/> followed by
     /// additional <paramref name="elements"/>.
     /// </summary>
     /// <typeparam name="T">The type of elements in the sequences.</typeparam>

--- a/Utils/Collections/MappedDictionary.cs
+++ b/Utils/Collections/MappedDictionary.cs
@@ -13,6 +13,8 @@ namespace Utils.Collections
     public class MappedDictionary<K, V> : ReadOnlyMappedDictionary<K, V>, IDictionary<K, V>
     {
         private readonly IDictionaryMap<K, V> map;
+        private readonly MappedKeyCollection _keysView;
+        private readonly MappedValueCollection _valuesView;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MappedDictionary{K, V}"/> class using a custom dictionary map.
@@ -21,6 +23,8 @@ namespace Utils.Collections
         public MappedDictionary(IDictionaryMap<K, V> map) : base(map)
         {
             this.map = map ?? throw new ArgumentNullException(nameof(map));
+            _keysView = new MappedKeyCollection(this);
+            _valuesView = new MappedValueCollection(this);
         }
 
         /// <summary>
@@ -43,7 +47,7 @@ namespace Utils.Collections
             Func<IEnumerable<KeyValuePair<K, V>>> getValues,
             Func<int> getCount,
             Action clear) :
-            base(new DictionaryMap<K, V>(containsKeyValue, addValue, getValue, setValue, removeValue, getValues, getCount, clear))
+            this(new DictionaryMap<K, V>(containsKeyValue, addValue, getValue, setValue, removeValue, getValues, getCount, clear))
         {
         }
 
@@ -61,7 +65,7 @@ namespace Utils.Collections
             Action<K, V> setValue,
             Func<K, bool> removeValue,
             Action clear) :
-            base(new DictionaryMap<K, V>(baseDictionary, addValue, setValue, removeValue, clear))
+            this(new DictionaryMap<K, V>(baseDictionary, addValue, setValue, removeValue, clear))
         {
         }
 
@@ -70,11 +74,9 @@ namespace Utils.Collections
         /// </summary>
         public bool IsReadOnly => false;
 
-        // Explicit interface implementation for IDictionary.Keys
-        ICollection<K> IDictionary<K, V>.Keys => map.GetValues().Select(kv => kv.Key).ToList();
-
-        // Explicit interface implementation for IDictionary.Values
-        ICollection<V> IDictionary<K, V>.Values => map.GetValues().Select(kv => kv.Value).ToList();
+        // Explicit interface implementation for IDictionary.Keys/Values — live views, no allocation per access.
+        ICollection<K> IDictionary<K, V>.Keys => _keysView;
+        ICollection<V> IDictionary<K, V>.Values => _valuesView;
 
         /// <summary>
         /// Gets or sets the value associated with the specified key.
@@ -127,6 +129,36 @@ namespace Utils.Collections
         /// Removes the value with the specified key from the dictionary.
         /// </summary>
         public bool Remove(K key) => map.Remove(key);
+
+        private sealed class MappedKeyCollection : ICollection<K>
+        {
+            private readonly MappedDictionary<K, V> _dict;
+            internal MappedKeyCollection(MappedDictionary<K, V> dict) => _dict = dict;
+            public int Count => _dict.Count;
+            public bool IsReadOnly => true;
+            public bool Contains(K item) { foreach (var kv in _dict) if (EqualityComparer<K>.Default.Equals(kv.Key, item)) return true; return false; }
+            public void CopyTo(K[] array, int arrayIndex) { foreach (var kv in _dict) array[arrayIndex++] = kv.Key; }
+            public IEnumerator<K> GetEnumerator() { foreach (var kv in _dict) yield return kv.Key; }
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+            public void Add(K item) => throw new NotSupportedException();
+            public void Clear() => throw new NotSupportedException();
+            public bool Remove(K item) => throw new NotSupportedException();
+        }
+
+        private sealed class MappedValueCollection : ICollection<V>
+        {
+            private readonly MappedDictionary<K, V> _dict;
+            internal MappedValueCollection(MappedDictionary<K, V> dict) => _dict = dict;
+            public int Count => _dict.Count;
+            public bool IsReadOnly => true;
+            public bool Contains(V item) { foreach (var kv in _dict) if (EqualityComparer<V>.Default.Equals(kv.Value, item)) return true; return false; }
+            public void CopyTo(V[] array, int arrayIndex) { foreach (var kv in _dict) array[arrayIndex++] = kv.Value; }
+            public IEnumerator<V> GetEnumerator() { foreach (var kv in _dict) yield return kv.Value; }
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+            public void Add(V item) => throw new NotSupportedException();
+            public void Clear() => throw new NotSupportedException();
+            public bool Remove(V item) => throw new NotSupportedException();
+        }
     }
 
     /// <summary>

--- a/UtilsTest/Collections/SkipTakeTests.cs
+++ b/UtilsTest/Collections/SkipTakeTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using Utils.Collections;
+
+namespace UtilsTest.Collections;
+
+[TestClass]
+public class SkipTakeTests
+{
+    // ── Array fast path ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Array_SkipTake_ReturnsSlice()
+    {
+        int[] source = [0, 1, 2, 3, 4, 5, 6];
+        CollectionAssert.AreEqual(new[] { 2, 3, 4 }, source.SkipTake(2, 3).ToArray());
+    }
+
+    [TestMethod]
+    public void Array_TakeExceedsLength_ClampedAtEnd()
+    {
+        int[] source = [0, 1, 2];
+        CollectionAssert.AreEqual(new[] { 1, 2 }, source.SkipTake(1, 100).ToArray());
+    }
+
+    [TestMethod]
+    public void Array_SkipEqualsLength_ReturnsEmpty()
+    {
+        int[] source = [0, 1, 2];
+        Assert.AreEqual(0, source.SkipTake(3, 5).Count());
+    }
+
+    // ── IList fast path ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void List_SkipTake_ReturnsSlice()
+    {
+        var source = new List<string> { "a", "b", "c", "d", "e" };
+        CollectionAssert.AreEqual(new[] { "b", "c" }, source.SkipTake(1, 2).ToArray());
+    }
+
+    // ── IEnumerable general path ─────────────────────────────────────────────
+
+    [TestMethod]
+    public void Enumerable_SkipTake_SingleEnumerator()
+    {
+        // Use a generator so only the general IEnumerable path is taken.
+        IEnumerable<int> Gen() { for (int i = 0; i < 10; i++) yield return i; }
+        CollectionAssert.AreEqual(new[] { 3, 4, 5 }, Gen().SkipTake(3, 3).ToArray());
+    }
+
+    [TestMethod]
+    public void Enumerable_TakeZero_ReturnsEmpty()
+    {
+        CollectionAssert.AreEqual(System.Array.Empty<int>(), new[] { 1, 2, 3 }.SkipTake(0, 0).ToArray());
+    }
+
+    [TestMethod]
+    public void Enumerable_SkipPastEnd_ReturnsEmpty()
+    {
+        Assert.AreEqual(0, new[] { 1, 2, 3 }.SkipTake(10, 5).Count());
+    }
+
+    // ── Semantic equivalence with Skip+Take ──────────────────────────────────
+
+    [TestMethod]
+    public void EquivalentToSkipTake_OnArray()
+    {
+        int[] source = Enumerable.Range(0, 20).ToArray();
+        var expected = source.Skip(5).Take(7).ToArray();
+        CollectionAssert.AreEqual(expected, source.SkipTake(5, 7).ToArray());
+    }
+
+    [TestMethod]
+    public void EquivalentToSkipTake_OnEnumerable()
+    {
+        IEnumerable<int> Gen() { for (int i = 0; i < 20; i++) yield return i; }
+        var expected = Gen().Skip(4).Take(6).ToArray();
+        CollectionAssert.AreEqual(expected, Gen().SkipTake(4, 6).ToArray());
+    }
+}


### PR DESCRIPTION
## Summary

- **`BaseEncoderStream.Write` (Utils.IO)**: `buffer.Skip(offset).Take(count)` allouait deux enumerators LINQ a chaque appel `Write()`. Remplace par une boucle `for` directe.
- **`StreamUtils.ReadBlock` (Utils.IO)**: `Queue<byte>` + `foreach` pour la fenetre glissante de detection du separateur. Remplace par un buffer circulaire `byte[]` avec index, eliminant l'enumerator struct par octet lu.
- **`GeoPoint.BuildRegexCoordinates` (Utils.Geography)**: `new Regex(..., Compiled)` recrée a chaque appel, appele dans des boucles qui iterent sur plusieurs cultures en fallback. Chaque compilation de Regex coute plusieurs dizaines de ms. Cache dans un `static ConcurrentDictionary` par profil (chiffres natifs + separateur decimal).
- **`MappedDictionary.Keys`/`.Values` (Utils.Collections)**: `.Select(...).ToList()` a chaque acces — meme bug que `LRUCache` (corrige en PR #324). Remplace par des vues live `MappedKeyCollection`/`MappedValueCollection` sans allocation. Les deux constructeurs secondaires sont maintenant chaines via `this(...)` pour garantir l'initialisation des champs.
- **`EnumerableEx.Zip` (Utils.Collections)**: deux overloads iteraient `enumerations` deux fois (`.Select(...).ToArray()` x2) pour construire deux tableaux. Remplace par une seule boucle `for`.

## Test plan

- [ ] 1677 tests unitaires passent (inchange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
