### PR TITLE
feat(vm): ReadSByte, TypedStackContext, overwrite flag, InstructionName, ReadOnlyMemory<byte>, FullContext 3-arg ctor

### DIFF
--- a/Utils.VirtualMachine/CallStack.cs
+++ b/Utils.VirtualMachine/CallStack.cs
@@ -66,8 +66,8 @@ public class CallStackContext : DefaultContext
     /// <summary>
     /// Initializes a new instance with a default <see cref="CallStack"/>.
     /// </summary>
-    /// <param name="data">The byte array containing the instruction stream.</param>
-    public CallStackContext(byte[] data) : base(data)
+    /// <param name="data">The byte data containing the instruction stream.</param>
+    public CallStackContext(ReadOnlyMemory<byte> data) : base(data)
     {
         CallStack = new CallStack();
     }
@@ -75,9 +75,9 @@ public class CallStackContext : DefaultContext
     /// <summary>
     /// Initializes a new instance with a caller-supplied <see cref="ICallStack"/> implementation.
     /// </summary>
-    /// <param name="data">The byte array containing the instruction stream.</param>
+    /// <param name="data">The byte data containing the instruction stream.</param>
     /// <param name="callStack">The call stack to use.</param>
-    public CallStackContext(byte[] data, ICallStack callStack) : base(data)
+    public CallStackContext(ReadOnlyMemory<byte> data, ICallStack callStack) : base(data)
     {
         CallStack = callStack ?? throw new ArgumentNullException(nameof(callStack));
     }

--- a/Utils.VirtualMachine/ControlFlowStack.cs
+++ b/Utils.VirtualMachine/ControlFlowStack.cs
@@ -174,8 +174,8 @@ public class ControlFlowContext : DefaultContext
     /// <summary>
     /// Initializes a new instance with the given instruction stream and a fresh <see cref="ControlFlowStack"/>.
     /// </summary>
-    /// <param name="data">The byte array containing the instruction stream.</param>
-    public ControlFlowContext(byte[] data) : base(data)
+    /// <param name="data">The byte data containing the instruction stream.</param>
+    public ControlFlowContext(ReadOnlyMemory<byte> data) : base(data)
     {
         ControlFlow = new ControlFlowStack();
     }
@@ -184,10 +184,10 @@ public class ControlFlowContext : DefaultContext
     /// Initializes a new instance with the given instruction stream and a caller-supplied
     /// <see cref="ControlFlowStack"/>, allowing pre-configuration or substitution.
     /// </summary>
-    /// <param name="data">The byte array containing the instruction stream.</param>
+    /// <param name="data">The byte data containing the instruction stream.</param>
     /// <param name="controlFlow">The control flow stack to use.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="controlFlow"/> is <see langword="null"/>.</exception>
-    public ControlFlowContext(byte[] data, ControlFlowStack controlFlow) : base(data)
+    public ControlFlowContext(ReadOnlyMemory<byte> data, ControlFlowStack controlFlow) : base(data)
     {
         ControlFlow = controlFlow ?? throw new ArgumentNullException(nameof(controlFlow));
     }
@@ -204,24 +204,43 @@ public class FullContext : DefaultContext
     public ICallStack CallStack { get; }
 
     /// <summary>Gets the control flow stack managing open structured blocks.</summary>
-    public ControlFlowStack ControlFlow { get; } = new();
+    public ControlFlowStack ControlFlow { get; }
 
     /// <summary>
-    /// Initializes a new instance with a default <see cref="CallStack"/>.
+    /// Initializes a new instance with a default <see cref="CallStack"/> and a fresh <see cref="ControlFlowStack"/>.
     /// </summary>
-    /// <param name="data">The byte array containing the instruction stream.</param>
-    public FullContext(byte[] data) : base(data)
+    /// <param name="data">The byte data containing the instruction stream.</param>
+    public FullContext(ReadOnlyMemory<byte> data) : base(data)
     {
         CallStack = new CallStack();
+        ControlFlow = new ControlFlowStack();
     }
 
     /// <summary>
-    /// Initializes a new instance with a caller-supplied <see cref="ICallStack"/> implementation.
+    /// Initializes a new instance with a caller-supplied <see cref="ICallStack"/> implementation
+    /// and a fresh <see cref="ControlFlowStack"/>.
     /// </summary>
-    /// <param name="data">The byte array containing the instruction stream.</param>
+    /// <param name="data">The byte data containing the instruction stream.</param>
     /// <param name="callStack">The call stack to use.</param>
-    public FullContext(byte[] data, ICallStack callStack) : base(data)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callStack"/> is <see langword="null"/>.</exception>
+    public FullContext(ReadOnlyMemory<byte> data, ICallStack callStack) : base(data)
     {
         CallStack = callStack ?? throw new ArgumentNullException(nameof(callStack));
+        ControlFlow = new ControlFlowStack();
+    }
+
+    /// <summary>
+    /// Initializes a new instance with caller-supplied <see cref="ICallStack"/> and
+    /// <see cref="ControlFlowStack"/> implementations, allowing full substitution for testing
+    /// or pre-configuration.
+    /// </summary>
+    /// <param name="data">The byte data containing the instruction stream.</param>
+    /// <param name="callStack">The call stack to use.</param>
+    /// <param name="controlFlow">The control flow stack to use.</param>
+    /// <exception cref="ArgumentNullException">Thrown when either argument is <see langword="null"/>.</exception>
+    public FullContext(ReadOnlyMemory<byte> data, ICallStack callStack, ControlFlowStack controlFlow) : base(data)
+    {
+        CallStack = callStack ?? throw new ArgumentNullException(nameof(callStack));
+        ControlFlow = controlFlow ?? throw new ArgumentNullException(nameof(controlFlow));
     }
 }

--- a/Utils.VirtualMachine/INumberReader.cs
+++ b/Utils.VirtualMachine/INumberReader.cs
@@ -17,6 +17,13 @@ public interface INumberReader
     byte ReadByte(Context context);
 
     /// <summary>
+    /// Reads a single signed byte from the supplied <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">The execution context containing the instruction stream.</param>
+    /// <returns>The next <see cref="sbyte"/> available in the context.</returns>
+    sbyte ReadSByte(Context context);
+
+    /// <summary>
     /// Reads a 16-bit signed integer from the supplied <paramref name="context"/>.
     /// </summary>
     /// <param name="context">The execution context containing the instruction stream.</param>
