### PR TITLE
Centralize parser named-action classification

### DIFF
--- a/Utils.Parser.Diagnostics/EmbeddedCode/IParserEmbeddedCodeTransformer.cs
+++ b/Utils.Parser.Diagnostics/EmbeddedCode/IParserEmbeddedCodeTransformer.cs
@@ -80,25 +80,25 @@ public enum ParserEmbeddedCodeDiagnosticSeverity
 public enum ParserEmbeddedCodeLocation
 {
     /// <summary>Parser header action.</summary>
-    ParserHeader,
+    ParserHeader = 0,
 
     /// <summary>Parser footer action.</summary>
-    ParserFooter,
+    ParserFooter = 1,
 
     /// <summary>Parser members action.</summary>
-    ParserMembers,
+    ParserMembers = 2,
 
     /// <summary>Rule <c>@init</c> action.</summary>
-    RuleInit,
+    RuleInit = 3,
 
     /// <summary>Rule <c>@after</c> action.</summary>
-    RuleAfter,
+    RuleAfter = 4,
 
     /// <summary>Inline parser action.</summary>
-    InlineAction,
+    InlineAction = 5,
 
     /// <summary>Semantic predicate.</summary>
-    SemanticPredicate
+    SemanticPredicate = 6
 }
 
 /// <summary>

--- a/Utils.Parser.Generators/Antlr4GrammarGenerator.cs
+++ b/Utils.Parser.Generators/Antlr4GrammarGenerator.cs
@@ -211,7 +211,7 @@ public sealed class Antlr4GrammarGenerator : IIncrementalGenerator
                 continue;
             }
 
-            var reason = FormatGrammarActionReason(grammar, action);
+            var reason = EmbeddedMembersSupport.FormatUnsupportedReason(grammar, action);
             ReportUnsupportedEmbeddedCodeDiagnostic(context, file, text, action.Line, constructKind, grammar.Name, reason);
         }
 
@@ -435,76 +435,6 @@ public sealed class Antlr4GrammarGenerator : IIncrementalGenerator
         return action.Target is null
             ? "Grammar " + name + " action"
             : "Grammar @" + action.Target + "::" + action.Name + " action";
