### PR TITLE
perf(net/reflection): cache DNS reflection, precompute powers-of-10, fix CallingConvention

### DIFF
--- a/Utils.Net/Net/DNS/DNSCanonicalWriter.cs
+++ b/Utils.Net/Net/DNS/DNSCanonicalWriter.cs
@@ -101,11 +101,9 @@ public class DNSCanonicalWriter : IDNSWriter<byte[]>
     /// <exception cref="ArgumentException">Thrown if the specified type is not annotated with <see cref="DNSRecordAttribute"/>.</exception>
     private void CreateReader(Type dnsElementType)
     {
-        var dnsClasses = dnsElementType.GetCustomAttributes<DNSRecordAttribute>();
-        if (!dnsClasses.Any())
-        {
+        var dnsClasses = dnsElementType.GetCustomAttributes<DNSRecordAttribute>().ToArray();
+        if (dnsClasses.Length == 0)
             throw new ArgumentException($"{dnsElementType.FullName} is not a DNS element", nameof(dnsElementType));
-        }
 
         // Build an expression-based writer for the user-defined DNS detail type (e.g., A-record, AAAA-record, etc.).
         var writer = CreateReader<DNSResponseDetail>(dnsElementType);

--- a/Utils.Net/Net/DNS/DNSFactory.cs
+++ b/Utils.Net/Net/DNS/DNSFactory.cs
@@ -220,7 +220,7 @@ public sealed class DNSFactory : IAdditionOperators<DNSFactory, DNSFactory, DNSF
     private static IReadOnlyList<Type> GetDNSClasses(IEnumerable<Type> types)
         => types
             .Where(t => typeof(DNSResponseDetail).IsAssignableFrom(t))
-            .Where(t => t.GetCustomAttributes<DNSRecordAttribute>().Any())
+            .Where(t => t.IsDefined(typeof(DNSRecordAttribute)))
             .ToImmutableList();
 
     /// <summary>

--- a/Utils.Net/Net/DNS/DNSPacketHelpers.cs
+++ b/Utils.Net/Net/DNS/DNSPacketHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -11,20 +12,24 @@ namespace Utils.Net.DNS;
 /// </summary>
 internal static class DNSPacketHelpers
 {
+    private static readonly ConcurrentDictionary<Type, IReadOnlyList<(DNSFieldAttribute Attribute, MemberInfo Member)>>
+        _fieldCache = new();
+
     /// <summary>
     /// Retrieves all public or non-public instance fields and properties from the specified <paramref name="type"/>
     /// that have a <see cref="DNSFieldAttribute"/> applied, along with the corresponding attribute data.
+    /// Results are cached per type: the member list of a DNS element type never changes at runtime.
     /// </summary>
     /// <param name="type">A <see cref="Type"/> that must derive from <see cref="DNSElement"/>.</param>
     /// <returns>
-    /// A sequence of tuples, where each tuple contains the <see cref="DNSFieldAttribute"/> and a
+    /// A cached sequence of tuples, where each tuple contains the <see cref="DNSFieldAttribute"/> and a
     /// <see cref="MemberInfo"/> object representing the annotated field or property.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="type"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentException">
     /// Thrown when the specified <paramref name="type"/> does not derive from <see cref="DNSElement"/>.
     /// </exception>
-    public static IEnumerable<(DNSFieldAttribute Attribute, MemberInfo Member)> GetDNSFields(Type type)
+    public static IReadOnlyList<(DNSFieldAttribute Attribute, MemberInfo Member)> GetDNSFields(Type type)
     {
         if (type is null)
             throw new ArgumentNullException(nameof(type));
@@ -32,16 +37,13 @@ internal static class DNSPacketHelpers
         if (!typeof(DNSElement).IsAssignableFrom(type))
             throw new ArgumentException($"{type.FullName} is not a DNSElement", nameof(type));
 
-        // Scan all instance fields and properties (public or non-public).
-        // Yield only those that carry the DNSFieldAttribute.
-        foreach (var member in type.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                                   .Where(m => m is PropertyInfo || m is FieldInfo))
-        {
-            var attribute = member.GetCustomAttribute<DNSFieldAttribute>();
-            if (attribute is null)
-                continue;
-
-            yield return (attribute, member);
-        }
+        return _fieldCache.GetOrAdd(type, static t =>
+            t.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+             .Where(m => m is PropertyInfo || m is FieldInfo)
+             .Select(m => (attribute: m.GetCustomAttribute<DNSFieldAttribute>(), member: m))
+             .Where(x => x.attribute is not null)
+             .Select(x => (x.attribute!, x.member))
+             .ToList()
+        );
     }
 }

--- a/Utils.Net/Net/DNS/DNSPacketReader.cs
+++ b/Utils.Net/Net/DNS/DNSPacketReader.cs
@@ -52,8 +52,8 @@ public class DNSPacketReader : IDNSReader<byte[]>, IDNSReader<Stream>
 
     private void CreateReader(Type dnsElementType)
     {
-        var dnsClasses = dnsElementType.GetCustomAttributes<DNSRecordAttribute>();
-        if (!dnsClasses.Any()) { throw new ArgumentException($"{dnsElementType.FullName} is not a DNS element", nameof(dnsElementType)); }
+        var dnsClasses = dnsElementType.GetCustomAttributes<DNSRecordAttribute>().ToArray();
+        if (dnsClasses.Length == 0) throw new ArgumentException($"{dnsElementType.FullName} is not a DNS element", nameof(dnsElementType));
         var reader = CreateReader<DNSResponseDetail>(dnsElementType);
         foreach (var dnsClass in dnsClasses)
         {

--- a/Utils.Net/Net/DNS/DNSPacketWriter.cs
+++ b/Utils.Net/Net/DNS/DNSPacketWriter.cs
@@ -101,11 +101,9 @@ public class DNSPacketWriter : IDNSWriter<byte[]>
     /// <exception cref="ArgumentException">Thrown if the specified type is not annotated with <see cref="DNSRecordAttribute"/>.</exception>
     private void CreateReader(Type dnsElementType)
     {
-        var dnsClasses = dnsElementType.GetCustomAttributes<DNSRecordAttribute>();
-        if (!dnsClasses.Any())
-        {
+        var dnsClasses = dnsElementType.GetCustomAttributes<DNSRecordAttribute>().ToArray();
+        if (dnsClasses.Length == 0)
             throw new ArgumentException($"{dnsElementType.FullName} is not a DNS element", nameof(dnsElementType));
-        }
 
         // Build an expression-based writer for the user-defined DNS detail type (e.g., A-record, AAAA-record, etc.).
         var writer = CreateReader<DNSResponseDetail>(dnsElementType);

--- a/Utils.Net/Net/DNS/DNSText.cs
+++ b/Utils.Net/Net/DNS/DNSText.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -20,6 +21,22 @@ public partial class DNSText : IDNSWriter<string>, IDNSReader<string>, IDNSReade
     private static readonly Regex FormatRegex = CreateFormatRegex();
     private static readonly Regex TokenRegex = CreateTokenRegex();
 
+    // Caches per-type member maps to avoid repeated GetMembers() reflection calls.
+    private static readonly ConcurrentDictionary<Type, MemberInfo[]> _memberCache = new();
+    private static readonly ConcurrentDictionary<Type, Dictionary<string, MemberInfo>> _memberDictCache = new();
+
+    private static MemberInfo[] GetAnnotatedMembers(Type type) =>
+        _memberCache.GetOrAdd(type, static t =>
+            t.GetMembers()
+             .Where(m => m.GetCustomAttribute<DNSFieldAttribute>() != null)
+             .ToArray());
+
+    private static Dictionary<string, MemberInfo> GetAllMembersDict(Type type) =>
+        _memberDictCache.GetOrAdd(type, static t =>
+            t.GetMembers()
+             .Where(m => m is PropertyInfo || m is FieldInfo)
+             .ToDictionary(m => m.Name));
+
     /// <summary>
     /// Gets a default instance of <see cref="DNSText"/> for convenience.
     /// </summary>
@@ -38,26 +55,18 @@ public partial class DNSText : IDNSWriter<string>, IDNSReader<string>, IDNSReade
         string rdataText = "";
         if (attr is null)
         {
-            var fields = rdata.GetType().GetMembers()
-                .Where(m => m.GetCustomAttribute<DNSFieldAttribute>() != null)
-                .Select(m =>
+            var rdataText2 = GetAnnotatedMembers(rdata.GetType())
+                .Select(m => m switch
                 {
-                    var member = rdata.GetType().GetMember(m.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault();
-                    return member switch
-                    {
-                        PropertyInfo pi => FormatValue(pi.GetValue(rdata)),
-                        FieldInfo fi => FormatValue(fi.GetValue(rdata)),
-                        _ => null
-                    };
+                    PropertyInfo pi => FormatValue(pi.GetValue(rdata)),
+                    FieldInfo fi => FormatValue(fi.GetValue(rdata)),
+                    _ => null
                 });
-
-            rdataText = string.Join(' ', fields);
+            rdataText = string.Join(' ', rdataText2);
         }
         else
         {
-            var fields = rdata.GetType().GetMembers()
-                .Where(m => m is PropertyInfo || m is FieldInfo)
-                .ToDictionary(m => m.Name);
+            var fields = GetAllMembersDict(rdata.GetType());
             rdataText = FormatRegex.Replace(attr.Format, m =>
                 fields[m.Groups["name"].Value] switch
                 {
@@ -103,7 +112,7 @@ public partial class DNSText : IDNSWriter<string>, IDNSReader<string>, IDNSReade
         var attr = rdataType.GetCustomAttribute<DNSTextRecordAttribute>();
         string[] fieldNames = attr != null
             ? FormatRegex.Matches(attr.Format).Select(m => m.Groups["name"].Value).ToArray()
-            : rdataType.GetMembers().Where(m => m.GetCustomAttribute<DNSFieldAttribute>() != null).Select(m => m.Name).ToArray();
+            : GetAnnotatedMembers(rdataType).Select(m => m.Name).ToArray();
         for (int i = 0; i < fieldNames.Length && i < rdataTokens.Length; i++)
         {
             SetValue(rdata, fieldNames[i], rdataTokens[i]);

--- a/Utils.Net/Net/DNS/RFC1876/LOC.cs
+++ b/Utils.Net/Net/DNS/RFC1876/LOC.cs
@@ -142,7 +142,14 @@ public class LOC : DNSResponseDetail
     /// </summary>
     /// <param name="value">The byte to convert.</param>
     /// <returns>The computed value.</returns>
-    private double ExponentialValueConvert(byte value) => (value >> 4) * Math.Pow(10, value & 0xF);
+    // The exponent nibble is 0–15; precomputing avoids Math.Pow on every property access.
+    private static readonly double[] PowersOf10 =
+    [
+        1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,
+        1e8,  1e9,  1e10, 1e11, 1e12, 1e13, 1e14, 1e15,
+    ];
+
+    private double ExponentialValueConvert(byte value) => (value >> 4) * PowersOf10[value & 0xF];
 
     /// <summary>
     /// Converts a double into its exponential representation in one byte.
@@ -153,7 +160,7 @@ public class LOC : DNSResponseDetail
     private byte InverseExponentialValueConvert(double value)
     {
         int exponent = (int)Math.Floor(Math.Log10(value));
-        int mantissa = (int)Math.Round(value / Math.Pow(10, exponent));
+        int mantissa = (int)Math.Round(value / PowersOf10[Math.Clamp(exponent, 0, 15)]);
         return (byte)((mantissa << 4) + exponent);
     }
 

--- a/Utils.Reflection/Reflection/Emit/EmitDllMappableClass.cs
+++ b/Utils.Reflection/Reflection/Emit/EmitDllMappableClass.cs
@@ -20,48 +20,46 @@ namespace Utils.Reflection.Reflection.Emit;
 /// </summary>
 public static class EmitDllMappableClass
 {
-    // Cache to store emitted types to avoid repeated generation for the same interface.
-    private static readonly Dictionary<Type, Type> emittedLibraries = new Dictionary<Type, Type>();
+    // Cache keyed by (interface type, calling convention) — the generated delegate attributes differ per convention.
+    private static readonly Dictionary<(Type, CallingConvention), Type> emittedLibraries = new();
 
     /// <summary>
     /// Emits a class that implements the specified interface and maps the interface methods to DLL functions.
+    /// Each delegate gets an <see cref="UnmanagedFunctionPointerAttribute"/> carrying the requested convention.
     /// </summary>
     /// <typeparam name="T">Interface type</typeparam>
-    /// <param name="callingConvention">The calling convention of the methods</param>
+    /// <param name="callingConvention">The calling convention of the unmanaged functions.</param>
     /// <returns>An instance of the dynamically generated class</returns>
-    public static T Emit<T>(CallingConvention callingConvention) where T : class => (T)Emit(typeof(T));
+    public static T Emit<T>(CallingConvention callingConvention) where T : class
+        => (T)Emit(typeof(T), callingConvention);
 
     /// <summary>
     /// Emits a class that implements the specified interface and maps the interface methods to DLL functions.
     /// </summary>
     /// <param name="type">Interface type</param>
+    /// <param name="callingConvention">The calling convention of the unmanaged functions.</param>
     /// <returns>An instance of the dynamically generated class</returns>
-    public static object Emit(Type type)
+    public static object Emit(Type type, CallingConvention callingConvention = CallingConvention.Winapi)
     {
         if (!type.IsInterface)
-        {
             throw new NotSupportedException($"{type.Name} is not an interface. Only interfaces are supported.");
-        }
 
-        // Check if the type was already generated and cached
-        if (!emittedLibraries.TryGetValue(type, out Type emittedType))
+        var cacheKey = (type, callingConvention);
+        if (!emittedLibraries.TryGetValue(cacheKey, out Type emittedType))
         {
-            // Generate the class name based on the interface
             string className = type.Name.StartsWith("I", StringComparison.InvariantCultureIgnoreCase)
-                ? type.Name.Substring(1) // Remove 'I' prefix
-                : "C" + type.Name; // Prefix with 'C' if no 'I'
+                ? type.Name.Substring(1)
+                : "C" + type.Name;
 
-            // Build the C# source code for the class
             StringBuilder csCode = new StringBuilder();
             csCode.AppendLine("namespace DllMapperClasses {");
             csCode.AppendLine("[System.Runtime.CompilerServices.CompilerGenerated]");
             csCode.AppendLine($"\tpublic class {className} : {typeof(LibraryMapper).FullName}, {type.FullName}");
             csCode.AppendLine("\t{");
 
-            // Generate methods and delegate fields for each interface method
             foreach (var method in type.GetMethods())
             {
-                string delegateClassName = csCode.WriteDelegateClass(method);
+                string delegateClassName = csCode.WriteDelegateClass(method, callingConvention);
                 string delegateFieldName = csCode.WriteDelegateField(method, delegateClassName);
                 csCode.WriteFunctionCall(method, delegateFieldName);
             }
@@ -69,13 +67,12 @@ public static class EmitDllMappableClass
             csCode.AppendLine("\t}");
             csCode.AppendLine("}");
 
-            // Compile the generated code into an assembly
             Assembly assembly = Compile(type, csCode);
             emittedType = assembly.GetTypes().FirstOrDefault(t => t.Name == className);
-            emittedLibraries.Add(type, emittedType); // Cache the generated type
+            emittedLibraries.Add(cacheKey, emittedType);
         }
 
-        return Activator.CreateInstance(emittedType); // Create an instance of the generated type
+        return Activator.CreateInstance(emittedType);
     }
 
     /// <summary>
@@ -84,9 +81,11 @@ public static class EmitDllMappableClass
     /// <param name="csCode">StringBuilder to append generated code</param>
     /// <param name="methodInfo">MethodInfo of the interface method</param>
     /// <returns>The name of the generated delegate class</returns>
-    private static string WriteDelegateClass(this StringBuilder csCode, MethodInfo methodInfo)
+    private static string WriteDelegateClass(this StringBuilder csCode, MethodInfo methodInfo, CallingConvention callingConvention)
     {
         string delegateName = methodInfo.Name + "Delegate";
+        // Emit [UnmanagedFunctionPointer] so the P/Invoke marshaller uses the correct calling convention.
+        csCode.AppendLine($"\t\t[{typeof(UnmanagedFunctionPointerAttribute).FullName}({typeof(CallingConvention).FullName}.{callingConvention})]");
         csCode.Append($"\t\tprivate delegate {methodInfo.ReturnType.FullName} {delegateName} ");
         csCode.WriteFunctionParameters(methodInfo, true);
         csCode.AppendLine(";");


### PR DESCRIPTION
## Summary

- **`LOC.cs`** : `Math.Pow(10, exponent)` remplace par une table `PowersOf10[exponent]` (16 entrees statiques) — elimine un appel transcendant a chaque acces aux proprietes Size/HorizontalPrecision/VerticalPrecision.
- **`DNSPacketHelpers.GetDNSFields`** : cache `ConcurrentDictionary<Type, IReadOnlyList<...>>` — la liste des membres annotes d'un type DNS ne change jamais ; auparavant, `GetMembers()` etait appele a chaque lecture/ecriture de paquet.
- **`DNSText`** : cache de `GetMembers()` par type via `_memberCache`/`_memberDictCache` (appele a chaque `ToText()` et `ParseLine()`). Suppression d'un `GetMember(m.Name, ...)` redondant dans un `Select()` qui avait deja le `MemberInfo` sous la main.
- **`DNSFactory`/`DNSCanonicalWriter`/`DNSPacketReader`/`DNSPacketWriter`** : `GetCustomAttributes<T>().Any()` remplace par `IsDefined(typeof(T))` (verif d'existence optimisee) ou par une materialisation unique en `.ToArray()` quand les attributs sont aussi iteres.
- **`EmitDllMappableClass`** (Utils.Reflection) : `CallingConvention` etait silencieusement ignore (`Emit<T>(convention)` appelait `Emit(typeof(T))` sans le transmettre). Desormais transmis a `WriteDelegateClass` qui emet `[UnmanagedFunctionPointer(CallingConvention.X)]` sur chaque delegate. Cle de cache passee de `Type` a `(Type, CallingConvention)`.

## Test plan

- [ ] Build : 0 erreur
- [ ] 1686 tests unitaires passent
- [ ] 265 tests fonctionnels passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
