### PR TITLE
fix(misc): remove debug traces, cache DI reflection, IsDefined guards

### DIFF
--- a/Utils.Collections/SkipList.cs
+++ b/Utils.Collections/SkipList.cs
@@ -274,7 +274,6 @@ public class SkipList<T> : ICollection<T>
 
     private void CreateNewSkipNode(Element startElement, Element endElement, Element currentElement)
     {
-        Debug.Print($"CreateNewSkipNode({startElement}, {endElement}, {currentElement})");
         Element previousUp, nextUp;
 
         if (startElement.Up is null)

--- a/Utils.DependencyInjection/HandlerCaller.cs
+++ b/Utils.DependencyInjection/HandlerCaller.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Utils.DependencyInjection;
 
@@ -25,6 +27,9 @@ public interface IHandlerCaller : IInjectable
 [Singleton]
 public class HandlerCaller : IHandlerCaller
 {
+    // Cached per (message runtime type, error type E) — types and their methods never change.
+    private static readonly ConcurrentDictionary<(Type MessageType, Type ErrorType), ReflectionEntry> _cache = new();
+
     private readonly IServiceProvider serviceProvider;
 
     /// <summary>
@@ -39,58 +44,57 @@ public class HandlerCaller : IHandlerCaller
     /// <inheritdoc />
     public bool Handle<E>(object message, List<CheckError<E>> errors)
     {
-        if (message is null)
-        {
-            throw new ArgumentNullException(nameof(message));
-        }
-
-        if (errors is null)
-        {
-            throw new ArgumentNullException(nameof(errors));
-        }
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(errors);
 
         errors.Clear();
         var messageType = message.GetType();
 
-        var checkType = typeof(ICheck<,>).MakeGenericType(messageType, typeof(E));
-        var checksType = typeof(IEnumerable<>).MakeGenericType(checkType);
-        var checks = (IEnumerable<object>?)this.serviceProvider.GetService(checksType) ?? [];
-        var checkMethod = checkType.GetMethod("Check");
+        var entry = _cache.GetOrAdd((messageType, typeof(E)), static key =>
+        {
+            var (msgType, errType) = key;
+            var checkType = typeof(ICheck<,>).MakeGenericType(msgType, errType);
+            var handlerType = typeof(IHandler<>).MakeGenericType(msgType);
+            return new ReflectionEntry(
+                ChecksType: typeof(IEnumerable<>).MakeGenericType(checkType),
+                CheckMethod: checkType.GetMethod("Check"),
+                HandlersType: typeof(IEnumerable<>).MakeGenericType(handlerType),
+                HandleMethod: handlerType.GetMethod("Handle")
+            );
+        });
+
+        var checks = (IEnumerable<object>?)this.serviceProvider.GetService(entry.ChecksType) ?? [];
         var isValid = true;
         foreach (var check in checks)
         {
             var checkErrors = new List<E>();
             object?[] parameters = [message, checkErrors];
-            if (!(bool)(checkMethod?.Invoke(check, parameters) ?? false))
+            if (!(bool)(entry.CheckMethod?.Invoke(check, parameters) ?? false))
             {
                 foreach (var error in checkErrors)
-                {
                     errors.Add(new CheckError<E>(check.GetType(), error));
-                }
                 isValid = false;
             }
         }
-        if (!isValid)
-        {
-            return false;
-        }
+        if (!isValid) return false;
 
-        var handlerType = typeof(IHandler<>).MakeGenericType(messageType);
-        var handlerCollectionType = typeof(IEnumerable<>).MakeGenericType(handlerType);
-        var handlers = (IEnumerable<object>?)this.serviceProvider.GetService(handlerCollectionType) ?? [];
-        var handleMethod = handlerType.GetMethod("Handle");
+        var handlers = (IEnumerable<object>?)this.serviceProvider.GetService(entry.HandlersType) ?? [];
         var invoked = false;
         foreach (var handler in handlers)
         {
-            handleMethod?.Invoke(handler, [message]);
+            entry.HandleMethod?.Invoke(handler, [message]);
             invoked = true;
         }
         if (!invoked)
-        {
             throw new InvalidOperationException($"No handler registered for type {messageType}");
-        }
 
         return true;
     }
+
+    private sealed record ReflectionEntry(
+        Type ChecksType,
+        MethodInfo? CheckMethod,
+        Type HandlersType,
+        MethodInfo? HandleMethod);
 }
 

--- a/Utils.DependencyInjection/ServiceConfigurationHelper.cs
+++ b/Utils.DependencyInjection/ServiceConfigurationHelper.cs
@@ -71,7 +71,7 @@ public static class ServiceConfigurationHelper
             }
         }
 
