### PR TITLE
feat(vm): structured control flow (ConditionalBlock, LoopBlock, ExceptionBlock, ControlFlowStack)

### DIFF
--- a/Utils.VirtualMachine/ConditionalBlock.cs
+++ b/Utils.VirtualMachine/ConditionalBlock.cs
@@ -1,0 +1,40 @@
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Represents an active if/else conditional block on a <see cref="ControlFlowStack"/>.
+/// </summary>
+/// <remarks>
+/// Typical VM usage:
+/// <list type="bullet">
+///   <item>IF instruction: evaluate condition; push a <see cref="ConditionalBlock"/>;
+///     if false, jump to <see cref="ElseAddress"/> (or <see cref="EndAddress"/> when no else).</item>
+///   <item>ELSE instruction: jump to <see cref="EndAddress"/>; execution continues in the else branch.</item>
+///   <item>ENDIF instruction: call <see cref="ControlFlowStack.Pop"/>.</item>
+/// </list>
+/// </remarks>
+public sealed class ConditionalBlock : IControlFlowBlock
+{
+    /// <inheritdoc/>
+    public int StartAddress { get; }
+
+    /// <summary>
+    /// Address of the else branch, or <see langword="null"/> when there is no else clause.
+    /// </summary>
+    public int? ElseAddress { get; }
+
+    /// <summary>First instruction after the entire if/else structure (ENDIF address).</summary>
+    public int EndAddress { get; }
+
+    /// <summary>
+    /// Initializes a new conditional block.
+    /// </summary>
+    /// <param name="startAddress">Address of the IF instruction.</param>
+    /// <param name="endAddress">Address immediately after the ENDIF.</param>
+    /// <param name="elseAddress">Address of the ELSE branch, or <see langword="null"/> if absent.</param>
+    public ConditionalBlock(int startAddress, int endAddress, int? elseAddress = null)
+    {
+        StartAddress = startAddress;
+        EndAddress = endAddress;
+        ElseAddress = elseAddress;
+    }
+}

