### PR TITLE
feat(vm): virtual memory system with paged address spaces and per-process access rights

### DIFF
--- a/Utils.VirtualMachine/MemoryAccessException.cs
+++ b/Utils.VirtualMachine/MemoryAccessException.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// The exception thrown when a virtual memory access violates the page's mapped access rights,
+/// or when the target address is not mapped in the process's page table.
+/// </summary>
+public class MemoryAccessException : Exception
+{
+    /// <summary>Gets the virtual address at which the access violation occurred.</summary>
+    public long VirtualAddress { get; }
+
+    /// <summary>Gets the access type that was requested (read or write).</summary>
+    public PageAccess RequestedAccess { get; }
+
+    /// <summary>
+    /// Gets the actual access rights of the mapped page, or <see langword="null"/> when the
+    /// address was not mapped at all.
+    /// </summary>
+    public PageAccess? ActualAccess { get; }
+
+    /// <summary>
+    /// Initializes a new instance for a write attempt on a read-only page.
+    /// </summary>
+    /// <param name="virtualAddress">The virtual address that caused the violation.</param>
+    /// <param name="requestedAccess">The access type that was requested.</param>
+    /// <param name="actualAccess">The access rights actually granted for the mapped page.</param>
+    public MemoryAccessException(long virtualAddress, PageAccess requestedAccess, PageAccess actualAccess)
+        : base(BuildMessage(virtualAddress, requestedAccess, actualAccess))
+    {
+        VirtualAddress = virtualAddress;
+        RequestedAccess = requestedAccess;
+        ActualAccess = actualAccess;
+    }
+
+    /// <summary>
+    /// Initializes a new instance for an access to an address that is not mapped in the
+    /// process's page table.
+    /// </summary>
+    /// <param name="virtualAddress">The virtual address that caused the violation.</param>
+    /// <param name="requestedAccess">The access type that was requested.</param>
+    public MemoryAccessException(long virtualAddress, PageAccess requestedAccess)
+        : base(BuildMessage(virtualAddress, requestedAccess, null))
+    {
+        VirtualAddress = virtualAddress;
+        RequestedAccess = requestedAccess;
+        ActualAccess = null;
+    }
+
+    private static string BuildMessage(long virtualAddress, PageAccess requestedAccess, PageAccess? actualAccess)
+    {
+        var requested = requestedAccess == PageAccess.ReadWrite ? "ReadWrite" : "ReadOnly";
+        var actual = actualAccess.HasValue
+            ? (actualAccess.Value == PageAccess.ReadOnly ? "ReadOnly" : "ReadWrite")
+            : "not mapped";
+        return $"Memory access violation at address 0x{virtualAddress:X}: requested {requested} but page is {actual}.";
+    }
+}

--- a/Utils.VirtualMachine/PageAccess.cs
+++ b/Utils.VirtualMachine/PageAccess.cs
@@ -1,0 +1,13 @@
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Specifies the access rights for a virtual memory page mapping.
+/// </summary>
+public enum PageAccess
+{
+    /// <summary>The page may only be read; write attempts throw <see cref="MemoryAccessException"/>.</summary>
+    ReadOnly,
+
+    /// <summary>The page may be both read and written.</summary>
+    ReadWrite,
+}