-    }
-
-    /// <summary>
-    /// Formats a grammar-level action reason for diagnostics.
-    /// </summary>
-    /// <param name="grammar">Grammar that owns the action.</param>
-    /// <param name="action">Grammar-level action metadata.</param>
-    /// <returns>Construct-specific diagnostic reason.</returns>
-    private static string FormatGrammarActionReason(G4Grammar grammar, G4GrammarAction action)
-    {
-        if (string.Equals(action.Target, "lexer", StringComparison.Ordinal)
-            && (string.Equals(action.Name, "header", StringComparison.Ordinal)
-                || string.Equals(action.Name, "members", StringComparison.Ordinal)
-                || string.Equals(action.Name, "footer", StringComparison.Ordinal)))
-        {
-            return $"Lexer named action '@lexer::{action.Name}' is not supported by this generator.";
-        }
-
-        if (string.Equals(action.Target, "parser", StringComparison.Ordinal)
-            && grammar.Kind is G4GrammarKind.Lexer
-            && IsParserCompatibilityActionName(action.Name))
-        {
-            return $"Parser named action '@parser::{action.Name}' is not valid in a lexer grammar.";
-        }
-
-        if (action.Target is null
-            && grammar.Kind is G4GrammarKind.Lexer
-            && IsParserCompatibilityActionName(action.Name))
-        {
-            return $"Unscoped grammar action '@{action.Name}' is not supported in lexer grammars by this generator.";
-        }
-
-        if (action.Target is not null && !string.Equals(action.Target, "parser", StringComparison.Ordinal))
-        {
-            return $"Named action scope '@{action.Target}::{action.Name}' is not supported by this generator.";
-        }
-
-        if (string.Equals(action.Target, "parser", StringComparison.Ordinal))
-        {
-            return $"Parser named action '@parser::{action.Name}' is not supported by this generator.";
-        }
-
-        if (string.Equals(action.Name, "header", StringComparison.Ordinal))
-        {
-            return "This header action is not a parser @header block supported by generated C# source-file injection and remains metadata-only.";
-        }
-
-        if (string.Equals(action.Name, "members", StringComparison.Ordinal))
-        {
-            return "This members action is not a parser @members block supported by the generated execution context and remains metadata-only.";
-        }
-
-        if (string.Equals(action.Name, "footer", StringComparison.Ordinal))
-        {
-            return "This footer action is not a parser @footer block supported by generated trailing C# source injection and remains metadata-only.";
-        }
-
-        return "Grammar-level actions are preserved as metadata only and are not injected into generated parser or lexer types.";
-    }
-
-    /// <summary>
-    /// Determines whether a grammar-level action name is one of the parser compatibility block names.
-    /// </summary>
-    /// <param name="name">ANTLR grammar-level action name.</param>
-    /// <returns><see langword="true"/> for header, members, or footer action names.</returns>
-    private static bool IsParserCompatibilityActionName(string name)
-    {
-        return string.Equals(name, "header", StringComparison.Ordinal)
-            || string.Equals(name, "members", StringComparison.Ordinal)
-            || string.Equals(name, "footer", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Utils.Parser.Generators/Internal/CSharpAntlrStyleParserEmbeddedCodeTransformer.cs
+++ b/Utils.Parser.Generators/Internal/CSharpAntlrStyleParserEmbeddedCodeTransformer.cs
@@ -29,6 +29,8 @@ internal sealed class CSharpAntlrStyleParserEmbeddedCodeTransformer : IParserEmb
         if (context is null) throw new System.ArgumentNullException(nameof(context));
         if (context.RuleName is null || !_rules.TryGetValue(context.RuleName, out G4Rule? rule))
         {
+            // Parser header/member/footer blocks are not tied to a current parser rule.
+            // ANTLR-style current-rule attribute rewriting is intentionally skipped there.
             return new ParserEmbeddedCodeTransformationResult { Code = context.Code };
         }
 

--- a/Utils.Parser.Generators/Internal/EmbeddedMembersSupport.cs
+++ b/Utils.Parser.Generators/Internal/EmbeddedMembersSupport.cs
@@ -3,11 +3,99 @@ using System;
 namespace Utils.Parser.Generators.Internal;
 
 /// <summary>
-/// Provides shared source-generator rules for deciding whether ANTLR grammar-level actions
-/// are parser compatibility blocks that can be injected into generated C# output.
+/// Identifies the source-generator support category for one ANTLR grammar-level action.
+/// </summary>
+internal enum GrammarActionSupportKind
+{
+    /// <summary>Parser <c>@header</c> or <c>@parser::header</c> action injected near the top of generated C# source.</summary>
+    ParserHeader,
+
+    /// <summary>Parser <c>@members</c> or <c>@parser::members</c> action injected into the generated execution context.</summary>
+    ParserMembers,
+
+    /// <summary>Parser <c>@footer</c> or <c>@parser::footer</c> action injected as trailing generated C# source.</summary>
+    ParserFooter,
+
+    /// <summary>Lexer <c>@lexer::header</c>, <c>@lexer::members</c>, or <c>@lexer::footer</c> action that remains unsupported.</summary>
+    UnsupportedLexerNamedAction,
+
+    /// <summary>Parser-scoped compatibility action used in a lexer grammar.</summary>
+    UnsupportedParserNamedActionInLexerGrammar,
+
+    /// <summary>Unscoped parser compatibility action used in a lexer grammar.</summary>
+    UnsupportedUnscopedParserCompatibilityActionInLexerGrammar,
+
+    /// <summary>Named action that uses an unsupported non-parser scope.</summary>
+    UnsupportedUnknownScope,
+
+    /// <summary>Parser-scoped named action whose name is not a supported parser compatibility block.</summary>
+    UnsupportedUnknownParserNamedAction,
+
+    /// <summary>Grammar-level action that is preserved as metadata only.</summary>
+    UnsupportedMetadataOnly
+}
+
+/// <summary>
+/// Provides the shared source of truth for ANTLR grammar-level action classification,
+/// source-generator injection eligibility, and unsupported diagnostic reasons.
 /// </summary>
 internal static class EmbeddedMembersSupport
 {
+    /// <summary>
+    /// Classifies a grammar-level action into the exact source-generator support category.
+    /// </summary>
+    /// <param name="grammar">Grammar that owns the action.</param>
+    /// <param name="action">Grammar-level action metadata to classify.</param>
+    /// <returns>The support category that all emitter and diagnostic paths must use.</returns>
+    public static GrammarActionSupportKind Classify(G4Grammar grammar, G4GrammarAction action)
+    {
+        if (IsLexerCompatibilityAction(action))
+        {
+            return GrammarActionSupportKind.UnsupportedLexerNamedAction;
+        }
+
+        if (string.Equals(action.Target, "parser", StringComparison.Ordinal)
+            && grammar.Kind is G4GrammarKind.Lexer
+            && IsParserCompatibilityActionName(action.Name))
+        {
+            return GrammarActionSupportKind.UnsupportedParserNamedActionInLexerGrammar;
+        }
+
+        if (action.Target is null
+            && grammar.Kind is G4GrammarKind.Lexer
+            && IsParserCompatibilityActionName(action.Name))
+        {
+            return GrammarActionSupportKind.UnsupportedUnscopedParserCompatibilityActionInLexerGrammar;
+        }
+
+        if (action.Target is not null && !string.Equals(action.Target, "parser", StringComparison.Ordinal))
+        {
+            return GrammarActionSupportKind.UnsupportedUnknownScope;
+        }
+
+        if (IsInjectableParserAction(grammar, action, "header"))
+        {
+            return GrammarActionSupportKind.ParserHeader;
+        }
+
+        if (IsInjectableParserAction(grammar, action, "members"))
+        {
+            return GrammarActionSupportKind.ParserMembers;
+        }
+
+        if (IsInjectableParserAction(grammar, action, "footer"))
+        {
+            return GrammarActionSupportKind.ParserFooter;
+        }
+
+        if (string.Equals(action.Target, "parser", StringComparison.Ordinal))
+        {
+            return GrammarActionSupportKind.UnsupportedUnknownParserNamedAction;
+        }
+
+        return GrammarActionSupportKind.UnsupportedMetadataOnly;
+    }
+
     /// <summary>
     /// Determines whether a grammar-level action is a parser members block supported
     /// by the generated per-parse execution-context compatibility bridge.
@@ -20,7 +108,7 @@ internal static class EmbeddedMembersSupport
     /// </returns>
     public static bool IsInjectableParserMembersAction(G4Grammar grammar, G4GrammarAction action)
     {
-        return IsInjectableParserAction(grammar, action, "members");
+        return Classify(grammar, action) is GrammarActionSupportKind.ParserMembers;
     }
 
     /// <summary>
@@ -35,7 +123,7 @@ internal static class EmbeddedMembersSupport
     /// </returns>
     public static bool IsInjectableParserHeaderAction(G4Grammar grammar, G4GrammarAction action)
     {
-        return IsInjectableParserAction(grammar, action, "header");
+        return Classify(grammar, action) is GrammarActionSupportKind.ParserHeader;
     }
 
     /// <summary>
@@ -50,7 +138,26 @@ internal static class EmbeddedMembersSupport
     /// </returns>
     public static bool IsInjectableParserFooterAction(G4Grammar grammar, G4GrammarAction action)
     {
-        return IsInjectableParserAction(grammar, action, "footer");
+        return Classify(grammar, action) is GrammarActionSupportKind.ParserFooter;
+    }
+
+    /// <summary>
+    /// Formats the deterministic unsupported diagnostic reason for a grammar-level action.
+    /// </summary>
+    /// <param name="grammar">Grammar that owns the action.</param>
+    /// <param name="action">Grammar-level action metadata to classify.</param>
+    /// <returns>Construct-specific diagnostic reason matching the classified support category.</returns>
+    public static string FormatUnsupportedReason(G4Grammar grammar, G4GrammarAction action)
+    {
+        return Classify(grammar, action) switch
+        {
+            GrammarActionSupportKind.UnsupportedLexerNamedAction => $"Lexer named action '@lexer::{action.Name}' is not supported by this generator.",
+            GrammarActionSupportKind.UnsupportedParserNamedActionInLexerGrammar => $"Parser named action '@parser::{action.Name}' is not valid in a lexer grammar.",
+            GrammarActionSupportKind.UnsupportedUnscopedParserCompatibilityActionInLexerGrammar => $"Unscoped grammar action '@{action.Name}' is not supported in lexer grammars by this generator.",
+            GrammarActionSupportKind.UnsupportedUnknownScope => $"Named action scope '@{action.Target}::{action.Name}' is not supported by this generator.",
+            GrammarActionSupportKind.UnsupportedUnknownParserNamedAction => $"Parser named action '@parser::{action.Name}' is not supported by this generator.",
+            _ => FormatMetadataOnlyReason(action)
+        };
     }
 
     /// <summary>
@@ -78,5 +185,52 @@ internal static class EmbeddedMembersSupport
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Determines whether a grammar-level action is one of the explicitly unsupported lexer named actions.
+    /// </summary>
+    /// <param name="action">Grammar-level action metadata to inspect.</param>
+    /// <returns><c>true</c> for <c>@lexer::header</c>, <c>@lexer::members</c>, or <c>@lexer::footer</c>.</returns>
+    private static bool IsLexerCompatibilityAction(G4GrammarAction action)
+    {
+        return string.Equals(action.Target, "lexer", StringComparison.Ordinal) && IsParserCompatibilityActionName(action.Name);
+    }
+
+    /// <summary>
+    /// Determines whether a grammar-level action name is one of the parser compatibility block names.
+    /// </summary>
+    /// <param name="name">ANTLR grammar-level action name.</param>
+    /// <returns><see langword="true"/> for header, members, or footer action names.</returns>
+    private static bool IsParserCompatibilityActionName(string name)
+    {
+        return string.Equals(name, "header", StringComparison.Ordinal)
+            || string.Equals(name, "members", StringComparison.Ordinal)
+            || string.Equals(name, "footer", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Formats the existing metadata-only diagnostic reason for an unsupported unscoped grammar action.
+    /// </summary>
+    /// <param name="action">Grammar-level action metadata to describe.</param>
+    /// <returns>Metadata-only unsupported diagnostic reason.</returns>
+    private static string FormatMetadataOnlyReason(G4GrammarAction action)
+    {
+        if (string.Equals(action.Name, "header", StringComparison.Ordinal))
+        {
+            return "This header action is not a parser @header block supported by generated C# source-file injection and remains metadata-only.";
+        }
+
+        if (string.Equals(action.Name, "members", StringComparison.Ordinal))
+        {
+            return "This members action is not a parser @members block supported by the generated execution context and remains metadata-only.";
+        }
+
+        if (string.Equals(action.Name, "footer", StringComparison.Ordinal))
+        {
+            return "This footer action is not a parser @footer block supported by generated trailing C# source injection and remains metadata-only.";
+        }
+
+        return "Grammar-level actions are preserved as metadata only and are not injected into generated parser or lexer types.";
     }
 }

--- a/Utils.Parser/AGENTS.md
+++ b/Utils.Parser/AGENTS.md
@@ -206,3 +206,11 @@ Before completing any PR, verify:
 - tests cover new or clarified invariants;
 - public API changes are documented when present;
 - no unsupported runtime feature was accidentally introduced.
+
+## Parser named actions
+
+- Grammar-level named-action classification must go through the shared internal helper. Do not duplicate `@header`/`@members`/`@footer` parser/lexer support rules in `GrammarEmitter` and `Antlr4GrammarGenerator`.
+- Parser header/member/footer are source-generator C# compatibility only.
+- Lexer named actions remain unsupported.
+- `@parser::members` is emitted into the generated execution context only.
+- `$...` current-rule rewriting is rule-bound and must not run for parser header/member/footer content.

--- a/UtilsTest/Parser/Antlr4GrammarGeneratorDiagnosticsTests.cs
+++ b/UtilsTest/Parser/Antlr4GrammarGeneratorDiagnosticsTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Text;
 using Utils.Parser.Diagnostics;
 using Utils.Parser.Generators;
+using Utils.Parser.Generators.Internal;
 
 namespace UtilsTest.Parser;
 
@@ -15,6 +16,30 @@ namespace UtilsTest.Parser;
 [TestClass]
 public class Antlr4GrammarGeneratorDiagnosticsTests
 {
+    /// <summary>
+    /// Ensures grammar-level named-action classification remains centralized and deterministic.
+    /// </summary>
+    [DataTestMethod]
+    [DataRow("grammar P; @header { } start : A ; A : 'a' ;", "ParserHeader")]
+    [DataRow("parser grammar P; @parser::header { } start : A ;", "ParserHeader")]
+    [DataRow("grammar P; @members { } start : A ; A : 'a' ;", "ParserMembers")]
+    [DataRow("parser grammar P; @parser::members { } start : A ;", "ParserMembers")]
+    [DataRow("grammar P; @footer { } start : A ; A : 'a' ;", "ParserFooter")]
+    [DataRow("parser grammar P; @parser::footer { } start : A ;", "ParserFooter")]
+    [DataRow("grammar P; @lexer::members { } start : A ; A : 'a' ;", "UnsupportedLexerNamedAction")]
+    [DataRow("lexer grammar L; @parser::header { } A : 'a' ;", "UnsupportedParserNamedActionInLexerGrammar")]
+    [DataRow("lexer grammar L; @members { } A : 'a' ;", "UnsupportedUnscopedParserCompatibilityActionInLexerGrammar")]
+    [DataRow("grammar P; @tree::members { } start : A ; A : 'a' ;", "UnsupportedUnknownScope")]
+    [DataRow("grammar P; @parser::custom { } start : A ; A : 'a' ;", "UnsupportedUnknownParserNamedAction")]
+    [DataRow("grammar P; @custom { } start : A ; A : 'a' ;", "UnsupportedMetadataOnly")]
+    public void GrammarActionSupport_Classify_ReturnsExpectedKind(string grammarText, string expectedKindName)
+    {
+        var grammar = new G4Parser(new G4Tokenizer(grammarText).Tokenize()).Parse();
+        var action = grammar.Actions.Single();
+
+        Assert.AreEqual(expectedKindName, EmbeddedMembersSupport.Classify(grammar, action).ToString());
+    }
+
     /// <summary>
     /// Ensures lexer actions are reported as unsupported generator execution constructs.
     /// </summary>


### PR DESCRIPTION
### Motivation
- Reduce duplicated classification and diagnostic logic for grammar-level named actions by centralizing the rules and invariants in one helper so emitter/generator code shares a single source of truth. 
- Preserve existing behavior for supported/unsupported parser and lexer named actions and keep diagnostics deterministic and unchanged. 
- Clarify transformer invariants so C# ANTLR-style `$...` rewriting remains rule-bound and is not applied to parser header/member/footer content.

### Description
- Introduce a single classification helper and support enum by expanding `Utils.Parser.Generators.Internal.EmbeddedMembersSupport` with `GrammarActionSupportKind` and a `Classify(G4Grammar, G4GrammarAction)` entry point, and expose `FormatUnsupportedReason(...)` for deterministic diagnostic reasons. 
- Make `IsInjectableParserHeaderAction`, `IsInjectableParserMembersAction`, and `IsInjectableParserFooterAction` rely on the new `Classify(...)` result so all emitter and diagnostic paths use the same logic. 
- Update `Utils.Parser.Generators.Antlr4GrammarGenerator` to use `EmbeddedMembersSupport.FormatUnsupportedReason(...)` instead of duplicating classification/formatting logic. 
- Add a short clarifying comment to `CSharpAntlrStyleParserEmbeddedCodeTransformer` to document that header/members/footer blocks are not tied to a current rule and therefore skip current-rule rewriting, and pin numeric values for `ParserEmbeddedCodeLocation` to preserve enum ordering. 
- Add a deterministic unit test in `UtilsTest/Parser/Antlr4GrammarGeneratorDiagnosticsTests` to assert the classification matrix and update `Utils.Parser/AGENTS.md` to record the classification source-of-truth invariant.

### Testing
- Ran `dotnet test UtilsTest/UtilsTest.Unit.csproj --no-restore` and the unit test suite passed (all unit tests passed; generator/Parser-related tests included). 
- The new data-driven test `GrammarActionSupport_Classify_ReturnsExpectedKind` was executed as part of the unit run and passed. 
- No behavioral tests or generator integration tests were changed; diagnostics and injection behavior remain covered by the existing test suite which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ccdf11a7c8326a55d1606f9b625ca)