@@ -145,12 +152,16 @@ internal class NormalReader : INumberReader
 {
     /// <inheritdoc />
     public byte ReadByte(Context context)
-        => context.Data[context.InstructionPointer++];
+        => context.Data.Span[context.InstructionPointer++];
+
+    /// <inheritdoc />
+    public sbyte ReadSByte(Context context)
+        => (sbyte)context.Data.Span[context.InstructionPointer++];
 
     /// <inheritdoc />
     public short ReadInt16(Context context)
     {
-        var result = MemoryMarshal.Read<short>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<short>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(short);
         return result;
     }
@@ -158,7 +169,7 @@ internal class NormalReader : INumberReader
     /// <inheritdoc />
     public int ReadInt32(Context context)
     {
-        var result = MemoryMarshal.Read<int>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<int>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(int);
         return result;
     }
@@ -166,7 +177,7 @@ internal class NormalReader : INumberReader
     /// <inheritdoc />
     public long ReadInt64(Context context)
     {
-        var result = MemoryMarshal.Read<long>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<long>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(long);
         return result;
     }
@@ -174,7 +185,7 @@ internal class NormalReader : INumberReader
     /// <inheritdoc />
     public ushort ReadUInt16(Context context)
     {
-        var result = MemoryMarshal.Read<ushort>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<ushort>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(ushort);
         return result;
     }
@@ -182,7 +193,7 @@ internal class NormalReader : INumberReader
     /// <inheritdoc />
     public uint ReadUInt32(Context context)
     {
-        var result = MemoryMarshal.Read<uint>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<uint>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(uint);
         return result;
     }
@@ -190,7 +201,7 @@ internal class NormalReader : INumberReader
     /// <inheritdoc />
     public ulong ReadUInt64(Context context)
     {
-        var result = MemoryMarshal.Read<ulong>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<ulong>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(ulong);
         return result;
     }
@@ -198,7 +209,7 @@ internal class NormalReader : INumberReader
     /// <inheritdoc />
     public float ReadSingle(Context context)
     {
-        var result = MemoryMarshal.Read<float>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<float>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(float);
         return result;
     }
@@ -206,7 +217,7 @@ internal class NormalReader : INumberReader
     /// <inheritdoc />
     public double ReadDouble(Context context)
     {
-        var result = MemoryMarshal.Read<double>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<double>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(double);
         return result;
     }
@@ -220,12 +231,15 @@ internal class NormalReader : INumberReader
 internal class InvertedReader : INumberReader
 {
     /// <inheritdoc />
-    public byte ReadByte(Context context) => context.Data[context.InstructionPointer++];
+    public byte ReadByte(Context context) => context.Data.Span[context.InstructionPointer++];
+
+    /// <inheritdoc />
+    public sbyte ReadSByte(Context context) => (sbyte)context.Data.Span[context.InstructionPointer++];
 
     /// <inheritdoc />
     public short ReadInt16(Context context)
     {
-        var result = MemoryMarshal.Read<short>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<short>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(short);
         return BinaryPrimitives.ReverseEndianness(result);
     }
@@ -233,7 +247,7 @@ internal class InvertedReader : INumberReader
     /// <inheritdoc />
     public int ReadInt32(Context context)
     {
-        var result = MemoryMarshal.Read<int>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<int>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(int);
         return BinaryPrimitives.ReverseEndianness(result);
     }
@@ -241,7 +255,7 @@ internal class InvertedReader : INumberReader
     /// <inheritdoc />
     public long ReadInt64(Context context)
     {
-        var result = MemoryMarshal.Read<long>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<long>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(long);
         return BinaryPrimitives.ReverseEndianness(result);
     }
@@ -249,7 +263,7 @@ internal class InvertedReader : INumberReader
     /// <inheritdoc />
     public ushort ReadUInt16(Context context)
     {
-        var result = MemoryMarshal.Read<ushort>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<ushort>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(ushort);
         return BinaryPrimitives.ReverseEndianness(result);
     }
@@ -257,7 +271,7 @@ internal class InvertedReader : INumberReader
     /// <inheritdoc />
     public uint ReadUInt32(Context context)
     {
-        var result = MemoryMarshal.Read<uint>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<uint>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(uint);
         return BinaryPrimitives.ReverseEndianness(result);
     }
@@ -265,7 +279,7 @@ internal class InvertedReader : INumberReader
     /// <inheritdoc />
     public ulong ReadUInt64(Context context)
     {
-        var result = MemoryMarshal.Read<ulong>(context.Data.AsSpan(context.InstructionPointer));
+        var result = MemoryMarshal.Read<ulong>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(ulong);
         return BinaryPrimitives.ReverseEndianness(result);
     }
@@ -273,7 +287,7 @@ internal class InvertedReader : INumberReader
     /// <inheritdoc />
     public float ReadSingle(Context context)
     {
-        var bits = MemoryMarshal.Read<uint>(context.Data.AsSpan(context.InstructionPointer));
+        var bits = MemoryMarshal.Read<uint>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(float);
         return BitConverter.UInt32BitsToSingle(BinaryPrimitives.ReverseEndianness(bits));
     }
@@ -281,7 +295,7 @@ internal class InvertedReader : INumberReader
     /// <inheritdoc />
     public double ReadDouble(Context context)
     {
-        var bits = MemoryMarshal.Read<ulong>(context.Data.AsSpan(context.InstructionPointer));
+        var bits = MemoryMarshal.Read<ulong>(context.Data.Span[context.InstructionPointer..]);
         context.InstructionPointer += sizeof(double);
         return BitConverter.UInt64BitsToDouble(BinaryPrimitives.ReverseEndianness(bits));
     }

--- a/Utils.VirtualMachine/TypedStackContext.cs
+++ b/Utils.VirtualMachine/TypedStackContext.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// A context providing a strongly-typed operand stack, avoiding boxing for value types.
+/// Use this instead of <see cref="DefaultContext"/> when all stack values share a common type
+/// (e.g. <see cref="int"/> for integer VMs, <see cref="double"/> for floating-point VMs).
+/// </summary>
+/// <typeparam name="TValue">Element type stored on the stack.</typeparam>
+public class TypedStackContext<TValue> : Context
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TypedStackContext{TValue}"/> class.
+    /// </summary>
+    /// <param name="data">The byte data containing the instruction stream.</param>
+    public TypedStackContext(ReadOnlyMemory<byte> data) : base(data)
+    {
+    }
+
+    /// <summary>
+    /// A strongly-typed operand stack for storing values without boxing overhead.
+    /// </summary>
+    public Stack<TValue> Stack { get; } = new Stack<TValue>();
+}

--- a/Utils.VirtualMachine/VirtualProcessor.cs
+++ b/Utils.VirtualMachine/VirtualProcessor.cs
@@ -156,6 +156,13 @@ public abstract class VirtualProcessor<T> where T : Context
     protected byte ReadByte(Context context) => _numberReader.ReadByte(context);
 
     /// <summary>
+    /// Reads a single signed byte from the context using the configured <see cref="INumberReader"/>.
+    /// </summary>
+    /// <param name="context">The current execution context.</param>
+    /// <returns>The signed byte read from the data stream.</returns>
+    protected sbyte ReadSByte(Context context) => _numberReader.ReadSByte(context);
+
+    /// <summary>
     /// Reads a 16-bit signed integer (short) from the context.
     /// </summary>
     /// <param name="context">The current execution context.</param>
@@ -281,17 +288,25 @@ public abstract class VirtualProcessor<T> where T : Context
     /// <param name="opcode">Byte sequence identifying the instruction.</param>
     /// <param name="name">Human-readable name used in diagnostics.</param>
     /// <param name="handler">Delegate invoked when the opcode is matched.</param>
-    public void RegisterInstruction(byte[] opcode, string name, Action<T> handler)
+    /// <param name="overwrite">
+    /// When <see langword="true"/>, replaces an existing registration for the same opcode.
+    /// When <see langword="false"/> (default), throws if the opcode is already registered.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="opcode"/> is empty, or when the opcode is already registered
+    /// and <paramref name="overwrite"/> is <see langword="false"/>.
+    /// </exception>
+    public void RegisterInstruction(byte[] opcode, string name, Action<T> handler, bool overwrite = false)
     {
         ArgumentNullException.ThrowIfNull(opcode);
         ArgumentNullException.ThrowIfNull(handler);
         if (opcode.Length == 0) throw new ArgumentException("Opcode cannot be empty.", nameof(opcode));
-        if (InstructionsSet.ContainsKey(opcode))
+        if (!overwrite && InstructionsSet.ContainsKey(opcode))
             throw new ArgumentException(
                 $"An instruction with opcode [{string.Join(", ", opcode.Select(b => $"0x{b:X2}"))}] is already registered.",
                 nameof(opcode));
 
-        InstructionsSet.Add(opcode, (name ?? string.Empty, ctx => handler(ctx)));
+        InstructionsSet[opcode] = (name ?? string.Empty, ctx => handler(ctx));
         if (opcode.Length > _maxInstructionSize)
         {
             _maxInstructionSize = opcode.Length;
@@ -325,7 +340,7 @@ public abstract class VirtualProcessor<T> where T : Context
                 catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentOutOfRangeException)
                 {
                     // INumberReader methods throw these when the byte stream ends before all operand bytes are read.
-                    throw new VirtualProcessorException(instructionStart, segment, ex);
+                    throw new VirtualProcessorException(instructionStart, segment, entry.Name, ex);
                 }
                 return;
             }
@@ -341,8 +356,9 @@ public abstract class Context
 {
     /// <summary>
     /// Gets the raw byte data to be processed by the virtual processor.
+    /// The data is read-only; instruction handlers cannot modify the instruction stream.
     /// </summary>
-    public byte[] Data { get; }
+    public ReadOnlyMemory<byte> Data { get; }
 
     /// <summary>
     /// Gets or sets the current instruction pointer indicating the byte offset into <see cref="Data"/>.
@@ -354,7 +370,7 @@ public abstract class Context
     /// <summary>
     /// Signals program termination by setting <see cref="InstructionPointer"/> to <c>-1</c>.
     /// The <see cref="VirtualProcessor{T}"/> execution loop stops before the next instruction.
-    /// Prefer this over setting <see cref="InstructionPointer"/> to <see cref="Data"/>.<see cref="Array.Length"/>
+    /// Prefer this over setting <see cref="InstructionPointer"/> to <see cref="Data"/>.<see cref="ReadOnlyMemory{T}.Length"/>
     /// so that intent is explicit and the mechanism can evolve without changing every HALT handler.
     /// </summary>
     public void Terminate() => InstructionPointer = -1;
@@ -362,10 +378,10 @@ public abstract class Context
     /// <summary>
     /// Initializes a new instance of the <see cref="Context"/> class with the given data buffer.
     /// </summary>
-    /// <param name="data">The byte array containing all instructions or data to process.</param>
-    protected Context(byte[] data)
+    /// <param name="data">The byte data containing all instructions or data to process.</param>
+    protected Context(ReadOnlyMemory<byte> data)
     {
-        Data = data ?? throw new ArgumentNullException(nameof(data));
+        Data = data;
     }
 }
 
@@ -377,8 +393,8 @@ public class DefaultContext : Context
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultContext"/> class with the given data buffer.
     /// </summary>
-    /// <param name="data">The byte array containing all instructions or data to process.</param>
-    public DefaultContext(byte[] data) : base(data)
+    /// <param name="data">The byte data containing all instructions or data to process.</param>
+    public DefaultContext(ReadOnlyMemory<byte> data) : base(data)
     {
     }
 

--- a/Utils.VirtualMachine/VirtualProcessorException.cs
+++ b/Utils.VirtualMachine/VirtualProcessorException.cs
@@ -16,6 +16,9 @@ public class VirtualProcessorException : Exception
     /// <summary>Gets the opcode bytes that triggered the error, if available.</summary>
     public byte[]? OpcodeBytes { get; }
 
+    /// <summary>Gets the human-readable name of the instruction that caused the error, if available.</summary>
+    public string? InstructionName { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="VirtualProcessorException"/> class.
     /// </summary>
@@ -70,6 +73,27 @@ public class VirtualProcessorException : Exception
         OpcodeBytes = [.. opcodeBytes];
     }
 
-    private static string BuildMessage(int instructionPointer, IReadOnlyList<byte> opcodeBytes)
-        => $"Instruction error at position {instructionPointer}: [{string.Join(", ", opcodeBytes.Select(b => $"0x{b:X2}"))}].";
+    /// <summary>
+    /// Initializes a new instance with the instruction position, opcode bytes, instruction name, and an inner exception.
+    /// Used when a matched and named instruction's operand read fails due to a truncated stream.
+    /// </summary>
+    /// <param name="instructionPointer">Byte offset in the instruction stream where the error occurred.</param>
+    /// <param name="opcodeBytes">Bytes of the matched opcode.</param>
+    /// <param name="instructionName">Human-readable name of the instruction that failed.</param>
+    /// <param name="innerException">The exception raised while reading the operand bytes.</param>
+    public VirtualProcessorException(int instructionPointer, IReadOnlyList<byte> opcodeBytes, string? instructionName, Exception innerException)
+        : base(BuildMessage(instructionPointer, opcodeBytes, instructionName), innerException)
+    {
+        InstructionPointer = instructionPointer;
+        OpcodeBytes = [.. opcodeBytes];
+        InstructionName = instructionName;
+    }
+
+    private static string BuildMessage(int instructionPointer, IReadOnlyList<byte> opcodeBytes, string? instructionName = null)
+    {
+        var opStr = string.Join(", ", opcodeBytes.Select(b => $"0x{b:X2}"));
+        return instructionName is null
+            ? $"Instruction error at position {instructionPointer}: [{opStr}]."
+            : $"Instruction '{instructionName}' error at position {instructionPointer}: [{opStr}].";
+    }
 }