-        ConfigureServices(assemblyTypes.Where(t => t.GetCustomAttributes(true).OfType<Attribute>().Any(a => a is InjectableClassAttribute)), serviceCollection);
+        ConfigureServices(assemblyTypes.Where(t => t.IsDefined(typeof(InjectableClassAttribute), inherit: true)), serviceCollection);
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ public static class ServiceConfigurationHelper
     public static void ConfigureServices(this IServiceConfigurator serviceConfiguration, IServiceCollection serviceCollection)
     {
         Assembly assembly = serviceCollection.GetType().Assembly;
-        var types = assembly.GetTypes(t => t.GetCustomAttributes(true).OfType<Attribute>().Any(a => a is InjectableClassAttribute));
+        var types = assembly.GetTypes(t => t.IsDefined(typeof(InjectableClassAttribute), inherit: true));
         ConfigureServices(types, serviceCollection);
     }
 

--- a/Utils.OData/ODataContext.cs
+++ b/Utils.OData/ODataContext.cs
@@ -160,7 +160,7 @@ public abstract class ODataContext
 
         client.Timeout = MetadataDownloadTimeout;
 
-        using var response = client.GetAsync(uri).GetAwaiter().GetResult();
+        using var response = client.GetAsync(uri).ConfigureAwait(false).GetAwaiter().GetResult();
         if (!response.IsSuccessStatusCode)
         {
             throw new InvalidOperationException($"Failed to download EDMX metadata from '{uri}'. Status code: {response.StatusCode}.");
@@ -172,7 +172,7 @@ public abstract class ODataContext
             throw new InvalidOperationException($"EDMX metadata from '{uri}' exceeds the maximum allowed size of {MaxMetadataBytes} bytes.");
         }
 
-        using var responseStream = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+        using var responseStream = response.Content.ReadAsStreamAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         return CopyToMemory(responseStream, MaxMetadataBytes);
     }
 

--- a/Utils.OData/QueryOData.cs
+++ b/Utils.OData/QueryOData.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Net;
@@ -166,7 +167,7 @@ public class QueryOData : IDisposable
             }
         }
 
-        Console.WriteLine($"Requesting : {url}");
+        Debug.WriteLine($"Requesting : {url}");
         var response = await _httpClient.SendAsync(
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
@@ -782,11 +783,7 @@ public class QueryOData : IDisposable
         }
 
         object[] values = new object[fieldCount];
-        for (int index = 0; index < fieldCount; index++)
-        {
-            values[index] = DBNull.Value;
-        }
-
+        Array.Fill(values, DBNull.Value);
         return values;
     }
 

--- a/Utils.VirtualMachine/VirtualProcessor.cs
+++ b/Utils.VirtualMachine/VirtualProcessor.cs
@@ -71,9 +71,8 @@ namespace Utils.VirtualMachine
 
             foreach (var method in methods)
             {
+                if (!method.IsDefined(typeof(InstructionAttribute), true)) continue;
                 var instructionAttributes = method.GetCustomAttributes(typeof(InstructionAttribute), true);
-                if (instructionAttributes.IsNullOrEmptyCollection())
-                    continue;
 
                 var parameters = method.GetParameters();
                 if (parameters[0].ParameterType != typeof(T)) continue;


### PR DESCRIPTION
## Summary

- **`SkipList.cs`** : suppression du `Debug.Print` dans `CreateNewSkipNode` (trace de debug sans utilite documentee).
- **`QueryOData.cs`** : `Console.WriteLine` -> `Debug.WriteLine` (elimine en Release). `CreateEmptyRow` : boucle `for` -> `Array.Fill`.
- **`ODataContext.cs`** : ajout de `.ConfigureAwait(false)` sur les deux appels sync-over-async (`GetAsync` / `ReadAsStreamAsync`) pour prevenir les deadlocks en presence d'un `SynchronizationContext` (frameworks UI, ASP.NET classic).
- **`HandlerCaller.cs`** : cache `ConcurrentDictionary<(messageType, errorType), ReflectionEntry>` pour les resultats de `MakeGenericType` + `GetMethod` -- ces 4 appels de reflexion etaient executes a chaque invocation de `Handle<E>(message)`.
- **`ServiceConfigurationHelper.cs`** : `GetCustomAttributes(true).OfType<Attribute>().Any(a => a is X)` -> `IsDefined(typeof(X), inherit: true)` dans les deux surcharges `ConfigureServices`.
- **`VirtualProcessor.cs`** : garde `IsDefined(typeof(InstructionAttribute))` avant le `GetCustomAttributes` couteux dans `DiscoverInstructionSet` -- la grande majorite des methodes n'a pas cet attribut.

## Test plan

- [ ] 1690 tests unitaires passent
- [ ] 265 tests fonctionnels passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