--- a/Utils.VirtualMachine/VirtualMemory.cs
+++ b/Utils.VirtualMachine/VirtualMemory.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Manages a pool of physical <see cref="VirtualPage"/> instances and a set of
+/// <see cref="VirtualProcess{TAddress}"/> objects, each with their own virtual address space.
+/// </summary>
+/// <typeparam name="TAddress">
+/// An integer type used for virtual addresses (e.g. <see cref="int"/>, <see cref="long"/>,
+/// <see cref="uint"/>). Must implement <see cref="IBinaryInteger{TSelf}"/>.
+/// </typeparam>
+/// <remarks>
+/// The master process (accessible via <see cref="MasterProcess"/>) automatically receives a
+/// <see cref="PageAccess.ReadWrite"/> mapping for every page created by <see cref="AllocatePage"/>.
+/// Additional processes created with <see cref="CreateProcess"/> start with an empty page table;
+/// use <see cref="MapPage"/> to grant them access to specific pages.
+/// </remarks>
+public class VirtualMemory<TAddress> where TAddress : IBinaryInteger<TAddress>
+{
+    private readonly List<VirtualPage> _pages = [];
+    private readonly List<VirtualProcess<TAddress>> _processes = [];
+    private int _nextPageId;
+    private int _nextProcessId;
+    private TAddress _masterNextVirtualIndex = TAddress.Zero;
+
+    /// <summary>Gets the size in bytes of each physical page.</summary>
+    public int PageSize { get; }
+
+    /// <summary>
+    /// Gets the master process. It automatically receives <see cref="PageAccess.ReadWrite"/>
+    /// mappings for every page allocated via <see cref="AllocatePage"/>.
+    /// </summary>
+    public VirtualProcess<TAddress> MasterProcess { get; }
+
+    /// <summary>Gets the list of all physical pages managed by this instance.</summary>
+    public IReadOnlyList<VirtualPage> Pages => _pages;
+
+    /// <summary>Gets the list of all processes, including the master process.</summary>
+    public IReadOnlyList<VirtualProcess<TAddress>> Processes => _processes;
+
+    /// <summary>
+    /// Initializes a new <see cref="VirtualMemory{TAddress}"/> and creates the master process.
+    /// </summary>
+    /// <param name="pageSize">Size in bytes of each physical page. Defaults to <c>4096</c>.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="pageSize"/> is less than one.</exception>
+    public VirtualMemory(int pageSize = 4096)
+    {
+        if (pageSize < 1) throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be at least 1.");
+        PageSize = pageSize;
+        MasterProcess = new VirtualProcess<TAddress>(_nextProcessId++, pageSize, isMaster: true);
+        _processes.Add(MasterProcess);
+    }
+
+    /// <summary>
+    /// Allocates a new physical page and automatically maps it into the master process
+    /// at the next sequential virtual page index with <see cref="PageAccess.ReadWrite"/> rights.
+    /// </summary>
+    /// <returns>The newly allocated page.</returns>
+    public VirtualPage AllocatePage()
+    {
+        var page = new VirtualPage(_nextPageId++, PageSize);
+        _pages.Add(page);
+        MasterProcess.MapPage(_masterNextVirtualIndex, page, PageAccess.ReadWrite);
+        _masterNextVirtualIndex += TAddress.One;
+        return page;
+    }
+
+    /// <summary>
+    /// Creates a new non-master process with an empty page table and registers it with this
+    /// <see cref="VirtualMemory{TAddress}"/>.
+    /// </summary>
+    /// <returns>The new process.</returns>
+    public VirtualProcess<TAddress> CreateProcess()
+    {
+        var process = new VirtualProcess<TAddress>(_nextProcessId++, PageSize, isMaster: false);
+        _processes.Add(process);
+        return process;
+    }
+
+    /// <summary>
+    /// Maps <paramref name="page"/> into <paramref name="process"/>'s virtual address space at
+    /// <paramref name="virtualPageIndex"/> with the given <paramref name="access"/> rights.
+    /// An existing mapping at that index is replaced.
+    /// </summary>
+    /// <param name="process">The process to map the page into.</param>
+    /// <param name="page">The page to map. Must have been allocated by this instance.</param>
+    /// <param name="virtualPageIndex">The virtual page index within the process's address space.</param>
+    /// <param name="access">The access rights granted to the process for this page.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="process"/> or <paramref name="page"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="page"/> was not allocated by this instance.</exception>
+    public void MapPage(VirtualProcess<TAddress> process, VirtualPage page, TAddress virtualPageIndex, PageAccess access)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+        ArgumentNullException.ThrowIfNull(page);
+        if (!_pages.Contains(page))
+            throw new ArgumentException("The page does not belong to this VirtualMemory instance.", nameof(page));
+        process.MapPage(virtualPageIndex, page, access);
+    }
+
+    /// <summary>
+    /// Removes the mapping at <paramref name="virtualPageIndex"/> from <paramref name="process"/>'s
+    /// page table. Does nothing when the index is not mapped.
+    /// </summary>
+    /// <param name="process">The process whose mapping is to be removed.</param>
+    /// <param name="virtualPageIndex">The virtual page index to unmap.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="process"/> is <see langword="null"/>.</exception>
+    public void UnmapPage(VirtualProcess<TAddress> process, TAddress virtualPageIndex)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+        process.UnmapPage(virtualPageIndex);
+    }
+}

