### PR TITLE
feat(vm): immutable call-stack depth, -1 return sentinel, FullContext

### DIFF
--- a/Utils.VirtualMachine/CallFrame.cs
+++ b/Utils.VirtualMachine/CallFrame.cs
@@ -52,4 +52,17 @@ public sealed class CallFrame
         value = default;
         return false;
     }
+
+    /// <summary>
+    /// Retrieves a typed local variable, throwing if the variable is absent or has an incompatible type.
+    /// </summary>
+    /// <typeparam name="T">Expected type of the value.</typeparam>
+    /// <param name="name">Variable name.</param>
+    /// <returns>The typed value stored under <paramref name="name"/>.</returns>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown when no variable with <paramref name="name"/> exists in this frame, or when the
+    /// stored value cannot be cast to <typeparamref name="T"/>.
+    /// </exception>
+    public T GetLocal<T>(string name)
+        => TryGetLocal<T>(name, out var v) ? v! : throw new KeyNotFoundException($"Local '{name}' not found or not assignable to {typeof(T).Name}.");
 }

--- a/Utils.VirtualMachine/CallStack.cs
+++ b/Utils.VirtualMachine/CallStack.cs
@@ -14,7 +14,6 @@ namespace Utils.VirtualMachine;
 public class CallStack : ICallStack
 {
     private readonly Stack<CallFrame> _frames = new();
-    private int _maxDepth = 512;
 
     /// <inheritdoc/>
     public int Depth => _frames.Count;
@@ -23,41 +22,35 @@ public class CallStack : ICallStack
     public bool IsEmpty => _frames.Count == 0;
 
     /// <inheritdoc/>
-    public int MaxDepth
-    {
-        get => _maxDepth;
-        set
-        {
-            if (value < 1) throw new ArgumentOutOfRangeException(nameof(value), "MaxDepth must be at least 1.");
-            _maxDepth = value;
-        }
-    }
+    public int MaxDepth { get; }
 
     /// <summary>Gets the frame at the top of the stack, or <see langword="null"/> when the stack is empty.</summary>
     public CallFrame? CurrentFrame => _frames.TryPeek(out var f) ? f : null;
 
+    /// <summary>
+    /// Initializes a new instance with the specified maximum stack depth.
+    /// </summary>
+    /// <param name="maxDepth">Maximum number of frames allowed. Defaults to <c>512</c>.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxDepth"/> is less than one.</exception>
+    public CallStack(int maxDepth = 512)
+    {
+        if (maxDepth < 1) throw new ArgumentOutOfRangeException(nameof(maxDepth), "MaxDepth must be at least 1.");
+        MaxDepth = maxDepth;
+    }
+
     /// <inheritdoc/>
     public void Call(int returnAddress)
     {
-        if (_frames.Count >= _maxDepth)
-            throw new InvalidOperationException($"Call stack overflow: maximum depth of {_maxDepth} exceeded.");
+        if (_frames.Count >= MaxDepth)
+            throw new InvalidOperationException($"Call stack overflow: maximum depth of {MaxDepth} exceeded.");
         _frames.Push(new CallFrame(returnAddress));
     }
 
     /// <inheritdoc/>
     public int Return()
     {
-        if (_frames.Count == 0)
-            throw new InvalidOperationException("Call stack underflow: cannot return from an empty call stack.");
+        if (_frames.Count == 0) return -1;
         return _frames.Pop().ReturnAddress;
-    }
-
-    /// <inheritdoc/>
-    public bool TryReturn(out int returnAddress)
-    {
-        if (_frames.Count == 0) { returnAddress = 0; return false; }
-        returnAddress = _frames.Pop().ReturnAddress;
-        return true;
     }
 }
 

--- a/Utils.VirtualMachine/ControlFlowStack.cs
+++ b/Utils.VirtualMachine/ControlFlowStack.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Utils.VirtualMachine;
 
@@ -19,8 +20,17 @@ public class ControlFlowStack
     /// <summary>Gets the number of currently open blocks.</summary>
     public int Depth => _blocks.Count;
 
+    /// <summary>Gets a value indicating whether no blocks are currently open.</summary>
+    public bool IsEmpty => _blocks.Count == 0;
+
     /// <summary>Gets the innermost open block, or <see langword="null"/> when the stack is empty.</summary>
     public IControlFlowBlock? CurrentBlock => _blocks.TryPeek(out var b) ? b : null;
+
+    /// <summary>
+    /// Gets all currently open blocks from innermost (top of stack) to outermost (bottom),
+    /// as a live enumerable. Useful for diagnostics and post-execution assertions.
+    /// </summary>
+    public IEnumerable<IControlFlowBlock> Blocks => _blocks;
 
     /// <summary>Opens a conditional (if/else) block.</summary>
     /// <param name="startAddress">Address of the IF instruction.</param>
@@ -51,6 +61,27 @@ public class ControlFlowStack
         if (_blocks.Count == 0)
             throw new InvalidOperationException("Control flow stack underflow: no open block to close.");
         return _blocks.Pop();
+    }
+
+    /// <summary>
+    /// Closes the innermost open block, asserting that it is of type <typeparamref name="T"/>.
+    /// Use this overload when the bytecode guarantees the block type (e.g. ENDIF always closes a
+    /// <see cref="ConditionalBlock"/>); mismatched types indicate malformed bytecode.
+    /// </summary>
+    /// <typeparam name="T">The expected concrete block type.</typeparam>
+    /// <returns>The closed block cast to <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no block is open.</exception>
+    /// <exception cref="VirtualProcessorException">
+    /// Thrown when the innermost block is not of type <typeparamref name="T"/>.
+    /// </exception>
+    public T Pop<T>() where T : class, IControlFlowBlock
+    {
+        if (_blocks.Count == 0)
+            throw new InvalidOperationException("Control flow stack underflow: no open block to close.");
+        if (_blocks.Peek() is not T)
+            throw new VirtualProcessorException(
+                $"Control flow type mismatch: expected {typeof(T).Name} but found {_blocks.Peek().GetType().Name}.");
+        return (T)_blocks.Pop();
     }
 
     /// <summary>
@@ -93,6 +124,16 @@ public class ControlFlowStack
     }
 
     /// <summary>
+    /// Returns the nearest enclosing block of type <typeparamref name="T"/> without removing it
+    /// from the stack, or <see langword="null"/> when no such block is open.
+    /// Useful for introspection (e.g. "are we inside a loop?") and diagnostic assertions.
+    /// </summary>
+    /// <typeparam name="T">The concrete block type to search for.</typeparam>
+    /// <returns>The innermost open block of type <typeparamref name="T"/>, or <see langword="null"/>.</returns>
+    public T? FindEnclosing<T>() where T : class, IControlFlowBlock
+        => _blocks.OfType<T>().FirstOrDefault();
+
+    /// <summary>
     /// Handles a THROW instruction: pops all blocks until the nearest <see cref="ExceptionBlock"/>
     /// is found, stores the thrown value in <see cref="ExceptionBlock.ThrownValue"/>, and
     /// redirects <see cref="Context.InstructionPointer"/> to the catch handler (or finally if
@@ -128,11 +169,59 @@ public class ControlFlowStack
 public class ControlFlowContext : DefaultContext
 {
     /// <summary>Gets the control flow stack managing open blocks for the current execution.</summary>
+    public ControlFlowStack ControlFlow { get; }
+
+    /// <summary>
+    /// Initializes a new instance with the given instruction stream and a fresh <see cref="ControlFlowStack"/>.
+    /// </summary>
+    /// <param name="data">The byte array containing the instruction stream.</param>
+    public ControlFlowContext(byte[] data) : base(data)
+    {
+        ControlFlow = new ControlFlowStack();
+    }
+
+    /// <summary>
+    /// Initializes a new instance with the given instruction stream and a caller-supplied
+    /// <see cref="ControlFlowStack"/>, allowing pre-configuration or substitution.
+    /// </summary>
+    /// <param name="data">The byte array containing the instruction stream.</param>
+    /// <param name="controlFlow">The control flow stack to use.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="controlFlow"/> is <see langword="null"/>.</exception>
+    public ControlFlowContext(byte[] data, ControlFlowStack controlFlow) : base(data)
+    {
+        ControlFlow = controlFlow ?? throw new ArgumentNullException(nameof(controlFlow));
+    }
+}
+
+/// <summary>
+/// A <see cref="DefaultContext"/> combining an <see cref="ICallStack"/> for subroutine calls
+/// with a <see cref="ControlFlowStack"/> for structured control flow.
+/// Use this when the VM needs both call/return and if/loop/try semantics.
+/// </summary>
+public class FullContext : DefaultContext
+{
+    /// <summary>Gets the call stack used to track subroutine return addresses.</summary>
+    public ICallStack CallStack { get; }
+
+    /// <summary>Gets the control flow stack managing open structured blocks.</summary>
     public ControlFlowStack ControlFlow { get; } = new();
 
     /// <summary>
-    /// Initializes a new instance with the given instruction stream.
+    /// Initializes a new instance with a default <see cref="CallStack"/>.
     /// </summary>
     /// <param name="data">The byte array containing the instruction stream.</param>
-    public ControlFlowContext(byte[] data) : base(data) { }
+    public FullContext(byte[] data) : base(data)
+    {
+        CallStack = new CallStack();
+    }
+
+    /// <summary>
+    /// Initializes a new instance with a caller-supplied <see cref="ICallStack"/> implementation.
+    /// </summary>
+    /// <param name="data">The byte array containing the instruction stream.</param>
+    /// <param name="callStack">The call stack to use.</param>
+    public FullContext(byte[] data, ICallStack callStack) : base(data)
+    {
+        CallStack = callStack ?? throw new ArgumentNullException(nameof(callStack));
+    }
 }

--- a/Utils.VirtualMachine/ICallStack.cs
+++ b/Utils.VirtualMachine/ICallStack.cs
@@ -21,11 +21,10 @@ public interface ICallStack
     bool IsEmpty { get; }
 
     /// <summary>
-    /// Gets or sets the maximum number of frames allowed before <see cref="Call"/> throws.
+    /// Gets the maximum number of frames allowed before <see cref="Call"/> throws.
+    /// Configured at construction time.
     /// </summary>
