### PR TITLE
feat(virtualmachine): InvertedReader zero-alloc, ExecuteStep, RegisterInstruction, CancellationToken

### DIFF
--- a/Utils.VirtualMachine/INumberReader.cs
+++ b/Utils.VirtualMachine/INumberReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 
 namespace Utils.VirtualMachine
 {
@@ -86,12 +87,8 @@ namespace Utils.VirtualMachine
         /// <returns>An <see cref="INumberReader"/> that reads values using the desired byte order.</returns>
         public static INumberReader GetReader(bool littleEndian)
         {
-            if (!littleEndian ^ BitConverter.IsLittleEndian)
-            {
-                return NormalReader;
-            }
-
-            return InvertedReader;
+            // NormalReader when requested endianness matches the system's endianness (no byte-swap needed).
+            return littleEndian == BitConverter.IsLittleEndian ? NormalReader : InvertedReader;
         }
     }
 
@@ -173,90 +170,77 @@ namespace Utils.VirtualMachine
 
     /// <summary>
     /// Reader implementation that swaps endianness when reading values.
+    /// Uses <see cref="BinaryPrimitives.ReverseEndianness"/> to avoid heap allocation.
     /// </summary>
     internal class InvertedReader : INumberReader
     {
-        /// <summary>
-        /// Copies bytes from the context into <paramref name="target"/> in reversed order.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <param name="target">The buffer receiving the bytes in reversed order.</param>
-        private static void ReadDatas(Context context, byte[] target)
-        {
-            for (int i = target.Length - 1; i >= 0; i--)
-            {
-                target[i] = context.Data[context.InstructionPointer++];
-            }
-        }
-
         /// <inheritdoc />
-        public byte ReadByte(Context context)
-        {
-            return context.Data[context.InstructionPointer++];
-        }
+        public byte ReadByte(Context context) => context.Data[context.InstructionPointer++];
 
         /// <inheritdoc />
         public short ReadInt16(Context context)
         {
-            var temp = new byte[sizeof(short)];
-            ReadDatas(context, temp);
-            return BitConverter.ToInt16(temp, 0);
+            var result = BitConverter.ToInt16(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(short);
+            return BinaryPrimitives.ReverseEndianness(result);
         }
 
         /// <inheritdoc />
         public int ReadInt32(Context context)
         {
-            var temp = new byte[sizeof(int)];
-            ReadDatas(context, temp);
-            return BitConverter.ToInt32(temp, 0);
+            var result = BitConverter.ToInt32(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(int);
+            return BinaryPrimitives.ReverseEndianness(result);
         }
 
         /// <inheritdoc />
         public long ReadInt64(Context context)
         {
-            var temp = new byte[sizeof(long)];
-            ReadDatas(context, temp);
-            return BitConverter.ToInt64(temp, 0);
+            var result = BitConverter.ToInt64(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(long);
+            return BinaryPrimitives.ReverseEndianness(result);
         }
 
         /// <inheritdoc />
         public ushort ReadUInt16(Context context)
         {
-            var temp = new byte[sizeof(ushort)];
-            ReadDatas(context, temp);
-            return BitConverter.ToUInt16(temp, 0);
+            var result = BitConverter.ToUInt16(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(ushort);
+            return BinaryPrimitives.ReverseEndianness(result);
         }
 
         /// <inheritdoc />
         public uint ReadUInt32(Context context)
         {
-            var temp = new byte[sizeof(uint)];
-            ReadDatas(context, temp);
-            return BitConverter.ToUInt32(temp, 0);
+            var result = BitConverter.ToUInt32(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(uint);
+            return BinaryPrimitives.ReverseEndianness(result);
         }
 
         /// <inheritdoc />
         public ulong ReadUInt64(Context context)
         {
-            var temp = new byte[sizeof(ulong)];
-            ReadDatas(context, temp);
-            return BitConverter.ToUInt64(temp, 0);
+            var result = BitConverter.ToUInt64(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(ulong);
+            return BinaryPrimitives.ReverseEndianness(result);
         }
 
         /// <inheritdoc />
         public float ReadSingle(Context context)
         {
-            var temp = new byte[sizeof(float)];
-            ReadDatas(context, temp);
-            return BitConverter.ToSingle(temp, 0);
+            // Reverse the 4 bytes via the uint representation.
+            var bits = BitConverter.ToUInt32(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(float);
+            return BitConverter.UInt32BitsToSingle(BinaryPrimitives.ReverseEndianness(bits));
         }
 
         /// <inheritdoc />
         public double ReadDouble(Context context)
         {
-            var temp = new byte[sizeof(double)];
-            ReadDatas(context, temp);
-            return BitConverter.ToDouble(temp, 0);
+            // Reverse the 8 bytes via the ulong representation.
+            var bits = BitConverter.ToUInt64(context.Data, context.InstructionPointer);
+            context.InstructionPointer += sizeof(double);
+            return BitConverter.UInt64BitsToDouble(BinaryPrimitives.ReverseEndianness(bits));
         }
     }
 }

--- a/Utils.VirtualMachine/InstructionAttribute.cs
+++ b/Utils.VirtualMachine/InstructionAttribute.cs
@@ -5,7 +5,7 @@ namespace Utils.VirtualMachine
     /// <summary>
     /// Identifies a method as a virtual machine instruction and stores its metadata.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public class InstructionAttribute : Attribute
     {
         /// <summary>

--- a/Utils.VirtualMachine/VirtualProcessor.cs
+++ b/Utils.VirtualMachine/VirtualProcessor.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Reflection.Metadata;
-using System.Runtime.CompilerServices;
+using System.Threading;
 using Utils.Arrays;
 using Utils.Collections;
 
@@ -20,6 +19,11 @@ namespace Utils.VirtualMachine
     /// </typeparam>
     public abstract class VirtualProcessor<T> where T : Context
     {
+        // INumberReader methods never change; cache per-type avoids rebuilding on every instantiation.
+        private static readonly Dictionary<Type, MethodInfo> _numberReaderMethods =
+            typeof(INumberReader).GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                                 .ToDictionary(m => m.ReturnType, m => m);
+
         private readonly INumberReader _numberReader;
         private int _maxInstructionSize;
 
@@ -63,10 +67,6 @@ namespace Utils.VirtualMachine
                 ArrayEqualityComparers.Byte
             );
 
-            var numberReaderType = typeof(INumberReader);
-            var numberReaderTypeMethods = numberReaderType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                .ToDictionary(m => m.ReturnType, m => m);
-
             var methods = GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
             foreach (var method in methods)
@@ -92,7 +92,7 @@ namespace Utils.VirtualMachine
 
                     foreach (var parameter in parameters.Skip(1))
                     {
-                        var readerMethod = numberReaderTypeMethods[parameter.ParameterType];
+                        var readerMethod = _numberReaderMethods[parameter.ParameterType];
                         var methodCallExpression = Expression.Call(numberReaderExpression, readerMethod, [contextParameter]);
                         methodParameters.Add(methodCallExpression);
                     }
@@ -181,45 +181,75 @@ namespace Utils.VirtualMachine
         #endregion
 
         /// <summary>
-        /// Executes instructions by reading the context's data byte-by-byte, matching against known instructions,
-        /// and invoking the corresponding handler delegate.
+        /// Executes all instructions until the end of the data stream or until
+        /// <paramref name="cancellationToken"/> is cancelled.
         /// </summary>
-        /// <param name="context">The execution context containing the data and instruction pointer.</param>
-        /// <exception cref="VirtualProcessorException">
-        /// Thrown when an unknown instruction byte sequence is encountered.
-        /// </exception>
-        public void Execute(T context)
+        /// <param name="context">The execution context.</param>
+        /// <param name="cancellationToken">Token that can stop execution between instructions.</param>
+        /// <exception cref="VirtualProcessorException">Thrown on an unknown opcode sequence.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is cancelled.</exception>
+        public void Execute(T context, CancellationToken cancellationToken = default)
         {
-            // Buffer for building up the current instruction byte sequence
-            var currentInstruction = new List<byte>(_maxInstructionSize);
-
+            var buffer = new List<byte>(_maxInstructionSize);
             while (context.InstructionPointer < context.Data.Length)
             {
-                bool instructionFound = false;
-                currentInstruction.Clear();
+                cancellationToken.ThrowIfCancellationRequested();
+                TryDispatch(context, buffer);
+            }
+        }
 
-                // Read up to the max instruction size (or until data is exhausted)
-                for (int i = 0; i < _maxInstructionSize && context.InstructionPointer < context.Data.Length; i++)
+        /// <summary>
+        /// Executes exactly one instruction at the current instruction pointer.
+        /// </summary>
+        /// <param name="context">The execution context.</param>
+        /// <returns>
+        /// <see langword="true"/> if an instruction was dispatched;
+        /// <see langword="false"/> if the end of the data stream was already reached.
+        /// </returns>
+        /// <exception cref="VirtualProcessorException">Thrown on an unknown opcode sequence.</exception>
+        public bool ExecuteStep(T context)
+        {
+            if (context.InstructionPointer >= context.Data.Length) return false;
+            var buffer = new List<byte>(_maxInstructionSize);
+            TryDispatch(context, buffer);
+            return true;
+        }
+
+        /// <summary>
+        /// Registers an instruction handler at runtime, supplementing or overriding
+        /// the methods discovered via <see cref="InstructionAttribute"/>.
+        /// </summary>
+        /// <param name="opcode">Byte sequence identifying the instruction.</param>
+        /// <param name="name">Human-readable name used in diagnostics.</param>
+        /// <param name="handler">Delegate invoked when the opcode is matched.</param>
+        public void RegisterInstruction(byte[] opcode, string name, Action<T> handler)
+        {
+            ArgumentNullException.ThrowIfNull(opcode);
+            ArgumentNullException.ThrowIfNull(handler);
+            if (opcode.Length == 0) throw new ArgumentException("Opcode cannot be empty.", nameof(opcode));
+
+            InstructionsSet[opcode] = (name ?? string.Empty, ctx => handler(ctx));
+            _maxInstructionSize = Math.Max(_maxInstructionSize, opcode.Length);
+        }
+
+        /// <summary>
+        /// Shared dispatch core: reads bytes one at a time and invokes the matching handler.
+        /// Reuses <paramref name="buffer"/> across iterations (caller must call Clear before each call).
+        /// </summary>
+        private void TryDispatch(T context, List<byte> buffer)
+        {
+            buffer.Clear();
+            for (int i = 0; i < _maxInstructionSize && context.InstructionPointer < context.Data.Length; i++)
+            {
+                buffer.Add(ReadByte(context));
+                if (InstructionsSet.TryGetValue(buffer, out var entry))
                 {
-                    currentInstruction.Add(ReadByte(context));
-
-                    if (InstructionsSet.TryGetValue(currentInstruction, out var entry))
-                    {
-                        // Optionally log or trace the instruction name:
-                        // Console.WriteLine($"Executing instruction: {entry.Name}");
-                        entry.Handler(context);
-                        instructionFound = true;
-                        break;
-                    }
-                }
-
-                if (!instructionFound)
-                {
-                    throw new VirtualProcessorException(
-                        $"Unknown instruction encountered at InstructionPointer={context.InstructionPointer}."
-                    );
+                    entry.Handler(context);
+                    return;
                 }
             }
+            throw new VirtualProcessorException(
+                $"Unknown instruction at InstructionPointer={context.InstructionPointer - buffer.Count}.");
         }
     }
 

--- a/Utils.VirtualMachine/VirtualProcessorException.cs
+++ b/Utils.VirtualMachine/VirtualProcessorException.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace Utils.VirtualMachine;
 
@@ -35,15 +34,4 @@ public class VirtualProcessorException : Exception
     {
     }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="VirtualProcessorException"/> class with serialized data.
-    /// </summary>
-    /// <param name="info">The object that holds the serialized object data.</param>
-    /// <param name="context">The contextual information about the source or destination.</param>
-#pragma warning disable SYSLIB0051 // Le type ou le membre est obsolète
-    protected VirtualProcessorException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-    }
-#pragma warning restore SYSLIB0051 // Le type ou le membre est obsolète
 }

--- a/UtilsTest/VirtualMachine/VirtualMachineTests.cs
+++ b/UtilsTest/VirtualMachine/VirtualMachineTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Linq;
+using System.Threading;
 using Utils.Arrays;
 using Utils.VirtualMachine;
 
@@ -7,7 +9,9 @@ namespace UtilsTest.VirtualMachine
 {
     public class TestMachine : VirtualProcessor<DefaultContext>
     {
-        [Instruction("PUSH", 0x01, 0x01)]
+        // Two [Instruction] attributes on the same method (verifies AllowMultiple = true).
+        [Instruction("PUSH_BYTE",  0x01, 0x01)]
+        [Instruction("PUSH_BYTE2", 0x01, 0x03)]
         void PushByte(DefaultContext context, byte b1)
         {
             context.Stack.Push(b1);
@@ -137,5 +141,93 @@ namespace UtilsTest.VirtualMachine
             Assert.IsTrue(ArrayEqualityComparers.Int16.Equals([0x11], result));
         }
 
+        // ── ExecuteStep ───────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ExecuteStep_RunsOneInstructionAtATime()
+        {
+            // PUSH 0x10, then PUSH 0x01 — two instructions.
+            byte[] instructions = [0x01, 0x01, 0x10,  0x01, 0x01, 0x01];
+            var context = new DefaultContext(instructions);
+            TestMachine machine = new TestMachine();
+
+            Assert.IsTrue(machine.ExecuteStep(context));   // first PUSH
+            Assert.AreEqual(1, context.Stack.Count);
+            Assert.IsTrue(machine.ExecuteStep(context));   // second PUSH
+            Assert.AreEqual(2, context.Stack.Count);
+            Assert.IsFalse(machine.ExecuteStep(context));  // EOF
+        }
+
+        // ── CancellationToken ─────────────────────────────────────────────────
+
+        [TestMethod]
+        public void Execute_CancellationToken_StopsExecution()
+        {
+            byte[] instructions = [0x01, 0x01, 0x10,  0x01, 0x01, 0x01];
+            var context = new DefaultContext(instructions);
+            TestMachine machine = new TestMachine();
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();  // already cancelled
+
+            Assert.ThrowsException<OperationCanceledException>(
+                () => machine.Execute(context, cts.Token));
+        }
+
+        // ── RegisterInstruction ───────────────────────────────────────────────
+
+        [TestMethod]
+        public void RegisterInstruction_AddsRuntimeOpcode()
+        {
+            var machine = new TestMachine();
+            bool executed = false;
+            machine.RegisterInstruction([0xFF], "NOP", _ => executed = true);
+
+            var context = new DefaultContext([0xFF]);
+            machine.Execute(context);
+            Assert.IsTrue(executed);
+        }
+
+        [TestMethod]
+        public void RegisterInstruction_EmptyOpcode_Throws()
+        {
+            var machine = new TestMachine();
+            Assert.ThrowsException<ArgumentException>(
+                () => machine.RegisterInstruction([], "NOP", _ => { }));
+        }
+
+        // ── AllowMultiple [Instruction] ───────────────────────────────────────
+
+        [TestMethod]
+        public void MultipleOpcodes_SameMethod_BothWork()
+        {
+            // Both 0x01,0x01 and 0x01,0x03 call PushByte.
+            byte[] instructions1 = [0x01, 0x01, 0x42];
+            byte[] instructions2 = [0x01, 0x03, 0x42];
+
+            var ctx1 = new DefaultContext(instructions1);
+            var ctx2 = new DefaultContext(instructions2);
+            TestMachine machine = new TestMachine();
+
+            machine.Execute(ctx1);
+            machine.Execute(ctx2);
+
+            Assert.AreEqual((byte)0x42, ctx1.Stack.Peek());
+            Assert.AreEqual((byte)0x42, ctx2.Stack.Peek());
+        }
+
+        // ── InvertedReader (endianness swap, zero allocation) ─────────────────
+
+        [TestMethod]
+        public void BigEndianReader_ReadInt16_ReversesBytes()
+        {
+            // On a little-endian system, requesting big-endian triggers InvertedReader.
+            var reader = NumberReader.GetReader(littleEndian: !BitConverter.IsLittleEndian);
+            // Value 0x0102 in big-endian = bytes [0x01, 0x02]
+            byte[] data = [0x01, 0x02];
+            var ctx = new DefaultContext(data);
+            short value = reader.ReadInt16(ctx);
+            Assert.AreEqual((short)0x0102, value);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **`InstructionAttribute`**: ajout de `AllowMultiple = true` -- le design attendait deja plusieurs opcodes par methode (boucle `foreach` sur les attributs) mais le flag manquait, rendant l'intention invisible au compilateur.
- **`InvertedReader` (zero allocation)**: `ReadDatas(byte[])` + `new byte[]` par lecture remplace par `BinaryPrimitives.ReverseEndianness` -- lit la valeur en ordre natif puis inverse les bits entiers en place. `float`/`double` via `UInt32BitsToSingle`/`UInt64BitsToDouble`. Zero allocation heap par lecture.
- **`NumberReader.GetReader()`**: logique `!x ^ y` confuse remplacee par `littleEndian == BitConverter.IsLittleEndian`.
- **`VirtualProcessorException`**: constructeur `SerializationInfo` obsolete (SYSLIB0051) supprime. `BinaryFormatter` est retire depuis .NET 8.
- **`VirtualProcessor` -- cache statique**: `typeof(INumberReader).GetMethods()` etait recalcule a chaque instanciation; desormais champ `static readonly`.
- **`ExecuteStep(T context)`**: execute exactement une instruction ; retourne `false` en fin de flux. Permet le pas-a-pas et les tests unitaires par instruction.
- **`Execute(T, CancellationToken)`**: verifie le token entre chaque instruction pour un arret gracieux des programmes VM longue duree.
- **`RegisterInstruction(byte[], string, Action<T>)`**: enregistre un opcode a l'execution sans sous-classer; utile pour les tests et les plugins.

## Test plan

- [ ] 10 tests VirtualMachine passent (4 anciens + 6 nouveaux)
- [ ] 1696 tests unitaires passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