--- a/UtilsTest/VirtualMachine/CallStackTests.cs
+++ b/UtilsTest/VirtualMachine/CallStackTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,7 +6,7 @@ using Utils.VirtualMachine;
 
 namespace UtilsTest.VirtualMachine;
 
-// ── Test processor wiring CALL/RET against CallStackContext ──────────────────
+// â”€â”€ Test processor wiring CALL/RET against CallStackContext â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 public class CallMachine : VirtualProcessor<CallStackContext>
 {
@@ -34,12 +34,12 @@ public class CallMachine : VirtualProcessor<CallStackContext>
     void Halt(CallStackContext ctx) => ctx.InstructionPointer = ctx.Data.Length;
 }
 
-// ── Unit tests ────────────────────────────────────────────────────────────────
+// â”€â”€ Unit tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 [TestClass]
 public class CallStackTests
 {
-    // ── ICallStack contract: CallStack ────────────────────────────────────────
+    // â”€â”€ ICallStack contract: CallStack â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void CallStack_Call_IncrementsDepth()
@@ -127,7 +127,7 @@ public class CallStackTests
         Assert.AreEqual(99, cs.CurrentFrame!.ReturnAddress);
     }
 
-    // ── CallFrame local variables ─────────────────────────────────────────────
+    // â”€â”€ CallFrame local variables â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void CallFrame_SetLocal_CanBeRetrievedTyped()
@@ -183,7 +183,7 @@ public class CallStackTests
         Assert.AreEqual(1, prev);
     }
 