-    /// <value>Defaults to <c>512</c>.</value>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a value less than one.</exception>
-    int MaxDepth { get; set; }
+    int MaxDepth { get; }
 
     /// <summary>
     /// Pushes a new frame onto the stack, recording <paramref name="returnAddress"/> as the
@@ -36,18 +35,21 @@ public interface ICallStack
     void Call(int returnAddress);
 
     /// <summary>
-    /// Pops the current frame and returns the saved return address.
+    /// Pops the current frame and returns the saved return address, or <c>-1</c> when the
+    /// stack is empty. A return address of <c>-1</c> is a sentinel signalling program
+    /// termination: callers should assign it to <see cref="Context.InstructionPointer"/>
+    /// so the <see cref="VirtualProcessor{T}"/> execution loop stops.
     /// </summary>
-    /// <returns>The instruction-pointer value saved by the matching <see cref="Call"/>.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the stack is empty.</exception>
+    /// <returns>
+    /// The instruction-pointer value saved by the matching <see cref="Call"/>,
+    /// or <c>-1</c> if the stack is empty.
+    /// </returns>
     int Return();
 
     /// <summary>
-    /// Attempts to pop the current frame without throwing when the stack is empty.
+    /// Gets the frame at the top of the stack, or <see langword="null"/> when the stack is
+    /// empty or the implementation does not support per-frame local variables
+    /// (e.g. <see cref="SimpleCallStack"/>).
     /// </summary>
-    /// <param name="returnAddress">
-    /// When this method returns <see langword="true"/>, receives the saved return address; otherwise, zero.
-    /// </param>
-    /// <returns><see langword="true"/> if a frame was popped; <see langword="false"/> if the stack was empty.</returns>
-    bool TryReturn(out int returnAddress);
+    CallFrame? CurrentFrame { get; }
 }

--- a/Utils.VirtualMachine/INumberReader.cs
+++ b/Utils.VirtualMachine/INumberReader.cs
@@ -1,290 +1,288 @@
 using System;
 using System.Buffers.Binary;
+using System.Runtime.InteropServices;
 
-namespace Utils.VirtualMachine
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Provides methods to read numbers from a virtual machine <see cref="Context"/>.
+/// </summary>
+public interface INumberReader
 {
     /// <summary>
-    /// Provides methods to read numbers from a virtual machine <see cref="Context"/>.
+    /// Reads a single byte from the supplied <paramref name="context"/>.
     /// </summary>
-    public interface INumberReader
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next byte available in the context.</returns>
+    byte ReadByte(Context context);
+
+    /// <summary>
+    /// Reads a 16-bit signed integer from the supplied <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next <see cref="short"/> value available in the context.</returns>
+    short ReadInt16(Context context);
+
+    /// <summary>
+    /// Reads a 32-bit signed integer from the supplied <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next <see cref="int"/> value available in the context.</returns>
+    int ReadInt32(Context context);
+
+    /// <summary>
+    /// Reads a 64-bit signed integer from the supplied <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next <see cref="long"/> value available in the context.</returns>
+    long ReadInt64(Context context);
+
+    /// <summary>
+    /// Reads a 16-bit unsigned integer from the supplied <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next <see cref="ushort"/> value available in the context.</returns>
+    ushort ReadUInt16(Context context);
+
+    /// <summary>
+    /// Reads a 32-bit unsigned integer from the supplied <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next <see cref="uint"/> value available in the context.</returns>
+    uint ReadUInt32(Context context);
+
+    /// <summary>
+    /// Reads a 64-bit unsigned integer from the supplied <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next <see cref="ulong"/> value available in the context.</returns>
+    ulong ReadUInt64(Context context);
+
+    /// <summary>
+    /// Reads a single-precision floating-point value from the supplied <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next <see cref="float"/> value available in the context.</returns>
+    float ReadSingle(Context context);
+
+    /// <summary>
+    /// Reads a double-precision floating-point value from the supplied <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next <see cref="double"/> value available in the context.</returns>
+    double ReadDouble(Context context);
+
+    /// <summary>
+    /// Reads an unsigned LEB128-encoded integer from the supplied <paramref name="context"/>.
+    /// LEB128 is byte-order independent; this default implementation delegates to <see cref="ReadByte"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The unsigned integer decoded from the LEB128 byte sequence.</returns>
+    ulong ReadULEB128(Context context)
     {
-        /// <summary>
-        /// Reads a single byte from the supplied <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The next byte available in the context.</returns>
-        byte ReadByte(Context context);
-
-        /// <summary>
-        /// Reads a 16-bit signed integer from the supplied <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The next <see cref="short"/> value available in the context.</returns>
-        short ReadInt16(Context context);
-
-        /// <summary>
-        /// Reads a 32-bit signed integer from the supplied <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The next <see cref="int"/> value available in the context.</returns>
-        int ReadInt32(Context context);
-
-        /// <summary>
-        /// Reads a 64-bit signed integer from the supplied <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The next <see cref="long"/> value available in the context.</returns>
-        long ReadInt64(Context context);
-
-        /// <summary>
-        /// Reads a 16-bit unsigned integer from the supplied <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The next <see cref="ushort"/> value available in the context.</returns>
-        ushort ReadUInt16(Context context);
-
-        /// <summary>
-        /// Reads a 32-bit unsigned integer from the supplied <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The next <see cref="uint"/> value available in the context.</returns>
-        uint ReadUInt32(Context context);
-
-        /// <summary>
-        /// Reads a 64-bit unsigned integer from the supplied <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The next <see cref="ulong"/> value available in the context.</returns>
-        ulong ReadUInt64(Context context);
-
-        /// <summary>
-        /// Reads a single-precision floating-point value from the supplied <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The next <see cref="float"/> value available in the context.</returns>
-        float ReadSingle(Context context);
-
-        /// <summary>
-        /// Reads a double-precision floating-point value from the supplied <paramref name="context"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The next <see cref="double"/> value available in the context.</returns>
-        double ReadDouble(Context context);
-
-        /// <summary>
-        /// Reads an unsigned LEB128-encoded integer from the supplied <paramref name="context"/>.
-        /// LEB128 is byte-order independent; this default implementation delegates to <see cref="ReadByte"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The unsigned integer decoded from the LEB128 byte sequence.</returns>
-        ulong ReadULEB128(Context context)
+        ulong result = 0;
+        int shift = 0;
+        byte b;
+        do
         {
-            ulong result = 0;
-            int shift = 0;
-            byte b;
-            do
-            {
-                b = ReadByte(context);
-                result |= (ulong)(b & 0x7F) << shift;
-                shift += 7;
-            }
-            while ((b & 0x80) != 0);
-            return result;
+            b = ReadByte(context);
+            result |= (ulong)(b & 0x7F) << shift;
+            shift += 7;
         }
-
-        /// <summary>
-        /// Reads a signed LEB128-encoded integer from the supplied <paramref name="context"/>.
-        /// LEB128 is byte-order independent; this default implementation delegates to <see cref="ReadByte"/>.
-        /// </summary>
-        /// <param name="context">The execution context containing the instruction stream.</param>
-        /// <returns>The signed integer decoded from the LEB128 byte sequence.</returns>
-        long ReadSLEB128(Context context)
-        {
-            long result = 0;
-            int shift = 0;
-            byte b;
-            do
-            {
-                b = ReadByte(context);
-                result |= (long)(b & 0x7F) << shift;
-                shift += 7;
-            }
-            while ((b & 0x80) != 0);
-            if (shift < 64 && (b & 0x40) != 0)
-                result |= -(1L << shift);
-            return result;
-        }
+        while ((b & 0x80) != 0);
+        return result;
     }
 
     /// <summary>
-    /// Factory methods for obtaining <see cref="INumberReader"/> instances.
+    /// Reads a signed LEB128-encoded integer from the supplied <paramref name="context"/>.
+    /// LEB128 is byte-order independent; this default implementation delegates to <see cref="ReadByte"/>.
     /// </summary>
-    public static class NumberReader
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The signed integer decoded from the LEB128 byte sequence.</returns>
+    long ReadSLEB128(Context context)
     {
-        private static INumberReader NormalReader { get; } = new NormalReader();
-        private static INumberReader InvertedReader { get; } = new InvertedReader();
-
-        /// <summary>
-        /// Returns a reader configured for the specified endianness.
-        /// </summary>
-        /// <param name="littleEndian">True for little-endian reading; otherwise, false.</param>
-        /// <returns>An <see cref="INumberReader"/> that reads values using the desired byte order.</returns>
-        public static INumberReader GetReader(bool littleEndian)
+        long result = 0;
+        int shift = 0;
+        byte b;
+        do
         {
-            // NormalReader when requested endianness matches the system's endianness (no byte-swap needed).
-            return littleEndian == BitConverter.IsLittleEndian ? NormalReader : InvertedReader;
+            b = ReadByte(context);
+            result |= (long)(b & 0x7F) << shift;
+            shift += 7;
         }
+        while ((b & 0x80) != 0);
+        if (shift < 64 && (b & 0x40) != 0)
+            result |= -(1L << shift);
+        return result;
     }
+}
+
+/// <summary>
+/// Factory methods for obtaining <see cref="INumberReader"/> instances.
+/// </summary>
+public static class NumberReader
+{
+    private static INumberReader NormalReader { get; } = new NormalReader();
+    private static INumberReader InvertedReader { get; } = new InvertedReader();
 
     /// <summary>
-    /// Reader implementation matching the system endianness.
+    /// Returns a reader configured for the specified endianness.
     /// </summary>
-    internal class NormalReader : INumberReader
+    /// <param name="littleEndian">True for little-endian reading; otherwise, false.</param>
+    /// <returns>An <see cref="INumberReader"/> that reads values using the desired byte order.</returns>
+    public static INumberReader GetReader(bool littleEndian)
     {
-        /// <inheritdoc />
-        public byte ReadByte(Context context)
-        {
-            return context.Data[context.InstructionPointer++];
-        }
+        // NormalReader when requested endianness matches the system's endianness (no byte-swap needed).
+        return littleEndian == BitConverter.IsLittleEndian ? NormalReader : InvertedReader;
+    }
+}
 