--- a/Utils.VirtualMachine/ControlFlowStack.cs
+++ b/Utils.VirtualMachine/ControlFlowStack.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Manages the nesting of structured control flow blocks at runtime:
+/// conditionals (<see cref="ConditionalBlock"/>), loops (<see cref="LoopBlock"/>),
+/// and exception handlers (<see cref="ExceptionBlock"/>).
+/// </summary>
+/// <remarks>
+/// No bytecodes are defined here. Instruction handlers of the concrete VM call the
+/// push/pop/navigate methods and are free to assign any opcode to each operation.
+/// </remarks>
+public class ControlFlowStack
+{
+    private readonly Stack<IControlFlowBlock> _blocks = new();
+
+    /// <summary>Gets the number of currently open blocks.</summary>
+    public int Depth => _blocks.Count;
+
+    /// <summary>Gets the innermost open block, or <see langword="null"/> when the stack is empty.</summary>
+    public IControlFlowBlock? CurrentBlock => _blocks.TryPeek(out var b) ? b : null;
+
+    /// <summary>Opens a conditional (if/else) block.</summary>
+    /// <param name="startAddress">Address of the IF instruction.</param>
+    /// <param name="endAddress">Address immediately after the ENDIF.</param>
+    /// <param name="elseAddress">Address of the ELSE branch, or <see langword="null"/> if absent.</param>
+    public void PushConditional(int startAddress, int endAddress, int? elseAddress = null)
+        => _blocks.Push(new ConditionalBlock(startAddress, endAddress, elseAddress));
+
+    /// <summary>Opens a loop block.</summary>
+    /// <param name="startAddress">Address of the loop header; target of CONTINUE.</param>
+    /// <param name="endAddress">Address after the loop; target of BREAK.</param>
+    public void PushLoop(int startAddress, int endAddress)
+        => _blocks.Push(new LoopBlock(startAddress, endAddress));
+
+    /// <summary>Opens a try/catch/finally block.</summary>
+    /// <param name="startAddress">Address of the TRY instruction.</param>
+    /// <param name="catchAddress">Address of the catch handler, or <see langword="null"/>.</param>
+    /// <param name="finallyAddress">Address of the finally block, or <see langword="null"/>.</param>
+    public void PushException(int startAddress, int? catchAddress, int? finallyAddress)
+        => _blocks.Push(new ExceptionBlock(startAddress, catchAddress, finallyAddress));
+
+    /// <summary>
+    /// Closes the innermost open block. Called at ENDIF, ENDLOOP, or ENDTRY.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no block is open.</exception>
+    public IControlFlowBlock Pop()
+    {
+        if (_blocks.Count == 0)
+            throw new InvalidOperationException("Control flow stack underflow: no open block to close.");
+        return _blocks.Pop();
+    }
+
+    /// <summary>
+    /// Handles a BREAK instruction: pops all blocks up to and including the nearest
+    /// <see cref="LoopBlock"/>, then sets <see cref="Context.InstructionPointer"/> to
+    /// the loop's <see cref="LoopBlock.EndAddress"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no enclosing loop is in scope.</exception>
+    public void Break(Context context)
+    {
+        while (_blocks.TryPop(out var block))
+        {
+            if (block is LoopBlock loop)
+            {
+                context.InstructionPointer = loop.EndAddress;
+                return;
+            }
+        }
+        throw new InvalidOperationException("BREAK used outside of a loop.");
+    }
+
+    /// <summary>
+    /// Handles a CONTINUE instruction: pops all blocks nested inside the nearest
+    /// <see cref="LoopBlock"/> (the loop itself stays on the stack), then sets
+    /// <see cref="Context.InstructionPointer"/> to the loop's <see cref="LoopBlock.StartAddress"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when no enclosing loop is in scope.</exception>
+    public void Continue(Context context)
+    {
+        while (_blocks.TryPeek(out var block))
+        {
+            if (block is LoopBlock loop)
+            {
+                context.InstructionPointer = loop.StartAddress;
+                return;
+            }
+            _blocks.Pop();
+        }
+        throw new InvalidOperationException("CONTINUE used outside of a loop.");
+    }
+
+    /// <summary>
+    /// Handles a THROW instruction: pops all blocks until the nearest <see cref="ExceptionBlock"/>
+    /// is found, stores the thrown value in <see cref="ExceptionBlock.ThrownValue"/>, and
+    /// redirects <see cref="Context.InstructionPointer"/> to the catch handler (or finally if
+    /// no catch is defined). The <see cref="ExceptionBlock"/> remains on the stack so that
+    /// the handler body can read <see cref="ExceptionBlock.ThrownValue"/>; ENDTRY pops it.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <param name="value">The value being thrown.</param>
+    /// <returns>
+    /// <see langword="true"/> if a handler was found and the instruction pointer was updated;
+    /// <see langword="false"/> if no handler is in scope (unhandled throw).
+    /// </returns>
+    public bool Throw(Context context, object? value)
+    {
+        while (_blocks.TryPop(out var block))
+        {
+            if (block is ExceptionBlock ex)
+            {
+                ex.ThrownValue = value;
+                _blocks.Push(ex);
+                context.InstructionPointer = ex.CatchAddress ?? ex.FinallyAddress!.Value;
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/// <summary>
+/// A <see cref="DefaultContext"/> that carries a <see cref="ControlFlowStack"/> for processors
+/// implementing structured control flow (conditionals, loops, try/catch/finally).
+/// </summary>
+public class ControlFlowContext : DefaultContext
+{
+    /// <summary>Gets the control flow stack managing open blocks for the current execution.</summary>
+    public ControlFlowStack ControlFlow { get; } = new();
+
+    /// <summary>
+    /// Initializes a new instance with the given instruction stream.
+    /// </summary>
+    /// <param name="data">The byte array containing the instruction stream.</param>
+    public ControlFlowContext(byte[] data) : base(data) { }
+}

--- a/Utils.VirtualMachine/ExceptionBlock.cs
+++ b/Utils.VirtualMachine/ExceptionBlock.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Represents an active try/catch/finally block on a <see cref="ControlFlowStack"/>.
+/// </summary>
+/// <remarks>
+/// Typical VM usage:
+/// <list type="bullet">
+///   <item>TRY instruction: push an <see cref="ExceptionBlock"/> with the handler addresses.</item>
+///   <item>THROW instruction: call <see cref="ControlFlowStack.Throw"/>; unwinds to this block,
+///     sets <see cref="ThrownValue"/>, and redirects execution to <see cref="CatchAddress"/>
+///     (or <see cref="FinallyAddress"/> when there is no catch). The block stays on the stack
+///     so that the handler body can inspect <see cref="ThrownValue"/>.</item>
+///   <item>ENDTRY instruction: call <see cref="ControlFlowStack.Pop"/>.</item>
+/// </list>
+/// At least one of <see cref="CatchAddress"/> or <see cref="FinallyAddress"/> must be provided.
+/// </remarks>
+public sealed class ExceptionBlock : IControlFlowBlock
+{
+    /// <inheritdoc/>
+    public int StartAddress { get; }
+
+    /// <summary>Address of the catch handler, or <see langword="null"/> if there is no catch clause.</summary>
+    public int? CatchAddress { get; }
+
+    /// <summary>Address of the finally block, or <see langword="null"/> if there is no finally clause.</summary>
+    public int? FinallyAddress { get; }
+
+    /// <summary>
+    /// The value thrown by the most recent THROW that targeted this block.
+    /// <see langword="null"/> when the block was entered normally or has not been thrown into yet.
+    /// Set by <see cref="ControlFlowStack.Throw"/> and readable from the catch/finally handler body.
+    /// </summary>
+    public object? ThrownValue { get; internal set; }
+
+    /// <summary>
+    /// Initializes a new exception block.
+    /// </summary>
+    /// <param name="startAddress">Address of the TRY instruction.</param>
+    /// <param name="catchAddress">Address of the catch handler, or <see langword="null"/>.</param>
+    /// <param name="finallyAddress">Address of the finally block, or <see langword="null"/>.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when both <paramref name="catchAddress"/> and <paramref name="finallyAddress"/> are <see langword="null"/>.
+    /// </exception>
+    public ExceptionBlock(int startAddress, int? catchAddress, int? finallyAddress)
+    {
+        if (catchAddress is null && finallyAddress is null)
+            throw new ArgumentException("An ExceptionBlock must have at least a catch or a finally address.");
+        StartAddress = startAddress;
+        CatchAddress = catchAddress;
+        FinallyAddress = finallyAddress;
+    }
+}

--- a/Utils.VirtualMachine/IControlFlowBlock.cs
+++ b/Utils.VirtualMachine/IControlFlowBlock.cs
@@ -1,0 +1,16 @@
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Base interface for all structured control flow blocks that can be pushed onto
+/// a <see cref="ControlFlowStack"/>: conditionals, loops, and exception handlers.
+/// </summary>
+/// <remarks>
+/// The three concrete implementations are <see cref="ConditionalBlock"/>,
+/// <see cref="LoopBlock"/>, and <see cref="ExceptionBlock"/>.
+/// No bytecode is associated at this level; opcodes are assigned by each concrete VM.
+/// </remarks>
+public interface IControlFlowBlock
+{
+    /// <summary>Gets the instruction-stream offset at which this block was opened.</summary>
+    int StartAddress { get; }
+}

--- a/Utils.VirtualMachine/LoopBlock.cs
+++ b/Utils.VirtualMachine/LoopBlock.cs
@@ -1,0 +1,38 @@
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Represents an active loop on a <see cref="ControlFlowStack"/>.
+/// </summary>
+/// <remarks>
+/// Typical VM usage:
+/// <list type="bullet">
+///   <item>LOOP instruction: push a <see cref="LoopBlock"/> with the current IP as
+///     <see cref="StartAddress"/> and the first byte after the loop as <see cref="EndAddress"/>.</item>
+///   <item>ENDLOOP instruction: jump to <see cref="StartAddress"/> to re-evaluate the condition
+///     (the block stays on the stack for the next iteration).</item>
+///   <item>BREAK instruction: call <see cref="ControlFlowStack.Break"/>; pops up to and
+///     including this block, then jumps to <see cref="EndAddress"/>.</item>
+///   <item>CONTINUE instruction: call <see cref="ControlFlowStack.Continue"/>; pops any blocks
+///     nested inside this loop, then jumps to <see cref="StartAddress"/>.</item>
+/// </list>
+/// </remarks>
+public sealed class LoopBlock : IControlFlowBlock
+{
+    /// <inheritdoc/>
+    /// <remarks>This is the target of a CONTINUE instruction.</remarks>
+    public int StartAddress { get; }
+
+    /// <summary>First instruction after the loop body; target of a BREAK instruction.</summary>
+    public int EndAddress { get; }
+
+    /// <summary>
+    /// Initializes a new loop block.
+    /// </summary>
+    /// <param name="startAddress">Address of the loop header (CONTINUE jumps here).</param>
+    /// <param name="endAddress">Address immediately after the loop (BREAK jumps here).</param>
+    public LoopBlock(int startAddress, int endAddress)
+    {
+        StartAddress = startAddress;
+        EndAddress = endAddress;
+    }
+}

--- a/UtilsTest/VirtualMachine/ControlFlowStackTests.cs
+++ b/UtilsTest/VirtualMachine/ControlFlowStackTests.cs
@@ -1,0 +1,372 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Utils.VirtualMachine;
+
+namespace UtilsTest.VirtualMachine;
+
+// ── Minimal test VM (opcodes assigned only here, not in the framework) ────────
+
+public class ControlFlowTestMachine : VirtualProcessor<ControlFlowContext>
+{
+    [Instruction("PUSH_INT", 0x01)]
+    void PushInt(ControlFlowContext ctx, int value) => ctx.Stack.Push(value);
+
+    [Instruction("HALT", 0xFF)]
+    void Halt(ControlFlowContext ctx) => ctx.InstructionPointer = ctx.Data.Length;
+
+    // ── Conditionals ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// IF_FALSE endAddr [elseAddr] — pops a bool; if false jumps to elseAddr (or endAddr).
+    /// Pushes a ConditionalBlock regardless so ENDIF can pop it correctly.
+    /// </summary>
+    [Instruction("IF_FALSE", 0x10)]
+    void IfFalse(ControlFlowContext ctx, int endAddress, int elseAddress)
+    {
+        bool condition = (bool)ctx.Stack.Pop();
+        ctx.ControlFlow.PushConditional(ctx.InstructionPointer, endAddress, elseAddress);
+        if (!condition)
+            ctx.InstructionPointer = elseAddress;
+    }
+
+    [Instruction("ENDIF", 0x11)]
+    void Endif(ControlFlowContext ctx) => ctx.ControlFlow.Pop();
+
+    // ── Loops ─────────────────────────────────────────────────────────────────
+
+    /// <summary>LOOP_START endAddr — marks the loop header; execution falls through into body.</summary>
+    [Instruction("LOOP_START", 0x20)]
+    void LoopStart(ControlFlowContext ctx, int endAddress)
+        => ctx.ControlFlow.PushLoop(ctx.InstructionPointer, endAddress);
+
+    /// <summary>LOOP_END — jumps back to loop StartAddress without popping the block.</summary>
+    [Instruction("LOOP_END", 0x21)]
+    void LoopEnd(ControlFlowContext ctx)
+        => ctx.InstructionPointer = ((LoopBlock)ctx.ControlFlow.CurrentBlock!).StartAddress;
+
+    [Instruction("BREAK", 0x22)]
+    void Break(ControlFlowContext ctx) => ctx.ControlFlow.Break(ctx);
+
+    [Instruction("CONTINUE", 0x23)]
+    void Continue(ControlFlowContext ctx) => ctx.ControlFlow.Continue(ctx);
+
+    // ── Exceptions ────────────────────────────────────────────────────────────
+
+    /// <summary>TRY catchAddr — opens an ExceptionBlock with the given catch handler address.</summary>
+    [Instruction("TRY", 0x30)]
+    void Try(ControlFlowContext ctx, int catchAddress)
+        => ctx.ControlFlow.PushException(ctx.InstructionPointer, catchAddress, null);
+
+    /// <summary>THROW — pops a value from the operand stack and throws it.</summary>
+    [Instruction("THROW", 0x31)]
+    void Throw(ControlFlowContext ctx)
+    {
+        var value = ctx.Stack.Pop();
+        if (!ctx.ControlFlow.Throw(ctx, value))
+            throw new InvalidOperationException($"Unhandled throw: {value}");
+    }
+
+    /// <summary>ENDTRY — closes the exception block.</summary>
+    [Instruction("ENDTRY", 0x32)]
+    void EndTry(ControlFlowContext ctx) => ctx.ControlFlow.Pop();
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+[TestClass]
+public class ControlFlowStackTests
+{
+    // ── ConditionalBlock ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void PushConditional_IncreasesDepth()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushConditional(0, 20);
+        Assert.AreEqual(1, cfs.Depth);
+        Assert.IsInstanceOfType<ConditionalBlock>(cfs.CurrentBlock);
+    }
+
+    [TestMethod]
+    public void ConditionalBlock_Properties_AreStored()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushConditional(startAddress: 0, endAddress: 20, elseAddress: 10);
+        var block = (ConditionalBlock)cfs.CurrentBlock!;
+        Assert.AreEqual(0, block.StartAddress);
+        Assert.AreEqual(20, block.EndAddress);
+        Assert.AreEqual(10, block.ElseAddress);
+    }
+
+    [TestMethod]
+    public void ConditionalBlock_NoElse_ElseAddressIsNull()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushConditional(0, 20);
+        Assert.IsNull(((ConditionalBlock)cfs.CurrentBlock!).ElseAddress);
+    }
+
+    [TestMethod]
+    public void Pop_ConditionalBlock_DecreasesDepth()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushConditional(0, 20);
+        cfs.Pop();
+        Assert.AreEqual(0, cfs.Depth);
+    }
+
+    // ── LoopBlock ─────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void PushLoop_IncreasesDepth()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 50);
+        Assert.AreEqual(1, cfs.Depth);
+        Assert.IsInstanceOfType<LoopBlock>(cfs.CurrentBlock);
+    }
+
+    [TestMethod]
+    public void LoopBlock_Properties_AreStored()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(startAddress: 5, endAddress: 40);
+        var block = (LoopBlock)cfs.CurrentBlock!;
+        Assert.AreEqual(5, block.StartAddress);
+        Assert.AreEqual(40, block.EndAddress);
+    }
+
+    [TestMethod]
+    public void Break_JumpsToEndAddress_AndPopsLoop()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(startAddress: 0, endAddress: 50);
+        var ctx = new ControlFlowContext([]);
+        cfs.Break(ctx);
+        Assert.AreEqual(50, ctx.InstructionPointer);
+        Assert.AreEqual(0, cfs.Depth);
+    }
+
+    [TestMethod]
+    public void Break_UnwindsNestedConditionals_ThenPopsLoop()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 50);
+        cfs.PushConditional(10, 30); // nested IF inside the loop
+        var ctx = new ControlFlowContext([]);
+        cfs.Break(ctx);
+        Assert.AreEqual(50, ctx.InstructionPointer);
+        Assert.AreEqual(0, cfs.Depth); // both blocks gone
+    }
+
+    [TestMethod]
+    public void Break_OutsideLoop_Throws()
+    {
+        var cfs = new ControlFlowStack();
+        var ctx = new ControlFlowContext([]);
+        Assert.ThrowsException<InvalidOperationException>(() => cfs.Break(ctx));
+    }
+
+    [TestMethod]
+    public void Continue_JumpsToStartAddress_KeepsLoop()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(startAddress: 5, endAddress: 40);
+        var ctx = new ControlFlowContext([]);
+        cfs.Continue(ctx);
+        Assert.AreEqual(5, ctx.InstructionPointer);
+        Assert.AreEqual(1, cfs.Depth); // loop stays on stack
+    }
+
+    [TestMethod]
+    public void Continue_UnwindsNestedConditionals_KeepsLoop()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(5, 40);
+        cfs.PushConditional(10, 30);
+        var ctx = new ControlFlowContext([]);
+        cfs.Continue(ctx);
+        Assert.AreEqual(5, ctx.InstructionPointer);
+        Assert.AreEqual(1, cfs.Depth); // only loop remains
+        Assert.IsInstanceOfType<LoopBlock>(cfs.CurrentBlock);
+    }
+
+    [TestMethod]
+    public void Continue_OutsideLoop_Throws()
+    {
+        var cfs = new ControlFlowStack();
+        var ctx = new ControlFlowContext([]);
+        Assert.ThrowsException<InvalidOperationException>(() => cfs.Continue(ctx));
+    }
+
+    // ── ExceptionBlock ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void PushException_IncreasesDepth()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushException(0, catchAddress: 10, finallyAddress: null);
+        Assert.AreEqual(1, cfs.Depth);
+        Assert.IsInstanceOfType<ExceptionBlock>(cfs.CurrentBlock);
+    }
+
+    [TestMethod]
+    public void ExceptionBlock_Properties_AreStored()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushException(0, catchAddress: 10, finallyAddress: 20);
+        var block = (ExceptionBlock)cfs.CurrentBlock!;
+        Assert.AreEqual(10, block.CatchAddress);
+        Assert.AreEqual(20, block.FinallyAddress);
+    }
+
+    [TestMethod]
+    public void ExceptionBlock_NoCatchAndNoFinally_Throws()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => new ExceptionBlock(0, catchAddress: null, finallyAddress: null));
+    }
+
+    [TestMethod]
+    public void Throw_JumpsToCatchAddress_SetsThrownValue()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushException(0, catchAddress: 42, finallyAddress: null);
+        var ctx = new ControlFlowContext([]);
+        bool handled = cfs.Throw(ctx, "error");
+        Assert.IsTrue(handled);
+        Assert.AreEqual(42, ctx.InstructionPointer);
+        var ex = (ExceptionBlock)cfs.CurrentBlock!;
+        Assert.AreEqual("error", ex.ThrownValue);
+    }
+
+    [TestMethod]
+    public void Throw_NoFinallyFallsBackToCatch_WhenCatchAddressNull_JumpsToFinally()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushException(0, catchAddress: null, finallyAddress: 99);
+        var ctx = new ControlFlowContext([]);
+        cfs.Throw(ctx, 42);
+        Assert.AreEqual(99, ctx.InstructionPointer);
+    }
+
+    [TestMethod]
+    public void Throw_ExceptionBlockRemainsOnStack_ForHandlerBody()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushException(0, catchAddress: 10, finallyAddress: null);
+        var ctx = new ControlFlowContext([]);
+        cfs.Throw(ctx, "oops");
+        Assert.AreEqual(1, cfs.Depth);
+        Assert.IsInstanceOfType<ExceptionBlock>(cfs.CurrentBlock);
+    }
+
+    [TestMethod]
+    public void Throw_UnwindsNestedBlocks_ThenFindsCatch()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushException(0, catchAddress: 50, finallyAddress: null);
+        cfs.PushLoop(5, 30);        // nested inside try
+        cfs.PushConditional(10, 20); // nested inside loop
+        var ctx = new ControlFlowContext([]);
+        bool handled = cfs.Throw(ctx, "e");
+        Assert.IsTrue(handled);
+        Assert.AreEqual(50, ctx.InstructionPointer);
+        Assert.AreEqual(1, cfs.Depth); // only the ExceptionBlock stays
+    }
+
+    [TestMethod]
+    public void Throw_NoHandler_ReturnsFalse()
+    {
+        var cfs = new ControlFlowStack();
+        var ctx = new ControlFlowContext([]);
+        Assert.IsFalse(cfs.Throw(ctx, "e"));
+    }
+
+    // ── Pop underflow ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Pop_EmptyStack_Throws()
+    {
+        var cfs = new ControlFlowStack();
+        Assert.ThrowsException<InvalidOperationException>(() => cfs.Pop());
+    }
+
+    // ── Integration: BREAK exits loop, PUSH_INT 99 is never reached ──────────
+
+    [TestMethod]
+    public void Integration_Break_ExitsLoop()
+    {
+        // 0: PUSH_INT 42       [0x01, 42,0,0,0]
+        // 5: LOOP_START 16     [0x20, 16,0,0,0]   end=16
+        //10: BREAK             [0x22]              jumps to 16, pops loop
+        //11: PUSH_INT 99       [0x01, 99,0,0,0]   never reached
+        //16: HALT              [0xFF]
+        byte[] program =
+        [
+            0x01, 42, 0, 0, 0,    // PUSH_INT 42
+            0x20, 16, 0, 0, 0,    // LOOP_START 16
+            0x22,                  // BREAK
+            0x01, 99, 0, 0, 0,    // PUSH_INT 99 (dead code)
+            0xFF                   // HALT
+        ];
+
+        var ctx = new ControlFlowContext(program);
+        new ControlFlowTestMachine().Execute(ctx);
+
+        Assert.AreEqual(0, ctx.ControlFlow.Depth);
+        Assert.AreEqual(42, (int)ctx.Stack.Peek());
+    }
+
+    [TestMethod]
+    public void Integration_Throw_JumpsToCatchHandler()
+    {
+        // 0: TRY 11            [0x30, 11,0,0,0]   catch=11
+        // 5: PUSH_INT 7        [0x01, 7,0,0,0]
+        //10: THROW             [0x31]              → IP=11
+        //11: ENDTRY            [0x32]
+        //12: HALT              [0xFF]
+        // Expected: ExceptionBlock.ThrownValue = 7 (then ENDTRY pops it)
+        byte[] program =
+        [
+            0x30, 11, 0, 0, 0,   // TRY 11
+            0x01, 7, 0, 0, 0,    // PUSH_INT 7
+            0x31,                 // THROW
+            0x32,                 // ENDTRY
+            0xFF                  // HALT
+        ];
+
+        var ctx = new ControlFlowContext(program);
+        new ControlFlowTestMachine().Execute(ctx);
+
+        Assert.AreEqual(0, ctx.ControlFlow.Depth); // ENDTRY popped the block
+    }
+
+    [TestMethod]
+    public void Integration_Throw_ThrownValueAccessibleInCatch()
+    {
+        // Same as above but we inspect ThrownValue inside the catch (before ENDTRY).
+        // We use a flag set by verifying the value is 7 at catch time.
+        // Implementation: after THROW lands at catch=11, ENDTRY at 11 pops the block.
+        // We capture ThrownValue before the full Execute by stepping.
+        byte[] program =
+        [
+            0x30, 11, 0, 0, 0,   // 0: TRY 11
+            0x01, 7, 0, 0, 0,    // 5: PUSH_INT 7
+            0x31,                 // 10: THROW → IP jumps to 11
+            0x32,                 // 11: ENDTRY
+            0xFF                  // 12: HALT
+        ];
+
+        var machine = new ControlFlowTestMachine();
+        var ctx = new ControlFlowContext(program);
+
+        // Step up to and including THROW (instructions 0, 1, 2)
+        machine.ExecuteStep(ctx); // TRY
+        machine.ExecuteStep(ctx); // PUSH_INT 7
+        machine.ExecuteStep(ctx); // THROW → IP=11, ExceptionBlock still on stack
+
+        var ex = (ExceptionBlock)ctx.ControlFlow.CurrentBlock!;
+        Assert.AreEqual(7, ex.ThrownValue);
+    }
+}