-    // ── ICallStack.CurrentFrame via SimpleCallStack ───────────────────────────
+    // â”€â”€ ICallStack.CurrentFrame via SimpleCallStack â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void SimpleCallStack_CurrentFrame_AlwaysNull()
@@ -193,7 +193,7 @@ public class CallStackTests
         Assert.IsNull(cs.CurrentFrame);
     }
 
-    // ── CallFrame.GetLocal<T> throwing variant ────────────────────────────────
+    // â”€â”€ CallFrame.GetLocal<T> throwing variant â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void CallFrame_GetLocal_ReturnsTypedValue()
@@ -221,7 +221,7 @@ public class CallStackTests
         Assert.ThrowsException<KeyNotFoundException>(() => cs.CurrentFrame.GetLocal<string>("x"));
     }
 
-    // ── ICallStack contract: SimpleCallStack ──────────────────────────────────
+    // â”€â”€ ICallStack contract: SimpleCallStack â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void SimpleCallStack_Call_IncrementsDepth()
@@ -270,12 +270,12 @@ public class CallStackTests
         Assert.AreEqual(5, cs.MaxDepth);
     }
 
-    // ── CallStackContext ──────────────────────────────────────────────────────
+    // â”€â”€ CallStackContext â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void CallStackContext_DefaultCtor_UsesCallStack()
     {
-        var ctx = new CallStackContext([]);
+        var ctx = new CallStackContext(new byte[0]);
         Assert.IsInstanceOfType<CallStack>(ctx.CallStack);
     }
 
@@ -283,17 +283,17 @@ public class CallStackTests
     public void CallStackContext_CustomCtor_UsesProvidedStack()
     {
         var simple = new SimpleCallStack();
-        var ctx = new CallStackContext([], simple);
+        var ctx = new CallStackContext(new byte[0], simple);
         Assert.AreSame(simple, ctx.CallStack);
     }
 
     [TestMethod]
     public void CallStackContext_CustomCtor_NullStack_Throws()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => new CallStackContext([], null!));
+        Assert.ThrowsException<ArgumentNullException>(() => new CallStackContext(new byte[0], null!));
     }
 
-    // ── Integration: CALL / RET in a VirtualProcessor ────────────────────────
+    // â”€â”€ Integration: CALL / RET in a VirtualProcessor â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void Integration_Call_JumpsToSubroutine_ReturnRestoresIP()
@@ -301,12 +301,12 @@ public class CallStackTests
         // Layout (little-endian, 14 bytes total):
         //   0: CALL 0xC0
         //   1-4: target = 8 (jump to subroutine)
-        //        → after operand read: IP=5, return addr = 5
+        //        â†’ after operand read: IP=5, return addr = 5
         //   5: HALT 0xFF
         //   6-7: (padding, never reached)
         //   8: PUSH_INT 0x01
         //   9-12: 99 (int operand)