-        /// <inheritdoc />
-        public short ReadInt16(Context context)
-        {
-            var result = BitConverter.ToInt16(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(short);
-            return result;
-        }
+/// <summary>
+/// Reader implementation matching the system endianness.
+/// Uses <see cref="MemoryMarshal.Read{T}"/> to read in native byte order without intermediate copies.
+/// </summary>
+internal class NormalReader : INumberReader
+{
+    /// <inheritdoc />
+    public byte ReadByte(Context context)
+        => context.Data[context.InstructionPointer++];
 
-        /// <inheritdoc />
-        public int ReadInt32(Context context)
-        {
-            var result = BitConverter.ToInt32(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(int);
-            return result;
-        }
-
-        /// <inheritdoc />
-        public long ReadInt64(Context context)
-        {
-            var result = BitConverter.ToInt64(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(long);
-            return result;
-        }
-
-        /// <inheritdoc />
-        public ushort ReadUInt16(Context context)
-        {
-            var result = BitConverter.ToUInt16(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(ushort);
-            return result;
-        }
-
-        /// <inheritdoc />
-        public uint ReadUInt32(Context context)
-        {
-            var result = BitConverter.ToUInt32(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(uint);
-            return result;
-        }
-
-        /// <inheritdoc />
-        public ulong ReadUInt64(Context context)
-        {
-            var result = BitConverter.ToUInt64(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(ulong);
-            return result;
-        }
-
-        /// <inheritdoc />
-        public float ReadSingle(Context context)
-        {
-            var result = BitConverter.ToSingle(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(float);
-            return result;
-        }
-
-        /// <inheritdoc />
-        public double ReadDouble(Context context)
-        {
-            var result = BitConverter.ToDouble(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(double);
-            return result;
-        }
+    /// <inheritdoc />
+    public short ReadInt16(Context context)
+    {
+        var result = MemoryMarshal.Read<short>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(short);
+        return result;
     }
 
-    /// <summary>
-    /// Reader implementation that swaps endianness when reading values.
-    /// Uses <see cref="BinaryPrimitives.ReverseEndianness"/> to avoid heap allocation.
-    /// </summary>
-    internal class InvertedReader : INumberReader
+    /// <inheritdoc />
+    public int ReadInt32(Context context)
     {
-        /// <inheritdoc />
-        public byte ReadByte(Context context) => context.Data[context.InstructionPointer++];
+        var result = MemoryMarshal.Read<int>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(int);
+        return result;
+    }
 
-        /// <inheritdoc />
-        public short ReadInt16(Context context)
-        {
-            var result = BitConverter.ToInt16(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(short);
-            return BinaryPrimitives.ReverseEndianness(result);
-        }
+    /// <inheritdoc />
+    public long ReadInt64(Context context)
+    {
+        var result = MemoryMarshal.Read<long>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(long);
+        return result;
+    }
 
-        /// <inheritdoc />
-        public int ReadInt32(Context context)
-        {
-            var result = BitConverter.ToInt32(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(int);
-            return BinaryPrimitives.ReverseEndianness(result);
-        }
+    /// <inheritdoc />
+    public ushort ReadUInt16(Context context)
+    {
+        var result = MemoryMarshal.Read<ushort>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(ushort);
+        return result;
+    }
 
-        /// <inheritdoc />
-        public long ReadInt64(Context context)
-        {
-            var result = BitConverter.ToInt64(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(long);
-            return BinaryPrimitives.ReverseEndianness(result);
-        }
+    /// <inheritdoc />
+    public uint ReadUInt32(Context context)
+    {
+        var result = MemoryMarshal.Read<uint>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(uint);
+        return result;
+    }
 
-        /// <inheritdoc />
-        public ushort ReadUInt16(Context context)
-        {
-            var result = BitConverter.ToUInt16(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(ushort);
-            return BinaryPrimitives.ReverseEndianness(result);
-        }
+    /// <inheritdoc />
+    public ulong ReadUInt64(Context context)
+    {
+        var result = MemoryMarshal.Read<ulong>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(ulong);
+        return result;
+    }
 
-        /// <inheritdoc />
-        public uint ReadUInt32(Context context)
-        {
-            var result = BitConverter.ToUInt32(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(uint);
-            return BinaryPrimitives.ReverseEndianness(result);
-        }
+    /// <inheritdoc />
+    public float ReadSingle(Context context)
+    {
+        var result = MemoryMarshal.Read<float>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(float);
+        return result;
+    }
 
-        /// <inheritdoc />
-        public ulong ReadUInt64(Context context)
-        {
-            var result = BitConverter.ToUInt64(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(ulong);
-            return BinaryPrimitives.ReverseEndianness(result);
-        }
+    /// <inheritdoc />
+    public double ReadDouble(Context context)
+    {
+        var result = MemoryMarshal.Read<double>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(double);
+        return result;
+    }
+}
 
-        /// <inheritdoc />
-        public float ReadSingle(Context context)
-        {
-            // Reverse the 4 bytes via the uint representation.
-            var bits = BitConverter.ToUInt32(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(float);
-            return BitConverter.UInt32BitsToSingle(BinaryPrimitives.ReverseEndianness(bits));
-        }
+/// <summary>
+/// Reader implementation that swaps endianness when reading values.
+/// Uses <see cref="MemoryMarshal.Read{T}"/> to obtain the native-endian value, then
+/// <see cref="BinaryPrimitives.ReverseEndianness"/> to invert byte order without heap allocation.
+/// </summary>
+internal class InvertedReader : INumberReader
+{
+    /// <inheritdoc />
+    public byte ReadByte(Context context) => context.Data[context.InstructionPointer++];
 
-        /// <inheritdoc />
-        public double ReadDouble(Context context)
-        {
-            // Reverse the 8 bytes via the ulong representation.
-            var bits = BitConverter.ToUInt64(context.Data, context.InstructionPointer);
-            context.InstructionPointer += sizeof(double);
-            return BitConverter.UInt64BitsToDouble(BinaryPrimitives.ReverseEndianness(bits));
-        }
+    /// <inheritdoc />
+    public short ReadInt16(Context context)
+    {
+        var result = MemoryMarshal.Read<short>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(short);
+        return BinaryPrimitives.ReverseEndianness(result);
+    }
+
+    /// <inheritdoc />
+    public int ReadInt32(Context context)
+    {
+        var result = MemoryMarshal.Read<int>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(int);
+        return BinaryPrimitives.ReverseEndianness(result);
+    }
+
+    /// <inheritdoc />
+    public long ReadInt64(Context context)
+    {
+        var result = MemoryMarshal.Read<long>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(long);
+        return BinaryPrimitives.ReverseEndianness(result);
+    }
+
+    /// <inheritdoc />
+    public ushort ReadUInt16(Context context)
+    {
+        var result = MemoryMarshal.Read<ushort>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(ushort);
+        return BinaryPrimitives.ReverseEndianness(result);
+    }
+
+    /// <inheritdoc />
+    public uint ReadUInt32(Context context)
+    {
+        var result = MemoryMarshal.Read<uint>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(uint);
+        return BinaryPrimitives.ReverseEndianness(result);
+    }
+
+    /// <inheritdoc />
+    public ulong ReadUInt64(Context context)
+    {
+        var result = MemoryMarshal.Read<ulong>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(ulong);
+        return BinaryPrimitives.ReverseEndianness(result);
+    }
+
+    /// <inheritdoc />
+    public float ReadSingle(Context context)
+    {
+        var bits = MemoryMarshal.Read<uint>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(float);
+        return BitConverter.UInt32BitsToSingle(BinaryPrimitives.ReverseEndianness(bits));
+    }
+
+    /// <inheritdoc />
+    public double ReadDouble(Context context)
+    {
+        var bits = MemoryMarshal.Read<ulong>(context.Data.AsSpan(context.InstructionPointer));
+        context.InstructionPointer += sizeof(double);
+        return BitConverter.UInt64BitsToDouble(BinaryPrimitives.ReverseEndianness(bits));
     }
 }

--- a/Utils.VirtualMachine/InstructionAttribute.cs
+++ b/Utils.VirtualMachine/InstructionAttribute.cs
@@ -1,32 +1,35 @@
 using System;
 
-namespace Utils.VirtualMachine
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Identifies a method as a virtual machine instruction and stores its metadata.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+public class InstructionAttribute : Attribute
 {
     /// <summary>
-    /// Identifies a method as a virtual machine instruction and stores its metadata.
+    /// Gets the human-readable name associated with the instruction.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    public class InstructionAttribute : Attribute
+    public string Name { get; }
+
+    /// <summary>
+    /// Gets the byte sequence representing the instruction opcode.
+    /// </summary>
+    public byte[] Instruction { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InstructionAttribute"/> class.
+    /// </summary>
+    /// <param name="name">The descriptive name of the instruction. Must not be <see langword="null"/>.</param>
+    /// <param name="instruction">The byte sequence that identifies the instruction. Must contain at least one byte.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="instruction"/> is empty.</exception>
+    public InstructionAttribute(string name, params byte[] instruction)
     {
-        /// <summary>
-        /// Gets the human-readable name associated with the instruction.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Gets the byte sequence representing the instruction opcode.
-        /// </summary>
-        public byte[] Instruction { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InstructionAttribute"/> class.
-        /// </summary>
-        /// <param name="name">The descriptive name of the instruction.</param>
-        /// <param name="instruction">The byte sequence that identifies the instruction.</param>
-        public InstructionAttribute(string name, params byte[] instruction)
-        {
-            Name = name;
-            Instruction = instruction;
-        }
+        ArgumentNullException.ThrowIfNull(name);
+        if (instruction.Length == 0) throw new ArgumentException("Instruction opcode cannot be empty.", nameof(instruction));
+        Name = name;
+        Instruction = instruction;
     }
 }

--- a/Utils.VirtualMachine/SimpleCallStack.cs
+++ b/Utils.VirtualMachine/SimpleCallStack.cs
@@ -10,7 +10,6 @@ namespace Utils.VirtualMachine;
 public class SimpleCallStack : ICallStack
 {
     private readonly Stack<int> _returnAddresses = new();
-    private int _maxDepth = 512;
 
     /// <inheritdoc/>
     public int Depth => _returnAddresses.Count;
@@ -19,37 +18,35 @@ public class SimpleCallStack : ICallStack
     public bool IsEmpty => _returnAddresses.Count == 0;
 
     /// <inheritdoc/>
-    public int MaxDepth
+    public int MaxDepth { get; }
+
+    /// <summary>
+    /// Initializes a new instance with the specified maximum stack depth.
+    /// </summary>
+    /// <param name="maxDepth">Maximum number of frames allowed. Defaults to <c>512</c>.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxDepth"/> is less than one.</exception>
+    public SimpleCallStack(int maxDepth = 512)
     {
-        get => _maxDepth;
-        set
-        {
-            if (value < 1) throw new ArgumentOutOfRangeException(nameof(value), "MaxDepth must be at least 1.");
-            _maxDepth = value;
-        }
+        if (maxDepth < 1) throw new ArgumentOutOfRangeException(nameof(maxDepth), "MaxDepth must be at least 1.");
+        MaxDepth = maxDepth;
     }
 
     /// <inheritdoc/>
     public void Call(int returnAddress)
     {
-        if (_returnAddresses.Count >= _maxDepth)
-            throw new InvalidOperationException($"Call stack overflow: maximum depth of {_maxDepth} exceeded.");
+        if (_returnAddresses.Count >= MaxDepth)
+            throw new InvalidOperationException($"Call stack overflow: maximum depth of {MaxDepth} exceeded.");
         _returnAddresses.Push(returnAddress);
     }
 
     /// <inheritdoc/>
     public int Return()
     {
-        if (_returnAddresses.Count == 0)
-            throw new InvalidOperationException("Call stack underflow: cannot return from an empty call stack.");
+        if (_returnAddresses.Count == 0) return -1;
         return _returnAddresses.Pop();
     }
 
     /// <inheritdoc/>
-    public bool TryReturn(out int returnAddress)
-    {
-        if (_returnAddresses.Count == 0) { returnAddress = 0; return false; }
-        returnAddress = _returnAddresses.Pop();
-        return true;
-    }
+    /// <remarks><see cref="SimpleCallStack"/> does not support per-frame locals; this property always returns <see langword="null"/>.</remarks>
+    public CallFrame? CurrentFrame => null;
 }

--- a/Utils.VirtualMachine/VirtualProcessor.cs
+++ b/Utils.VirtualMachine/VirtualProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -7,340 +7,383 @@ using System.Threading;
 using Utils.Arrays;
 using Utils.Collections;
 
-namespace Utils.VirtualMachine
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Provides an abstract base class for a virtual processor that interprets and executes
+/// instructions from a byte array-based context. Instructions are defined by methods
+/// annotated with <see cref="InstructionAttribute"/>.
+/// </summary>
+/// <typeparam name="T">
+/// The type of execution context, which must derive from <see cref="Context"/>.
+/// </typeparam>
+/// <remarks>
+/// This class is not thread-safe. Concurrent calls to <see cref="Execute"/> or
+/// <see cref="ExecuteStep"/> on the same instance share a dispatch buffer and must not
+/// overlap; use one <see cref="VirtualProcessor{T}"/> instance per thread, or synchronize externally.
+/// </remarks>
+public abstract class VirtualProcessor<T> where T : Context
+{
+    // INumberReader methods never change; cache per-type avoids rebuilding on every instantiation.
+    // IsAbstract filters to fixed-width methods only; default-implementation methods (LEB128) share
+    // return types with ulong/long and would cause duplicate-key conflicts in the dictionary.
+    private static readonly Dictionary<Type, MethodInfo> _numberReaderMethods =
+        typeof(INumberReader).GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                             .Where(m => m.IsAbstract)
+                             .ToDictionary(m => m.ReturnType, m => m);
+
+    /// <summary>Number reader configured for the requested endianness.</summary>
+    private readonly INumberReader _numberReader;
+
+    /// <summary>Length (in bytes) of the longest registered opcode; bounds the dispatch loop.</summary>
+    private int _maxInstructionSize;
+
+    /// <summary>Pre-allocated scratch buffer for opcode accumulation during dispatch; length equals <see cref="_maxInstructionSize"/>.</summary>
+    private byte[] _buffer;
+
+    /// <summary>Number of bytes written into <see cref="_buffer"/> for the current dispatch attempt.</summary>
+    private int _bufferLength;
+
+    /// <summary>
+    /// Represents a delegate to handle an instruction, given the current context.
+    /// </summary>
+    /// <param name="context">An instance of the execution context.</param>
+    public delegate void InstructionDelegate(T context);
+
+    /// <summary>
+    /// A dictionary mapping each instruction byte sequence to a (name, delegate) pair.
+    /// The equality comparer for keys is configured to handle byte-array comparison.
+    /// </summary>
+    protected Dictionary<IReadOnlyCollection<byte>, (string Name, InstructionDelegate Handler)> InstructionsSet { get; }
+
+    /// <summary>
+    /// Gets a read-only enumeration of all registered instructions, including those discovered via
+    /// <see cref="InstructionAttribute"/> and those added with <see cref="RegisterInstruction"/>.
+    /// </summary>
+    public IEnumerable<(IReadOnlyCollection<byte> Opcode, string Name)> Instructions
+        => InstructionsSet.Select(kv => (kv.Key, kv.Value.Name));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VirtualProcessor{T}"/> class,
+    /// specifying whether the byte data should be interpreted as little-endian.
+    /// </summary>
+    /// <param name="littleEndian">
+    /// If <see langword="true"/>, uses little-endian byte ordering; otherwise, uses big-endian.
+    /// Defaults to <see langword="true"/>.
+    /// </param>
+    protected VirtualProcessor(bool littleEndian = true)
+    {
+        _numberReader = NumberReader.GetReader(littleEndian);
+        InstructionsSet = DiscoverInstructionSet();
+        _buffer = new byte[_maxInstructionSize];
+    }
+
+    /// <summary>
+    /// Discovers all instruction methods via reflection, collecting them into a dictionary
+    /// keyed by their associated byte sequences.
+    /// </summary>
+    private Dictionary<IReadOnlyCollection<byte>, (string Name, InstructionDelegate Handler)> DiscoverInstructionSet()
+    {
+        var result = new Dictionary<IReadOnlyCollection<byte>, (string, InstructionDelegate)>(
+            ArrayEqualityComparers.Byte
+        );
+
+        var methods = GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        foreach (var method in methods)
+        {
+            if (!method.IsDefined(typeof(InstructionAttribute), true)) continue;
+            var instructionAttributes = method.GetCustomAttributes(typeof(InstructionAttribute), true);
+
+            var parameters = method.GetParameters();
+            if (parameters.Length > 0 && parameters[0].ParameterType != typeof(T)) continue;
+            InstructionDelegate instructionDelegate;
+            if (parameters.Length == 0)
+            {
+                // Parameterless method (e.g. NOOP): compile a wrapper lambda that discards the context
+                // so the signature matches InstructionDelegate.
+                var ctxParam = Expression.Parameter(typeof(T), "context");
+                var callExpr = Expression.Call(Expression.Constant(this), method);
+                instructionDelegate = Expression.Lambda<InstructionDelegate>(callExpr, ctxParam).Compile();
+            }
+            else if (parameters.Length == 1)
+            {
+                instructionDelegate = (InstructionDelegate)method.CreateDelegate(typeof(InstructionDelegate), this);
+            }
+            else
+            {
+                // Build an expression-tree delegate that reads each operand from the INumberReader
+                // and passes them to the instruction method. This compiles to a direct call with no
+                // boxing or reflection overhead at dispatch time.
+                var contextParameter = Expression.Parameter(typeof(T), "context");
+                var numberReaderExpression = Expression.Constant(_numberReader);
+
+                List<Expression> methodParameters = [
+                    contextParameter
+                ];
+
+                foreach (var parameter in parameters.Skip(1))
+                {
+                    // Map each parameter type to the INumberReader method returning that type
+                    // (e.g. short → ReadInt16, int → ReadInt32). Lookup table cached in _numberReaderMethods.
+                    var readerMethod = _numberReaderMethods[parameter.ParameterType];
+                    var methodCallExpression = Expression.Call(numberReaderExpression, readerMethod, [contextParameter]);
+                    methodParameters.Add(methodCallExpression);
+                }
+
+                // Final lambda: (T context) => this.Method(context, reader.ReadXxx(context), ...)
+                var expression = Expression.Lambda<InstructionDelegate>(Expression.Call(Expression.Constant(this), method, methodParameters.ToArray()), [contextParameter]);
+                instructionDelegate = expression.Compile();
+            }
+
+            foreach (InstructionAttribute attr in instructionAttributes.OfType<InstructionAttribute>())
+            {
+                result.Add(attr.Instruction, (attr.Name, instructionDelegate));
+                _maxInstructionSize = Math.Max(_maxInstructionSize, attr.Instruction.Length);
+            }
+        }
+
+        return result;
+    }
+
+    #region Reading Methods
+
+    /// <summary>
+    /// Reads a single byte from the context using the configured <see cref="INumberReader"/>.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>The byte read from the data stream.</returns>
+    protected byte ReadByte(Context context) => _numberReader.ReadByte(context);
+
+    /// <summary>
+    /// Reads a 16-bit signed integer (short) from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A 16-bit signed integer.</returns>
+    protected short ReadInt16(Context context) => _numberReader.ReadInt16(context);
+
+    /// <summary>
+    /// Reads a 32-bit signed integer (int) from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A 32-bit signed integer.</returns>
+    protected int ReadInt32(Context context) => _numberReader.ReadInt32(context);
+
+    /// <summary>
+    /// Reads a 64-bit signed integer (long) from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A 64-bit signed integer.</returns>
+    protected long ReadInt64(Context context) => _numberReader.ReadInt64(context);
+
+    /// <summary>
+    /// Reads a 16-bit unsigned integer (ushort) from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A 16-bit unsigned integer.</returns>
+    protected ushort ReadUInt16(Context context) => _numberReader.ReadUInt16(context);
+
+    /// <summary>
+    /// Reads a 32-bit unsigned integer (uint) from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A 32-bit unsigned integer.</returns>
+    protected uint ReadUInt32(Context context) => _numberReader.ReadUInt32(context);
+
+    /// <summary>
+    /// Reads a 64-bit unsigned integer (ulong) from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A 64-bit unsigned integer.</returns>
+    protected ulong ReadUInt64(Context context) => _numberReader.ReadUInt64(context);
+
+    /// <summary>
+    /// Reads a 32-bit floating-point number (float) from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A 32-bit floating-point number.</returns>
+    protected float ReadSingle(Context context) => _numberReader.ReadSingle(context);
+
+    /// <summary>
+    /// Reads a 64-bit floating-point number (double) from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>A 64-bit floating-point number.</returns>
+    protected double ReadDouble(Context context) => _numberReader.ReadDouble(context);
+
+    /// <summary>
+    /// Reads an unsigned LEB128-encoded integer from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>The unsigned integer decoded from the LEB128 byte sequence.</returns>
+    protected ulong ReadULEB128(Context context) => _numberReader.ReadULEB128(context);
+
+    /// <summary>
+    /// Reads a signed LEB128-encoded integer from the context.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>The signed integer decoded from the LEB128 byte sequence.</returns>
+    protected long ReadSLEB128(Context context) => _numberReader.ReadSLEB128(context);
+
+    #endregion
+
+    /// <summary>
+    /// Called before each instruction is dispatched during <see cref="Execute"/> and
+    /// <see cref="ExecuteStep"/>. The default implementation does nothing.
+    /// Override to add breakpoints, tracing, or profiling without modifying the dispatch loop.
+    /// At the time of the call, <see cref="Context.InstructionPointer"/> points to the
+    /// first byte of the instruction about to execute.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    protected virtual void OnStep(T context) { }
+
+    /// <summary>
+    /// Executes all instructions until the end of the data stream, until
+    /// <see cref="Context.InstructionPointer"/> becomes negative (program termination signal),
+    /// or until <paramref name="cancellationToken"/> is cancelled.
+    /// </summary>
+    /// <param name="context">The execution context.</param>
+    /// <param name="cancellationToken">Token that can stop execution between instructions.</param>
+    /// <exception cref="VirtualProcessorException">Thrown on an unknown opcode sequence.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is cancelled.</exception>
+    public void Execute(T context, CancellationToken cancellationToken = default)
+    {
+        while (context.InstructionPointer >= 0 && context.InstructionPointer < context.Data.Length)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            OnStep(context);
+            TryDispatch(context);
+        }
+    }
+
+    /// <summary>
+    /// Executes exactly one instruction at the current instruction pointer.
+    /// </summary>
+    /// <param name="context">The execution context.</param>
+    /// <returns>
+    /// <see langword="true"/> if an instruction was dispatched;
+    /// <see langword="false"/> if the instruction pointer is past the end of the data stream
+    /// or is negative (program termination signal).
+    /// </returns>
+    /// <exception cref="VirtualProcessorException">Thrown on an unknown opcode sequence.</exception>
+    public bool ExecuteStep(T context)
+    {
+        if (context.InstructionPointer < 0 || context.InstructionPointer >= context.Data.Length) return false;
+        OnStep(context);
+        TryDispatch(context);
+        return true;
+    }
+
+    /// <summary>
+    /// Registers an instruction handler at runtime, supplementing or overriding
+    /// the methods discovered via <see cref="InstructionAttribute"/>.
+    /// </summary>
+    /// <param name="opcode">Byte sequence identifying the instruction.</param>
+    /// <param name="name">Human-readable name used in diagnostics.</param>
+    /// <param name="handler">Delegate invoked when the opcode is matched.</param>
+    public void RegisterInstruction(byte[] opcode, string name, Action<T> handler)
+    {
+        ArgumentNullException.ThrowIfNull(opcode);
+        ArgumentNullException.ThrowIfNull(handler);
+        if (opcode.Length == 0) throw new ArgumentException("Opcode cannot be empty.", nameof(opcode));
+        if (InstructionsSet.ContainsKey(opcode))
+            throw new ArgumentException(
+                $"An instruction with opcode [{string.Join(", ", opcode.Select(b => $"0x{b:X2}"))}] is already registered.",
+                nameof(opcode));
+
+        InstructionsSet.Add(opcode, (name ?? string.Empty, ctx => handler(ctx)));
+        if (opcode.Length > _maxInstructionSize)
+        {
+            _maxInstructionSize = opcode.Length;
+            Array.Resize(ref _buffer, _maxInstructionSize);
+        }
+    }
+
+    /// <summary>
+    /// Shared dispatch core: reads bytes one at a time and invokes the matching handler.
+    /// Reuses the instance-level <see cref="_buffer"/> array; not thread-safe.
+    /// </summary>
+    /// <exception cref="VirtualProcessorException">
+    /// Thrown when no instruction matches the bytes at the current position, or when a matched
+    /// instruction's handler raises <see cref="IndexOutOfRangeException"/> or
+    /// <see cref="ArgumentOutOfRangeException"/> (indicating truncated operand data).
+    /// </exception>
+    private void TryDispatch(T context)
+    {
+        _bufferLength = 0;
+        int instructionStart = context.InstructionPointer;
+        for (int i = 0; i < _maxInstructionSize && context.InstructionPointer < context.Data.Length; i++)
+        {
+            _buffer[_bufferLength++] = ReadByte(context);
+            var segment = new ArraySegment<byte>(_buffer, 0, _bufferLength);
+            if (InstructionsSet.TryGetValue(segment, out var entry))
+            {
+                try
+                {
+                    entry.Handler(context);
+                }
+                catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
+                {
+                    // INumberReader methods throw these when the byte stream ends before all operand bytes are read.
+                    throw new VirtualProcessorException(instructionStart, segment, ex);
+                }
+                return;
+            }
+        }
+        throw new VirtualProcessorException(instructionStart, new ArraySegment<byte>(_buffer, 0, _bufferLength));
+    }
+}
+
+/// <summary>
+/// Represents the base execution context used by <see cref="VirtualProcessor{T}"/>.
+/// </summary>
+public abstract class Context
 {
     /// <summary>
-    /// Provides an abstract base class for a virtual processor that interprets and executes
-    /// instructions from a byte array-based context. Instructions are defined by methods
-    /// annotated with <see cref="InstructionAttribute"/>.
+    /// Gets the raw byte data to be processed by the virtual processor.
     /// </summary>
-    /// <typeparam name="T">
-    /// The type of execution context, which must derive from <see cref="Context"/>.
-    /// </typeparam>
-    public abstract class VirtualProcessor<T> where T : Context
+    public byte[] Data { get; }
+
+    /// <summary>
+    /// Gets or sets the current instruction pointer indicating the byte offset into <see cref="Data"/>.
+    /// Setting this to a negative value (typically <c>-1</c>) signals program termination to the
+    /// <see cref="VirtualProcessor{T}"/> execution loop.
+    /// </summary>
+    public int InstructionPointer { get; set; }
+
+    /// <summary>
+    /// Signals program termination by setting <see cref="InstructionPointer"/> to <c>-1</c>.
+    /// The <see cref="VirtualProcessor{T}"/> execution loop stops before the next instruction.
+    /// Prefer this over setting <see cref="InstructionPointer"/> to <see cref="Data"/>.<see cref="Array.Length"/>
+    /// so that intent is explicit and the mechanism can evolve without changing every HALT handler.
+    /// </summary>
+    public void Terminate() => InstructionPointer = -1;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Context"/> class with the given data buffer.
+    /// </summary>
+    /// <param name="data">The byte array containing all instructions or data to process.</param>
+    protected Context(byte[] data)
     {
-        // INumberReader methods never change; cache per-type avoids rebuilding on every instantiation.
-        // IsAbstract filters to fixed-width methods only; default-implementation methods (LEB128) share
-        // return types with ulong/long and would cause duplicate-key conflicts in the dictionary.
-        private static readonly Dictionary<Type, MethodInfo> _numberReaderMethods =
-            typeof(INumberReader).GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                                 .Where(m => m.IsAbstract)
-                                 .ToDictionary(m => m.ReturnType, m => m);
+        Data = data ?? throw new ArgumentNullException(nameof(data));
+    }
+}
 
-        private readonly INumberReader _numberReader;
-        private int _maxInstructionSize;
-
-        /// <summary>
-        /// Represents a delegate to handle an instruction, given the current context.
-        /// </summary>
-        /// <param name="context">An instance of the execution context.</param>
-        public delegate void InstructionDelegate(T context);
-
-        /// <summary>
-        /// A dictionary mapping each instruction byte sequence to a (name, delegate) pair.
-        /// The equality comparer for keys is configured to handle byte-array comparison.
-        /// </summary>
-        protected Dictionary<IReadOnlyCollection<byte>, (string Name, InstructionDelegate Handler)> InstructionsSet { get; }
-
-        /// <summary>
-        /// Gets a read-only enumeration of all registered instructions, including those discovered via
-        /// <see cref="InstructionAttribute"/> and those added with <see cref="RegisterInstruction"/>.
-        /// </summary>
-        public IEnumerable<(IReadOnlyCollection<byte> Opcode, string Name)> Instructions
-            => InstructionsSet.Select(kv => (kv.Key, kv.Value.Name));
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VirtualProcessor{T}"/> class,
-        /// specifying whether the byte data should be interpreted as little-endian.
-        /// </summary>
-        /// <param name="littleEndian">
-        /// If <see langword="true"/>, uses little-endian byte ordering; otherwise, uses big-endian.
-        /// Defaults to <see langword="true"/>.
-        /// </param>
-        protected VirtualProcessor(bool littleEndian = true)
-        {
-            _numberReader = NumberReader.GetReader(littleEndian);
-            InstructionsSet = DiscoverInstructionSet();
-        }
-
-        /// <summary>
-        /// Discovers all instruction methods via reflection, collecting them into a dictionary
-        /// keyed by their associated byte sequences.
-        /// </summary>
-        /// <returns>
-        /// A dictionary where the key is the instruction byte sequence, and the value is a tuple
-        /// containing the instruction name and its delegate handler.
-        /// </returns>
-        private Dictionary<IReadOnlyCollection<byte>, (string Name, InstructionDelegate Handler)> DiscoverInstructionSet()
-        {
-            var result = new Dictionary<IReadOnlyCollection<byte>, (string, InstructionDelegate)>(
-                ArrayEqualityComparers.Byte
-            );
-
-            var methods = GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-
-            foreach (var method in methods)
-            {
-                if (!method.IsDefined(typeof(InstructionAttribute), true)) continue;
-                var instructionAttributes = method.GetCustomAttributes(typeof(InstructionAttribute), true);
-
-                var parameters = method.GetParameters();
-                if (parameters[0].ParameterType != typeof(T)) continue;
-                InstructionDelegate instructionDelegate;
-                if (parameters.Length == 1)
-                {
-                    instructionDelegate = (InstructionDelegate)method.CreateDelegate(typeof(InstructionDelegate), this);
-                }
-                else
-                {
-                    // Build an expression-tree delegate that reads each operand from the INumberReader
-                    // and passes them to the instruction method. This compiles to a direct call with no
-                    // boxing or reflection overhead at dispatch time.
-                    var contextParameter = Expression.Parameter(typeof(T), "context");
-                    var numberReaderExpression = Expression.Constant(_numberReader);
-
-                    List<Expression> methodParameters = [
-                        contextParameter
-                    ];
-
-                    foreach (var parameter in parameters.Skip(1))
-                    {
-                        // Map each parameter type to the INumberReader method returning that type
-                        // (e.g. short → ReadInt16, int → ReadInt32). Lookup table cached in _numberReaderMethods.
-                        var readerMethod = _numberReaderMethods[parameter.ParameterType];
-                        var methodCallExpression = Expression.Call(numberReaderExpression, readerMethod, [contextParameter]);
-                        methodParameters.Add(methodCallExpression);
-                    }
-
-                    // Final lambda: (T context) => this.Method(context, reader.ReadXxx(context), ...)
-                    var expression = Expression.Lambda<InstructionDelegate>(Expression.Call(Expression.Constant(this), method, methodParameters.ToArray()), [contextParameter]);
-                    instructionDelegate = expression.Compile();
-                }
-
-                foreach (InstructionAttribute attr in instructionAttributes.OfType<InstructionAttribute>())
-                {
-                    result.Add(attr.Instruction, (attr.Name, instructionDelegate));
-                    _maxInstructionSize = Math.Max(_maxInstructionSize, attr.Instruction.Length);
-                }
-
-
-            }
-
-            return result;
-        }
-
-        #region Reading Methods
-
-        /// <summary>
-        /// Reads a single byte from the context using the configured <see cref="INumberReader"/>.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>The byte read from the data stream.</returns>
-        protected byte ReadByte(Context context) => _numberReader.ReadByte(context);
-
-        /// <summary>
-        /// Reads a 16-bit signed integer (short) from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>A 16-bit signed integer.</returns>
-        protected short ReadInt16(Context context) => _numberReader.ReadInt16(context);
-
-        /// <summary>
-        /// Reads a 32-bit signed integer (int) from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>A 32-bit signed integer.</returns>
-        protected int ReadInt32(Context context) => _numberReader.ReadInt32(context);
-
-        /// <summary>
-        /// Reads a 64-bit signed integer (long) from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>A 64-bit signed integer.</returns>
-        protected long ReadInt64(Context context) => _numberReader.ReadInt64(context);
-
-        /// <summary>
-        /// Reads a 16-bit unsigned integer (ushort) from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>A 16-bit unsigned integer.</returns>
-        protected ushort ReadUInt16(Context context) => _numberReader.ReadUInt16(context);
-
-        /// <summary>
-        /// Reads a 32-bit unsigned integer (uint) from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>A 32-bit unsigned integer.</returns>
-        protected uint ReadUInt32(Context context) => _numberReader.ReadUInt32(context);
-
-        /// <summary>
-        /// Reads a 64-bit unsigned integer (ulong) from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>A 64-bit unsigned integer.</returns>
-        protected ulong ReadUInt64(Context context) => _numberReader.ReadUInt64(context);
-
-        /// <summary>
-        /// Reads a 32-bit floating-point number (float) from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>A 32-bit floating-point number.</returns>
-        protected float ReadSingle(Context context) => _numberReader.ReadSingle(context);
-
-        /// <summary>
-        /// Reads a 64-bit floating-point number (double) from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>A 64-bit floating-point number.</returns>
-        protected double ReadDouble(Context context) => _numberReader.ReadDouble(context);
-
-        /// <summary>
-        /// Reads an unsigned LEB128-encoded integer from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>The unsigned integer decoded from the LEB128 byte sequence.</returns>
-        protected ulong ReadULEB128(Context context) => _numberReader.ReadULEB128(context);
-
-        /// <summary>
-        /// Reads a signed LEB128-encoded integer from the context.
-        /// </summary>
-        /// <param name="context">The current execution context.</param>
-        /// <returns>The signed integer decoded from the LEB128 byte sequence.</returns>
-        protected long ReadSLEB128(Context context) => _numberReader.ReadSLEB128(context);
-
-        #endregion
-
-        /// <summary>
-        /// Executes all instructions until the end of the data stream or until
-        /// <paramref name="cancellationToken"/> is cancelled.
-        /// </summary>
-        /// <param name="context">The execution context.</param>
-        /// <param name="cancellationToken">Token that can stop execution between instructions.</param>
-        /// <exception cref="VirtualProcessorException">Thrown on an unknown opcode sequence.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is cancelled.</exception>
-        public void Execute(T context, CancellationToken cancellationToken = default)
-        {
-            var buffer = new List<byte>(_maxInstructionSize);
-            while (context.InstructionPointer < context.Data.Length)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                TryDispatch(context, buffer);
-            }
-        }
-
-        /// <summary>
-        /// Executes exactly one instruction at the current instruction pointer.
-        /// </summary>
-        /// <param name="context">The execution context.</param>
-        /// <returns>
-        /// <see langword="true"/> if an instruction was dispatched;
-        /// <see langword="false"/> if the end of the data stream was already reached.
-        /// </returns>
-        /// <exception cref="VirtualProcessorException">Thrown on an unknown opcode sequence.</exception>
-        public bool ExecuteStep(T context)
-        {
-            if (context.InstructionPointer >= context.Data.Length) return false;
-            var buffer = new List<byte>(_maxInstructionSize);
-            TryDispatch(context, buffer);
-            return true;
-        }
-
-        /// <summary>
-        /// Registers an instruction handler at runtime, supplementing or overriding
-        /// the methods discovered via <see cref="InstructionAttribute"/>.
-        /// </summary>
-        /// <param name="opcode">Byte sequence identifying the instruction.</param>
-        /// <param name="name">Human-readable name used in diagnostics.</param>
-        /// <param name="handler">Delegate invoked when the opcode is matched.</param>
-        public void RegisterInstruction(byte[] opcode, string name, Action<T> handler)
-        {
-            ArgumentNullException.ThrowIfNull(opcode);
-            ArgumentNullException.ThrowIfNull(handler);
-            if (opcode.Length == 0) throw new ArgumentException("Opcode cannot be empty.", nameof(opcode));
-            if (InstructionsSet.ContainsKey(opcode))
-                throw new ArgumentException(
-                    $"An instruction with opcode [{string.Join(", ", opcode.Select(b => $"0x{b:X2}"))}] is already registered.",
-                    nameof(opcode));
-
-            InstructionsSet.Add(opcode, (name ?? string.Empty, ctx => handler(ctx)));
-            _maxInstructionSize = Math.Max(_maxInstructionSize, opcode.Length);
-        }
-
-        /// <summary>
-        /// Shared dispatch core: reads bytes one at a time and invokes the matching handler.
-        /// Reuses <paramref name="buffer"/> across iterations (caller must call Clear before each call).
-        /// </summary>
-        /// <exception cref="VirtualProcessorException">
-        /// Thrown when no instruction matches the bytes at the current position, or when a matched
-        /// instruction's handler raises <see cref="IndexOutOfRangeException"/> or
-        /// <see cref="ArgumentOutOfRangeException"/> (indicating truncated operand data).
-        /// </exception>
-        private void TryDispatch(T context, List<byte> buffer)
-        {
-            buffer.Clear();
-            int instructionStart = context.InstructionPointer;
-            for (int i = 0; i < _maxInstructionSize && context.InstructionPointer < context.Data.Length; i++)
-            {
-                buffer.Add(ReadByte(context));
-                if (InstructionsSet.TryGetValue(buffer, out var entry))
-                {
-                    try
-                    {
-                        entry.Handler(context);
-                    }
-                    catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
-                    {
-                        // INumberReader methods throw these when the byte stream ends before all operand bytes are read.
-                        throw new VirtualProcessorException(instructionStart, buffer, ex);
-                    }
-                    return;
-                }
-            }
-            throw new VirtualProcessorException(instructionStart, buffer);
-        }
+/// <summary>
+/// A default context implementation providing an object stack.
+/// </summary>
+public class DefaultContext : Context
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultContext"/> class with the given data buffer.
+    /// </summary>
+    /// <param name="data">The byte array containing all instructions or data to process.</param>
+    public DefaultContext(byte[] data) : base(data)
+    {
     }
 
     /// <summary>
-    /// Represents the base execution context used by <see cref="VirtualProcessor{T}"/>.
+    /// A stack of objects that can be used during instruction execution for temporary data storage.
     /// </summary>
-    public abstract class Context
-    {
-        /// <summary>
-        /// Gets the raw byte data to be processed by the virtual processor.
-        /// </summary>
-        public byte[] Data { get; }
-
-        /// <summary>
-        /// Gets or sets the current instruction pointer indicating the byte offset into <see cref="Data"/>.
-        /// </summary>
-        public int InstructionPointer { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Context"/> class with the given data buffer.
-        /// </summary>
-        /// <param name="data">The byte array containing all instructions or data to process.</param>
-        protected Context(byte[] data)
-        {
-            Data = data ?? throw new ArgumentNullException(nameof(data));
-        }
-    }
-
-    /// <summary>
-    /// A default context implementation providing an object stack.
-    /// </summary>
-    public class DefaultContext : Context
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultContext"/> class with the given data buffer.
-        /// </summary>
-        /// <param name="data">The byte array containing all instructions or data to process.</param>
-        public DefaultContext(byte[] data) : base(data)
-        {
-        }
-
-        /// <summary>
-        /// A stack of objects that can be used during instruction execution for temporary data storage.
-        /// </summary>
-        public Stack<object> Stack { get; } = new Stack<object>();
-    }
+    public Stack<object> Stack { get; } = new Stack<object>();
 }

--- a/UtilsTest/VirtualMachine/CallStackTests.cs
+++ b/UtilsTest/VirtualMachine/CallStackTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Utils.VirtualMachine;
 
@@ -21,7 +22,10 @@ public class CallMachine : VirtualProcessor<CallStackContext>
         ctx.InstructionPointer = target;
     }
 
-    /// <summary>Returns to the address saved by the most recent CALL.</summary>
+    /// <summary>
+    /// Returns to the address saved by the most recent CALL.
+    /// When the call stack is empty, Return() yields -1, which terminates the Execute loop.
+    /// </summary>
     [Instruction("RET", 0xC1)]
     void Ret(CallStackContext ctx) => ctx.InstructionPointer = ctx.CallStack.Return();
 
@@ -70,34 +74,24 @@ public class CallStackTests
     }
 
     [TestMethod]
-    public void CallStack_Return_OnEmpty_Throws()
+    public void CallStack_Return_OnEmpty_ReturnsMinusOne()
     {
         var cs = new CallStack();
-        Assert.ThrowsException<InvalidOperationException>(() => cs.Return());
+        Assert.AreEqual(-1, cs.Return());
     }
 
     [TestMethod]
-    public void CallStack_TryReturn_OnEmpty_ReturnsFalse()
+    public void CallStack_Return_OnEmpty_DoesNotAlterDepth()
     {
         var cs = new CallStack();
-        Assert.IsFalse(cs.TryReturn(out int addr));
-        Assert.AreEqual(0, addr);
-    }
-
-    [TestMethod]
-    public void CallStack_TryReturn_WhenNotEmpty_ReturnsTrueAndAddress()
-    {
-        var cs = new CallStack();
-        cs.Call(42);
-        Assert.IsTrue(cs.TryReturn(out int addr));
-        Assert.AreEqual(42, addr);
-        Assert.IsTrue(cs.IsEmpty);
+        cs.Return();
+        Assert.AreEqual(0, cs.Depth);
     }
 
     [TestMethod]
     public void CallStack_MaxDepth_Overflow_Throws()
     {
-        var cs = new CallStack { MaxDepth = 3 };
+        var cs = new CallStack(maxDepth: 3);
         cs.Call(1);
         cs.Call(2);
         cs.Call(3);
@@ -107,8 +101,14 @@ public class CallStackTests
     [TestMethod]
     public void CallStack_MaxDepth_SetBelowOne_Throws()
     {
-        var cs = new CallStack();
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => cs.MaxDepth = 0);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new CallStack(0));
+    }
+
+    [TestMethod]
+    public void CallStack_MaxDepth_IsImmutable()
+    {
+        var cs = new CallStack(maxDepth: 10);
+        Assert.AreEqual(10, cs.MaxDepth);
     }
 
     [TestMethod]
@@ -183,6 +183,44 @@ public class CallStackTests
         Assert.AreEqual(1, prev);
     }
 
+    // ── ICallStack.CurrentFrame via SimpleCallStack ───────────────────────────
+
+    [TestMethod]
+    public void SimpleCallStack_CurrentFrame_AlwaysNull()
+    {
+        ICallStack cs = new SimpleCallStack();
+        cs.Call(42);
+        Assert.IsNull(cs.CurrentFrame);
+    }
+
+    // ── CallFrame.GetLocal<T> throwing variant ────────────────────────────────
+
+    [TestMethod]
+    public void CallFrame_GetLocal_ReturnsTypedValue()
+    {
+        var cs = new CallStack();
+        cs.Call(0);
+        cs.CurrentFrame!.SetLocal("x", 99);
+        Assert.AreEqual(99, cs.CurrentFrame.GetLocal<int>("x"));
+    }
+
+    [TestMethod]
+    public void CallFrame_GetLocal_MissingKey_ThrowsKeyNotFoundException()
+    {
+        var cs = new CallStack();
+        cs.Call(0);
+        Assert.ThrowsException<KeyNotFoundException>(() => cs.CurrentFrame!.GetLocal<int>("missing"));
+    }
+
+    [TestMethod]
+    public void CallFrame_GetLocal_WrongType_ThrowsKeyNotFoundException()
+    {
+        var cs = new CallStack();
+        cs.Call(0);
+        cs.CurrentFrame!.SetLocal("x", 42);
+        Assert.ThrowsException<KeyNotFoundException>(() => cs.CurrentFrame.GetLocal<string>("x"));
+    }
+
     // ── ICallStack contract: SimpleCallStack ──────────────────────────────────
 
     [TestMethod]
@@ -204,23 +242,16 @@ public class CallStackTests
     }
 
     [TestMethod]
-    public void SimpleCallStack_Return_OnEmpty_Throws()
+    public void SimpleCallStack_Return_OnEmpty_ReturnsMinusOne()
     {
         var cs = new SimpleCallStack();
-        Assert.ThrowsException<InvalidOperationException>(() => cs.Return());
-    }
-
-    [TestMethod]
-    public void SimpleCallStack_TryReturn_OnEmpty_ReturnsFalse()
-    {
-        var cs = new SimpleCallStack();
-        Assert.IsFalse(cs.TryReturn(out _));
+        Assert.AreEqual(-1, cs.Return());
     }
 
     [TestMethod]
     public void SimpleCallStack_MaxDepth_Overflow_Throws()
     {
-        var cs = new SimpleCallStack { MaxDepth = 2 };
+        var cs = new SimpleCallStack(maxDepth: 2);
         cs.Call(1);
         cs.Call(2);
         Assert.ThrowsException<InvalidOperationException>(() => cs.Call(3));
@@ -229,8 +260,14 @@ public class CallStackTests
     [TestMethod]
     public void SimpleCallStack_MaxDepth_SetBelowOne_Throws()
     {
-        var cs = new SimpleCallStack();
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => cs.MaxDepth = 0);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new SimpleCallStack(0));
+    }
+
+    [TestMethod]
+    public void SimpleCallStack_MaxDepth_IsImmutable()
+    {
+        var cs = new SimpleCallStack(maxDepth: 5);
+        Assert.AreEqual(5, cs.MaxDepth);
     }
 
     // ── CallStackContext ──────────────────────────────────────────────────────
@@ -333,5 +370,18 @@ public class CallStackTests
         new CallMachine().Execute(ctx);
 
         Assert.AreEqual(55, (int)ctx.Stack.Peek());
+    }
+
+    [TestMethod]
+    public void Integration_Ret_OnEmptyStack_TerminatesExecution()
+    {
+        // RET with an empty call stack yields IP = -1; the Execute loop stops.
+        // Program: RET (0xC1) — no prior CALL.
+        byte[] program = [0xC1];
+        var ctx = new CallStackContext(program);
+        new CallMachine().Execute(ctx);
+
+        Assert.AreEqual(-1, ctx.InstructionPointer);
+        Assert.AreEqual(0, ctx.CallStack.Depth);
     }
 }

--- a/UtilsTest/VirtualMachine/ControlFlowStackTests.cs
+++ b/UtilsTest/VirtualMachine/ControlFlowStackTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Linq;
 using Utils.VirtualMachine;
 
 namespace UtilsTest.VirtualMachine;
@@ -292,6 +293,87 @@ public class ControlFlowStackTests
         Assert.ThrowsException<InvalidOperationException>(() => cfs.Pop());
     }
 
+    // ── Typed Pop<T> ──────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void PopTyped_CorrectType_ReturnsBlock()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushConditional(0, 20, 10);
+        var block = cfs.Pop<ConditionalBlock>();
+        Assert.IsNotNull(block);
+        Assert.AreEqual(0, block.StartAddress);
+        Assert.AreEqual(0, cfs.Depth);
+    }
+
+    [TestMethod]
+    public void PopTyped_WrongType_ThrowsVirtualProcessorException()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 50); // LoopBlock is on top
+        Assert.ThrowsException<VirtualProcessorException>(() => cfs.Pop<ConditionalBlock>());
+    }
+
+    [TestMethod]
+    public void PopTyped_WrongType_BlockNotConsumed()
+    {
+        // Pop<T> peeks before popping: on type mismatch the block stays on the stack.
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 50);
+        try { cfs.Pop<ConditionalBlock>(); } catch (VirtualProcessorException) { }
+        Assert.AreEqual(1, cfs.Depth);
+        Assert.IsInstanceOfType<LoopBlock>(cfs.CurrentBlock);
+    }
+
+    [TestMethod]
+    public void PopTyped_EmptyStack_Throws()
+    {
+        var cfs = new ControlFlowStack();
+        Assert.ThrowsException<InvalidOperationException>(() => cfs.Pop<LoopBlock>());
+    }
+
+    // ── FullContext ───────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void FullContext_DefaultCtor_HasCallStackAndControlFlow()
+    {
+        var ctx = new FullContext([]);
+        Assert.IsNotNull(ctx.CallStack);
+        Assert.IsNotNull(ctx.ControlFlow);
+        Assert.IsInstanceOfType<CallStack>(ctx.CallStack);
+    }
+
+    [TestMethod]
+    public void FullContext_CustomCallStack_IsUsed()
+    {
+        var simple = new SimpleCallStack();
+        var ctx = new FullContext([], simple);
+        Assert.AreSame(simple, ctx.CallStack);
+    }
+
+    [TestMethod]
+    public void FullContext_NullCallStack_Throws()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => new FullContext([], null!));
+    }
+
+    [TestMethod]
+    public void FullContext_CallAndControlFlow_WorkIndependently()
+    {
+        var ctx = new FullContext([]);
+        ctx.CallStack.Call(42);
+        ctx.ControlFlow.PushLoop(0, 100);
+
+        Assert.AreEqual(1, ctx.CallStack.Depth);
+        Assert.AreEqual(1, ctx.ControlFlow.Depth);
+
+        Assert.AreEqual(42, ctx.CallStack.Return());
+        ctx.ControlFlow.Pop();
+
+        Assert.IsTrue(ctx.CallStack.IsEmpty);
+        Assert.AreEqual(0, ctx.ControlFlow.Depth);
+    }
+
     // ── Integration: BREAK exits loop, PUSH_INT 99 is never reached ──────────
 
     [TestMethod]