### PR DESCRIPTION
## Summary

Infrastructure de flux de contrôle structuré pour `Utils.VirtualMachine`. **Aucun bytecode n'est défini** dans le framework — les opcodes sont attribués par chaque VM concrète. Les handlers d'instructions appellent `ControlFlowStack` pour la bookkeeping.

### Nouveaux types

**`IControlFlowBlock`** — interface marqueur avec `StartAddress`. Tous les blocs vont sur la même pile.

**`ConditionalBlock`** (`StartAddress`, `EndAddress`, `ElseAddress?`)
- Poussé par IF ; dépilé par ENDIF
- Si condition fausse → IP = `ElseAddress ?? EndAddress`

**`LoopBlock`** (`StartAddress` = cible de CONTINUE, `EndAddress` = cible de BREAK)
- Poussé par LOOP ; reste sur la pile à chaque itération
- Dépilé par BREAK (via `ControlFlowStack.Break`)

**`ExceptionBlock`** (`CatchAddress?`, `FinallyAddress?`, `ThrownValue`)
- Au moins un des deux adresses obligatoire
- Reste sur la pile pendant le corps catch/finally pour exposer `ThrownValue`
- Dépilé par ENDTRY

**`ControlFlowStack`**
- `PushConditional` / `PushLoop` / `PushException` / `Pop`
- `Break(ctx)` — dépile jusqu'au `LoopBlock` inclusif, saute à `EndAddress`
- `Continue(ctx)` — dépile les blocs imbriqués dans le loop (exclusif), saute à `StartAddress`
- `Throw(ctx, value)` — dépile jusqu'à `ExceptionBlock`, set `ThrownValue`, saute au handler ; retourne `false` si non géré
- `CurrentBlock` / `Depth`

**`ControlFlowContext : DefaultContext`** — contexte prêt à l'emploi avec un `ControlFlowStack`.

## Test plan

- [ ] 24 tests : ConditionalBlock sans/avec else, LoopBlock Break/Continue avec blocs imbriqués, ExceptionBlock Throw vers catch/finally, unwinding multi-niveaux, handler non trouvé
- [ ] Intégration : BREAK sort d'une boucle (PUSH_INT 99 jamais atteint), THROW atteint le handler, ThrownValue accessible par step
- [ ] Suite complète `UtilsTest.Unit` : 2170 passent, 3 ignorés

Generated with [Claude Code](https://claude.com/claude-code)