--- a/Utils.VirtualMachine/VirtualMemoryContext.cs
+++ b/Utils.VirtualMachine/VirtualMemoryContext.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Numerics;
+
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// A <see cref="DefaultContext"/> that associates an instruction stream with a specific
+/// <see cref="VirtualProcess{TAddress}"/>, allowing the executing processor to perform
+/// virtual memory reads and writes on behalf of that process.
+/// </summary>
+/// <typeparam name="TAddress">
+/// The integer address type used by the associated process. Must implement
+/// <see cref="IBinaryInteger{TSelf}"/>.
+/// </typeparam>
+public class VirtualMemoryContext<TAddress> : DefaultContext
+    where TAddress : IBinaryInteger<TAddress>
+{
+    /// <summary>Gets the virtual process associated with this execution context.</summary>
+    public VirtualProcess<TAddress> Process { get; }
+
+    /// <summary>
+    /// Initializes a new instance with an external instruction buffer and an associated process.
+    /// Use this overload when instructions reside in a managed buffer (ROM, pre-loaded code, etc.)
+    /// rather than in a virtual memory page.
+    /// </summary>
+    /// <param name="instructionData">The instruction stream.</param>
+    /// <param name="process">The process that owns the execution context.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="process"/> is <see langword="null"/>.</exception>
+    public VirtualMemoryContext(ReadOnlyMemory<byte> instructionData, VirtualProcess<TAddress> process)
+        : base(instructionData)
+    {
+        Process = process ?? throw new ArgumentNullException(nameof(process));
+    }
+
+    /// <summary>
+    /// Initializes a new instance whose instruction stream is the content of a
+    /// <see cref="VirtualPage"/>. The page's current byte content is exposed read-only via
+    /// <see cref="Context.Data"/>.
+    /// </summary>
+    /// <param name="instructionPage">The page whose bytes serve as the instruction stream.</param>
+    /// <param name="process">The process that owns the execution context.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="instructionPage"/> or <paramref name="process"/> is <see langword="null"/>.
+    /// </exception>
+    public VirtualMemoryContext(VirtualPage instructionPage, VirtualProcess<TAddress> process)
+        : base((instructionPage ?? throw new ArgumentNullException(nameof(instructionPage))).AsReadOnlyMemory())
+    {
+        Process = process ?? throw new ArgumentNullException(nameof(process));
+    }
+}

--- a/Utils.VirtualMachine/VirtualPage.cs
+++ b/Utils.VirtualMachine/VirtualPage.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Represents a fixed-size physical memory page managed by a <see cref="VirtualMemory{TAddress}"/>.
+/// Pages are created exclusively by <see cref="VirtualMemory{TAddress}.AllocatePage"/> and mapped
+/// into process virtual address spaces with per-process access rights.
+/// </summary>
+public sealed class VirtualPage
+{
+    private readonly byte[] _data;
+
+    /// <summary>Gets the unique identifier assigned to this page by its owning <see cref="VirtualMemory{TAddress}"/>.</summary>
+    public int PageId { get; }
+
+    /// <summary>Gets the size of this page in bytes.</summary>
+    public int Size => _data.Length;
+
+    /// <summary>
+    /// Returns the page content as a <see cref="ReadOnlyMemory{T}"/>, suitable for use as
+    /// <see cref="Context.Data"/> when the page holds an instruction stream.
+    /// </summary>
+    public ReadOnlyMemory<byte> AsReadOnlyMemory() => _data;
+
+    /// <summary>Gets the raw backing array. Internal access only; never expose publicly.</summary>
+    internal byte[] Data => _data;
+
+    internal VirtualPage(int pageId, int pageSize)
+    {
+        PageId = pageId;
+        _data = new byte[pageSize];
+    }
+}