@@ -368,5 +450,141 @@ public class ControlFlowStackTests
 
         var ex = (ExceptionBlock)ctx.ControlFlow.CurrentBlock!;
         Assert.AreEqual(7, ex.ThrownValue);
+    }
+
+    // ── FindEnclosing<T> ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void FindEnclosing_ReturnsNearestBlockOfType_WithoutModifyingStack()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 50);
+        cfs.PushConditional(10, 30);
+        var loop = cfs.FindEnclosing<LoopBlock>();
+        Assert.IsNotNull(loop);
+        Assert.AreEqual(0, loop.StartAddress);
+        Assert.AreEqual(2, cfs.Depth); // stack unchanged
+    }
+
+    [TestMethod]
+    public void FindEnclosing_TypeNotPresent_ReturnsNull()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushConditional(0, 20);
+        Assert.IsNull(cfs.FindEnclosing<LoopBlock>());
+    }
+
+    [TestMethod]
+    public void FindEnclosing_ReturnsInnermostMatchWhenMultiplePresent()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 100);   // outer loop
+        cfs.PushLoop(10, 50);   // inner loop (top of stack)
+        var found = cfs.FindEnclosing<LoopBlock>();
+        Assert.AreEqual(10, found!.StartAddress);
+    }
+
+    [TestMethod]
+    public void FindEnclosing_EmptyStack_ReturnsNull()
+    {
+        var cfs = new ControlFlowStack();
+        Assert.IsNull(cfs.FindEnclosing<LoopBlock>());
+    }
+
+    // ── ControlFlowContext injectable constructor ──────────────────────────────
+
+    [TestMethod]
+    public void ControlFlowContext_InjectableStack_IsUsed()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 100);
+        var ctx = new ControlFlowContext([], cfs);
+        Assert.AreSame(cfs, ctx.ControlFlow);
+        Assert.AreEqual(1, ctx.ControlFlow.Depth);
+    }
+
+    [TestMethod]
+    public void ControlFlowContext_NullStack_Throws()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => new ControlFlowContext([], null!));
+    }
+
+    // ── IsEmpty ───────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void IsEmpty_TrueWhenNoBlocksOpen()
+    {
+        var cfs = new ControlFlowStack();
+        Assert.IsTrue(cfs.IsEmpty);
+    }
+
+    [TestMethod]
+    public void IsEmpty_FalseAfterPush()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 10);
+        Assert.IsFalse(cfs.IsEmpty);
+    }
+
+    [TestMethod]
+    public void IsEmpty_TrueAfterPopAll()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 10);
+        cfs.Pop();
+        Assert.IsTrue(cfs.IsEmpty);
+    }
+
+    // ── Blocks enumerable ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Blocks_EmptyWhenNoBlocksOpen()
+    {
+        var cfs = new ControlFlowStack();
+        Assert.AreEqual(0, cfs.Blocks.Count());
+    }
+
+    [TestMethod]
+    public void Blocks_EnumeratesInnermostFirst()
+    {
+        var cfs = new ControlFlowStack();
+        cfs.PushLoop(0, 50);
+        cfs.PushConditional(10, 30);
+
+        var blocks = cfs.Blocks.ToArray();
+        Assert.AreEqual(2, blocks.Length);
+        Assert.IsInstanceOfType<ConditionalBlock>(blocks[0]); // innermost first
+        Assert.IsInstanceOfType<LoopBlock>(blocks[1]);
+    }
+
+    [TestMethod]
+    public void Blocks_IsLiveView_ReflectsSubsequentPush()
+    {
+        var cfs = new ControlFlowStack();
+        var view = cfs.Blocks;
+        cfs.PushLoop(0, 10);
+        Assert.AreEqual(1, view.Count());
+    }
+
+    // ── Context.Terminate ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Context_Terminate_SetsInstructionPointerToMinusOne()
+    {
+        var ctx = new ControlFlowContext([0x01, 0x02, 0x03]);
+        ctx.Terminate();
+        Assert.AreEqual(-1, ctx.InstructionPointer);
+    }
+
+    [TestMethod]
+    public void Context_Terminate_StopsExecution()
+    {
+        // Terminate() before Execute: the PUSH_INT at byte 0 must never run.
+        byte[] program = [0x01, 99, 0, 0, 0]; // PUSH_INT 99
+        var ctx = new ControlFlowContext(program);
+        ctx.Terminate();
+        new ControlFlowTestMachine().Execute(ctx);
+
+        Assert.AreEqual(0, ctx.Stack.Count);
     }
 }

