### PR TITLE
fix(collections): correct 4 structural bugs in SkipList

### DIFF
--- a/Utils.Collections/SkipList.cs
+++ b/Utils.Collections/SkipList.cs
@@ -106,7 +106,7 @@ public class SkipList<T> : ICollection<T>
             // make it the first element in the object hierarchy
             for (var levelElement = elementAfter?.Up; levelElement != null; levelElement = levelElement.Up)
             {
-                newElement.CreateUp(null, levelElement);
+                newElement = newElement.CreateUp(null, levelElement);
             }
             elementAfter?.RemoveUp();
             _firstElement = newElement;
@@ -182,6 +182,7 @@ public class SkipList<T> : ICollection<T>
             {
                 next = next.CreateUp(levelElement, levelElement.Next);
             }
+            _firstElement = next;
         }
         else if (element.Next is null && element.Previous is not null)
         {
@@ -190,9 +191,8 @@ public class SkipList<T> : ICollection<T>
             {
                 previous = previous.CreateUp(levelElement.Previous, levelElement);
             }
+            _lastElement = previous;
         }
-        if (element == _firstElement) _firstElement = element.Next;
-        if (element == _lastElement) _lastElement = element.Previous;
         element.Remove();
         while (_firstElement?.Sub is not null && _lastElement?.Sub is not null && _firstElement.Next == _lastElement)
         {
@@ -251,13 +251,14 @@ public class SkipList<T> : ICollection<T>
         Element currentElement;
         Element previousElement = startElement?.Previous;
         int counter = 0;
+        Element lastUpperNode = startElement.Up;
 
         for (currentElement = startElement; currentElement != null; currentElement = currentElement.Next)
         {
-            if (currentElement.Up is not null) counter = 0;
+            if (currentElement.Up is not null) { counter = 0; lastUpperNode = currentElement.Up; }
             if (counter > _threshold && currentElement.Next is not null && currentElement.Next?.Up is null)
             {
-                CreateNewSkipNode(startElement, endElement, currentElement);
+                lastUpperNode = CreateNewSkipNode(startElement, endElement, currentElement, lastUpperNode);
                 counter = 0;
             }
             int comparison = comparer.Compare(value, currentElement.Value);
@@ -272,7 +273,7 @@ public class SkipList<T> : ICollection<T>
         return (previousElement, null);
     }
 
-    private void CreateNewSkipNode(Element startElement, Element endElement, Element currentElement)
+    private Element CreateNewSkipNode(Element startElement, Element endElement, Element currentElement, Element lastUpperNode)
     {
         Element previousUp, nextUp;
 
@@ -287,11 +288,11 @@ public class SkipList<T> : ICollection<T>
         }
         else
         {
-            // insert into existing upper level
-            previousUp = startElement.Up;
+            // use lastUpperNode as left anchor to avoid overwriting links from previously created skip nodes
+            previousUp = lastUpperNode ?? startElement.Up;
             nextUp = endElement.Up;
         }
-        currentElement.CreateUp(previousUp, nextUp);
+        return currentElement.CreateUp(previousUp, nextUp);
     }
 
     private IEnumerable<T> Enumerate()

--- a/UtilsTest/Lists/SkipListTests.cs
+++ b/UtilsTest/Lists/SkipListTests.cs
@@ -129,5 +129,51 @@ namespace UtilsTest.Lists
             TestRemove(5, result);
         }
 
+        [TestMethod]
+        public void AddBeforeFirstWithLevels_MaintainsStructure()
+        {
+            SkipList<int> list = new(2);
+            foreach (var v in new[] { 5, 6, 7, 8 }) list.Add(v);
+            list.Add(1);
+            list.Add(0);
+            CollectionAssert.AreEqual(new[] { 0, 1, 5, 6, 7, 8 }, list.ToArray());
+        }
+
+        [TestMethod]
+        public void RemoveFirstElementWithUpLinks_MaintainsStructure()
+        {
+            SkipList<int> list = new(2);
+            foreach (var v in new[] { 1, 2, 3, 4, 5, 6 }) list.Add(v);
+            Assert.IsTrue(list.Remove(1));
+            Assert.AreEqual(5, list.Count);
+            CollectionAssert.AreEqual(new[] { 2, 3, 4, 5, 6 }, list.ToArray());
+            list.Add(0);
+            Assert.IsTrue(list.Contains(0));
+            CollectionAssert.AreEqual(new[] { 0, 2, 3, 4, 5, 6 }, list.ToArray());
+        }
+
+        [TestMethod]
+        public void RemoveLastElementWithUpLinks_MaintainsStructure()
+        {
+            SkipList<int> list = new(2);
+            foreach (var v in new[] { 1, 2, 3, 4, 5, 6 }) list.Add(v);
+            Assert.IsTrue(list.Remove(6));
+            Assert.AreEqual(5, list.Count);
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5 }, list.ToArray());
+            list.Add(7);
+            Assert.IsTrue(list.Contains(7));
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5, 7 }, list.ToArray());
+        }
+
+        [TestMethod]
+        public void AddAndContains_WithSmallThreshold_NoSkipNodeBeyondEnd()
+        {
+            SkipList<int> list = new(2);
+            int[] values = [10, 20, 30, 40, 50];
+            foreach (var v in values) list.Add(v);
+            foreach (var v in values) Assert.IsTrue(list.Contains(v));
+            CollectionAssert.AreEqual(values, list.ToArray());
+        }
+
     }
 }


### PR DESCRIPTION
## Summary

- **Bug 1 (Add)**: `CreateUp` result was discarded when inserting before the first element — `_firstElement` was set to a level-0 node instead of the topmost level, desynchronizing it from `_lastElement`. Fix: `newElement = newElement.CreateUp(null, levelElement)`.
- **Bug 2/3 (Remove first/last)**: `_firstElement`/`_lastElement` were not updated after the loop that creates upper-level representatives for the successor/predecessor.
- **Bug 4 (CreateNewSkipNode)**: multiple skip nodes created at the same level during a single scan all used `startElement.Up` as `previousUp`, overwriting `previousUp.Next` on every call. Earlier nodes ended up with a stale `Previous` pointing to a dead node. Fix: track `lastUpperNode` across calls.

## Test plan

- [x] `AddBeforeFirstWithLevels_MaintainsStructure` — covers Bug 1
- [x] `RemoveFirstElementWithUpLinks_MaintainsStructure` — covers Bugs 2/3
- [x] `RemoveLastElementWithUpLinks_MaintainsStructure` — covers Bugs 2/3
- [x] `AddAndContains_WithSmallThreshold_NoSkipNodeBeyondEnd` — covers Bug 4
- [x] All original 9 SkipList tests continue to pass
- [x] Full suite: 2355 pass, 3 ignored (no regressions)

Generated with [Claude Code](https://claude.com/claude-code)