--- a/Utils.VirtualMachine/VirtualProcess.cs
+++ b/Utils.VirtualMachine/VirtualProcess.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+namespace Utils.VirtualMachine;
+
+/// <summary>
+/// Represents a virtual process with its own page table mapping virtual page indices to physical
+/// <see cref="VirtualPage"/> instances and their per-process access rights.
+/// </summary>
+/// <typeparam name="TAddress">
+/// An integer type used for virtual addresses (e.g. <see cref="int"/>, <see cref="long"/>,
+/// <see cref="uint"/>). Must implement <see cref="IBinaryInteger{TSelf}"/>.
+/// </typeparam>
+/// <remarks>
+/// Instances are created exclusively by <see cref="VirtualMemory{TAddress}"/>. Call
+/// <see cref="Read"/> or <see cref="Write"/> to access memory; both methods handle cross-page
+/// operations transparently.
+/// </remarks>
+public class VirtualProcess<TAddress> where TAddress : IBinaryInteger<TAddress>
+{
+    private readonly Dictionary<TAddress, (VirtualPage Page, PageAccess Access)> _pageTable = [];
+    private readonly int _pageSize;
+
+    /// <summary>Gets the unique identifier assigned to this process.</summary>
+    public int ProcessId { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this is the master process. The master process receives
+    /// automatic <see cref="PageAccess.ReadWrite"/> mappings for every page allocated by
+    /// <see cref="VirtualMemory{TAddress}.AllocatePage"/>.
+    /// </summary>
+    public bool IsMaster { get; }
+
+    /// <summary>
+    /// Gets all current page mappings for this process as an enumerable of
+    /// (virtual page index, physical page, access rights) tuples.
+    /// </summary>
+    public IEnumerable<(TAddress VirtualPageIndex, VirtualPage Page, PageAccess Access)> Mappings
+        => _pageTable.Select(kv => (kv.Key, kv.Value.Page, kv.Value.Access));
+
+    internal VirtualProcess(int processId, int pageSize, bool isMaster)
+    {
+        ProcessId = processId;
+        _pageSize = pageSize;
+        IsMaster = isMaster;
+    }
+
+    internal void MapPage(TAddress virtualPageIndex, VirtualPage page, PageAccess access)
+        => _pageTable[virtualPageIndex] = (page, access);
+
+    internal void UnmapPage(TAddress virtualPageIndex)
+        => _pageTable.Remove(virtualPageIndex);
+
+    /// <summary>
+    /// Reads <paramref name="destination"/><c>.Length</c> bytes starting at
+    /// <paramref name="virtualAddress"/>. Transparently crosses page boundaries.
+    /// </summary>
+    /// <param name="virtualAddress">The virtual address to read from.</param>
+    /// <param name="destination">Buffer that receives the bytes.</param>
+    /// <exception cref="MemoryAccessException">
+    /// Thrown when any byte of the range falls in an unmapped page.
+    /// </exception>
+    public void Read(TAddress virtualAddress, Span<byte> destination)
+    {
+        int remaining = destination.Length;
+        int destOffset = 0;
+        TAddress currentAddress = virtualAddress;
+
+        while (remaining > 0)
+        {
+            var (pageIndex, byteOffset) = Decompose(currentAddress);
+            if (!_pageTable.TryGetValue(pageIndex, out var entry))
+                throw new MemoryAccessException(long.CreateChecked(currentAddress), PageAccess.ReadOnly);
+
+            int bytesInPage = Math.Min(remaining, _pageSize - byteOffset);
+            entry.Page.Data.AsSpan(byteOffset, bytesInPage).CopyTo(destination.Slice(destOffset, bytesInPage));
+            remaining -= bytesInPage;
+            destOffset += bytesInPage;
+            currentAddress += TAddress.CreateChecked(bytesInPage);
+        }
+    }
+
+    /// <summary>
+    /// Writes <paramref name="source"/> bytes starting at <paramref name="virtualAddress"/>.
+    /// Transparently crosses page boundaries.
+    /// </summary>
+    /// <param name="virtualAddress">The virtual address to write to.</param>
+    /// <param name="source">Bytes to write.</param>
+    /// <exception cref="MemoryAccessException">
+    /// Thrown when any byte of the range falls in an unmapped page or in a
+    /// <see cref="PageAccess.ReadOnly"/> page.
+    /// </exception>
+    public void Write(TAddress virtualAddress, ReadOnlySpan<byte> source)
+    {
+        int remaining = source.Length;
+        int srcOffset = 0;
+        TAddress currentAddress = virtualAddress;
+
+        while (remaining > 0)
+        {
+            var (pageIndex, byteOffset) = Decompose(currentAddress);
+            if (!_pageTable.TryGetValue(pageIndex, out var entry))
+                throw new MemoryAccessException(long.CreateChecked(currentAddress), PageAccess.ReadWrite);
+            if (entry.Access == PageAccess.ReadOnly)
+                throw new MemoryAccessException(long.CreateChecked(currentAddress), PageAccess.ReadWrite, PageAccess.ReadOnly);
+
+            int bytesInPage = Math.Min(remaining, _pageSize - byteOffset);
+            source.Slice(srcOffset, bytesInPage).CopyTo(entry.Page.Data.AsSpan(byteOffset, bytesInPage));
+            remaining -= bytesInPage;
+            srcOffset += bytesInPage;
+            currentAddress += TAddress.CreateChecked(bytesInPage);
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="virtualAddress"/> falls within a mapped page.
+    /// </summary>
+    public bool IsAccessible(TAddress virtualAddress)
+    {
+        var (pageIndex, _) = Decompose(virtualAddress);
+        return _pageTable.ContainsKey(pageIndex);
+    }
+
+    /// <summary>
+    /// Returns the access rights for the page that contains <paramref name="virtualAddress"/>,
+    /// or <see langword="null"/> when the address is not mapped.
+    /// </summary>
+    public PageAccess? GetAccess(TAddress virtualAddress)
+    {
+        var (pageIndex, _) = Decompose(virtualAddress);
+        return _pageTable.TryGetValue(pageIndex, out var entry) ? entry.Access : null;
+    }
+
+    private (TAddress pageIndex, int offset) Decompose(TAddress virtualAddress)
+    {
+        var ps = TAddress.CreateChecked(_pageSize);
+        return (virtualAddress / ps, int.CreateChecked(virtualAddress % ps));
+    }
+}

--- a/UtilsTest/VirtualMachine/VirtualMemoryTests.cs
+++ b/UtilsTest/VirtualMachine/VirtualMemoryTests.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.VirtualMachine;
+
+namespace UtilsTest.VirtualMachine;
+
+[TestClass]
+public class VirtualMemoryTests
+{
+    // ───────────────────────────── AllocatePage / MasterProcess ─────────────────────────────
+
+    [TestMethod]
+    public void AllocatePage_ReturnsNewPage()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var page = mem.AllocatePage();
+        Assert.IsNotNull(page);
+        Assert.AreEqual(16, page.Size);
+    }
+
+    [TestMethod]
+    public void AllocatePage_AddsToPages()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        Assert.AreEqual(0, mem.Pages.Count);
+        mem.AllocatePage();
+        mem.AllocatePage();
+        Assert.AreEqual(2, mem.Pages.Count);
+    }
+
+    [TestMethod]
+    public void AllocatePage_MasterAutoMapped_ReadWrite()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var page = mem.AllocatePage();
+        var mapping = mem.MasterProcess.Mappings.Single();
+        Assert.AreSame(page, mapping.Page);
+        Assert.AreEqual(PageAccess.ReadWrite, mapping.Access);
+    }
+
+    [TestMethod]
+    public void AllocatePage_MasterMapsAtIncreasingIndices()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        mem.AllocatePage();
+        mem.AllocatePage();
+        mem.AllocatePage();
+        var indices = mem.MasterProcess.Mappings.Select(m => m.VirtualPageIndex).OrderBy(i => i).ToArray();
+        CollectionAssert.AreEqual(new[] { 0, 1, 2 }, indices);
+    }
+
+    // ─────────────────────────────── CreateProcess ───────────────────────────────────────────
+
+    [TestMethod]
+    public void CreateProcess_AddedToProcesses()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var proc = mem.CreateProcess();
+        Assert.IsTrue(mem.Processes.Contains(proc));
+    }
+
+    [TestMethod]
+    public void CreateProcess_IsNotMaster()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var proc = mem.CreateProcess();
+        Assert.IsFalse(proc.IsMaster);
+    }
+
+    [TestMethod]
+    public void CreateProcess_EmptyMappings()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var proc = mem.CreateProcess();
+        Assert.AreEqual(0, proc.Mappings.Count());
+    }
+
+    // ─────────────────────────────── MapPage / rights ────────────────────────────────────────
+
+    [TestMethod]
+    public void MapPage_TwoProcesses_DifferentRights()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var page = mem.AllocatePage();
+        var proc = mem.CreateProcess();
+        mem.MapPage(proc, page, 0, PageAccess.ReadOnly);
+        Assert.AreEqual(PageAccess.ReadWrite, mem.MasterProcess.GetAccess(0));
+        Assert.AreEqual(PageAccess.ReadOnly, proc.GetAccess(0));
+    }
+
+    [TestMethod]
+    public void MapPage_PageNotOwned_Throws()
+    {
+        var mem1 = new VirtualMemory<int>(pageSize: 16);
+        var mem2 = new VirtualMemory<int>(pageSize: 16);
+        var foreignPage = mem2.AllocatePage();
+        var proc = mem1.CreateProcess();
+        Assert.ThrowsException<ArgumentException>(() => mem1.MapPage(proc, foreignPage, 0, PageAccess.ReadWrite));
+    }
+
+    [TestMethod]
+    public void MapPage_NullProcess_Throws()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var page = mem.AllocatePage();
+        Assert.ThrowsException<ArgumentNullException>(() => mem.MapPage(null!, page, 0, PageAccess.ReadWrite));
+    }
+
+    [TestMethod]
+    public void MapPage_NullPage_Throws()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var proc = mem.CreateProcess();
+        Assert.ThrowsException<ArgumentNullException>(() => mem.MapPage(proc, null!, 0, PageAccess.ReadWrite));
+    }
+
+    // ───────────────────────────────────── Read ──────────────────────────────────────────────
+
+    [TestMethod]
+    public void Read_SinglePage_CorrectBytes()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        mem.AllocatePage();
+        // Write via public API, then read back
+        mem.MasterProcess.Write(2, new byte[] { 0xAB, 0xCD });
+        var buf = new byte[2];
+        mem.MasterProcess.Read(2, buf);
+        Assert.AreEqual(0xAB, buf[0]);
+        Assert.AreEqual(0xCD, buf[1]);
+    }
+
+    [TestMethod]
+    public void Read_CrossPage_TransparentCopy()
+    {
+        // pageSize=4 forces cross-page with a 6-byte read starting at offset 2 in page 0
+        var mem = new VirtualMemory<int>(pageSize: 4);
+        mem.AllocatePage();
+        mem.AllocatePage();
+        // Virtual address 0..3 = page 0, 4..7 = page 1
+        mem.MasterProcess.Write(2, new byte[] { 1, 2, 3, 4, 5, 6 });
+        var buf = new byte[6];
+        mem.MasterProcess.Read(2, buf);
+        CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5, 6 }, buf);
+    }
+
+    [TestMethod]
+    public void Read_UnmappedAddress_ThrowsMemoryAccessException()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var buf = new byte[1];
+        Assert.ThrowsException<MemoryAccessException>(() => mem.MasterProcess.Read(0, buf));
+    }
+
+    // ───────────────────────────────────── Write ─────────────────────────────────────────────
+
+    [TestMethod]
+    public void Write_SinglePage_DataPersists()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        mem.AllocatePage();
+        mem.MasterProcess.Write(5, new byte[] { 0x11, 0x22 });
+        var buf = new byte[2];
+        mem.MasterProcess.Read(5, buf);
+        Assert.AreEqual(0x11, buf[0]);
+        Assert.AreEqual(0x22, buf[1]);
+    }
+
+    [TestMethod]
+    public void Write_CrossPage_TransparentCopy()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 4);
+        mem.AllocatePage();
+        mem.AllocatePage();
+        // byte at virtual addr 3 goes into page 0, byte at addr 4 goes into page 1
+        mem.MasterProcess.Write(3, new byte[] { 0xAA, 0xBB });
+        var buf = new byte[2];
+        mem.MasterProcess.Read(3, buf);
+        Assert.AreEqual(0xAA, buf[0]);
+        Assert.AreEqual(0xBB, buf[1]);
+    }
+
+    [TestMethod]
+    public void Write_ReadOnlyPage_ThrowsMemoryAccessException()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var page = mem.AllocatePage();
+        var proc = mem.CreateProcess();
+        mem.MapPage(proc, page, 0, PageAccess.ReadOnly);
+        var ex = Assert.ThrowsException<MemoryAccessException>(() => proc.Write(0, new byte[] { 1 }));
+        Assert.AreEqual(PageAccess.ReadWrite, ex.RequestedAccess);
+        Assert.AreEqual(PageAccess.ReadOnly, ex.ActualAccess);
+    }
+
+    [TestMethod]
+    public void Write_UnmappedAddress_ThrowsMemoryAccessException()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var proc = mem.CreateProcess();
+        var ex = Assert.ThrowsException<MemoryAccessException>(() => proc.Write(0, new byte[] { 1 }));
+        Assert.IsNull(ex.ActualAccess);
+    }
+
+    // ──────────────────────────────────── VirtualPage ────────────────────────────────────────
+
+    [TestMethod]
+    public void VirtualPage_AsReadOnlyMemory_LengthEqualsPageSize()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 32);
+        var page = mem.AllocatePage();
+        Assert.AreEqual(32, page.AsReadOnlyMemory().Length);
+    }
+
+    [TestMethod]
+    public void VirtualPage_AsReadOnlyMemory_UsableAsContextData()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var page = mem.AllocatePage();
+        var ctx = new DefaultContext(page.AsReadOnlyMemory());
+        Assert.AreEqual(16, ctx.Data.Length);
+    }
+
+    [TestMethod]
+    public void VirtualPage_Write_ReflectedInAsReadOnlyMemory()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var page = mem.AllocatePage();
+        mem.MasterProcess.Write(0, new byte[] { 0xFF });
+        Assert.AreEqual(0xFF, page.AsReadOnlyMemory().Span[0]);
+    }
+
+    // ──────────────────────────────── VirtualMemoryContext ───────────────────────────────────
+
+    [TestMethod]
+    public void VirtualMemoryContext_ExternalBuffer_CtorSetsProcess()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var proc = mem.MasterProcess;
+        var ctx = new VirtualMemoryContext<int>(new byte[] { 0x01, 0x02 }, proc);
+        Assert.AreSame(proc, ctx.Process);
+        Assert.AreEqual(2, ctx.Data.Length);
+    }
+
+    [TestMethod]
+    public void VirtualMemoryContext_PageCtor_DataIsPageContent()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 8);
+        var page = mem.AllocatePage();
+        mem.MasterProcess.Write(0, new byte[] { 0xDE });
+        var ctx = new VirtualMemoryContext<int>(page, mem.MasterProcess);
+        Assert.AreEqual(8, ctx.Data.Length);
+        Assert.AreEqual(0xDE, ctx.Data.Span[0]);
+    }
+
+    [TestMethod]
+    public void VirtualMemoryContext_PageCtor_NullPage_Throws()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        Assert.ThrowsException<ArgumentNullException>(() =>
+            new VirtualMemoryContext<int>((VirtualPage)null!, mem.MasterProcess));
+    }
+
+    [TestMethod]
+    public void VirtualMemoryContext_NullProcess_Throws()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() =>
+            new VirtualMemoryContext<int>(ReadOnlyMemory<byte>.Empty, null!));
+    }
+
+    // ──────────────────────────────── IsAccessible / GetAccess ───────────────────────────────
+
+    [TestMethod]
+    public void IsAccessible_Mapped_ReturnsTrue()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        mem.AllocatePage();
+        Assert.IsTrue(mem.MasterProcess.IsAccessible(0));
+        Assert.IsTrue(mem.MasterProcess.IsAccessible(15));
+    }
+
+    [TestMethod]
+    public void IsAccessible_Unmapped_ReturnsFalse()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        Assert.IsFalse(mem.MasterProcess.IsAccessible(0));
+    }
+
+    [TestMethod]
+    public void GetAccess_MappedReadOnly()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        var page = mem.AllocatePage();
+        var proc = mem.CreateProcess();
+        mem.MapPage(proc, page, 0, PageAccess.ReadOnly);
+        Assert.AreEqual(PageAccess.ReadOnly, proc.GetAccess(0));
+    }
+
+    [TestMethod]
+    public void GetAccess_Unmapped_ReturnsNull()
+    {
+        var mem = new VirtualMemory<int>(pageSize: 16);
+        Assert.IsNull(mem.MasterProcess.GetAccess(0));
+    }
+}