--- a/UtilsTest/VirtualMachine/VirtualMachineTests.cs
+++ b/UtilsTest/VirtualMachine/VirtualMachineTests.cs
@@ -7,6 +7,18 @@ using Utils.VirtualMachine;
 
 namespace UtilsTest.VirtualMachine
 {
+    /// <summary>
+    /// Minimal machine whose NOP instruction has no parameters at all (not even a context).
+    /// Validates that parameterless [Instruction] methods are dispatched correctly.
+    /// </summary>
+    public class NoopTestMachine : VirtualProcessor<DefaultContext>
+    {
+        public bool NopExecuted;
+
+        [Instruction("NOP", 0xF0)]
+        void Nop() => NopExecuted = true;
+    }
+
     public class LEB128TestMachine : VirtualProcessor<DefaultContext>
     {
         [Instruction("PUSH_ULEB128", 0x20)]
@@ -354,5 +366,117 @@ namespace UtilsTest.VirtualMachine
             Assert.IsTrue(names.Contains("POP"));
             Assert.IsTrue(names.Contains("NOP"));
         }
+
+        // ── OnStep ────────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void OnStep_IsCalledBeforeEachInstruction()
+        {
+            // Two PUSH instructions → OnStep must fire twice, each time with the correct IP.
+            byte[] instructions = [0x01, 0x01, 0x10,  0x01, 0x01, 0x01];
+            var context = new DefaultContext(instructions);
+
+            var recordedPointers = new System.Collections.Generic.List<int>();
+            var machine = new TrackingTestMachine(recordedPointers);
+            machine.Execute(context);
+
+            Assert.AreEqual(2, recordedPointers.Count);
+            Assert.AreEqual(0, recordedPointers[0]); // first PUSH starts at 0
+            Assert.AreEqual(3, recordedPointers[1]); // second PUSH starts at 3
+        }
+
+        [TestMethod]
+        public void OnStep_IsCalledByExecuteStep()
+        {
+            byte[] instructions = [0x01, 0x01, 0x42];
+            var context = new DefaultContext(instructions);
+
+            var recordedPointers = new System.Collections.Generic.List<int>();
+            var machine = new TrackingTestMachine(recordedPointers);
+            machine.ExecuteStep(context);
+
+            Assert.AreEqual(1, recordedPointers.Count);
+            Assert.AreEqual(0, recordedPointers[0]);
+        }
+
+        // ── IP = -1 termination ───────────────────────────────────────────────
+
+        [TestMethod]
+        public void Execute_NegativeInstructionPointer_TerminatesImmediately()
+        {
+            // Start with IP = -1: the Execute loop must not dispatch any instruction.
+            byte[] instructions = [0x02]; // POP — would crash on empty stack
+            var context = new DefaultContext(instructions);
+            context.InstructionPointer = -1;
+
+            new TestMachine().Execute(context); // must not throw
+            Assert.AreEqual(0, context.Stack.Count);
+        }
+
+        // ── InstructionAttribute validation ───────────────────────────────────
+
+        [TestMethod]
+        public void InstructionAttribute_NullName_Throws()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new InstructionAttribute(null!, 0x01));
+        }
+
+        [TestMethod]
+        public void InstructionAttribute_EmptyOpcode_Throws()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new InstructionAttribute("NOP"));
+        }
+
+        [TestMethod]
+        public void InstructionAttribute_ValidArgs_StoresNameAndInstruction()
+        {
+            var attr = new InstructionAttribute("HALT", 0xFF);
+            Assert.AreEqual("HALT", attr.Name);
+            CollectionAssert.AreEqual(new byte[] { 0xFF }, attr.Instruction);
+        }
+
+        // ── Parameterless instruction (NOOP) ──────────────────────────────────────
+
+        [TestMethod]
+        public void ParameterlessInstruction_IsDispatched()
+        {
+            var machine = new NoopTestMachine();
+            var ctx = new DefaultContext([0xF0]);
+            machine.Execute(ctx);
+            Assert.IsTrue(machine.NopExecuted);
+        }
+
+        [TestMethod]
+        public void ParameterlessInstruction_DoesNotConsumeOperandBytes()
+        {
+            // NOP (0xF0) followed by POP (0x02) — POP must execute correctly after NOP.
+            byte[] program = [0xF0, 0x02];
+            var machine = new NoopTestMachine();
+            // Inherit POP from TestMachine? No — NoopTestMachine has no POP.
+            // Just verify NOP + EOF leaves the IP at position 1 (NOP consumes only its opcode).
+            var ctx = new DefaultContext(program);
+            machine.ExecuteStep(ctx); // NOP
+            Assert.AreEqual(1, ctx.InstructionPointer);
+            Assert.IsTrue(machine.NopExecuted);
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Minimal processor that records the IP seen by OnStep before each dispatch.
+    /// Extends VirtualProcessor directly (not TestMachine) so that its own instruction
+    /// methods are found by reflection — private methods of base classes are not returned
+    /// by GetMethods on derived types.
+    /// </summary>
+    public class TrackingTestMachine : VirtualProcessor<DefaultContext>
+    {
+        private readonly System.Collections.Generic.List<int> _steps;
+
+        [Instruction("PUSH_BYTE", 0x01, 0x01)]
+        void PushByte(DefaultContext context, byte b1) => context.Stack.Push(b1);
+
+        public TrackingTestMachine(System.Collections.Generic.List<int> steps) => _steps = steps;
+        protected override void OnStep(DefaultContext context) => _steps.Add(context.InstructionPointer);
     }
 }


### PR DESCRIPTION
## Summary
- `CallStack`/`SimpleCallStack.MaxDepth` is now set at construction (immutable) instead of via a mutable setter
- `Return()` yields `-1` on an empty stack instead of throwing, letting `VirtualProcessor.Execute` terminate naturally on a top-level `RET` (`TryReturn` removed as redundant)
- `ControlFlowStack` gains `IsEmpty`, `Blocks` (diagnostics), a typed `Pop<T>()` assertion, and `FindEnclosing<T>()`
- New `FullContext` combines `ICallStack` + `ControlFlowStack` for VMs needing both call/return and structured control flow
- `VirtualProcessor` supports parameterless instruction methods, exposes `Context.Terminate()`, and reuses a single byte buffer across dispatches instead of allocating a `List<byte>` per instruction
- `INumberReader` implementations switch from `BitConverter` to `MemoryMarshal.Read<T>`

## Test plan
- [x] `dotnet build Utils.VirtualMachine/Utils.VirtualMachine.csproj` succeeds
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter "FullyQualifiedName~VirtualMachine"` - 107 passed, 0 failed

Generated with Claude Code