-        //   13: RET 0xC1  → pops 5, sets IP=5 → HALT
+        //   13: RET 0xC1  â†’ pops 5, sets IP=5 â†’ HALT
         byte[] program =
         [
             0xC0, 8, 0, 0, 0,   // CALL 8  (bytes 0-4)
@@ -327,10 +327,10 @@ public class CallStackTests
     public void Integration_NestedCalls_UnwindCorrectly()
     {
         // Layout:
-        //   0: CALL → 10    (return to 5)
+        //   0: CALL â†’ 10    (return to 5)
         //   5: HALT
         //   6-9: padding
-        //  10: CALL → 20   (return to 15)
+        //  10: CALL â†’ 20   (return to 15)
         //  15: RET          (return to 5)
         //  16-19: padding
         //  20: PUSH_INT 7
@@ -376,7 +376,7 @@ public class CallStackTests
     public void Integration_Ret_OnEmptyStack_TerminatesExecution()
     {
         // RET with an empty call stack yields IP = -1; the Execute loop stops.
-        // Program: RET (0xC1) — no prior CALL.
+        // Program: RET (0xC1) â€” no prior CALL.
         byte[] program = [0xC1];
         var ctx = new CallStackContext(program);
         new CallMachine().Execute(ctx);

--- a/UtilsTest/VirtualMachine/ControlFlowStackTests.cs
+++ b/UtilsTest/VirtualMachine/ControlFlowStackTests.cs
@@ -1,11 +1,11 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 using Utils.VirtualMachine;
 
 namespace UtilsTest.VirtualMachine;
 
-// ── Minimal test VM (opcodes assigned only here, not in the framework) ────────
+// â”€â”€ Minimal test VM (opcodes assigned only here, not in the framework) â”€â”€â”€â”€â”€â”€â”€â”€
 
 public class ControlFlowTestMachine : VirtualProcessor<ControlFlowContext>
 {
@@ -15,10 +15,10 @@ public class ControlFlowTestMachine : VirtualProcessor<ControlFlowContext>
     [Instruction("HALT", 0xFF)]
     void Halt(ControlFlowContext ctx) => ctx.InstructionPointer = ctx.Data.Length;
 
-    // ── Conditionals ─────────────────────────────────────────────────────────
+    // â”€â”€ Conditionals â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// <summary>
-    /// IF_FALSE endAddr [elseAddr] — pops a bool; if false jumps to elseAddr (or endAddr).
+    /// IF_FALSE endAddr [elseAddr] â€” pops a bool; if false jumps to elseAddr (or endAddr).
     /// Pushes a ConditionalBlock regardless so ENDIF can pop it correctly.
     /// </summary>
     [Instruction("IF_FALSE", 0x10)]
@@ -33,14 +33,14 @@ public class ControlFlowTestMachine : VirtualProcessor<ControlFlowContext>
     [Instruction("ENDIF", 0x11)]
     void Endif(ControlFlowContext ctx) => ctx.ControlFlow.Pop();
 
-    // ── Loops ─────────────────────────────────────────────────────────────────
+    // â”€â”€ Loops â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-    /// <summary>LOOP_START endAddr — marks the loop header; execution falls through into body.</summary>
+    /// <summary>LOOP_START endAddr â€” marks the loop header; execution falls through into body.</summary>
     [Instruction("LOOP_START", 0x20)]
     void LoopStart(ControlFlowContext ctx, int endAddress)
         => ctx.ControlFlow.PushLoop(ctx.InstructionPointer, endAddress);
 
-    /// <summary>LOOP_END — jumps back to loop StartAddress without popping the block.</summary>
+    /// <summary>LOOP_END â€” jumps back to loop StartAddress without popping the block.</summary>
     [Instruction("LOOP_END", 0x21)]
     void LoopEnd(ControlFlowContext ctx)
         => ctx.InstructionPointer = ((LoopBlock)ctx.ControlFlow.CurrentBlock!).StartAddress;
@@ -51,14 +51,14 @@ public class ControlFlowTestMachine : VirtualProcessor<ControlFlowContext>
     [Instruction("CONTINUE", 0x23)]
     void Continue(ControlFlowContext ctx) => ctx.ControlFlow.Continue(ctx);
 
-    // ── Exceptions ────────────────────────────────────────────────────────────
+    // â”€â”€ Exceptions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-    /// <summary>TRY catchAddr — opens an ExceptionBlock with the given catch handler address.</summary>
+    /// <summary>TRY catchAddr â€” opens an ExceptionBlock with the given catch handler address.</summary>
     [Instruction("TRY", 0x30)]
     void Try(ControlFlowContext ctx, int catchAddress)
         => ctx.ControlFlow.PushException(ctx.InstructionPointer, catchAddress, null);
 
-    /// <summary>THROW — pops a value from the operand stack and throws it.</summary>
+    /// <summary>THROW â€” pops a value from the operand stack and throws it.</summary>
     [Instruction("THROW", 0x31)]
     void Throw(ControlFlowContext ctx)
     {
@@ -67,17 +67,17 @@ public class ControlFlowTestMachine : VirtualProcessor<ControlFlowContext>
             throw new InvalidOperationException($"Unhandled throw: {value}");
     }
 
-    /// <summary>ENDTRY — closes the exception block.</summary>
+    /// <summary>ENDTRY â€” closes the exception block.</summary>
     [Instruction("ENDTRY", 0x32)]
     void EndTry(ControlFlowContext ctx) => ctx.ControlFlow.Pop();
 }
 
-// ── Unit tests ────────────────────────────────────────────────────────────────
+// â”€â”€ Unit tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 [TestClass]
 public class ControlFlowStackTests
 {
-    // ── ConditionalBlock ──────────────────────────────────────────────────────
+    // â”€â”€ ConditionalBlock â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void PushConditional_IncreasesDepth()
@@ -116,7 +116,7 @@ public class ControlFlowStackTests
         Assert.AreEqual(0, cfs.Depth);
     }
 
-    // ── LoopBlock ─────────────────────────────────────────────────────────────
+    // â”€â”€ LoopBlock â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void PushLoop_IncreasesDepth()
@@ -142,7 +142,7 @@ public class ControlFlowStackTests
     {
         var cfs = new ControlFlowStack();
         cfs.PushLoop(startAddress: 0, endAddress: 50);
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         cfs.Break(ctx);
         Assert.AreEqual(50, ctx.InstructionPointer);
         Assert.AreEqual(0, cfs.Depth);
@@ -154,7 +154,7 @@ public class ControlFlowStackTests
         var cfs = new ControlFlowStack();
         cfs.PushLoop(0, 50);
         cfs.PushConditional(10, 30); // nested IF inside the loop
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         cfs.Break(ctx);
         Assert.AreEqual(50, ctx.InstructionPointer);
         Assert.AreEqual(0, cfs.Depth); // both blocks gone
@@ -164,7 +164,7 @@ public class ControlFlowStackTests
     public void Break_OutsideLoop_Throws()
     {
         var cfs = new ControlFlowStack();
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         Assert.ThrowsException<InvalidOperationException>(() => cfs.Break(ctx));
     }
 
@@ -173,7 +173,7 @@ public class ControlFlowStackTests
     {
         var cfs = new ControlFlowStack();
         cfs.PushLoop(startAddress: 5, endAddress: 40);
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         cfs.Continue(ctx);
         Assert.AreEqual(5, ctx.InstructionPointer);
         Assert.AreEqual(1, cfs.Depth); // loop stays on stack
@@ -185,7 +185,7 @@ public class ControlFlowStackTests
         var cfs = new ControlFlowStack();
         cfs.PushLoop(5, 40);
         cfs.PushConditional(10, 30);
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         cfs.Continue(ctx);
         Assert.AreEqual(5, ctx.InstructionPointer);
         Assert.AreEqual(1, cfs.Depth); // only loop remains
@@ -196,11 +196,11 @@ public class ControlFlowStackTests
     public void Continue_OutsideLoop_Throws()
     {
         var cfs = new ControlFlowStack();
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         Assert.ThrowsException<InvalidOperationException>(() => cfs.Continue(ctx));
     }
 
-    // ── ExceptionBlock ────────────────────────────────────────────────────────
+    // â”€â”€ ExceptionBlock â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void PushException_IncreasesDepth()
@@ -233,7 +233,7 @@ public class ControlFlowStackTests
     {
         var cfs = new ControlFlowStack();
         cfs.PushException(0, catchAddress: 42, finallyAddress: null);
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         bool handled = cfs.Throw(ctx, "error");
         Assert.IsTrue(handled);
         Assert.AreEqual(42, ctx.InstructionPointer);
@@ -246,7 +246,7 @@ public class ControlFlowStackTests
     {
         var cfs = new ControlFlowStack();
         cfs.PushException(0, catchAddress: null, finallyAddress: 99);
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         cfs.Throw(ctx, 42);
         Assert.AreEqual(99, ctx.InstructionPointer);
     }
@@ -256,7 +256,7 @@ public class ControlFlowStackTests
     {
         var cfs = new ControlFlowStack();
         cfs.PushException(0, catchAddress: 10, finallyAddress: null);
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         cfs.Throw(ctx, "oops");
         Assert.AreEqual(1, cfs.Depth);
         Assert.IsInstanceOfType<ExceptionBlock>(cfs.CurrentBlock);
@@ -269,7 +269,7 @@ public class ControlFlowStackTests
         cfs.PushException(0, catchAddress: 50, finallyAddress: null);
         cfs.PushLoop(5, 30);        // nested inside try
         cfs.PushConditional(10, 20); // nested inside loop
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         bool handled = cfs.Throw(ctx, "e");
         Assert.IsTrue(handled);
         Assert.AreEqual(50, ctx.InstructionPointer);
@@ -280,11 +280,11 @@ public class ControlFlowStackTests
     public void Throw_NoHandler_ReturnsFalse()
     {
         var cfs = new ControlFlowStack();
-        var ctx = new ControlFlowContext([]);
+        var ctx = new ControlFlowContext(new byte[0]);
         Assert.IsFalse(cfs.Throw(ctx, "e"));
     }
 
-    // ── Pop underflow ─────────────────────────────────────────────────────────
+    // â”€â”€ Pop underflow â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void Pop_EmptyStack_Throws()
@@ -293,7 +293,7 @@ public class ControlFlowStackTests
         Assert.ThrowsException<InvalidOperationException>(() => cfs.Pop());
     }
 
-    // ── Typed Pop<T> ──────────────────────────────────────────────────────────
+    // â”€â”€ Typed Pop<T> â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void PopTyped_CorrectType_ReturnsBlock()
@@ -332,12 +332,12 @@ public class ControlFlowStackTests
         Assert.ThrowsException<InvalidOperationException>(() => cfs.Pop<LoopBlock>());
     }
 
-    // ── FullContext ───────────────────────────────────────────────────────────
+    // â”€â”€ FullContext â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void FullContext_DefaultCtor_HasCallStackAndControlFlow()
     {
-        var ctx = new FullContext([]);
+        var ctx = new FullContext(new byte[0]);
         Assert.IsNotNull(ctx.CallStack);
         Assert.IsNotNull(ctx.ControlFlow);
         Assert.IsInstanceOfType<CallStack>(ctx.CallStack);
@@ -347,20 +347,20 @@ public class ControlFlowStackTests
     public void FullContext_CustomCallStack_IsUsed()
     {
         var simple = new SimpleCallStack();
-        var ctx = new FullContext([], simple);
+        var ctx = new FullContext(new byte[0], simple);
         Assert.AreSame(simple, ctx.CallStack);
     }
 
     [TestMethod]
     public void FullContext_NullCallStack_Throws()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => new FullContext([], null!));
+        Assert.ThrowsException<ArgumentNullException>(() => new FullContext(new byte[0], null!));
     }
 
     [TestMethod]
     public void FullContext_CallAndControlFlow_WorkIndependently()
     {
-        var ctx = new FullContext([]);
+        var ctx = new FullContext(new byte[0]);
         ctx.CallStack.Call(42);
         ctx.ControlFlow.PushLoop(0, 100);
 
@@ -374,7 +374,26 @@ public class ControlFlowStackTests
         Assert.AreEqual(0, ctx.ControlFlow.Depth);
     }
 
-    // ── Integration: BREAK exits loop, PUSH_INT 99 is never reached ──────────
+    [TestMethod]
+    public void FullContext_ThreeArgCtor_UsesBothProvidedInstances()
+    {
+        var callStack = new SimpleCallStack();
+        var controlFlow = new ControlFlowStack();
+        controlFlow.PushLoop(0, 10);
+        var ctx = new FullContext(new byte[0], callStack, controlFlow);
+        Assert.AreSame(callStack, ctx.CallStack);
+        Assert.AreSame(controlFlow, ctx.ControlFlow);
+        Assert.AreEqual(1, ctx.ControlFlow.Depth);
+    }
+
+    [TestMethod]
+    public void FullContext_ThreeArgCtor_NullControlFlow_Throws()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => new FullContext(new byte[0], new SimpleCallStack(), null!));
+    }
+
+    // â”€â”€ Integration: BREAK exits loop, PUSH_INT 99 is never reached â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void Integration_Break_ExitsLoop()
@@ -405,7 +424,7 @@ public class ControlFlowStackTests
     {
         // 0: TRY 11            [0x30, 11,0,0,0]   catch=11
         // 5: PUSH_INT 7        [0x01, 7,0,0,0]
-        //10: THROW             [0x31]              → IP=11
+        //10: THROW             [0x31]              â†’ IP=11
         //11: ENDTRY            [0x32]
         //12: HALT              [0xFF]
         // Expected: ExceptionBlock.ThrownValue = 7 (then ENDTRY pops it)
@@ -435,7 +454,7 @@ public class ControlFlowStackTests
         [
             0x30, 11, 0, 0, 0,   // 0: TRY 11
             0x01, 7, 0, 0, 0,    // 5: PUSH_INT 7
-            0x31,                 // 10: THROW → IP jumps to 11
+            0x31,                 // 10: THROW â†’ IP jumps to 11
             0x32,                 // 11: ENDTRY
             0xFF                  // 12: HALT
         ];
@@ -446,13 +465,13 @@ public class ControlFlowStackTests
         // Step up to and including THROW (instructions 0, 1, 2)
         machine.ExecuteStep(ctx); // TRY
         machine.ExecuteStep(ctx); // PUSH_INT 7
-        machine.ExecuteStep(ctx); // THROW → IP=11, ExceptionBlock still on stack
+        machine.ExecuteStep(ctx); // THROW â†’ IP=11, ExceptionBlock still on stack
 
         var ex = (ExceptionBlock)ctx.ControlFlow.CurrentBlock!;
         Assert.AreEqual(7, ex.ThrownValue);
     }
 
-    // ── FindEnclosing<T> ──────────────────────────────────────────────────────
+    // â”€â”€ FindEnclosing<T> â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void FindEnclosing_ReturnsNearestBlockOfType_WithoutModifyingStack()
@@ -491,14 +510,14 @@ public class ControlFlowStackTests
         Assert.IsNull(cfs.FindEnclosing<LoopBlock>());
     }
 
-    // ── ControlFlowContext injectable constructor ──────────────────────────────
+    // â”€â”€ ControlFlowContext injectable constructor â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void ControlFlowContext_InjectableStack_IsUsed()
     {
         var cfs = new ControlFlowStack();
         cfs.PushLoop(0, 100);
-        var ctx = new ControlFlowContext([], cfs);
+        var ctx = new ControlFlowContext(new byte[0], cfs);
         Assert.AreSame(cfs, ctx.ControlFlow);
         Assert.AreEqual(1, ctx.ControlFlow.Depth);
     }
@@ -506,10 +525,10 @@ public class ControlFlowStackTests
     [TestMethod]
     public void ControlFlowContext_NullStack_Throws()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => new ControlFlowContext([], null!));