### PR DESCRIPTION
## Summary

- **`PageAccess`** — enum `ReadOnly` / `ReadWrite`
- **`VirtualPage`** — physical memory page with fixed size; internal `Data` array; `AsReadOnlyMemory()` for use as `Context.Data`
- **`MemoryAccessException`** — thrown on unmapped address or write to read-only page
- **`VirtualProcess<TAddress>`** — owns a page table (`Dictionary<TAddress, (Page, Access)>`); transparent cross-page `Read`/`Write` using `IBinaryInteger<TAddress>` arithmetic; `IsAccessible`, `GetAccess`
- **`VirtualMemory<TAddress>`** — pool of pages + processes; `MasterProcess` gets auto ReadWrite mapping on every `AllocatePage()`; `MapPage` / `UnmapPage` for non-master processes
- **`VirtualMemoryContext<TAddress>`** — `DefaultContext` subclass that carries the executing `VirtualProcess`; accepts either a `ReadOnlyMemory<byte>` or a `VirtualPage` as instruction stream

Address type is generic (`IBinaryInteger<TAddress>`) so callers can choose `int`, `long`, `uint`, etc. without boxing.

## Test plan

- [x] `AllocatePage_ReturnsNewPage`, `_AddsToPages`, `_MasterAutoMapped_ReadWrite`, `_MasterMapsAtIncreasingIndices`
- [x] `CreateProcess_AddedToProcesses`, `_IsNotMaster`, `_EmptyMappings`
- [x] `MapPage_TwoProcesses_DifferentRights`, `_PageNotOwned_Throws`, `_NullProcess_Throws`, `_NullPage_Throws`
- [x] `Read_SinglePage_CorrectBytes`, `_CrossPage_TransparentCopy`, `_UnmappedAddress_ThrowsMemoryAccessException`
- [x] `Write_SinglePage_DataPersists`, `_CrossPage_TransparentCopy`, `_ReadOnlyPage_ThrowsMemoryAccessException`, `_UnmappedAddress_ThrowsMemoryAccessException`
- [x] `VirtualPage_AsReadOnlyMemory_LengthEqualsPageSize`, `_UsableAsContextData`, `_Write_ReflectedInAsReadOnlyMemory`
- [x] `VirtualMemoryContext_ExternalBuffer_CtorSetsProcess`, `_PageCtor_DataIsPageContent`, `_PageCtor_NullPage_Throws`, `_NullProcess_Throws`
- [x] `IsAccessible_Mapped_ReturnsTrue`, `_Unmapped_ReturnsFalse`, `GetAccess_MappedReadOnly`, `_Unmapped_ReturnsNull`

29 new tests — 2263 pass total (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)