+        Assert.ThrowsException<ArgumentNullException>(() => new ControlFlowContext(new byte[0], null!));
     }
 
-    // ── IsEmpty ───────────────────────────────────────────────────────────────
+    // â”€â”€ IsEmpty â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void IsEmpty_TrueWhenNoBlocksOpen()
@@ -535,7 +554,7 @@ public class ControlFlowStackTests
         Assert.IsTrue(cfs.IsEmpty);
     }
 
-    // ── Blocks enumerable ─────────────────────────────────────────────────────
+    // â”€â”€ Blocks enumerable â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void Blocks_EmptyWhenNoBlocksOpen()
@@ -566,12 +585,12 @@ public class ControlFlowStackTests
         Assert.AreEqual(1, view.Count());
     }
 
-    // ── Context.Terminate ─────────────────────────────────────────────────────
+    // â”€â”€ Context.Terminate â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     [TestMethod]
     public void Context_Terminate_SetsInstructionPointerToMinusOne()
     {
-        var ctx = new ControlFlowContext([0x01, 0x02, 0x03]);
+        var ctx = new ControlFlowContext(new byte[] { 0x01, 0x02, 0x03 });
         ctx.Terminate();
         Assert.AreEqual(-1, ctx.InstructionPointer);
     }

--- a/UtilsTest/VirtualMachine/VirtualMachineTests.cs
+++ b/UtilsTest/VirtualMachine/VirtualMachineTests.cs
@@ -28,6 +28,26 @@ namespace UtilsTest.VirtualMachine
         void PushSLEB128(DefaultContext context) => context.Stack.Push(ReadSLEB128(context));
     }
 
+    public class SByteTestMachine : VirtualProcessor<DefaultContext>
+    {
+        [Instruction("PUSH_SBYTE", 0x30)]
+        void PushSByte(DefaultContext context, sbyte b) => context.Stack.Push(b);
+    }
+
+    public class IntMachine : VirtualProcessor<TypedStackContext<int>>
+    {
+        [Instruction("PUSH_INT", 0x40)]
+        void Push(TypedStackContext<int> context, int v) => context.Stack.Push(v);
+
+        [Instruction("ADD_INT", 0x41)]
+        void Add(TypedStackContext<int> context)
+        {
+            var b = context.Stack.Pop();
+            var a = context.Stack.Pop();
+            context.Stack.Push(a + b);
+        }
+    }
+
     public class TestMachine : VirtualProcessor<DefaultContext>
     {
         // Two [Instruction] attributes on the same method (verifies AllowMultiple = true).
@@ -204,7 +224,7 @@ namespace UtilsTest.VirtualMachine
             bool executed = false;
             machine.RegisterInstruction([0xFF], "NOP", _ => executed = true);
 
-            var context = new DefaultContext([0xFF]);
+            var context = new DefaultContext(new byte[] { 0xFF });
             machine.Execute(context);
             Assert.IsTrue(executed);
         }
@@ -256,7 +276,7 @@ namespace UtilsTest.VirtualMachine
         [TestMethod]
         public void Execute_UnknownOpcode_ThrowsWithDetails()
         {
-            var context = new DefaultContext([0xFF]);
+            var context = new DefaultContext(new byte[] { 0xFF });
             var machine = new TestMachine();
             var ex = Assert.ThrowsException<VirtualProcessorException>(() => machine.Execute(context));
             Assert.AreEqual(0, ex.InstructionPointer);
@@ -267,7 +287,7 @@ namespace UtilsTest.VirtualMachine
         public void Execute_PartialMultiByteOpcode_ThrowsVirtualProcessorException()
         {
             // 0x01 alone doesn't match any instruction — all opcodes starting with 0x01 are 2 bytes.
-            var context = new DefaultContext([0x01]);
+            var context = new DefaultContext(new byte[] { 0x01 });
             var machine = new TestMachine();
             var ex = Assert.ThrowsException<VirtualProcessorException>(() => machine.Execute(context));
             Assert.AreEqual(0, ex.InstructionPointer);
@@ -277,7 +297,7 @@ namespace UtilsTest.VirtualMachine
         public void Execute_IncompleteOperand_ThrowsVirtualProcessorException()
         {
             // Opcode [0x01, 0x01] (PUSH_BYTE) matches, but no operand byte follows.
-            var context = new DefaultContext([0x01, 0x01]);
+            var context = new DefaultContext(new byte[] { 0x01, 0x01 });
             var machine = new TestMachine();
             var ex = Assert.ThrowsException<VirtualProcessorException>(() => machine.Execute(context));
             Assert.AreEqual(0, ex.InstructionPointer);
@@ -441,7 +461,7 @@ namespace UtilsTest.VirtualMachine
         public void ParameterlessInstruction_IsDispatched()
         {
             var machine = new NoopTestMachine();
-            var ctx = new DefaultContext([0xF0]);
+            var ctx = new DefaultContext(new byte[] { 0xF0 });
             machine.Execute(ctx);
             Assert.IsTrue(machine.NopExecuted);
         }
@@ -458,6 +478,112 @@ namespace UtilsTest.VirtualMachine
             machine.ExecuteStep(ctx); // NOP
             Assert.AreEqual(1, ctx.InstructionPointer);
             Assert.IsTrue(machine.NopExecuted);
+        }
+
+        // ── ReadSByte ─────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ReadSByte_PositiveValue_PushedCorrectly()
+        {
+            byte[] instructions = [0x30, 0x7F]; // PUSH_SBYTE 127
+            var context = new DefaultContext(instructions);
+            new SByteTestMachine().Execute(context);
+            Assert.AreEqual((sbyte)127, (sbyte)context.Stack.Peek());
+        }
+
+        [TestMethod]
+        public void ReadSByte_NegativeValue_SignExtended()
+        {
+            byte[] instructions = [0x30, 0xFF]; // PUSH_SBYTE -1
+            var context = new DefaultContext(instructions);
+            new SByteTestMachine().Execute(context);
+            Assert.AreEqual((sbyte)-1, (sbyte)context.Stack.Peek());
+        }
+
+        [TestMethod]
+        public void ReadSByte_BigEndian_SameResultAsLittleEndian()
+        {
+            // sbyte is one byte — endianness has no effect
+            var readerLE = NumberReader.GetReader(littleEndian: true);
+            var readerBE = NumberReader.GetReader(littleEndian: false);
+            byte[] data = [0x80]; // -128 as sbyte
+            Assert.AreEqual(readerLE.ReadSByte(new DefaultContext(data)),
+                            readerBE.ReadSByte(new DefaultContext(data)));
+        }
+
+        // ── TypedStackContext<TValue> ─────────────────────────────────────────
+
+        [TestMethod]
+        public void TypedStackContext_PushAndAdd_ReturnsCorrectSum()
+        {
+            byte[] prog = [
+                0x40, 0x0A, 0, 0, 0,  // PUSH_INT 10
+                0x40, 0x05, 0, 0, 0,  // PUSH_INT 5
+                0x41                   // ADD_INT
+            ];
+            var ctx = new TypedStackContext<int>(prog);
+            new IntMachine().Execute(ctx);
+            Assert.AreEqual(15, ctx.Stack.Peek());
+        }
+
+        // ── RegisterInstruction with overwrite ───────────────────────────────
+
+        [TestMethod]
+        public void RegisterInstruction_Overwrite_ReplacesHandler()
+        {
+            var machine = new TestMachine();
+            machine.RegisterInstruction([0xFF], "OLD", _ => { });
+            int newCount = 0;
+            machine.RegisterInstruction([0xFF], "NEW", _ => newCount++, overwrite: true);
+
+            var context = new DefaultContext(new byte[] { 0xFF });
+            machine.Execute(context);
+            Assert.AreEqual(1, newCount);
+        }
+
+        [TestMethod]
+        public void RegisterInstruction_Overwrite_UpdatesName()
+        {
+            var machine = new TestMachine();
+            machine.RegisterInstruction([0xFF], "OLD", _ => { });
+            machine.RegisterInstruction([0xFF], "NEW", _ => { }, overwrite: true);
+            Assert.IsTrue(machine.Instructions.Any(i => i.Name == "NEW"));
+            Assert.IsFalse(machine.Instructions.Any(i => i.Name == "OLD"));
+        }
+
+        // ── InstructionName in VirtualProcessorException ──────────────────────
+
+        [TestMethod]
+        public void Execute_IncompleteOperand_ExceptionContainsInstructionName()
+        {
+            // PUSH_BYTE matches [0x01, 0x01] but operand byte is missing
+            var context = new DefaultContext(new byte[] { 0x01, 0x01 });
+            var ex = Assert.ThrowsException<VirtualProcessorException>(
+                () => new TestMachine().Execute(context));
+            Assert.AreEqual("PUSH_BYTE", ex.InstructionName);
+        }
+
+        [TestMethod]
+        public void Execute_UnknownOpcode_InstructionNameIsNull()
+        {
+            // Unknown opcode: no instruction matched, so no name is available
+            var context = new DefaultContext(new byte[] { 0xAA });
+            var ex = Assert.ThrowsException<VirtualProcessorException>(
+                () => new TestMachine().Execute(context));
+            Assert.IsNull(ex.InstructionName);
+        }
+
+        // ── Context.Data as ReadOnlyMemory<byte> ─────────────────────────────
+
+        [TestMethod]
+        public void Context_Data_AcceptsMemorySlice()
+        {
+            // Execute only a slice of a larger byte array without copying
+            byte[] backing = [0x00, 0x01, 0x01, 0x42, 0x00]; // [padding, PUSH_BYTE, operand, padding]
+            var memory = new ReadOnlyMemory<byte>(backing, 1, 3);
+            var context = new DefaultContext(memory);
+            new TestMachine().Execute(context);
+            Assert.AreEqual((byte)0x42, context.Stack.Peek());
         }
     }
 


### PR DESCRIPTION
## Summary

Six améliorations appliquées a `Utils.VirtualMachine` :

- **`ReadSByte`** — `INumberReader` propose maintenant `ReadSByte` (complete la symetrie signe/non-signe pour tous les types, y compris l octet)
- **`Context.Data` -> `ReadOnlyMemory<byte>`** — Le buffer d instructions est maintenant en lecture seule ; les handlers ne peuvent plus modifier le bytecode en cours d execution. Accepte des slices sans copie (`new ReadOnlyMemory<byte>(buf, offset, length)`)
- **`InstructionName` dans `VirtualProcessorException`** — Quand une instruction matche mais que ses operandes sont tronquees, l exception inclut maintenant le nom de l instruction (ex : `PUSH_BYTE`) pour faciliter le debug
- **`RegisterInstruction(overwrite: true)`** — Parametre optionnel permettant de remplacer un handler deja enregistre (par attribut ou au runtime)
- **`TypedStackContext<TValue>`** — Nouveau contexte generique avec `Stack<TValue>` evitant le boxing pour les VMs numeriques
- **`FullContext` constructeur 3 arguments** — `FullContext(data, ICallStack, ControlFlowStack)` complete la symetrie avec `ControlFlowContext`

## Test plan

- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` — 2223 tests passent, 3 ignores, 0 echoues
- [x] `Utils.Fonts` compile sans erreur (la conversion implicite `byte[]` -> `ReadOnlyMemory<byte>` preserve la compatibilite de `TtfHintingContext`)
- [x] 11 nouveaux tests couvrant les 6 ajouts

Generated with [Claude Code](https://claude.com/claude-code)