### PR TITLE
feat(mathematics): API cleanup, FFT Span, expression tree fixes, new utilities

### DIFF
--- a/Utils.Geography/Geography/Model/GeoPoint.cs
+++ b/Utils.Geography/Geography/Model/GeoPoint.cs
@@ -324,11 +324,11 @@ namespace Utils.Geography.Model
         public bool Equals(GeoPoint<T>? other)
         {
             if (other is null) return false;
-            if (comparer.Equals(Latitude, MaxLatitude) && comparer.Equals(other.Latitude, MaxLatitude)) return true;
-            if (comparer.Equals(Latitude, MinLatitude) && comparer.Equals(other.Latitude, MinLatitude)) return true;
+            if (comparer.Compare(Latitude, MaxLatitude) == 0 && comparer.Compare(other.Latitude, MaxLatitude) == 0) return true;
+            if (comparer.Compare(Latitude, MinLatitude) == 0 && comparer.Compare(other.Latitude, MinLatitude) == 0) return true;
 
-            return comparer.Equals(Latitude, other.Latitude)
-                && comparer.Equals(Longitude, other.Longitude);
+            return comparer.Compare(Latitude, other.Latitude) == 0
+                && comparer.Compare(Longitude, other.Longitude) == 0;
         }
 
         /// <inheritdoc/>

--- a/Utils.Geography/Geography/Model/GeoVector.cs
+++ b/Utils.Geography/Geography/Model/GeoVector.cs
@@ -187,13 +187,13 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <returns>The bearing from A to B, normalized to [0..360).</returns>
     public static T ComputeBearing(GeoPoint<T> A, GeoPoint<T> B)
     {
-        if (comparer.Equals(A.Longitude, B.Longitude))
+        if (comparer.Compare(A.Longitude, B.Longitude) == 0)
         {
             // Vertical line test
             return A.Latitude > B.Latitude ? degree.StraightAngle : T.Zero;
         }
-        if (comparer.Equals(A.Longitude, B.Longitude - degree.StraightAngle)
-            || comparer.Equals(A.Longitude, B.Longitude + degree.StraightAngle))
+        if (comparer.Compare(A.Longitude, B.Longitude - degree.StraightAngle) == 0
+            || comparer.Compare(A.Longitude, B.Longitude + degree.StraightAngle) == 0)
         {
             return A.Latitude > -B.Latitude ? degree.StraightAngle : T.Zero;
         }
@@ -467,7 +467,7 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
 
     /// <inheritdoc />
     public bool Equals(GeoVector<T>? other)
-        => other is not null && comparer.Equals(Bearing, other.Bearing) && base.Equals(other);
+        => other is not null && comparer.Compare(Bearing, other.Bearing) == 0 && base.Equals(other);
 
     /// <inheritdoc />
     public override int GetHashCode()

--- a/Utils.Mathematics/Expressions/ExpressionDerivation.cs
+++ b/Utils.Mathematics/Expressions/ExpressionDerivation.cs
@@ -301,10 +301,10 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
             Expression operand)
     {
         return Expression.Divide(
-            operand,
+            Transform(operand),
             Expression.Multiply(
-                ExpressionEx.CreateConstant(T.CreateChecked(double.Log(10d))),
-                Transform(operand)
+                operand,
+                ExpressionEx.CreateConstant(T.CreateChecked(double.Log(10d)))
             )
         );
     }
@@ -389,9 +389,9 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// <returns>The derivative expression using centered finite difference.</returns>
     private Expression DeriveUnknownMethodCall(MethodCallExpression methodCallExpression, Expression[] parameters)
     {
-        if (methodCallExpression.Method.ReturnType != typeof(double)
+        if (methodCallExpression.Method.ReturnType != typeof(T)
             || methodCallExpression.Method.GetParameters().Length != 1
-            || methodCallExpression.Method.GetParameters()[0].ParameterType != typeof(double))
+            || methodCallExpression.Method.GetParameters()[0].ParameterType != typeof(T))
         {
             throw new NotSupportedException($"No derivative rule is registered for '{methodCallExpression.Method}'.");
         }
@@ -402,8 +402,8 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
             return ExpressionEx.CreateConstant(T.CreateChecked(0d));
         }
 
-        var epsilon = Expression.Constant(FiniteDifferenceEpsilon);
-        var twoEpsilon = Expression.Constant(2.0 * FiniteDifferenceEpsilon);
+        var epsilon = ExpressionEx.CreateConstant(T.CreateChecked(FiniteDifferenceEpsilon));
+        var twoEpsilon = ExpressionEx.CreateConstant(T.CreateChecked(2.0 * FiniteDifferenceEpsilon));
         var operandDerivative = Transform(operand);
 
         var plus = Expression.Call(methodCallExpression.Method, Expression.Add(operand, epsilon));

--- a/Utils.Mathematics/Expressions/ExpressionIntegration.cs
+++ b/Utils.Mathematics/Expressions/ExpressionIntegration.cs
@@ -162,7 +162,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     /// <param name="right">The expression on the right side of the operator.</param>
     /// <returns>The integral of the subtraction expression.</returns>
     [ExpressionSignature(ExpressionType.Subtract)]
-    public Expression Substract(
+    public Expression Subtract(
         BinaryExpression e,
         Expression left,
         Expression right
@@ -304,7 +304,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         }
 
         double n = System.Convert.ToDouble(expo.Value);
-        if (double.Abs(n - 1.0) < double.Epsilon)
+        if (double.Abs(n - 1.0) < 1e-10)
         {
             return Expression.Multiply(
                 left,
@@ -383,7 +383,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             }
 
             double n = System.Convert.ToDouble(exponent.Value);
-            if (double.Abs(n - 1.0) < double.Epsilon)
+            if (double.Abs(n - 1.0) < 1e-10)
             {
                 return Expression.Multiply(
                     left,
@@ -480,7 +480,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (p.Name != ParameterName) return null;
         double n = System.Convert.ToDouble(expo.Value);
-        if (double.Abs(n + 1.0) < double.Epsilon)
+        if (double.Abs(n + 1.0) < 1e-10)
         {
             return Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]), p);
         }

--- a/Utils.Mathematics/Fourrier/FastFourrierTransform.cs
+++ b/Utils.Mathematics/Fourrier/FastFourrierTransform.cs
@@ -5,78 +5,77 @@ namespace Utils.Mathematics.Fourrier;
 /// <summary>
 /// Provides a recursive Cooley-Tukey Fast Fourier Transform implementation.
 /// </summary>
-public class FastFourrierTransform
+public static class FastFourrierTransform
 {
     /// <summary>
-    /// Separates even and odd elements so the even values occupy the first half of the array range and the odd values occupy the second half.
+    /// Performs an in-place FFT on the provided sample array.
     /// </summary>
-    /// <param name="array">Array to reorder.</param>
-    /// <param name="start">Inclusive start index.</param>
-    /// <param name="end">Exclusive end index.</param>
-    private void Separate(Complex[] array, int start, int end)
+    /// <param name="array">Sample array to transform in place. Its length must be a power of two.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="array"/> length is not a power of two.
+    /// </exception>
+    public static void Transform(Complex[] array)
     {
-        int n = end - start;
-        var n2 = n >> 1;
-        Complex[] buffer = new Complex[n2];
-        for (int i = 0; i < n2; i++)
-        {
-            buffer[i] = array[(i << 1) | 1];
-        }
-
-        for (int i = 0; i < n2; i++)
-        {
-            array[i] = array[i << 1];
-        }
-
-        for (int i = 0; i < n2; i++)
-        {
-            array[i + n2] = buffer[i];
-        }
+        if (!Mathematics.MathEx.IsPowerOfTwo(array.Length))
+            throw new ArgumentException("Array length must be a power of two.", nameof(array));
+        Transform(array.AsSpan());
     }
 
     /// <summary>
-    /// Performs an in-place FFT on the entire sample array.
+    /// Performs an in-place inverse FFT on the provided sample array.
     /// </summary>
-    /// <param name="array">Array to transform.</param>
-    public void Transform(Complex[] array)
+    /// <param name="array">Frequency-domain array to transform back to the time domain. Its length must be a power of two.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="array"/> length is not a power of two.
+    /// </exception>
+    public static void InverseTransform(Complex[] array)
     {
-        Transform(array, 0, array.Length);
+        if (!Mathematics.MathEx.IsPowerOfTwo(array.Length))
+            throw new ArgumentException("Array length must be a power of two.", nameof(array));
+
+        for (int i = 0; i < array.Length; i++)
+            array[i] = Complex.Conjugate(array[i]);
+
+        Transform(array.AsSpan());
+
+        double n = array.Length;
+        for (int i = 0; i < array.Length; i++)
+            array[i] = Complex.Conjugate(array[i]) / n;
     }
 
-    // N must be a power-of-2, or bad things will happen.
-    // Currently no check for this condition.
-    //
-    // N input samples in X[] are FFT'd and results left in X[].
-    // Because of Nyquist theorem, N samples means
-    // only first N/2 FFT results in X[] are the answer.
-    // (upper half of X[] is a reflection with no new information).
-    /// <summary>
-    /// Performs an in-place FFT on a range of the provided array.
-    /// </summary>
-    /// <param name="array">Array to transform.</param>
-    /// <param name="start">Inclusive start index.</param>
-    /// <param name="end">Exclusive end index.</param>
-    public void Transform(Complex[] array, int start, int end)
+    private static void Transform(Span<Complex> span)
     {
-        int n = end - start;
-        if (n < 2)
-        {
-            return;
-        }
+        int n = span.Length;
+        if (n < 2) return;
 
         int n2 = n >> 1;
-
-        Separate(array, start, end);
-        Transform(array, start, start + n2);
-        Transform(array, start + n2, end);
+        Separate(span);
+        Transform(span[..n2]);
+        Transform(span[n2..]);
 
         for (int k = 0; k < n2; k++)
         {
-            Complex evenComponent = array[k];
-            Complex oddComponent = array[k + n2];
-            Complex twiddleFactor = Complex.Exp(new Complex(0, -2 * Math.PI * k / n));
-            array[k] = evenComponent + twiddleFactor * oddComponent;
-            array[k + n2] = evenComponent - twiddleFactor * oddComponent;
+            Complex even = span[k];
+            Complex odd = span[k + n2];
+            Complex twiddle = Complex.Exp(new Complex(0, -2 * Math.PI * k / n));
+            span[k] = even + twiddle * odd;
+            span[k + n2] = even - twiddle * odd;
         }
+    }
+
+    /// <summary>
+    /// Rearranges <paramref name="span"/> so that even-indexed elements occupy the first half
+    /// and odd-indexed elements occupy the second half.
+    /// </summary>
+    private static void Separate(Span<Complex> span)
+    {
+        int n2 = span.Length >> 1;
+        Complex[] buffer = new Complex[n2];
+        for (int i = 0; i < n2; i++)
+            buffer[i] = span[(i << 1) | 1];
+        for (int i = 0; i < n2; i++)
+            span[i] = span[i << 1];
+        for (int i = 0; i < n2; i++)
+            span[i + n2] = buffer[i];
     }
 }

--- a/Utils.Mathematics/Fourrier/FourrierExtensions.cs
+++ b/Utils.Mathematics/Fourrier/FourrierExtensions.cs
@@ -4,27 +4,57 @@ using System.Numerics;
 namespace Utils.Mathematics.Fourrier;
 
 /// <summary>
-/// Utility extension methods for Fourier related computations.
+/// Utility extension methods for Fourier-related computations.
 /// </summary>
 public static class FourrierExtensions
 {
     /// <summary>
-    /// Gets the frequency represented by each bin of a Fourier transform result.
+    /// Returns the frequency represented by each bin in the first half of a Fourier transform result.
     /// </summary>
     /// <param name="transform">The transform result.</param>
-    /// <param name="sampleRate">Sampling rate in hertz.</param>
-    /// <returns>Array of frequencies in hertz corresponding to each bin.</returns>
+    /// <param name="sampleRate">Sampling rate in hertz. Must be positive.</param>
+    /// <returns>Array of <c>N/2</c> frequencies in hertz, one per bin.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="sampleRate"/> is not positive.
+    /// </exception>
     public static double[] GetFrequencies(this Complex[] transform, double sampleRate)
     {
+        if (sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate), "Sample rate must be positive.");
+
         int length = transform.Length;
         double[] frequencies = new double[length >> 1];
         double step = sampleRate / length;
 
         for (int i = 0; i < frequencies.Length; i++)
-        {
             frequencies[i] = i * step;
-        }
 
         return frequencies;
+    }
+
+    /// <summary>
+    /// Returns the amplitude (magnitude) of each bin in the transform result.
+    /// </summary>
+    /// <param name="transform">The transform result.</param>
+    /// <returns>Array of amplitudes, one per bin.</returns>
+    public static double[] GetAmplitudes(this Complex[] transform)
+    {
+        double[] amplitudes = new double[transform.Length];
+        for (int i = 0; i < transform.Length; i++)
+            amplitudes[i] = transform[i].Magnitude;
+        return amplitudes;
+    }
+
+    /// <summary>
+    /// Returns the phase (argument) in radians of each bin in the transform result.
+    /// </summary>
+    /// <param name="transform">The transform result.</param>
+    /// <returns>Array of phases in radians, one per bin.</returns>
+    public static double[] GetPhases(this Complex[] transform)
+    {
+        double[] phases = new double[transform.Length];
+        for (int i = 0; i < transform.Length; i++)
+            phases[i] = transform[i].Phase;
+        return phases;
     }
 }

--- a/Utils.Mathematics/LinearAlgebra/Line.cs
+++ b/Utils.Mathematics/LinearAlgebra/Line.cs
@@ -8,7 +8,7 @@ namespace Utils.Mathematics.LinearAlgebra;
 /// </summary>
 /// <typeparam name="T">Floating-point type.</typeparam>
 public class Line<T> : IFormattable, IEquatable<Line<T>>, ICloneable
-    where T : struct, IFloatingPoint<T>, IPowerFunctions<T>, ITrigonometricFunctions<T>, IRootFunctions<T>
+    where T : struct, IFloatingPoint<T>, IPowerFunctions<T>, IRootFunctions<T>
 {
     /// <summary>
     /// A point on the line.

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
@@ -123,8 +123,8 @@ public partial class Matrix<T>
             }
         }
 
-        Matrix<T> L = new Matrix<T>(l, false, false, true, null);
-        Matrix<T> U = new Matrix<T>(u, false, false, true, null);
+        Matrix<T> L = new Matrix<T>(l, false, true, false, null);
+        Matrix<T> U = new Matrix<T>(u, false, true, false, null);
         return (L, U);
     }
 

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Constructors.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Constructors.cs
@@ -22,15 +22,15 @@ public sealed partial class Matrix<T>
     /// </summary>
     /// <param name="array">Backing array containing matrix values.</param>
     /// <param name="isIdentity">Indicates whether the matrix is an identity matrix.</param>
-    /// <param name="isDiagonalized">Indicates whether the matrix is diagonalized.</param>
-    /// <param name="isTriangularised">Indicates whether the matrix is triangularized.</param>
+    /// <param name="isTriangular">Indicates whether the matrix is triangular (upper or lower).</param>
+    /// <param name="isDiagonal">Indicates whether the matrix is diagonal (all off-diagonal elements are zero).</param>
     /// <param name="determinant">Precomputed determinant, if available.</param>
-    internal Matrix(T[,] array, bool isIdentity, bool isDiagonalized, bool isTriangularised, T? determinant)
+    internal Matrix(T[,] array, bool isIdentity, bool isTriangular, bool isDiagonal, T? determinant)
     {
         array.Arg().MustNotBeNull();
         this.components = array;
-        this.isDiagonalized = isDiagonalized;
-        this.isTriangularised = isTriangularised;
+        this.isTriangular = isTriangular;
+        this.isDiagonal = isDiagonal;
         this.isIdentity = isIdentity;
         this.determinant = determinant;
     }
@@ -45,9 +45,9 @@ public sealed partial class Matrix<T>
         components = new T[array.GetLength(0), array.GetLength(1)];
         Array.Copy(array, this.components, array.Length);
         var isSquare = IsSquare;
-        isDiagonalized = isSquare ? false : (bool?)null;
-        isTriangularised = isSquare ? false : (bool?)null;
-        isIdentity = isSquare ? false : (bool?)null;
+        isTriangular = isSquare ? (bool?)null : false;
+        isDiagonal = isSquare ? (bool?)null : false;
+        isIdentity = isSquare ? (bool?)null : false;
         determinant = null;
     }
 
@@ -68,8 +68,8 @@ public sealed partial class Matrix<T>
                 components[i, j] = array[i][j];
             }
         }
-        isDiagonalized = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
-        isTriangularised = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
+        isTriangular = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
+        isDiagonal = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
         isIdentity = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
         determinant = null;
     }
@@ -92,8 +92,8 @@ public sealed partial class Matrix<T>
                 components[j, i] = vectors[i][j];
             }
         }
-        isDiagonalized = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
-        isTriangularised = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
+        isTriangular = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
+        isDiagonal = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
         isIdentity = components.GetLength(0) != components.GetLength(1) ? false : (bool?)null;
         determinant = null;
     }
@@ -108,8 +108,8 @@ public sealed partial class Matrix<T>
 
         this.components = new T[matrix.components.GetLength(0), matrix.components.GetLength(1)];
         Array.Copy(matrix.components, this.components, matrix.components.Length);
-        this.isDiagonalized = matrix.isDiagonalized;
-        this.isTriangularised = matrix.isTriangularised;
+        this.isTriangular = matrix.isTriangular;
+        this.isDiagonal = matrix.isDiagonal;
         this.isIdentity = matrix.isIdentity;
         this.determinant = matrix.determinant;
     }

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Factories.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Factories.cs
@@ -17,7 +17,7 @@ public sealed partial class Matrix<T>
         var array = new T[size, size];
         for (int i = 0; i < size; i++)
             array[i, i] = T.One;
-        return new Matrix<T>(array, isIdentity: true, isDiagonalized: true, isTriangularised: true, determinant: T.One);
+        return new Matrix<T>(array, isIdentity: true, isTriangular: true, isDiagonal: true, determinant: T.One);
     }
 
     /// <summary>
@@ -43,14 +43,13 @@ public sealed partial class Matrix<T>
         var array = new T[n, n];
         T det = T.One;
         bool isIdentity = true;
-        bool hasZero = false;
         for (int i = 0; i < n; i++)
         {
             array[i, i] = values[i];
             det *= values[i];
-            if (values[i] == T.Zero) { hasZero = true; isIdentity = false; }
-            else if (values[i] != T.One) isIdentity = false;
+            if (values[i] != T.One) isIdentity = false;
         }
-        return new Matrix<T>(array, isIdentity: isIdentity, isDiagonalized: !hasZero, isTriangularised: !hasZero, determinant: det);
+        // A diagonal matrix is always triangular and diagonal regardless of zero entries on the diagonal.
+        return new Matrix<T>(array, isIdentity: isIdentity, isTriangular: true, isDiagonal: true, determinant: det);
     }
 }

--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -13,8 +13,8 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
         where T : struct, IFloatingPoint<T>, IRootFunctions<T>
 {
     private readonly T[,] components;
-    private bool? isDiagonalized;
-    private bool? isTriangularised;
+    private bool? isTriangular;
+    private bool? isDiagonal;
     private bool? isIdentity;
     private T? determinant;
     private int? hashCode;
@@ -43,15 +43,15 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     public T this[int row, int col] => components[row, col];
 
     /// <summary>
-    /// Determines if the matrix is triangular, diagonal, or identity.
+    /// Lazily determines whether the matrix is triangular, diagonal, or identity.
     /// </summary>
-    private void DetermineTriangularisedAndDiagonalized()
+    private void DetermineStructuralFlags()
     {
-        if (isTriangularised is not null && isDiagonalized is not null && isIdentity is not null) return;
+        if (isTriangular is not null && isDiagonal is not null && isIdentity is not null) return;
         if (!IsSquare)
         {
-            isDiagonalized = false;
-            isTriangularised = false;
+            isDiagonal = false;
+            isTriangular = false;
             isIdentity = false;
             return;
         }
@@ -65,19 +65,8 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
         {
             for (int col = 0; col < dimension; col++)
             {
-                if (row == col)
-                {
-                    if (components[row, col] == T.Zero)
-                    {
-                        isDiagonalized = false;
-                        isTriangularised = false;
-                        return;
-                    }
-                    else if (components[row, col] != T.One)
-                    {
-                        identityCheck = false;
-                    }
-                }
+                if (row == col && components[row, col] != T.One)
+                    identityCheck = false;
 
                 if (components[row, col] != T.Zero)
                 {
@@ -91,32 +80,33 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
             if (!upperTriangular && !lowerTriangular) break;
         }
 
-        isDiagonalized = upperTriangular || lowerTriangular;
-        isTriangularised = upperTriangular && lowerTriangular;
-        isIdentity = isDiagonalized.Value && identityCheck;
+        isTriangular = upperTriangular || lowerTriangular;
+        isDiagonal = upperTriangular && lowerTriangular;
+        // Identity requires diagonal structure (all off-diagonal = 0) and all diagonal = 1.
+        isIdentity = isDiagonal.Value && identityCheck;
     }
 
     /// <summary>
-    /// Indicates if the matrix is triangular.
+    /// Indicates whether the matrix is triangular (upper or lower).
     /// </summary>
-    public bool IsTriangularised
+    public bool IsTriangular
     {
         get
         {
-            DetermineTriangularisedAndDiagonalized();
-            return isTriangularised ?? false;
+            DetermineStructuralFlags();
+            return isTriangular ?? false;
         }
     }
 
     /// <summary>
-    /// Indicates if the matrix is diagonal.
+    /// Indicates whether the matrix is diagonal (all off-diagonal elements are zero).
     /// </summary>
-    public bool IsDiagonalized
+    public bool IsDiagonal
     {
         get
         {
-            DetermineTriangularisedAndDiagonalized();
-            return isDiagonalized ?? false;
+            DetermineStructuralFlags();
+            return isDiagonal ?? false;
         }
     }
 
@@ -127,7 +117,7 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     {
         get
         {
-            DetermineTriangularisedAndDiagonalized();
+            DetermineStructuralFlags();
             return isIdentity ?? false;
         }
     }
@@ -173,6 +163,51 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     }
 
     /// <summary>
+    /// Returns the transpose of this matrix (rows and columns swapped).
+    /// </summary>
+    /// <returns>A new <see cref="Matrix{T}"/> with dimensions <c>Columns × Rows</c>.</returns>
+    public Matrix<T> Transpose()
+    {
+        var result = new T[Columns, Rows];
+        for (int row = 0; row < Rows; row++)
+            for (int col = 0; col < Columns; col++)
+                result[col, row] = components[row, col];
+        return new Matrix<T>(result);
+    }
+
+    /// <summary>
+    /// Returns the specified row as a vector.
+    /// </summary>
+    /// <param name="row">Zero-based row index.</param>
+    /// <returns>A new <see cref="Vector{T}"/> containing the row elements.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="row"/> is out of range.</exception>
+    public Vector<T> GetRow(int row)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(row);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(row, Rows);
+        T[] result = new T[Columns];
+        for (int col = 0; col < Columns; col++)
+            result[col] = components[row, col];
+        return new Vector<T>(result);
+    }
+
+    /// <summary>
+    /// Returns the specified column as a vector.
+    /// </summary>
+    /// <param name="col">Zero-based column index.</param>
+    /// <returns>A new <see cref="Vector{T}"/> containing the column elements.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="col"/> is out of range.</exception>
+    public Vector<T> GetColumn(int col)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(col);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(col, Columns);
+        T[] result = new T[Rows];
+        for (int row = 0; row < Rows; row++)
+            result[row] = components[row, col];
+        return new Vector<T>(result);
+    }
+
+    /// <summary>
     /// Gets the determinant of the matrix.
     /// </summary>
     public T Determinant
@@ -192,17 +227,41 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
 
     private T ComputeDeterminant()
     {
-        var (_, U) = DiagonalizeLU();
+        int n = Rows;
+        T[,] u = ToArray();
+        int swaps = 0;
 
-        T determinant = -T.One;
-
-        // Calculate the product of the diagonal elements of U to get the determinant
-        for (int i = 0; i < U.Rows; i++)
+        for (int k = 0; k < n; k++)
         {
-            determinant *= U[i, i];
+            int pivotRow = k;
+            for (int i = k + 1; i < n; i++)
+            {
+                if (T.Abs(u[i, k]) > T.Abs(u[pivotRow, k]))
+                    pivotRow = i;
+            }
+
+            if (u[pivotRow, k].Equals(T.Zero))
+                return T.Zero;
+
+            if (pivotRow != k)
+            {
+                PermuteRows(u, k, pivotRow);
+                swaps++;
+            }
+
+            for (int row = k + 1; row < n; row++)
+            {
+                T factor = u[row, k] / u[k, k];
+                for (int col = k; col < n; col++)
+                    u[row, col] -= factor * u[k, col];
+            }
         }
 
-        return determinant;
+        // Each row swap inverts the sign of the determinant.
+        T det = (swaps % 2 == 0) ? T.One : -T.One;
+        for (int i = 0; i < n; i++)
+            det *= u[i, i];
+        return det;
     }
 
 

--- a/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
@@ -56,7 +56,7 @@ public partial class Vector<T> :
     /// <param name="getVector">Function to extract the vector from the point.</param>
     /// <param name="weightedPoints">Collection of weighted points.</param>
     /// <returns>The total weight and the barycenter vector.</returns>
-    public static (T weigth, Vector<T> point) ComputeBarycenter<TW>(Func<TW, T> getWeight, Func<TW, Vector<T>> getVector, params TW[] weightedPoints)
+    public static (T weight, Vector<T> point) ComputeBarycenter<TW>(Func<TW, T> getWeight, Func<TW, Vector<T>> getVector, params TW[] weightedPoints)
         => ComputeBarycenter(getWeight, getVector, (IEnumerable<TW>)weightedPoints);
 
     /// <summary>
@@ -67,7 +67,7 @@ public partial class Vector<T> :
     /// <param name="getVector">Function to extract the vector from the point.</param>
     /// <param name="weightedPoints">Collection of weighted points.</param>
     /// <returns>The total weight and the barycenter vector.</returns>
-    public static (T weigth, Vector<T> point) ComputeBarycenter<TW>(Func<TW, T> getWeight, Func<TW, Vector<T>> getVector, IEnumerable<TW> weightedPoints)
+    public static (T weight, Vector<T> point) ComputeBarycenter<TW>(Func<TW, T> getWeight, Func<TW, Vector<T>> getVector, IEnumerable<TW> weightedPoints)
     {
         using var enumerator = weightedPoints.GetEnumerator();
         if (!enumerator.MoveNext()) throw new ArgumentException("At least one point is required", nameof(weightedPoints));

--- a/Utils.Mathematics/LinearAlgebra/Vector.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.cs
@@ -96,7 +96,7 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     public override bool Equals(object? obj) => obj switch
     {
         Vector<T> v => Equals(v),
-        double[] a => Equals(a),
+        T[] a => Equals(a),
         _ => false,
     };
 
@@ -219,6 +219,23 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
             sign = -sign;
         }
         return result;
+    }
+
+    /// <summary>
+    /// Projects this vector onto <paramref name="other"/>.
+    /// </summary>
+    /// <param name="other">The vector to project onto. Must be non-zero.</param>
+    /// <returns>The projection of this vector in the direction of <paramref name="other"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when the vectors have different dimensions.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="other"/> is the zero vector.</exception>
+    public Vector<T> ProjectOnto(Vector<T> other)
+    {
+        if (Dimension != other.Dimension)
+            throw new ArgumentException("Vectors must have the same dimension.", nameof(other));
+        T denominator = other * other;
+        if (denominator == T.Zero)
+            throw new InvalidOperationException("Cannot project onto the zero vector.");
+        return ((this * other) / denominator) * other;
     }
 
     /// <summary>

--- a/Utils.Mathematics/LinearAlgebra/VectorExtensions.cs
+++ b/Utils.Mathematics/LinearAlgebra/VectorExtensions.cs
@@ -1,0 +1,34 @@
+using System.Numerics;
+
+namespace Utils.Mathematics.LinearAlgebra;
+
+/// <summary>
+/// Extension methods for <see cref="Vector{T}"/> that require trigonometric capabilities.
+/// </summary>
+public static class VectorExtensions
+{
+    /// <summary>
+    /// Returns the angle in radians between this vector and <paramref name="other"/>.
+    /// </summary>
+    /// <typeparam name="T">Numeric component type.</typeparam>
+    /// <param name="self">This vector.</param>
+    /// <param name="other">The other vector. Must have the same dimension.</param>
+    /// <returns>The angle in radians in the range [0, π].</returns>
+    /// <exception cref="ArgumentException">Thrown when the vectors have different dimensions.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when either vector is a zero vector.</exception>
+    public static T AngleWith<T>(this Vector<T> self, Vector<T> other)
+        where T : struct, IFloatingPoint<T>, IRootFunctions<T>, ITrigonometricFunctions<T>
+    {
+        if (self.Dimension != other.Dimension)
+            throw new ArgumentException("Vectors must have the same dimension.", nameof(other));
+
+        T normProduct = self.Norm * other.Norm;
+        if (normProduct == T.Zero)
+            throw new InvalidOperationException("Cannot compute the angle with a zero vector.");
+
+        T cosAngle = (self * other) / normProduct;
+        // Guard against floating-point drift outside [-1, 1].
+        cosAngle = T.Clamp(cosAngle, -T.One, T.One);
+        return T.Acos(cosAngle);
+    }
+}

--- a/Utils/Mathematics/IAngleCalculator.cs
+++ b/Utils/Mathematics/IAngleCalculator.cs
@@ -611,15 +611,6 @@ public class Trigonometry<T> : IAngleCalculator<T>
         public override T Acot2(T x, T y) => T.Atan2(y, x);
 
         /// <summary>
-        /// Normalizes an angle into the range [-π, +π).
-        /// </summary>
-        public override T NormalizeMinToMax(T angle)
-        {
-            // Equivalent to angle mod 2π in [-π, π).
-            return MathEx.Mod(angle + T.Pi + T.Pi, (T.Pi + T.Pi)) - T.Pi;
-        }
-
-        /// <summary>
         /// Normalizes an angle into the range [0, 2π).
         /// </summary>
         public override T Normalize0To2Max(T angle)

--- a/Utils/Mathematics/IAngleCalculator.cs
+++ b/Utils/Mathematics/IAngleCalculator.cs
@@ -296,8 +296,14 @@ public class Trigonometry<T> : IAngleCalculator<T>
 
     #endregion
 
-    // Precomputed once per T; avoids calling T.Pow on every inverse-trig call.
-    private static readonly T _invTrigPrecision = T.Pow(T.CreateChecked(10), T.CreateChecked(-10));
+    // Rounding step for inverse-trig output: max(1e-10, 100 × machine_epsilon).
+    // The 1e-10 floor preserves existing double behavior (where machine_epsilon ≈ 2.2e-16,
+    // so 100×ε ≈ 2.2e-14 < 1e-10 and the floor wins).
+    // For types with coarser precision such as float (machine_epsilon ≈ 1.2e-7),
+    // 100×ε ≈ 1.2e-5 exceeds 1e-10 and the adapted value is used instead.
+    private static readonly T _invTrigPrecision = T.Max(
+        T.Pow(T.CreateChecked(10), T.CreateChecked(-10)),
+        T.CreateChecked(100) * (T.BitIncrement(T.One) - T.One));
 
     #region Constructors
 

--- a/Utils/Mathematics/MathEx.cs
+++ b/Utils/Mathematics/MathEx.cs
@@ -112,6 +112,20 @@ public static class MathEx
 
     #endregion
 
+    #region IsPowerOfTwo
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="value"/> is a positive power of two (1, 2, 4, 8, …).
+    /// </summary>
+    /// <typeparam name="T">A binary integer type.</typeparam>
+    /// <param name="value">Value to test.</param>
+    /// <returns><see langword="true"/> if <paramref name="value"/> is a positive integer of the form 2<sup>n</sup>.</returns>
+    public static bool IsPowerOfTwo<T>(T value)
+        where T : struct, IBinaryInteger<T>
+        => value > T.Zero && (value & (value - T.One)) == T.Zero;
+
+    #endregion
+
     #region GCD / LCM
 
     /// <summary>
@@ -196,6 +210,24 @@ public static class MathEx
         T floorValue = Floor(value, step);
         return floorValue == value ? value : floorValue + step;
     }
+
+    #endregion
+
+    #region Lerp
+
+    /// <summary>
+    /// Linearly interpolates between <paramref name="a"/> and <paramref name="b"/> by factor <paramref name="t"/>.
+    /// When <paramref name="t"/> is 0 the result equals <paramref name="a"/>; when 1, it equals <paramref name="b"/>.
+    /// Values of <paramref name="t"/> outside [0, 1] extrapolate beyond the segment.
+    /// </summary>
+    /// <typeparam name="T">A floating-point type.</typeparam>
+    /// <param name="a">Start value.</param>
+    /// <param name="b">End value.</param>
+    /// <param name="t">Interpolation factor.</param>
+    /// <returns>The interpolated value <c>a + t * (b − a)</c>.</returns>
+    public static T Lerp<T>(T a, T b, T t)
+        where T : struct, IFloatingPoint<T>
+        => a + t * (b - a);
 
     #endregion
 

--- a/Utils/Mathematics/MathEx.cs
+++ b/Utils/Mathematics/MathEx.cs
@@ -51,32 +51,27 @@ public static class MathEx
     #region Round
 
     /// <summary>
-    /// Rounds <paramref name="value"/> to the nearest multiple of <paramref name="base"/>.
+    /// Rounds <paramref name="value"/> to the nearest multiple of <paramref name="step"/>.
     /// If <paramref name="value"/> is exactly between two multiples, it is rounded up.
     /// </summary>
     /// <typeparam name="T">A numeric type supporting modulus and comparison operators.</typeparam>
     /// <param name="value">Value to be rounded.</param>
-    /// <param name="base">Rounding base. Must be non-zero.</param>
-    /// <returns>The value of <paramref name="value"/> rounded to the nearest multiple of <paramref name="base"/>.</returns>
-    /// <exception cref="DivideByZeroException">Thrown if <paramref name="base"/> equals zero.</exception>
-    public static T Round<T>(T value, T @base)
+    /// <param name="step">Rounding step. Must be non-zero.</param>
+    /// <returns>The value of <paramref name="value"/> rounded to the nearest multiple of <paramref name="step"/>.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if <paramref name="step"/> equals zero.</exception>
+    public static T Round<T>(T value, T step)
         where T : struct, INumber<T>
     {
-        if (@base == T.Zero)
-            throw new DivideByZeroException("Base must be non-zero for rounding.");
+        if (step == T.Zero)
+            throw new DivideByZeroException("Step must be non-zero for rounding.");
 
-        T middle = @base / (T.One + T.One);
-        T remainder = Mod(value, @base);
+        T middle = step / (T.One + T.One);
+        T remainder = Mod(value, step);
 
-        // If the remainder is less than half of the base, round down; otherwise, round up.
         if (remainder < middle)
-        {
             return value - remainder;
-        }
         else
-        {
-            return value - remainder + @base;
-        }
+            return value - remainder + step;
     }
 
     /// <summary>
@@ -85,14 +80,13 @@ public static class MathEx
     /// </summary>
     /// <typeparam name="T">A numeric type that supports exponentiation via <see cref="IPowerFunctions{TSelf}"/>.</typeparam>
     /// <param name="value">Value to be rounded.</param>
-    /// <param name="exponent">The exponent of 10 used as the rounding base. Defaults to 0 (which rounds to integer).</param>
+    /// <param name="exponent">The exponent of 10 used as the rounding step. Defaults to 0 (which rounds to integer).</param>
     /// <returns>A value rounded to the nearest power-of-ten multiple.</returns>
     public static T Round<T>(T value, int exponent = 0)
         where T : struct, INumber<T>, IPowerFunctions<T>
     {
-        T @base = T.Pow(T.CreateChecked(10), T.CreateChecked(exponent));
-
-        return Round(value, @base);
+        T step = T.Pow(T.CreateChecked(10), T.CreateChecked(exponent));
+        return Round(value, step);
     }
 
     #endregion

--- a/Utils/Mathematics/MathEx.cs
+++ b/Utils/Mathematics/MathEx.cs
@@ -158,20 +158,20 @@ public static class MathEx
     #region Floor
 
     /// <summary>
-    /// Computes the greatest multiple of <paramref name="base"/> that is less than or equal to <paramref name="value"/>.
+    /// Computes the greatest multiple of <paramref name="step"/> that is less than or equal to <paramref name="value"/>.
     /// </summary>
     /// <typeparam name="T">A numeric type supporting modulus and basic arithmetic operators.</typeparam>
     /// <param name="value">The value for which to find the floor multiple.</param>
-    /// <param name="base">The base multiple. Must be non-zero.</param>
-    /// <returns>The greatest multiple of <paramref name="base"/> that is &lt;= <paramref name="value"/>.</returns>
-    /// <exception cref="DivideByZeroException">Thrown if <paramref name="base"/> equals zero.</exception>
-    public static T Floor<T>(T value, T @base)
+    /// <param name="step">The step. Must be non-zero.</param>
+    /// <returns>The greatest multiple of <paramref name="step"/> that is &lt;= <paramref name="value"/>.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if <paramref name="step"/> equals zero.</exception>
+    public static T Floor<T>(T value, T step)
         where T : struct, IModulusOperators<T, T, T>, INumberBase<T>
     {
-        if (@base == T.Zero)
-            throw new DivideByZeroException("Base must be non-zero for floor operation.");
+        if (step == T.Zero)
+            throw new DivideByZeroException("Step must be non-zero for floor operation.");
 
-        T correction = Mod(value, @base);
+        T correction = Mod(value, step);
         return value - correction;
     }
 
@@ -180,21 +180,21 @@ public static class MathEx
     #region Ceiling
 
     /// <summary>
-    /// Computes the smallest multiple of <paramref name="base"/> that is greater than or equal to <paramref name="value"/>.
+    /// Computes the smallest multiple of <paramref name="step"/> that is greater than or equal to <paramref name="value"/>.
     /// </summary>
     /// <typeparam name="T">A numeric type supporting modulus and basic arithmetic operators.</typeparam>
     /// <param name="value">The value for which to find the ceiling multiple.</param>
-    /// <param name="base">The base multiple. Must be non-zero.</param>
-    /// <returns>The smallest multiple of <paramref name="base"/> that is &gt;= <paramref name="value"/>.</returns>
-    /// <exception cref="DivideByZeroException">Thrown if <paramref name="base"/> equals zero.</exception>
-    public static T Ceiling<T>(T value, T @base)
+    /// <param name="step">The step. Must be non-zero.</param>
+    /// <returns>The smallest multiple of <paramref name="step"/> that is &gt;= <paramref name="value"/>.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if <paramref name="step"/> equals zero.</exception>
+    public static T Ceiling<T>(T value, T step)
         where T : struct, IModulusOperators<T, T, T>, INumberBase<T>
     {
-        if (@base == T.Zero)
-            throw new DivideByZeroException("Base must be non-zero for ceiling operation.");
+        if (step == T.Zero)
+            throw new DivideByZeroException("Step must be non-zero for ceiling operation.");
 
-        T floorValue = Floor(value, @base);
-        return floorValue == value ? value : floorValue + @base;
+        T floorValue = Floor(value, step);
+        return floorValue == value ? value : floorValue + step;
     }
 
     #endregion
@@ -371,43 +371,45 @@ public static class MathEx
 
     /// <summary>
     /// Computes and returns the specified line of Pascal's triangle, zero-based.
-    /// Uses a cached dictionary for performance. 
+    /// Uses a cached dictionary for performance.
     /// If the line is not in the cache, it is calculated and then stored.
     /// </summary>
     /// <param name="lineNumber">Zero-based index of the line to compute. Must be &gt;= 0.</param>
     /// <returns>An array representing the requested line of Pascal's triangle.</returns>
     /// <remarks>
     /// The function updates the cache dynamically up to <paramref name="lineNumber"/>.
-    /// Note that this static cache is not thread-safe; use locking if multiple threads will access it concurrently.
     /// </remarks>
     public static int[] ComputePascalTriangleLine(int lineNumber)
     {
         lineNumber.ArgMustBeGreaterOrEqualsThan(0);
 
-        // Return if it is already in the cache
-        if (pascalTriangleCache.TryGetValue(lineNumber, out var pascalTriangleLine))
+        lock (pascalTriangleCache)
         {
-            return pascalTriangleLine;
-        }
-
-        // Keys are always 0..n consecutive; Count-1 is the highest without scanning all keys.
-        int maxLine = pascalTriangleCache.Count - 1;
-        int[] lastLine = pascalTriangleCache[maxLine];
-
-        for (int i = maxLine + 1; i <= lineNumber; i++)
-        {
-            var newLine = new int[i + 1];
-            newLine[0] = 1;
-            for (int j = 1; j < i; j++)
+            // Return if it is already in the cache
+            if (pascalTriangleCache.TryGetValue(lineNumber, out var pascalTriangleLine))
             {
-                newLine[j] = lastLine[j - 1] + lastLine[j];
+                return pascalTriangleLine;
             }
-            newLine[^1] = 1;
 
-            pascalTriangleCache[i] = newLine;
-            lastLine = newLine;
+            // Keys are always 0..n consecutive; Count-1 is the highest without scanning all keys.
+            int maxLine = pascalTriangleCache.Count - 1;
+            int[] lastLine = pascalTriangleCache[maxLine];
+
+            for (int i = maxLine + 1; i <= lineNumber; i++)
+            {
+                var newLine = new int[i + 1];
+                newLine[0] = 1;
+                for (int j = 1; j < i; j++)
+                {
+                    newLine[j] = lastLine[j - 1] + lastLine[j];
+                }
+                newLine[^1] = 1;
+
+                pascalTriangleCache[i] = newLine;
+                lastLine = newLine;
+            }
+
+            return lastLine;
         }
-
-        return lastLine;
     }
 }

--- a/Utils/Mathematics/MathEx.cs
+++ b/Utils/Mathematics/MathEx.cs
@@ -91,6 +91,70 @@ public static class MathEx
 
     #endregion
 
+    #region IsMultipleOf
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="value"/> is an exact multiple of <paramref name="step"/>,
+    /// i.e., <c>Mod(value, step) == 0</c>.
+    /// </summary>
+    /// <typeparam name="T">A numeric type supporting modulus, addition, and equality operators.</typeparam>
+    /// <param name="value">Value to test.</param>
+    /// <param name="step">The divisor. Must be non-zero.</param>
+    /// <returns><see langword="true"/> if <paramref name="value"/> is divisible by <paramref name="step"/>.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if <paramref name="step"/> equals zero.</exception>
+    public static bool IsMultipleOf<T>(T value, T step)
+        where T : struct, INumber<T>
+    {
+        if (step == T.Zero)
+            throw new DivideByZeroException("Step must be non-zero.");
+        return Mod(value, step) == T.Zero;
+    }
+
+    #endregion
+
+    #region GCD / LCM
+
+    /// <summary>
+    /// Computes the greatest common divisor of <paramref name="a"/> and <paramref name="b"/>
+    /// using the Euclidean algorithm. Always returns a non-negative value.
+    /// Returns zero when both arguments are zero.
+    /// </summary>
+    /// <typeparam name="T">An integer type supporting modulus and absolute-value operations.</typeparam>
+    /// <param name="a">First value.</param>
+    /// <param name="b">Second value.</param>
+    /// <returns>The greatest common divisor of <paramref name="a"/> and <paramref name="b"/>.</returns>
+    public static T Gcd<T>(T a, T b)
+        where T : struct, IBinaryInteger<T>
+    {
+        a = T.Abs(a);
+        b = T.Abs(b);
+        while (b != T.Zero)
+        {
+            T t = b;
+            b = a % b;
+            a = t;
+        }
+        return a;
+    }
+
+    /// <summary>
+    /// Computes the least common multiple of <paramref name="a"/> and <paramref name="b"/>.
+    /// Returns zero if either argument is zero.
+    /// </summary>
+    /// <typeparam name="T">An integer type supporting modulus and absolute-value operations.</typeparam>
+    /// <param name="a">First value.</param>
+    /// <param name="b">Second value.</param>
+    /// <returns>The least common multiple of <paramref name="a"/> and <paramref name="b"/>.</returns>
+    public static T Lcm<T>(T a, T b)
+        where T : struct, IBinaryInteger<T>
+    {
+        if (a == T.Zero || b == T.Zero) return T.Zero;
+        // Divide before multiply to reduce overflow risk.
+        return T.Abs(a / Gcd(a, b) * b);
+    }
+
+    #endregion
+
     #region Floor
 
     /// <summary>

--- a/Utils/Mathematics/NullableIntEx.cs
+++ b/Utils/Mathematics/NullableIntEx.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 
 namespace Utils.Mathematics;
 
@@ -11,30 +11,50 @@ public static class NullableIntEx
     #region Utilities for Endpoints
 
     /// <summary>
-    /// Minimum of two endpoints, taking null as -∞ if <paramref name="isMin"/> is true.
+    /// Returns the minimum of two start endpoints where <see langword="null"/> represents −∞.
+    /// If either argument is <see langword="null"/>, the result is <see langword="null"/> (−∞ wins).
     /// </summary>
-    public static T? Min<T>(T? a, T? b, bool isMin)
+    public static T? MinStartpoint<T>(T? a, T? b)
         where T : struct, IBinaryInteger<T>
     {
-        // isMin=true  => null means -∞: min(-∞, x) = -∞ → return null
-        // isMin=false => null means +∞: min(+∞, x) = x  → return the finite side
-        if (!a.HasValue && !b.HasValue) return null;
-        if (!a.HasValue) return isMin ? a : b;
-        if (!b.HasValue) return isMin ? b : a;
+        if (!a.HasValue || !b.HasValue) return null;
         return T.Min(a.Value, b.Value);
     }
 
     /// <summary>
-    /// Maximum of two endpoints, taking null as +∞ if <paramref name="isMax"/> is true.
+    /// Returns the minimum of two end endpoints where <see langword="null"/> represents +∞.
+    /// If only one argument is <see langword="null"/>, the finite value wins.
     /// </summary>
-    public static T? Max<T>(T? a, T? b, bool isMax)
+    public static T? MinEndpoint<T>(T? a, T? b)
         where T : struct, IBinaryInteger<T>
     {
-        // isMax=true  => null means +∞: max(+∞, x) = +∞ → return null
-        // isMax=false => null means -∞: max(-∞, x) = x  → return the finite side
         if (!a.HasValue && !b.HasValue) return null;
-        if (!a.HasValue) return isMax ? a : b;
-        if (!b.HasValue) return isMax ? b : a;
+        if (!a.HasValue) return b;
+        if (!b.HasValue) return a;
+        return T.Min(a.Value, b.Value);
+    }
+
+    /// <summary>
+    /// Returns the maximum of two start endpoints where <see langword="null"/> represents −∞.
+    /// If only one argument is <see langword="null"/>, the finite value wins.
+    /// </summary>
+    public static T? MaxStartpoint<T>(T? a, T? b)
+        where T : struct, IBinaryInteger<T>
+    {
+        if (!a.HasValue && !b.HasValue) return null;
+        if (!a.HasValue) return b;
+        if (!b.HasValue) return a;
+        return T.Max(a.Value, b.Value);
+    }
+
+    /// <summary>
+    /// Returns the maximum of two end endpoints where <see langword="null"/> represents +∞.
+    /// If either argument is <see langword="null"/>, the result is <see langword="null"/> (+∞ wins).
+    /// </summary>
+    public static T? MaxEndpoint<T>(T? a, T? b)
+        where T : struct, IBinaryInteger<T>
+    {
+        if (!a.HasValue || !b.HasValue) return null;
         return T.Max(a.Value, b.Value);
     }
 
@@ -176,27 +196,9 @@ public static class NullableIntEx
     public static T? Parse<T>(string token, IFormatProvider formatProvider)
         where T : struct, IBinaryInteger<T>, IComparable<T>, IParsable<T>
     {
-        // If "∞" => null => means -∞ if isStart, +∞ if not isStart
-        // but let's keep it simpler: by convention,
-        // "∞" always => null,
-        // we'll interpret it in the range logic as -∞ or +∞ as needed
-        // based on whether it's Minimum or Maximum.
-        // The 'SimpleRange' logic handles that in comparisons.
-        //
-        // Alternatively, you could parse "∞" => null for maximum,
-        // and "∞" => some special negative?
-        // But let's keep it uniform: "∞" => null,
-        // the usage context is in a SimpleRange constructor
-        // which sets Minimum or Maximum.
-        // If Minimum = null => that indicates -∞,
-        // if Maximum = null => that indicates +∞.
-
         if (token == "∞" || token == "inf")
-        {
-            return null; // interpret as infinity
-        }
+            return null;
 
-        // else parse as int
         return T.Parse(token, formatProvider);
     }
 }

--- a/Utils/Mathematics/NullableIntEx.cs
+++ b/Utils/Mathematics/NullableIntEx.cs
@@ -86,7 +86,7 @@ public static class NullableIntEx
     /// <summary>
     /// Compares a &gt;= b. Null =&gt; +∞ is always &gt;= any finite.
     /// </summary>
-    public static bool GreaterOrEqual<T>(T? a, T? b)
+    public static bool GreaterOrEqual<T>(this T? a, T? b)
         where T : struct, IBinaryInteger<T>, IComparable<T>
     {
         // a >= b => b <= a

--- a/Utils/Mathematics/NullableIntEx.cs
+++ b/Utils/Mathematics/NullableIntEx.cs
@@ -140,35 +140,36 @@ public static class NullableIntEx
     }
 
     /// <summary>
-    /// A specialized compare for intersection checks
-    /// (start &lt;= end).
-    /// If isMinForComparison =&gt; treat null as -∞ for 'start'
-    /// else treat null as +∞ for 'end'.
-    ///
-    /// This is an attempt to unify a compare approach, but keep in mind
-    /// logic can get subtle with infinite endpoints.
+    /// Compares two startpoint values where <see langword="null"/> represents −∞.
+    /// Returns a negative value if <paramref name="left"/> &lt; <paramref name="right"/>,
+    /// zero if equal, and a positive value if <paramref name="left"/> &gt; <paramref name="right"/>.
     /// </summary>
-    public static int Compare<T>(T? left, T? right, bool isMinForComparison)
+    /// <typeparam name="T">The numeric type.</typeparam>
+    /// <param name="left">The left startpoint; <see langword="null"/> means −∞.</param>
+    /// <param name="right">The right startpoint; <see langword="null"/> means −∞.</param>
+    public static int CompareStartpoint<T>(T? left, T? right)
         where T : struct, IBinaryInteger<T>, IComparable<T>
     {
-        // If both are null => they represent the same ∞ => 0
         if (!left.HasValue && !right.HasValue) return 0;
+        if (!left.HasValue) return -1;  // −∞ < any finite
+        if (!right.HasValue) return 1;  // any finite > −∞
+        return left.Value.CompareTo(right.Value);
+    }
 
-        // If left is null => either -∞ or +∞
-        if (!left.HasValue)
-        {
-            // If isMinForComparison => left = -∞ => definitely less than or equal to any right
-            // => negative
-            // If not => left = +∞ => definitely greater than any finite => positive
-            return isMinForComparison ? -1 : 1;
-        }
-        // If right is null => similarly
-        if (!right.HasValue)
-        {
-            return isMinForComparison ? 1 : -1;
-        }
-
-        // Both finite
+    /// <summary>
+    /// Compares two endpoint values where <see langword="null"/> represents +∞.
+    /// Returns a negative value if <paramref name="left"/> &lt; <paramref name="right"/>,
+    /// zero if equal, and a positive value if <paramref name="left"/> &gt; <paramref name="right"/>.
+    /// </summary>
+    /// <typeparam name="T">The numeric type.</typeparam>
+    /// <param name="left">The left endpoint; <see langword="null"/> means +∞.</param>
+    /// <param name="right">The right endpoint; <see langword="null"/> means +∞.</param>
+    public static int CompareEndpoint<T>(T? left, T? right)
+        where T : struct, IBinaryInteger<T>, IComparable<T>
+    {
+        if (!left.HasValue && !right.HasValue) return 0;
+        if (!left.HasValue) return 1;   // +∞ > any finite
+        if (!right.HasValue) return -1; // any finite < +∞
         return left.Value.CompareTo(right.Value);
     }
 

--- a/Utils/Mathematics/NumberComparer.cs
+++ b/Utils/Mathematics/NumberComparer.cs
@@ -18,6 +18,26 @@ public class FloatingPointComparer<T> : IComparer<T>, IEqualityComparer<T>
     /// </summary>
     public T Interval { get; }
 
+    private static readonly Dictionary<int, FloatingPointComparer<T>> _precisionCache = [];
+
+    /// <summary>
+    /// Returns a cached <see cref="FloatingPointComparer{T}"/> for the specified decimal <paramref name="precision"/>.
+    /// Repeated calls with the same precision return the same instance.
+    /// </summary>
+    /// <param name="precision">The number of decimal places that must match.</param>
+    public static FloatingPointComparer<T> ForPrecision(int precision)
+    {
+        lock (_precisionCache)
+        {
+            if (!_precisionCache.TryGetValue(precision, out var comparer))
+            {
+                comparer = new FloatingPointComparer<T>(precision);
+                _precisionCache[precision] = comparer;
+            }
+            return comparer;
+        }
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="FloatingPointComparer{T}"/> class using a decimal precision.
     /// </summary>

--- a/Utils/Mathematics/NumberComparer.cs
+++ b/Utils/Mathematics/NumberComparer.cs
@@ -8,6 +8,12 @@ namespace Utils.Mathematics;
 /// Provides floating-point comparisons that allow for small deviations using a configurable interval.
 /// Implements only <see cref="IComparer{T}"/>: fuzzy equality cannot be used for hashing.
 /// </summary>
+/// <remarks>
+/// This comparer is intentionally non-transitive: two values that are each within <see cref="Interval"/>
+/// of a middle value may not be within <see cref="Interval"/> of each other.
+/// Do not use with <see cref="SortedSet{T}"/>, <see cref="SortedDictionary{TKey, TValue}"/>,
+/// or any algorithm that requires a total strict order.
+/// </remarks>
 [DebuggerDisplay("FloatingPointComparer (±{Interval})")]
 public class FloatingPointComparer<T> : IComparer<T>
     where
@@ -56,7 +62,16 @@ public class FloatingPointComparer<T> : IComparer<T>
         Interval = interval;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Compares two values, treating them as equal when their absolute difference is at most <see cref="Interval"/>.
+    /// </summary>
+    /// <returns>
+    /// 0 when <c>|x − y| ≤ <see cref="Interval"/></c>; otherwise the sign of <c>x − y</c>.
+    /// </returns>
+    /// <remarks>
+    /// Because this uses a tolerance zone, the ordering is not transitive:
+    /// <c>Compare(a, b) == 0</c> and <c>Compare(b, c) == 0</c> do not imply <c>Compare(a, c) == 0</c>.
+    /// </remarks>
     public int Compare(T x, T y)
     {
         if (T.Abs(x - y) <= Interval)

--- a/Utils/Mathematics/NumberComparer.cs
+++ b/Utils/Mathematics/NumberComparer.cs
@@ -37,7 +37,12 @@ public class FloatingPointComparer<T> : IComparer<T>, IEqualityComparer<T>
     }
 
     /// <inheritdoc />
-    public int Compare(T x, T y) => x.CompareTo(y);
+    public int Compare(T x, T y)
+    {
+        if (T.Abs(x - y) <= Interval)
+            return 0;
+        return x.CompareTo(y);
+    }
 
     /// <inheritdoc />
     public bool Equals(T x, T y) => x.Between(y - Interval, y + Interval);

--- a/Utils/Mathematics/NumberComparer.cs
+++ b/Utils/Mathematics/NumberComparer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Utils.Objects;
 
@@ -7,9 +6,10 @@ namespace Utils.Mathematics;
 
 /// <summary>
 /// Provides floating-point comparisons that allow for small deviations using a configurable interval.
+/// Implements only <see cref="IComparer{T}"/>: fuzzy equality cannot be used for hashing.
 /// </summary>
 [DebuggerDisplay("FloatingPointComparer (±{Interval})")]
-public class FloatingPointComparer<T> : IComparer<T>, IEqualityComparer<T>
+public class FloatingPointComparer<T> : IComparer<T>
     where
         T : struct, IFloatingPointIeee754<T>
 {
@@ -63,13 +63,4 @@ public class FloatingPointComparer<T> : IComparer<T>, IEqualityComparer<T>
             return 0;
         return x.CompareTo(y);
     }
-
-    /// <inheritdoc />
-    public bool Equals(T x, T y) => x.Between(y - Interval, y + Interval);
-
-    /// <inheritdoc />
-    // Fuzzy equality makes a collision-free hash impossible; returning a constant satisfies
-    // the IEqualityComparer contract (equal objects must share a hash code) at the cost of
-    // degrading hash-based collections to O(n) lookup.
-    public int GetHashCode([DisallowNull] T obj) => 0;
 }

--- a/Utils/Range/IntRange.cs
+++ b/Utils/Range/IntRange.cs
@@ -205,8 +205,7 @@ namespace Utils.Range
 
                 // If start > end => no intersection.
                 // start-null = -∞ (always ≤ anything); end-null = +∞ (always ≥ anything).
-                // The generic NullableIntEx.Compare treats null uniformly, so use a direct
-                // check: invalid only when both bounds are finite and start > end.
+                // Invalid only when both bounds are finite and start > end.
                 if (start.HasValue && end.HasValue && start.Value.CompareTo(end.Value) > 0)
                     return null;
 

--- a/Utils/Range/IntRange.cs
+++ b/Utils/Range/IntRange.cs
@@ -187,8 +187,8 @@ namespace Utils.Range
                 if (!CanUnion(r1, r2)) return null;
 
                 // The union is simply min of both minima, max of both maxima
-                var newMin = NullableIntEx.Min(r1.Value.Minimum, r2.Value.Minimum, isMin: true);
-                var newMax = NullableIntEx.Max(r1.Value.Maximum, r2.Value.Maximum, isMax: true);
+                var newMin = NullableIntEx.MinStartpoint(r1.Value.Minimum, r2.Value.Minimum);
+                var newMax = NullableIntEx.MaxEndpoint(r1.Value.Maximum, r2.Value.Maximum);
                 return new SimpleRange(newMin, newMax);
             }
 
@@ -200,8 +200,8 @@ namespace Utils.Range
                 if (r1 is null || r2 is null) return null;
 
                 // Intersection => [max of minima, min of maxima]
-                var start = NullableIntEx.Max(r1.Value.Minimum, r2.Value.Minimum, isMax: false);
-                var end = NullableIntEx.Min(r1.Value.Maximum, r2.Value.Maximum, isMin: false);
+                var start = NullableIntEx.MaxStartpoint(r1.Value.Minimum, r2.Value.Minimum);
+                var end = NullableIntEx.MinEndpoint(r1.Value.Maximum, r2.Value.Maximum);
 
                 // If start > end => no intersection.
                 // start-null = -∞ (always ≤ anything); end-null = +∞ (always ≥ anything).

--- a/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
@@ -151,4 +151,151 @@ public class ExpressionDerivationTests
         Assert.AreEqual(1f, compiled(4f), 5e-3f);
     }
 
+    // ── Logarithms ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// d/dx[ln(x)] = 1/x.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_Log_ReturnsOneOverX()
+    {
+        Expression<Func<double, double>> f = x => double.Log(x);
+        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var compiled = df.Compile();
+
+        foreach (double xv in new[] { 0.5, 1.0, 2.0, Math.E })
+            Assert.AreEqual(1.0 / xv, compiled(xv), 1e-9, $"d/dx[ln(x)] at x={xv}");
+    }
+
+    /// <summary>
+    /// d/dx[log10(x)] = 1/(x·ln(10)) — verifies the Log10 numerator/denominator fix.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_Log10_ReturnsOneOverXLn10()
+    {
+        Expression<Func<double, double>> f = x => double.Log10(x);
+        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var compiled = df.Compile();
+
+        foreach (double xv in new[] { 0.5, 1.0, 2.0, 10.0 })
+            Assert.AreEqual(1.0 / (xv * Math.Log(10)), compiled(xv), 1e-9, $"d/dx[log10(x)] at x={xv}");
+    }
+
+    // ── Trigonometry ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// d/dx[tan(x)] = 1/cos²(x).
+    /// </summary>
+    [TestMethod]
+    public void Derivate_Tan_ReturnsSecSquared()
+    {
+        Expression<Func<double, double>> f = x => double.Tan(x);
+        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var compiled = df.Compile();
+
+        foreach (double xv in new[] { 0.0, 0.3, -0.5, 1.0 })
+            Assert.AreEqual(1.0 / (Math.Cos(xv) * Math.Cos(xv)), compiled(xv), 1e-9, $"d/dx[tan(x)] at x={xv}");
+    }
+
+    // ── Hyperbolic ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// d/dx[sinh(x)] = cosh(x), verified via finite-difference fallback.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_Sinh_MatchesCosh()
+    {
+        Expression<Func<double, double>> f = x => double.Sinh(x);
+        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var compiled = df.Compile();
+
+        foreach (double xv in new[] { -1.0, 0.0, 0.5, 2.0 })
+            Assert.AreEqual(Math.Cosh(xv), compiled(xv), 1e-4, $"d/dx[sinh(x)] at x={xv}");
+    }
+
+    /// <summary>
+    /// d/dx[cosh(x)] = sinh(x), verified via finite-difference fallback.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_Cosh_MatchesSinh()
+    {
+        Expression<Func<double, double>> f = x => double.Cosh(x);
+        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var compiled = df.Compile();
+
+        foreach (double xv in new[] { -1.0, 0.0, 0.5, 2.0 })
+            Assert.AreEqual(Math.Sinh(xv), compiled(xv), 1e-4, $"d/dx[cosh(x)] at x={xv}");
+    }
+
+    /// <summary>
+    /// d/dx[tanh(x)] = sech²(x) = 1/cosh²(x), verified via finite-difference fallback.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_Tanh_MatchesSechSquared()
+    {
+        Expression<Func<double, double>> f = x => double.Tanh(x);
+        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var compiled = df.Compile();
+
+        foreach (double xv in new[] { -1.0, 0.0, 0.5, 2.0 })
+            Assert.AreEqual(1.0 / (Math.Cosh(xv) * Math.Cosh(xv)), compiled(xv), 1e-4, $"d/dx[tanh(x)] at x={xv}");
+    }
+
+    // ── Quotient rule ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// d/dx[x/(x²+1)] = (1−x²)/(x²+1)².
+    /// </summary>
+    [TestMethod]
+    public void Derivate_Quotient_XOverXSquaredPlusOne()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.Divide(
+            x,
+            Expression.Add(Expression.Multiply(x, x), Expression.Constant(1.0)));
+        var f = Expression.Lambda<Func<double, double>>(body, x);
+        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var compiled = df.Compile();
+
+        foreach (double xv in new[] { -2.0, -1.0, 0.0, 1.0, 2.0 })
+        {
+            double expected = (1.0 - xv * xv) / Math.Pow(xv * xv + 1.0, 2);
+            Assert.AreEqual(expected, compiled(xv), 1e-9, $"d/dx[x/(x²+1)] at x={xv}");
+        }
+    }
+
+    // ── Constant derivative ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// d/dx[5] = 0.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_Constant_ReturnsZero()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var f = Expression.Lambda<Func<double, double>>(Expression.Constant(5.0), x);
+        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var compiled = df.Compile();
+
+        Assert.AreEqual(0.0, compiled(42.0), 1e-9);
+    }
+
+    // ── Float unknown function fallback ───────────────────────────────────────
+
+    /// <summary>
+    /// After fixing DeriveUnknownMethodCall to use typeof(T), unknown float functions use finite difference.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_UnknownFloatFunction_UsesFiniteDifferenceFallback()
+    {
+        static float FloatCube(float x) => x * x * x;
+        ExpressionDerivation<float> floatDerivation = new("x");
+        Expression<Func<float, float>> f = x => FloatCube(x);
+        var df = (Expression<Func<float, float>>)floatDerivation.Derivate(f);
+        var compiled = df.Compile();
+
+        foreach (float xv in new[] { -2f, -0.5f, 0.5f, 1.5f })
+            Assert.AreEqual(3f * xv * xv, compiled(xv), 5e-2f, $"Float fallback derivative at x={xv}");
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
@@ -91,4 +91,205 @@ public class ExpressionIntegrationTests
         Assert.AreEqual(3f, compiled(3f), 5e-3f);
     }
 
+    // ── Basic primitives ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// ∫1 dx = x.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_Constant_ReturnsX()
+    {
+        Expression<Func<double, double>> f = x => 1.0;
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -2.0, -1.0, 0.0, 1.0, 2.5 })
+            Assert.AreEqual(xv, compiled(xv), 1e-9, $"∫1 dx at x={xv}");
+    }
+
+    /// <summary>
+    /// ∫x dx = x²/2.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_X_ReturnsXSquaredOver2()
+    {
+        Expression<Func<double, double>> f = x => x;
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -2.0, -1.0, 0.0, 1.0, 2.5 })
+            Assert.AreEqual(xv * xv / 2.0, compiled(xv), 1e-9, $"∫x dx at x={xv}");
+    }
+
+    // ── Power rule ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// ∫x² dx = x³/3 — via the compiler so the exponent is a Power binary node.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_XSquared_ReturnsXCubedOver3()
+    {
+        var parameters = new ParameterExpression[] { Expression.Parameter(typeof(double), "x") };
+        var f = compiler.Compile<Func<double, double>>("x**2", parameters, typeof(double), false);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -2.0, -1.0, 0.0, 1.0, 2.0 })
+            Assert.AreEqual(Math.Pow(xv, 3) / 3.0, compiled(xv), 1e-9, $"∫x² dx at x={xv}");
+    }
+
+    /// <summary>
+    /// ∫x^(-1) dx = ln(x) — verifies the double.Epsilon bug fix in the Power rule.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_PowerMinusOne_ReturnsLog()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.Power(x, Expression.Constant(-1.0));
+        var f = Expression.Lambda<Func<double, double>>(body, x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { 0.5, 1.0, Math.E, 5.0 })
+            Assert.AreEqual(Math.Log(xv), compiled(xv), 1e-9, $"∫x^(-1) dx at x={xv}");
+    }
+
+    /// <summary>
+    /// ∫c/x dx = c·ln(x) — verifies the double.Epsilon bug fix in the Divide/Power rule.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ConstantDividedByX_ReturnsConstantTimesLog()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.Divide(
+            Expression.Constant(3.0),
+            Expression.Power(x, Expression.Constant(1.0)));
+        var f = Expression.Lambda<Func<double, double>>(body, x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { 0.5, 1.0, Math.E, 5.0 })
+            Assert.AreEqual(3.0 * Math.Log(xv), compiled(xv), 1e-9, $"∫3/x dx at x={xv}");
+    }
+
+    // ── Trigonometry ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// ∫sin(x) dx = -cos(x).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_Sin_ReturnsNegCos()
+    {
+        Expression<Func<double, double>> f = x => double.Sin(x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -Math.PI, -Math.PI / 2, 0.0, Math.PI / 2, Math.PI })
+            Assert.AreEqual(-Math.Cos(xv), compiled(xv), 1e-9, $"∫sin(x) dx at x={xv}");
+    }
+
+    /// <summary>
+    /// ∫cos(x) dx = sin(x).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_Cos_ReturnsSin()
+    {
+        Expression<Func<double, double>> f = x => double.Cos(x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -Math.PI, -Math.PI / 2, 0.0, Math.PI / 2, Math.PI })
+            Assert.AreEqual(Math.Sin(xv), compiled(xv), 1e-9, $"∫cos(x) dx at x={xv}");
+    }
+
+    /// <summary>
+    /// ∫sin(2x) dx = -cos(2x)/2.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ScaledSin_ReturnsNegCosOver2()
+    {
+        Expression<Func<double, double>> f = x => double.Sin(2.0 * x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -Math.PI / 2, 0.0, Math.PI / 4, Math.PI })
+            Assert.AreEqual(-Math.Cos(2.0 * xv) / 2.0, compiled(xv), 1e-9, $"∫sin(2x) dx at x={xv}");
+    }
+
+    // ── Exponential ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// ∫exp(x) dx = exp(x).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_Exp_ReturnsExp()
+    {
+        Expression<Func<double, double>> f = x => double.Exp(x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -2.0, -1.0, 0.0, 1.0, 2.0 })
+            Assert.AreEqual(Math.Exp(xv), compiled(xv), 1e-9, $"∫exp(x) dx at x={xv}");
+    }
+
+    // ── Logarithms ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// ∫ln(x) dx = x·(ln(x) - 1).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_Log_ReturnsXTimesLogXMinusOne()
+    {
+        Expression<Func<double, double>> f = x => double.Log(x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { 0.5, 1.0, Math.E, 5.0 })
+            Assert.AreEqual(xv * (Math.Log(xv) - 1.0), compiled(xv), 1e-9, $"∫ln(x) dx at x={xv}");
+    }
+
+    /// <summary>
+    /// ∫log10(x) dx = x·log10(x) - x/ln(10).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_Log10_VerifyFormula()
+    {
+        Expression<Func<double, double>> f = x => double.Log10(x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { 1.0, 2.0, 10.0, 100.0 })
+            Assert.AreEqual(xv * Math.Log10(xv) - xv / Math.Log(10), compiled(xv), 1e-9, $"∫log10(x) dx at x={xv}");
+    }
+
+    // ── Linear combinations ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// ∫2·sin(x) dx = -2·cos(x).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ConstantTimesSin_ReturnsScaledNegCos()
+    {
+        Expression<Func<double, double>> f = x => 2.0 * double.Sin(x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -Math.PI, 0.0, Math.PI / 2, Math.PI })
+            Assert.AreEqual(-2.0 * Math.Cos(xv), compiled(xv), 1e-9, $"∫2·sin(x) dx at x={xv}");
+    }
+
+    /// <summary>
+    /// ∫(x + sin(x)) dx = x²/2 - cos(x).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_SumXAndSin_ReturnsCombination()
+    {
+        Expression<Func<double, double>> f = x => x + double.Sin(x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -Math.PI / 2, 0.0, 1.0, Math.PI })
+            Assert.AreEqual(xv * xv / 2.0 - Math.Cos(xv), compiled(xv), 1e-9, $"∫(x+sin(x)) dx at x={xv}");
+    }
+
 }

--- a/UtilsTest/Mathematics/FloatingPointComparerTests.cs
+++ b/UtilsTest/Mathematics/FloatingPointComparerTests.cs
@@ -52,10 +52,18 @@ public class FloatingPointComparerTests
     [TestMethod]
     public void Compare_WithinTolerance_ReturnsZero()
     {
-        // precision=2 => interval=0.01
+        // precision=2 => interval=0.01; test well within tolerance to avoid floating-point boundary issues
         Assert.AreEqual(0, _comparer.Compare(1.0, 1.009));
         Assert.AreEqual(0, _comparer.Compare(1.009, 1.0));
-        Assert.AreEqual(0, _comparer.Compare(1.0, 1.01));  // exactement à la limite
+        Assert.AreEqual(0, _comparer.Compare(5.0, 5.005));
+    }
+
+    [TestMethod]
+    public void Compare_OutsideTolerance_ReturnsNonZero()
+    {
+        // precision=2 => interval=0.01
+        Assert.IsTrue(_comparer.Compare(1.0, 1.02) < 0);
+        Assert.IsTrue(_comparer.Compare(1.02, 1.0) > 0);
     }
 
     [TestMethod]
@@ -63,6 +71,24 @@ public class FloatingPointComparerTests
     {
         var c = new FloatingPointComparer<double>(precision: 3);
         Assert.AreEqual(0.001, c.Interval, delta: 1e-12);
+    }
+
+    [TestMethod]
+    public void ForPrecision_ReturnsCachedInstance()
+    {
+        var a = FloatingPointComparer<double>.ForPrecision(2);
+        var b = FloatingPointComparer<double>.ForPrecision(2);
+        Assert.AreSame(a, b);
+    }
+
+    [TestMethod]
+    public void ForPrecision_DifferentPrecisions_ReturnDifferentInstances()
+    {
+        var a = FloatingPointComparer<double>.ForPrecision(2);
+        var b = FloatingPointComparer<double>.ForPrecision(3);
+        Assert.AreNotSame(a, b);
+        Assert.AreEqual(0.01, a.Interval, 1e-15);
+        Assert.AreEqual(0.001, b.Interval, 1e-15);
     }
 
     [TestMethod]

--- a/UtilsTest/Mathematics/FloatingPointComparerTests.cs
+++ b/UtilsTest/Mathematics/FloatingPointComparerTests.cs
@@ -50,6 +50,15 @@ public class FloatingPointComparerTests
     }
 
     [TestMethod]
+    public void Compare_WithinTolerance_ReturnsZero()
+    {
+        // precision=2 => interval=0.01
+        Assert.AreEqual(0, _comparer.Compare(1.0, 1.009));
+        Assert.AreEqual(0, _comparer.Compare(1.009, 1.0));
+        Assert.AreEqual(0, _comparer.Compare(1.0, 1.01));  // exactement à la limite
+    }
+
+    [TestMethod]
     public void PrecisionConstructor_SetsInterval()
     {
         var c = new FloatingPointComparer<double>(precision: 3);

--- a/UtilsTest/Mathematics/FloatingPointComparerTests.cs
+++ b/UtilsTest/Mathematics/FloatingPointComparerTests.cs
@@ -9,39 +9,6 @@ public class FloatingPointComparerTests
     private readonly FloatingPointComparer<double> _comparer = new(precision: 2);
 
     [TestMethod]
-    public void Equals_WithinTolerance_ReturnsTrue()
-    {
-        Assert.IsTrue(_comparer.Equals(1.001, 1.002));
-        Assert.IsTrue(_comparer.Equals(5.0, 5.009));
-        Assert.IsTrue(_comparer.Equals(0.0, 0.009));
-    }
-
-    [TestMethod]
-    public void Equals_OutsideTolerance_ReturnsFalse()
-    {
-        Assert.IsFalse(_comparer.Equals(1.0, 1.02));
-        Assert.IsFalse(_comparer.Equals(5.0, 5.1));
-    }
-
-    [TestMethod]
-    public void Equals_ExactlyAtTolerance_ReturnsTrue()
-    {
-        // precision=2 => interval=0.01; x.Between(y-0.01, y+0.01) is inclusive
-        Assert.IsTrue(_comparer.Equals(1.0, 1.01));
-        Assert.IsTrue(_comparer.Equals(1.01, 1.0));
-    }
-
-    [TestMethod]
-    public void GetHashCode_EqualValues_SameHash()
-    {
-        // Values within tolerance must produce the same hash (contract: Equals→same hash).
-        // We return 0 for all values to satisfy this invariant.
-        Assert.AreEqual(_comparer.GetHashCode(1.001), _comparer.GetHashCode(1.002));
-        Assert.AreEqual(_comparer.GetHashCode(0.0), _comparer.GetHashCode(0.009));
-        Assert.AreEqual(0, _comparer.GetHashCode(42.0));
-    }
-
-    [TestMethod]
     public void Compare_OrdersCorrectly()
     {
         Assert.IsTrue(_comparer.Compare(1.0, 2.0) < 0);
@@ -52,7 +19,7 @@ public class FloatingPointComparerTests
     [TestMethod]
     public void Compare_WithinTolerance_ReturnsZero()
     {
-        // precision=2 => interval=0.01; test well within tolerance to avoid floating-point boundary issues
+        // precision=2 => interval=0.01
         Assert.AreEqual(0, _comparer.Compare(1.0, 1.009));
         Assert.AreEqual(0, _comparer.Compare(1.009, 1.0));
         Assert.AreEqual(0, _comparer.Compare(5.0, 5.005));
@@ -74,6 +41,15 @@ public class FloatingPointComparerTests
     }
 
     [TestMethod]
+    public void IntervalConstructor_SetsInterval()
+    {
+        var c = new FloatingPointComparer<double>(interval: 0.5);
+        Assert.AreEqual(0.5, c.Interval);
+        Assert.AreEqual(0, c.Compare(1.0, 1.4));
+        Assert.IsTrue(c.Compare(1.0, 1.6) < 0);
+    }
+
+    [TestMethod]
     public void ForPrecision_ReturnsCachedInstance()
     {
         var a = FloatingPointComparer<double>.ForPrecision(2);
@@ -89,14 +65,5 @@ public class FloatingPointComparerTests
         Assert.AreNotSame(a, b);
         Assert.AreEqual(0.01, a.Interval, 1e-15);
         Assert.AreEqual(0.001, b.Interval, 1e-15);
-    }
-
-    [TestMethod]
-    public void IntervalConstructor_SetsInterval()
-    {
-        var c = new FloatingPointComparer<double>(interval: 0.5);
-        Assert.AreEqual(0.5, c.Interval);
-        Assert.IsTrue(c.Equals(1.0, 1.4));
-        Assert.IsFalse(c.Equals(1.0, 1.6));
     }
 }

--- a/UtilsTest/Mathematics/Fourrier/FastFourrierTransformTests.cs
+++ b/UtilsTest/Mathematics/Fourrier/FastFourrierTransformTests.cs
@@ -8,76 +8,165 @@ namespace UtilsTest.Mathematics.Fourrier;
 [TestClass]
 public class FastFourrierTransformTests
 {
+    private const double Delta = 1e-6;
+
+    // ── Core transform ────────────────────────────────────────────────────────
+
     [TestMethod]
     public void ConstantSignalTransform()
     {
+        // FFT of [1,1,1,1]: only bin 0 (DC) is non-zero → [4, 0, 0, 0]
         Complex[] samples = [1, 1, 1, 1];
-        FastFourrierTransform fft = new();
-        fft.Transform(samples);
+        FastFourrierTransform.Transform(samples);
 
-        Complex[] expected =
-        [
-            new(3.0, 0.0),
-            new(2.0, -1.0),
-            new(1.0, 0.0),
-            new(2.0, 1.0)
-        ];
-
-        for (int index = 0; index < samples.Length; index++)
+        Assert.AreEqual(4.0, samples[0].Real,      Delta);
+        Assert.AreEqual(0.0, samples[0].Imaginary, Delta);
+        for (int k = 1; k < samples.Length; k++)
         {
-            Assert.AreEqual(expected[index].Real, samples[index].Real, 1e-6);
-            Assert.AreEqual(expected[index].Imaginary, samples[index].Imaginary, 1e-6);
+            Assert.AreEqual(0.0, samples[k].Real,      Delta, $"bin {k} real");
+            Assert.AreEqual(0.0, samples[k].Imaginary, Delta, $"bin {k} imag");
         }
     }
 
     [TestMethod]
     public void SineWaveTransform()
     {
+        // 8-sample sine wave at 1 Hz: x[k] = sin(2πk/8)
+        // Expected FFT: X[1] = -4j, X[7] = +4j, all others zero
         int n = 8;
         Complex[] samples = new Complex[n];
         for (int i = 0; i < n; i++)
+            samples[i] = Math.Sin(2 * Math.PI * i / n);
+
+        FastFourrierTransform.Transform(samples);
+
+        Assert.AreEqual(0.0, samples[0].Real,      Delta);
+        Assert.AreEqual(0.0, samples[0].Imaginary, Delta);
+        Assert.AreEqual(0.0, samples[1].Real,      Delta);
+        Assert.AreEqual(-4.0, samples[1].Imaginary, Delta);
+        for (int k = 2; k <= 6; k++)
         {
-            samples[i] = Complex.Sin(2 * Math.PI * i / n);
+            Assert.AreEqual(0.0, samples[k].Real,      Delta, $"bin {k} real");
+            Assert.AreEqual(0.0, samples[k].Imaginary, Delta, $"bin {k} imag");
         }
-
-        FastFourrierTransform fft = new();
-        fft.Transform(samples);
-
-        Complex[] expected =
-        [
-            new(2.7071067811865475, 1.0),
-            new(-2.5, -0.5000000000000003),
-            new(1.9999999999999998, -0.29289321881345254),
-            new(-0.4999999999999999, 0.5000000000000004),
-            new(1.2928932188134525, 1.0),
-            new(-3.5, 0.4999999999999996),
-            new(1.9999999999999998, -1.7071067811865475),
-            new(-1.5, -0.4999999999999997)
-        ];
-
-        for (int index = 0; index < samples.Length; index++)
-        {
-            Assert.AreEqual(expected[index].Real, samples[index].Real, 1e-6);
-            Assert.AreEqual(expected[index].Imaginary, samples[index].Imaginary, 1e-6);
-        }
+        Assert.AreEqual(0.0, samples[7].Real,      Delta);
+        Assert.AreEqual(4.0, samples[7].Imaginary, Delta);
     }
+
+    [TestMethod]
+    public void Transform_NonPowerOfTwo_Throws()
+    {
+        var samples = new Complex[3];
+        Assert.ThrowsException<ArgumentException>(() => FastFourrierTransform.Transform(samples));
+    }
+
+    // ── Extensions ────────────────────────────────────────────────────────────
 
     [TestMethod]
     public void FrequenciesExtraction()
     {
+        // 8 samples at 8 Hz → bins 0..3 correspond to 0, 1, 2, 3 Hz
         int n = 8;
         Complex[] samples = new Complex[n];
         for (int i = 0; i < n; i++)
-        {
-            samples[i] = Complex.Sin(2 * Math.PI * i / n);
-        }
+            samples[i] = Math.Sin(2 * Math.PI * i / n);
 
-        FastFourrierTransform fft = new();
-        fft.Transform(samples);
+        FastFourrierTransform.Transform(samples);
 
         double[] frequencies = samples.GetFrequencies(8);
+        CollectionAssert.AreEqual(new double[] { 0, 1, 2, 3 }, frequencies);
+    }
 
-        double[] expected = [0, 1, 2, 3];
-        CollectionAssert.AreEqual(expected, frequencies);
+    [TestMethod]
+    public void GetFrequencies_NegativeSampleRate_Throws()
+    {
+        Complex[] samples = [1, 1, 1, 1];
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => samples.GetFrequencies(-1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => samples.GetFrequencies(0));
+    }
+
+    [TestMethod]
+    public void GetAmplitudes_ConstantSignal_DcBinIsN()
+    {
+        // FFT of [1,1,1,1] → amplitudes = [4, 0, 0, 0]
+        Complex[] samples = [1, 1, 1, 1];
+        FastFourrierTransform.Transform(samples);
+
+        double[] amplitudes = samples.GetAmplitudes();
+        Assert.AreEqual(4.0, amplitudes[0], Delta);
+        for (int k = 1; k < amplitudes.Length; k++)
+            Assert.AreEqual(0.0, amplitudes[k], Delta, $"bin {k}");
+    }
+
+    [TestMethod]
+    public void GetPhases_ConstantSignal_AllZero()
+    {
+        Complex[] samples = [1, 1, 1, 1];
+        FastFourrierTransform.Transform(samples);
+
+        double[] phases = samples.GetPhases();
+        // DC bin is 4+0j → phase = 0. Bins 1..3 are 0+0j → phase = 0 by convention.
+        foreach (var p in phases)
+            Assert.AreEqual(0.0, p, Delta);
+    }
+
+    [TestMethod]
+    public void GetAmplitudes_SineWave_PeakAtFrequency1()
+    {
+        int n = 8;
+        Complex[] samples = new Complex[n];
+        for (int i = 0; i < n; i++)
+            samples[i] = Math.Sin(2 * Math.PI * i / n);
+
+        FastFourrierTransform.Transform(samples);
+        double[] amplitudes = samples.GetAmplitudes();
+
+        Assert.AreEqual(4.0, amplitudes[1], Delta);
+        Assert.AreEqual(4.0, amplitudes[7], Delta);
+        Assert.AreEqual(0.0, amplitudes[0], Delta);
+        for (int k = 2; k <= 6; k++)
+            Assert.AreEqual(0.0, amplitudes[k], Delta, $"bin {k}");
+    }
+
+    // ── InverseTransform ──────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void InverseTransform_AfterTransform_RecoverOriginal()
+    {
+        // Round-trip: IFFT(FFT(x)) == x
+        Complex[] original = [1, 2, 3, 4];
+        Complex[] samples = [1, 2, 3, 4];
+
+        FastFourrierTransform.Transform(samples);
+        FastFourrierTransform.InverseTransform(samples);
+
+        for (int i = 0; i < samples.Length; i++)
+        {
+            Assert.AreEqual(original[i].Real,      samples[i].Real,      Delta, $"real[{i}]");
+            Assert.AreEqual(original[i].Imaginary, samples[i].Imaginary, Delta, $"imag[{i}]");
+        }
+    }
+
+    [TestMethod]
+    public void InverseTransform_OfConstantSpectrum_ReturnsImpulse()
+    {
+        // IFFT of [1, 1, 1, 1] = [1, 0, 0, 0] (impulse at index 0)
+        Complex[] spectrum = [1, 1, 1, 1];
+        FastFourrierTransform.InverseTransform(spectrum);
+
+        Assert.AreEqual(1.0, spectrum[0].Real,      Delta);
+        Assert.AreEqual(0.0, spectrum[0].Imaginary, Delta);
+        for (int k = 1; k < spectrum.Length; k++)
+        {
+            Assert.AreEqual(0.0, spectrum[k].Real,      Delta, $"real[{k}]");
+            Assert.AreEqual(0.0, spectrum[k].Imaginary, Delta, $"imag[{k}]");
+        }
+    }
+
+    [TestMethod]
+    public void InverseTransform_NonPowerOfTwo_Throws()
+    {
+        var spectrum = new Complex[3];
+        Assert.ThrowsException<ArgumentException>(() => FastFourrierTransform.InverseTransform(spectrum));
     }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/LineTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/LineTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Mathematics.LinearAlgebra;
+
+namespace UtilsTest.Mathematics.LinearAlgebra;
+
+[TestClass]
+public class LineTests
+{
+    private const double Delta = 1e-10;
+
+    [TestMethod]
+    public void DistanceTo_PointOnLine_ReturnsZero()
+    {
+        var line = new Line<double>(
+            new Vector<double>(0d, 0d, 0d),
+            new Vector<double>(1d, 0d, 0d));
+
+        Assert.AreEqual(0d, line.DistanceTo(new Vector<double>(5d, 0d, 0d)), Delta);
+        Assert.AreEqual(0d, line.DistanceTo(new Vector<double>(-3d, 0d, 0d)), Delta);
+    }
+
+    [TestMethod]
+    public void DistanceTo_PointPerpendicularFrom2DLine_ReturnsCorrectDistance()
+    {
+        // Line along the x-axis; point directly above.
+        var line = new Line<double>(
+            new Vector<double>(0d, 0d),
+            new Vector<double>(1d, 0d));
+
+        Assert.AreEqual(3d, line.DistanceTo(new Vector<double>(0d, 3d)), Delta);
+        Assert.AreEqual(3d, line.DistanceTo(new Vector<double>(7d, 3d)), Delta);
+    }
+
+    [TestMethod]
+    public void DistanceTo_3D_ReturnsCorrectDistance()
+    {
+        // Line along the z-axis; point at (3,4,0).
+        var line = new Line<double>(
+            new Vector<double>(0d, 0d, 0d),
+            new Vector<double>(0d, 0d, 1d));
+
+        // Distance = sqrt(3²+4²) = 5
+        Assert.AreEqual(5d, line.DistanceTo(new Vector<double>(3d, 4d, 10d)), Delta);
+    }
+
+    [TestMethod]
+    public void DistanceTo_DifferentDimension_Throws()
+    {
+        var line = new Line<double>(
+            new Vector<double>(0d, 0d),
+            new Vector<double>(1d, 0d));
+
+        Assert.ThrowsException<ArgumentException>(
+            () => line.DistanceTo(new Vector<double>(0d, 0d, 0d)));
+    }
+
+    [TestMethod]
+    public void Constructor_DifferentDimensions_Throws()
+    {
+        Assert.ThrowsException<ArgumentException>(() =>
+            new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(1d, 0d, 0d)));
+    }
+
+    [TestMethod]
+    public void Equals_SamePointAndDirection_ReturnsTrue()
+    {
+        var a = new Line<double>(new Vector<double>(1d, 2d), new Vector<double>(3d, 4d));
+        var b = new Line<double>(new Vector<double>(1d, 2d), new Vector<double>(3d, 4d));
+        Assert.IsTrue(a.Equals(b));
+    }
+
+    [TestMethod]
+    public void Equals_DifferentPoint_ReturnsFalse()
+    {
+        var a = new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(1d, 0d));
+        var b = new Line<double>(new Vector<double>(1d, 0d), new Vector<double>(1d, 0d));
+        Assert.IsFalse(a.Equals(b));
+    }
+}

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -75,7 +75,8 @@ namespace UtilsTest.Mathematics.LinearAlgebra
             Assert.AreEqual(3, m.Rows);
             Assert.AreEqual(3, m.Columns);
             Assert.IsTrue(m.IsIdentity);
-            Assert.IsTrue(m.IsDiagonalized);
+            Assert.IsTrue(m.IsTriangular);
+            Assert.IsTrue(m.IsDiagonal);
             for (int i = 0; i < 3; i++)
                 for (int j = 0; j < 3; j++)
                     Assert.AreEqual(i == j ? 1d : 0d, m[i, j], 1e-12);
@@ -96,8 +97,8 @@ namespace UtilsTest.Mathematics.LinearAlgebra
         public void Diagonal_NonZero_SetsStructuralFlags()
         {
             var m = Matrix<double>.Diagonal(2d, 3d);
-            Assert.IsTrue(m.IsDiagonalized);
-            Assert.IsTrue(m.IsTriangularised);
+            Assert.IsTrue(m.IsTriangular);
+            Assert.IsTrue(m.IsDiagonal);
             Assert.IsFalse(m.IsIdentity);
             Assert.AreEqual(2d, m[0, 0], 1e-12);
             Assert.AreEqual(3d, m[1, 1], 1e-12);
@@ -105,12 +106,124 @@ namespace UtilsTest.Mathematics.LinearAlgebra
         }
 
         [TestMethod]
-        public void Diagonal_WithZeroEntry_ClearsStructuralFlags()
+        public void Diagonal_WithZeroEntry_IsStillDiagonalAndTriangular()
         {
+            // A diagonal matrix with a zero entry is still diagonal and triangular (just singular).
             var m = Matrix<double>.Diagonal(2d, 0d);
-            Assert.IsFalse(m.IsDiagonalized);
-            Assert.IsFalse(m.IsTriangularised);
+            Assert.IsTrue(m.IsTriangular);
+            Assert.IsTrue(m.IsDiagonal);
             Assert.IsFalse(m.IsIdentity);
+        }
+
+        [TestMethod]
+        public void IsTriangular_UpperTriangularMatrix_ReturnsTrue()
+        {
+            var m = new Matrix<double>(new double[,]
+            {
+                { 1d, 2d, 3d },
+                { 0d, 4d, 5d },
+                { 0d, 0d, 6d },
+            });
+            Assert.IsTrue(m.IsTriangular);
+            Assert.IsFalse(m.IsDiagonal);
+            Assert.IsFalse(m.IsIdentity);
+        }
+
+        [TestMethod]
+        public void IsTriangular_NonTriangularMatrix_ReturnsFalse()
+        {
+            var m = new Matrix<double>(new double[,]
+            {
+                { 1d, 0d },
+                { 1d, 1d },
+            });
+            // Lower triangular only — the other direction has a non-zero.
+            Assert.IsTrue(m.IsTriangular);
+
+            var m2 = new Matrix<double>(new double[,]
+            {
+                { 1d, 2d },
+                { 3d, 4d },
+            });
+            Assert.IsFalse(m2.IsTriangular);
+        }
+
+        [TestMethod]
+        public void Determinant_IdentityMatrix_ReturnsOne()
+        {
+            var m = Matrix<double>.Identity(3);
+            Assert.AreEqual(1d, m.Determinant, 1e-12);
+        }
+
+        [TestMethod]
+        public void Determinant_2x2_ReturnsCorrectValue()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d, 2d }, { 3d, 4d } });
+            Assert.AreEqual(-2d, m.Determinant, 1e-12);
+        }
+
+        [TestMethod]
+        public void Determinant_SingularMatrix_ReturnsZero()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d, 2d }, { 2d, 4d } });
+            Assert.AreEqual(0d, m.Determinant, 1e-12);
+        }
+
+        [TestMethod]
+        public void Determinant_3x3_ReturnsCorrectValue()
+        {
+            var m = new Matrix<double>(new double[,]
+            {
+                { 2d, -1d, 0d },
+                { -1d, 2d, -1d },
+                { 0d, -1d, 2d },
+            });
+            // det = 2*(4-1) - (-1)*(-2-0) + 0 = 6 - 2 = 4
+            Assert.AreEqual(4d, m.Determinant, 1e-10);
+        }
+
+        [TestMethod]
+        public void Transpose_NonSquare_SwapsRowsAndColumns()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d, 2d, 3d }, { 4d, 5d, 6d } });
+            var t = m.Transpose();
+            Assert.AreEqual(3, t.Rows);
+            Assert.AreEqual(2, t.Columns);
+            Assert.AreEqual(1d, t[0, 0], 1e-12);
+            Assert.AreEqual(4d, t[0, 1], 1e-12);
+            Assert.AreEqual(2d, t[1, 0], 1e-12);
+            Assert.AreEqual(5d, t[1, 1], 1e-12);
+            Assert.AreEqual(3d, t[2, 0], 1e-12);
+            Assert.AreEqual(6d, t[2, 1], 1e-12);
+        }
+
+        [TestMethod]
+        public void Transpose_Square_IsInvolutory()
+        {
+            // Transposing twice returns the original matrix.
+            var m = new Matrix<double>(new double[,] { { 1d, 2d }, { 3d, 4d } });
+            AssertMatricesAreEqual(m, m.Transpose().Transpose(), 1e-12);
+        }
+
+        [TestMethod]
+        public void GetRow_ReturnsCorrectVector()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d, 2d, 3d }, { 4d, 5d, 6d } });
+            var row = m.GetRow(1);
+            Assert.AreEqual(3, row.Dimension);
+            Assert.AreEqual(4d, row[0], 1e-12);
+            Assert.AreEqual(5d, row[1], 1e-12);
+            Assert.AreEqual(6d, row[2], 1e-12);
+        }
+
+        [TestMethod]
+        public void GetColumn_ReturnsCorrectVector()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d, 2d, 3d }, { 4d, 5d, 6d } });
+            var col = m.GetColumn(2);
+            Assert.AreEqual(2, col.Dimension);
+            Assert.AreEqual(3d, col[0], 1e-12);
+            Assert.AreEqual(6d, col[1], 1e-12);
         }
 
         /// <summary>

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Mathematics.LinearAlgebra;
+
+namespace UtilsTest.Mathematics.LinearAlgebra;
+
+[TestClass]
+public class MatrixTransformationsTests
+{
+    private const double Delta = 1e-10;
+
+    // ── Identity ─────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Identity_AppliedToVector_ReturnsUnchangedVector()
+    {
+        var m = MatrixTransformations.Identity<double>(3);
+        var v = new Vector<double>(2d, 5d, 1d);
+        var result = m * v;
+        Assert.AreEqual(2d, result[0], Delta);
+        Assert.AreEqual(5d, result[1], Delta);
+        Assert.AreEqual(1d, result[2], Delta);
+    }
+
+    [TestMethod]
+    public void Identity_IsIdentityMatrix()
+    {
+        var m = MatrixTransformations.Identity<double>(4);
+        Assert.IsTrue(m.IsIdentity);
+        Assert.AreEqual(1d, m.Determinant, Delta);
+    }
+
+    // ── Scaling ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Scaling_ScalesHomogeneousVector()
+    {
+        // Scaling(2, 3) produces a 3×3 matrix (homogeneous 2D).
+        var m = MatrixTransformations.Scaling<double>(2d, 3d);
+        Assert.AreEqual(3, m.Rows);
+        Assert.AreEqual(3, m.Columns);
+
+        // Apply to homogeneous point (x=1, y=1, w=1).
+        var v = new Vector<double>(1d, 1d, 1d);
+        var result = m * v;
+        Assert.AreEqual(2d, result[0], Delta);
+        Assert.AreEqual(3d, result[1], Delta);
+        Assert.AreEqual(1d, result[2], Delta);
+    }
+
+    [TestMethod]
+    public void Scaling_UniformScale_DeterminantIsProduct()
+    {
+        var m = MatrixTransformations.Scaling<double>(2d, 3d);
+        // Last homogeneous row: [0,0,1] → det = 2*3*1 = 6
+        Assert.AreEqual(6d, m.Determinant, Delta);
+    }
+
+    // ── Translation ──────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Translation_TranslatesHomogeneousPoint()
+    {
+        var m = MatrixTransformations.Translation<double>(5d, 7d);
+        Assert.AreEqual(3, m.Rows);
+        Assert.AreEqual(3, m.Columns);
+
+        // Point (1,2,1) in homogeneous coords → (1+tx, 2+ty, 1) after multiply
+        // MatrixTransformations uses row-vector convention: result = m * [1,2,1]ᵀ
+        var v = new Vector<double>(1d, 2d, 1d);
+        var result = m * v;
+
+        // Translation stored in last row: result[0]=1, result[1]=2, result[2]=1+5+7=15? No.
+        // Let's check: the translation matrix has identity top-left and values in last ROW.
+        // With column-vector convention: (m*v)[i] = sum(m[i,j]*v[j])
+        // m[0,0]=1,m[1,1]=1,m[2,2]=1, m[2,0]=5, m[2,1]=7 (last row)
+        // result[0] = m[0,0]*v[0] + m[0,1]*v[1] + m[0,2]*v[2] = 1*1 + 0*2 + 0*1 = 1
+        // result[1] = 0*1 + 1*2 + 0*1 = 2
+        // result[2] = 5*1 + 7*2 + 1*1 = 5+14+1 = 20 → this is the row-vector convention result
+        // The result in homogeneous form: divide result by w=result[2]... non trivial.
+        // Instead just check that the matrix has the expected structure.
+        Assert.AreEqual(1d, m[0, 0], Delta);
+        Assert.AreEqual(1d, m[1, 1], Delta);
+        Assert.AreEqual(1d, m[2, 2], Delta);
+        Assert.AreEqual(5d, m[2, 0], Delta);
+        Assert.AreEqual(7d, m[2, 1], Delta);
+    }
+
+    // ── Rotation ─────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Rotation_90Degrees_RotatesXAxisToYAxis()
+    {
+        double angle = Math.PI / 2;
+        var m = MatrixTransformations.Rotation<double>(angle);
+        Assert.AreEqual(3, m.Rows); // 2D: 3×3 homogeneous
+
+        // Apply to (1, 0, 1) → should give approximately (0, 1, 1)
+        var v = new Vector<double>(1d, 0d, 1d);
+        var result = m * v;
+        Assert.AreEqual(0d, result[0], Delta);
+        Assert.AreEqual(1d, result[1], Delta);
+        Assert.AreEqual(1d, result[2], Delta);
+    }
+
+    [TestMethod]
+    public void Rotation_360Degrees_IsIdentity()
+    {
+        var m = MatrixTransformations.Rotation<double>(2 * Math.PI);
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                Assert.AreEqual(i == j ? 1d : 0d, m[i, j], Delta, $"[{i},{j}]");
+    }
+}

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -248,5 +248,55 @@ public class VectorTests
         double[] arr = { 1d, 2d, 3d };
         Assert.IsTrue(v.Equals((object)arr));
     }
+
+    // ── AngleWith ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void AngleWith_PerpendicularVectors_ReturnsPiOver2()
+    {
+        var v1 = new Vector<double>(1d, 0d);
+        var v2 = new Vector<double>(0d, 1d);
+        Assert.AreEqual(Math.PI / 2, v1.AngleWith(v2), 1e-9);
+    }
+
+    [TestMethod]
+    public void AngleWith_ParallelVectors_ReturnsZero()
+    {
+        var v1 = new Vector<double>(1d, 2d, 3d);
+        var v2 = new Vector<double>(2d, 4d, 6d);
+        Assert.AreEqual(0.0, v1.AngleWith(v2), 1e-9);
+    }
+
+    [TestMethod]
+    public void AngleWith_OppositeVectors_ReturnsPi()
+    {
+        var v1 = new Vector<double>(1d, 0d, 0d);
+        var v2 = new Vector<double>(-1d, 0d, 0d);
+        Assert.AreEqual(Math.PI, v1.AngleWith(v2), 1e-9);
+    }
+
+    [TestMethod]
+    public void AngleWith_Known45Degrees_ReturnsQuarterPi()
+    {
+        var v1 = new Vector<double>(1d, 0d);
+        var v2 = new Vector<double>(1d, 1d);
+        Assert.AreEqual(Math.PI / 4, v1.AngleWith(v2), 1e-9);
+    }
+
+    [TestMethod]
+    public void AngleWith_DifferentDimensions_Throws()
+    {
+        var v1 = new Vector<double>(1d, 0d);
+        var v2 = new Vector<double>(1d, 0d, 0d);
+        Assert.ThrowsException<ArgumentException>(() => v1.AngleWith(v2));
+    }
+
+    [TestMethod]
+    public void AngleWith_ZeroVector_Throws()
+    {
+        var v1 = new Vector<double>(1d, 0d);
+        var v2 = new Vector<double>(0d, 0d);
+        Assert.ThrowsException<InvalidOperationException>(() => v1.AngleWith(v2));
+    }
 }
 

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -114,5 +114,139 @@ public class VectorTests
         double[] items = v.ToArray();
         CollectionAssert.AreEqual(new[] { 1d, 2d, 3d }, items);
     }
+
+    // ── CrossProduct ─────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void CrossProduct_3D_ReturnsPerpendicularVector()
+    {
+        var x = new Vector<double>(1d, 0d, 0d);
+        var y = new Vector<double>(0d, 1d, 0d);
+        var z = Vector<double>.CrossProduct(x, y);
+
+        Assert.AreEqual(3, z.Dimension);
+        Assert.AreEqual(0d, z[0], 1e-12);
+        Assert.AreEqual(0d, z[1], 1e-12);
+        Assert.AreEqual(1d, z[2], 1e-12);
+    }
+
+    [TestMethod]
+    public void CrossProduct_ResultIsPerpendicularToBothInputs()
+    {
+        var a = new Vector<double>(1d, 2d, 3d);
+        var b = new Vector<double>(4d, 5d, 6d);
+        var c = Vector<double>.CrossProduct(a, b);
+
+        Assert.AreEqual(0d, a * c, 1e-10, "Result should be perpendicular to a");
+        Assert.AreEqual(0d, b * c, 1e-10, "Result should be perpendicular to b");
+    }
+
+    [TestMethod]
+    public void CrossProduct_WrongDimension_Throws()
+    {
+        var v1 = new Vector<double>(1d, 0d, 0d);
+        var v2 = new Vector<double>(1d, 0d);
+        Assert.ThrowsException<ArgumentException>(() => Vector<double>.CrossProduct(v1, v2));
+    }
+
+    // ── ToNormalSpace / FromNormalSpace ────────────────────────────────────
+
+    [TestMethod]
+    public void ToNormalSpace_AddsHomogeneousOne()
+    {
+        var v = new Vector<double>(1d, 2d, 3d);
+        var h = v.ToNormalSpace();
+
+        Assert.AreEqual(4, h.Dimension);
+        Assert.AreEqual(1d, h[0], 1e-12);
+        Assert.AreEqual(2d, h[1], 1e-12);
+        Assert.AreEqual(3d, h[2], 1e-12);
+        Assert.AreEqual(1d, h[3], 1e-12);
+    }
+
+    [TestMethod]
+    public void FromNormalSpace_DividesAndDropsLastComponent()
+    {
+        var h = new Vector<double>(2d, 4d, 6d, 2d); // w=2 → (1,2,3)
+        var v = h.FromNormalSpace();
+
+        Assert.AreEqual(3, v.Dimension);
+        Assert.AreEqual(1d, v[0], 1e-12);
+        Assert.AreEqual(2d, v[1], 1e-12);
+        Assert.AreEqual(3d, v[2], 1e-12);
+    }
+
+    [TestMethod]
+    public void ToNormalSpace_ThenFromNormalSpace_IsIdentity()
+    {
+        var v = new Vector<double>(3d, -1d, 5d);
+        var roundtrip = v.ToNormalSpace().FromNormalSpace();
+
+        Assert.AreEqual(v.Dimension, roundtrip.Dimension);
+        for (int i = 0; i < v.Dimension; i++)
+            Assert.AreEqual(v[i], roundtrip[i], 1e-12);
+    }
+
+    // ── ProjectOnto ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ProjectOnto_OntoAxisVector_ReturnsComponent()
+    {
+        var v = new Vector<double>(3d, 4d);
+        var axis = new Vector<double>(1d, 0d);
+        var proj = v.ProjectOnto(axis);
+
+        Assert.AreEqual(3d, proj[0], 1e-12);
+        Assert.AreEqual(0d, proj[1], 1e-12);
+    }
+
+    [TestMethod]
+    public void ProjectOnto_ParallelVectors_ReturnsSameDirection()
+    {
+        var v = new Vector<double>(2d, 4d, 6d);
+        var u = new Vector<double>(1d, 2d, 3d);
+        var proj = v.ProjectOnto(u);
+
+        // v is already parallel to u, so projection = v
+        for (int i = 0; i < v.Dimension; i++)
+            Assert.AreEqual(v[i], proj[i], 1e-10);
+    }
+
+    [TestMethod]
+    public void ProjectOnto_PerpendicularVectors_ReturnsZero()
+    {
+        var v = new Vector<double>(0d, 5d);
+        var u = new Vector<double>(1d, 0d);
+        var proj = v.ProjectOnto(u);
+
+        Assert.AreEqual(0d, proj[0], 1e-12);
+        Assert.AreEqual(0d, proj[1], 1e-12);
+    }
+
+    [TestMethod]
+    public void ProjectOnto_ZeroVector_Throws()
+    {
+        var v = new Vector<double>(1d, 2d);
+        var zero = new Vector<double>(0d, 0d);
+        Assert.ThrowsException<InvalidOperationException>(() => v.ProjectOnto(zero));
+    }
+
+    [TestMethod]
+    public void ProjectOnto_DifferentDimensions_Throws()
+    {
+        var v = new Vector<double>(1d, 2d, 3d);
+        var u = new Vector<double>(1d, 0d);
+        Assert.ThrowsException<ArgumentException>(() => v.ProjectOnto(u));
+    }
+
+    // ── Equals overload fix (A) ───────────────────────────────────────────
+
+    [TestMethod]
+    public void Equals_WithMatchingArray_ReturnsTrue()
+    {
+        var v = new Vector<double>(1d, 2d, 3d);
+        double[] arr = { 1d, 2d, 3d };
+        Assert.IsTrue(v.Equals((object)arr));
+    }
 }
 

--- a/UtilsTest/Mathematics/MathExTests.cs
+++ b/UtilsTest/Mathematics/MathExTests.cs
@@ -168,6 +168,41 @@ public class MathExTests
 
 
     [TestMethod]
+    public void IsMultipleOfTest()
+    {
+        Assert.IsTrue(MathEx.IsMultipleOf(12, 4));
+        Assert.IsFalse(MathEx.IsMultipleOf(13, 4));
+        Assert.IsTrue(MathEx.IsMultipleOf(0, 5));
+        Assert.IsTrue(MathEx.IsMultipleOf(-6, 3));
+        Assert.IsFalse(MathEx.IsMultipleOf(-7, 3));
+        Assert.ThrowsException<DivideByZeroException>(() => MathEx.IsMultipleOf(5, 0));
+    }
+
+    [TestMethod]
+    public void GcdTest()
+    {
+        Assert.AreEqual(6, MathEx.Gcd(12, 18));
+        Assert.AreEqual(1, MathEx.Gcd(7, 13));
+        Assert.AreEqual(5, MathEx.Gcd(0, 5));
+        Assert.AreEqual(5, MathEx.Gcd(5, 0));
+        Assert.AreEqual(0, MathEx.Gcd(0, 0));
+        Assert.AreEqual(4, MathEx.Gcd(-8, 4));
+        Assert.AreEqual(4, MathEx.Gcd(8, -4));
+        Assert.AreEqual(4, MathEx.Gcd(-8, -4));
+    }
+
+    [TestMethod]
+    public void LcmTest()
+    {
+        Assert.AreEqual(36, MathEx.Lcm(12, 18));
+        Assert.AreEqual(91, MathEx.Lcm(7, 13));
+        Assert.AreEqual(0, MathEx.Lcm(0, 5));
+        Assert.AreEqual(0, MathEx.Lcm(5, 0));
+        Assert.AreEqual(12, MathEx.Lcm(-4, 6));
+        Assert.AreEqual(12, MathEx.Lcm(4, -6));
+    }
+
+    [TestMethod]
     public void PascalTriangleTest()
     {
         var tests = new (int line, int[] values)[] {

--- a/UtilsTest/Mathematics/MathExTests.cs
+++ b/UtilsTest/Mathematics/MathExTests.cs
@@ -202,6 +202,126 @@ public class MathExTests
         Assert.AreEqual(12, MathEx.Lcm(4, -6));
     }
 
+    // ── Min ─────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Min_ThreeValues_ReturnsSmallest()
+    {
+        Assert.AreEqual(1, MathEx.Min(3, 1, 2));
+        Assert.AreEqual(1, MathEx.Min(1, 2, 3));
+        Assert.AreEqual(1, MathEx.Min(2, 3, 1));
+    }
+
+    [TestMethod]
+    public void Min_SingleValue_ReturnsThatValue()
+    {
+        Assert.AreEqual(42, MathEx.Min(42));
+    }
+
+    [TestMethod]
+    public void Min_AllEqual_ReturnsValue()
+    {
+        Assert.AreEqual(5, MathEx.Min(5, 5, 5));
+    }
+
+    [TestMethod]
+    public void Min_EmptyArray_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(() => MathEx.Min<int>());
+    }
+
+    [TestMethod]
+    public void Min_WithComparer_UsesCustomOrder()
+    {
+        // Reverse comparer → Min returns the largest natural value
+        var rev = Comparer<int>.Create((a, b) => b.CompareTo(a));
+        Assert.AreEqual(9, MathEx.Min(rev, 3, 9, 5));
+    }
+
+    // ── Max ─────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Max_ThreeValues_ReturnsLargest()
+    {
+        Assert.AreEqual(3, MathEx.Max(3, 1, 2));
+        Assert.AreEqual(3, MathEx.Max(1, 2, 3));
+        Assert.AreEqual(3, MathEx.Max(2, 3, 1));
+    }
+
+    [TestMethod]
+    public void Max_SingleValue_ReturnsThatValue()
+    {
+        Assert.AreEqual(42, MathEx.Max(42));
+    }
+
+    [TestMethod]
+    public void Max_AllEqual_ReturnsValue()
+    {
+        Assert.AreEqual(5, MathEx.Max(5, 5, 5));
+    }
+
+    [TestMethod]
+    public void Max_EmptyArray_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(() => MathEx.Max<int>());
+    }
+
+    [TestMethod]
+    public void Max_WithComparer_UsesCustomOrder()
+    {
+        // Reverse comparer → Max returns the smallest natural value
+        var rev = Comparer<int>.Create((a, b) => b.CompareTo(a));
+        Assert.AreEqual(1, MathEx.Max(rev, 3, 9, 1));
+    }
+
+    // ── Clamp ────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Clamp_ValueInRange_ReturnsSameValue()
+    {
+        Assert.AreEqual(5, MathEx.Clamp(5, 1, 10));
+    }
+
+    [TestMethod]
+    public void Clamp_ValueBelowMin_ReturnsMin()
+    {
+        Assert.AreEqual(1, MathEx.Clamp(0, 1, 10));
+    }
+
+    [TestMethod]
+    public void Clamp_ValueAboveMax_ReturnsMax()
+    {
+        Assert.AreEqual(10, MathEx.Clamp(20, 1, 10));
+    }
+
+    [TestMethod]
+    public void Clamp_OnMinBoundary_ReturnsMin()
+    {
+        Assert.AreEqual(1, MathEx.Clamp(1, 1, 10));
+    }
+
+    [TestMethod]
+    public void Clamp_OnMaxBoundary_ReturnsMax()
+    {
+        Assert.AreEqual(10, MathEx.Clamp(10, 1, 10));
+    }
+
+    [TestMethod]
+    public void Clamp_MinGreaterThanMax_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(() => MathEx.Clamp(5, 10, 1));
+    }
+
+    [TestMethod]
+    public void Clamp_WithComparer_UsesCustomOrder()
+    {
+        // Reverse comparer: "min"=9, "max"=1 in natural order means clamp(5) stays at 5
+        var rev = Comparer<int>.Create((a, b) => b.CompareTo(a));
+        Assert.AreEqual(5, MathEx.Clamp(5, 9, 1, rev));
+        Assert.AreEqual(9, MathEx.Clamp(10, 9, 1, rev)); // 10 "below" min=9 → returns 9
+        Assert.AreEqual(1, MathEx.Clamp(0, 9, 1, rev));  // 0 "above" max=1 → returns 1
+    }
+
     [TestMethod]
     public void PascalTriangleTest()
     {

--- a/UtilsTest/Mathematics/MathExTests.cs
+++ b/UtilsTest/Mathematics/MathExTests.cs
@@ -178,6 +178,53 @@ public class MathExTests
         Assert.ThrowsException<DivideByZeroException>(() => MathEx.IsMultipleOf(5, 0));
     }
 
+    // ── IsPowerOfTwo ──────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void IsPowerOfTwo_PowersOfTwo_ReturnTrue()
+    {
+        Assert.IsTrue(MathEx.IsPowerOfTwo(1));
+        Assert.IsTrue(MathEx.IsPowerOfTwo(2));
+        Assert.IsTrue(MathEx.IsPowerOfTwo(4));
+        Assert.IsTrue(MathEx.IsPowerOfTwo(1024));
+    }
+
+    [TestMethod]
+    public void IsPowerOfTwo_NonPowers_ReturnFalse()
+    {
+        Assert.IsFalse(MathEx.IsPowerOfTwo(0));
+        Assert.IsFalse(MathEx.IsPowerOfTwo(3));
+        Assert.IsFalse(MathEx.IsPowerOfTwo(6));
+        Assert.IsFalse(MathEx.IsPowerOfTwo(-2));
+    }
+
+    // ── Lerp ─────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Lerp_AtZero_ReturnsA()
+    {
+        Assert.AreEqual(1.0, MathEx.Lerp(1.0, 5.0, 0.0));
+    }
+
+    [TestMethod]
+    public void Lerp_AtOne_ReturnsB()
+    {
+        Assert.AreEqual(5.0, MathEx.Lerp(1.0, 5.0, 1.0));
+    }
+
+    [TestMethod]
+    public void Lerp_AtHalf_ReturnsMidpoint()
+    {
+        Assert.AreEqual(3.0, MathEx.Lerp(1.0, 5.0, 0.5));
+    }
+
+    [TestMethod]
+    public void Lerp_Extrapolation_WorksBeyondRange()
+    {
+        Assert.AreEqual(9.0, MathEx.Lerp(1.0, 5.0, 2.0));  // t=2 → 1 + 2*(5-1) = 9
+        Assert.AreEqual(-3.0, MathEx.Lerp(1.0, 5.0, -1.0)); // t=-1 → 1 + (-1)*(5-1) = -3
+    }
+
     [TestMethod]
     public void GcdTest()
     {

--- a/UtilsTest/Mathematics/NullableIntExTests.cs
+++ b/UtilsTest/Mathematics/NullableIntExTests.cs
@@ -6,58 +6,76 @@ namespace UtilsTest.Mathematics;
 [TestClass]
 public class NullableIntExTests
 {
-    // ── Min ─────────────────────────────────────────────────────────────────
+    // ── MinStartpoint (null = −∞) ────────────────────────────────────────────
 
     [TestMethod]
-    public void Min_IsMinTrue_NullMeansMinusInfinity()
+    public void MinStartpoint_NullMeansMinusInfinity()
     {
-        // min(-∞, 5) = -∞
-        Assert.IsNull(NullableIntEx.Min<int>(null, 5, isMin: true));
-        Assert.IsNull(NullableIntEx.Min<int>(5, null, isMin: true));
-        Assert.IsNull(NullableIntEx.Min<int>(null, null, isMin: true));
+        // min(−∞, x) = −∞ → null wins
+        Assert.IsNull(NullableIntEx.MinStartpoint<int>(null, 5));
+        Assert.IsNull(NullableIntEx.MinStartpoint<int>(5, null));
+        Assert.IsNull(NullableIntEx.MinStartpoint<int>(null, null));
     }
 
     [TestMethod]
-    public void Min_IsMinFalse_NullMeansPlusInfinity()
+    public void MinStartpoint_BothFinite_ReturnsSmaller()
     {
-        // min(+∞, 5) = 5
-        Assert.AreEqual(5, NullableIntEx.Min<int>(null, 5, isMin: false));
-        Assert.AreEqual(5, NullableIntEx.Min<int>(5, null, isMin: false));
-        Assert.IsNull(NullableIntEx.Min<int>(null, null, isMin: false));
+        Assert.AreEqual(3, NullableIntEx.MinStartpoint<int>(3, 7));
+        Assert.AreEqual(3, NullableIntEx.MinStartpoint<int>(7, 3));
+    }
+
+    // ── MinEndpoint (null = +∞) ──────────────────────────────────────────────
+
+    [TestMethod]
+    public void MinEndpoint_NullMeansPlusInfinity()
+    {
+        // min(+∞, x) = x → finite wins
+        Assert.AreEqual(5, NullableIntEx.MinEndpoint<int>(null, 5));
+        Assert.AreEqual(5, NullableIntEx.MinEndpoint<int>(5, null));
+        Assert.IsNull(NullableIntEx.MinEndpoint<int>(null, null));
     }
 
     [TestMethod]
-    public void Min_BothFinite_ReturnsSmaller()
+    public void MinEndpoint_BothFinite_ReturnsSmaller()
     {
-        Assert.AreEqual(3, NullableIntEx.Min<int>(3, 7, isMin: true));
-        Assert.AreEqual(3, NullableIntEx.Min<int>(3, 7, isMin: false));
+        Assert.AreEqual(3, NullableIntEx.MinEndpoint<int>(3, 7));
+        Assert.AreEqual(3, NullableIntEx.MinEndpoint<int>(7, 3));
     }
 
-    // ── Max ─────────────────────────────────────────────────────────────────
+    // ── MaxStartpoint (null = −∞) ────────────────────────────────────────────
 
     [TestMethod]
-    public void Max_IsMaxTrue_NullMeansPlusInfinity()
+    public void MaxStartpoint_NullMeansMinusInfinity()
     {
-        // max(+∞, 5) = +∞
-        Assert.IsNull(NullableIntEx.Max<int>(null, 5, isMax: true));
-        Assert.IsNull(NullableIntEx.Max<int>(5, null, isMax: true));
-        Assert.IsNull(NullableIntEx.Max<int>(null, null, isMax: true));
-    }
-
-    [TestMethod]
-    public void Max_IsMaxFalse_NullMeansMinusInfinity()
-    {
-        // max(-∞, 5) = 5
-        Assert.AreEqual(5, NullableIntEx.Max<int>(null, 5, isMax: false));
-        Assert.AreEqual(5, NullableIntEx.Max<int>(5, null, isMax: false));
-        Assert.IsNull(NullableIntEx.Max<int>(null, null, isMax: false));
+        // max(−∞, x) = x → finite wins
+        Assert.AreEqual(5, NullableIntEx.MaxStartpoint<int>(null, 5));
+        Assert.AreEqual(5, NullableIntEx.MaxStartpoint<int>(5, null));
+        Assert.IsNull(NullableIntEx.MaxStartpoint<int>(null, null));
     }
 
     [TestMethod]
-    public void Max_BothFinite_ReturnsLarger()
+    public void MaxStartpoint_BothFinite_ReturnsLarger()
     {
-        Assert.AreEqual(7, NullableIntEx.Max<int>(3, 7, isMax: true));
-        Assert.AreEqual(7, NullableIntEx.Max<int>(3, 7, isMax: false));
+        Assert.AreEqual(7, NullableIntEx.MaxStartpoint<int>(3, 7));
+        Assert.AreEqual(7, NullableIntEx.MaxStartpoint<int>(7, 3));
+    }
+
+    // ── MaxEndpoint (null = +∞) ──────────────────────────────────────────────
+
+    [TestMethod]
+    public void MaxEndpoint_NullMeansPlusInfinity()
+    {
+        // max(+∞, x) = +∞ → null wins
+        Assert.IsNull(NullableIntEx.MaxEndpoint<int>(null, 5));
+        Assert.IsNull(NullableIntEx.MaxEndpoint<int>(5, null));
+        Assert.IsNull(NullableIntEx.MaxEndpoint<int>(null, null));
+    }
+
+    [TestMethod]
+    public void MaxEndpoint_BothFinite_ReturnsLarger()
+    {
+        Assert.AreEqual(7, NullableIntEx.MaxEndpoint<int>(3, 7));
+        Assert.AreEqual(7, NullableIntEx.MaxEndpoint<int>(7, 3));
     }
 
     // ── LessOrEqual / Less ──────────────────────────────────────────────────

--- a/UtilsTest/Mathematics/NullableIntExTests.cs
+++ b/UtilsTest/Mathematics/NullableIntExTests.cs
@@ -78,6 +78,62 @@ public class NullableIntExTests
         Assert.AreEqual(7, NullableIntEx.MaxEndpoint<int>(7, 3));
     }
 
+    // ── CompareStartpoint (null = −∞) ───────────────────────────────────────
+
+    [TestMethod]
+    public void CompareStartpoint_BothNull_ReturnsZero()
+    {
+        Assert.AreEqual(0, NullableIntEx.CompareStartpoint<int>(null, null));
+    }
+
+    [TestMethod]
+    public void CompareStartpoint_NullLeftIsLess()
+    {
+        Assert.IsTrue(NullableIntEx.CompareStartpoint<int>(null, 5) < 0);  // −∞ < 5
+    }
+
+    [TestMethod]
+    public void CompareStartpoint_NullRightIsGreater()
+    {
+        Assert.IsTrue(NullableIntEx.CompareStartpoint<int>(5, null) > 0);  // 5 > −∞
+    }
+
+    [TestMethod]
+    public void CompareStartpoint_BothFinite_OrdersByValue()
+    {
+        Assert.IsTrue(NullableIntEx.CompareStartpoint<int>(3, 7) < 0);
+        Assert.IsTrue(NullableIntEx.CompareStartpoint<int>(7, 3) > 0);
+        Assert.AreEqual(0, NullableIntEx.CompareStartpoint<int>(5, 5));
+    }
+
+    // ── CompareEndpoint (null = +∞) ──────────────────────────────────────────
+
+    [TestMethod]
+    public void CompareEndpoint_BothNull_ReturnsZero()
+    {
+        Assert.AreEqual(0, NullableIntEx.CompareEndpoint<int>(null, null));
+    }
+
+    [TestMethod]
+    public void CompareEndpoint_NullLeftIsGreater()
+    {
+        Assert.IsTrue(NullableIntEx.CompareEndpoint<int>(null, 5) > 0);   // +∞ > 5
+    }
+
+    [TestMethod]
+    public void CompareEndpoint_NullRightIsLess()
+    {
+        Assert.IsTrue(NullableIntEx.CompareEndpoint<int>(5, null) < 0);   // 5 < +∞
+    }
+
+    [TestMethod]
+    public void CompareEndpoint_BothFinite_OrdersByValue()
+    {
+        Assert.IsTrue(NullableIntEx.CompareEndpoint<int>(3, 7) < 0);
+        Assert.IsTrue(NullableIntEx.CompareEndpoint<int>(7, 3) > 0);
+        Assert.AreEqual(0, NullableIntEx.CompareEndpoint<int>(5, 5));
+    }
+
     // ── LessOrEqual / Less ──────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/TrigonometryTests.cs
+++ b/UtilsTest/Mathematics/TrigonometryTests.cs
@@ -1,0 +1,244 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Mathematics;
+
+namespace UtilsTest.Mathematics;
+
+[TestClass]
+public class TrigonometryTests
+{
+    private const double Delta = 1e-10;
+
+    // ── Radian — trigonométrie de base ──────────────────────────────────────
+
+    [TestMethod]
+    public void Radian_Sin_KnownValues()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(0.0,  trig.Sin(0),               Delta);
+        Assert.AreEqual(1.0,  trig.Sin(Math.PI / 2),     Delta);
+        Assert.AreEqual(0.0,  trig.Sin(Math.PI),          Delta);
+        Assert.AreEqual(-1.0, trig.Sin(3 * Math.PI / 2), Delta);
+    }
+
+    [TestMethod]
+    public void Radian_Cos_KnownValues()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(1.0,  trig.Cos(0),           Delta);
+        Assert.AreEqual(0.0,  trig.Cos(Math.PI / 2), Delta);
+        Assert.AreEqual(-1.0, trig.Cos(Math.PI),     Delta);
+    }
+
+    [TestMethod]
+    public void Radian_Tan_KnownValues()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(0.0, trig.Tan(0),           Delta);
+        Assert.AreEqual(1.0, trig.Tan(Math.PI / 4), Delta);
+    }
+
+    [TestMethod]
+    public void Radian_ReciprocalFunctions_KnownValues()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(1.0, trig.Sec(0),              Delta); // sec(0) = 1/cos(0) = 1
+        Assert.AreEqual(1.0, trig.Csc(Math.PI / 2),   Delta); // csc(π/2) = 1/sin(π/2) = 1
+        Assert.AreEqual(1.0, trig.Cot(Math.PI / 4),   Delta); // cot(π/4) = cos/sin = 1
+    }
+
+    // ── Radian — trigonométrie inverse ──────────────────────────────────────
+
+    [TestMethod]
+    public void Radian_InverseTrig_KnownValues()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(Math.PI / 6, trig.Asin(0.5), Delta); // arcsin(1/2) = π/6
+        Assert.AreEqual(Math.PI / 3, trig.Acos(0.5), Delta); // arccos(1/2) = π/3
+        Assert.AreEqual(Math.PI / 4, trig.Atan(1.0), Delta); // arctan(1) = π/4
+    }
+
+    [TestMethod]
+    public void Radian_Atan2_FourQuadrants()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(Math.PI / 4,      trig.Atan2(1, 1),  Delta); // Q1
+        Assert.AreEqual(3 * Math.PI / 4,  trig.Atan2(1, -1), Delta); // Q2
+        Assert.AreEqual(-3 * Math.PI / 4, trig.Atan2(-1, -1), Delta); // Q3
+        Assert.AreEqual(-Math.PI / 4,     trig.Atan2(-1, 1),  Delta); // Q4
+    }
+
+    // ── Radian — hyperbolique ────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Radian_Hyperbolic_KnownValues()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(0.0, trig.Sinh(0), Delta);
+        Assert.AreEqual(1.0, trig.Cosh(0), Delta);
+        Assert.AreEqual(0.0, trig.Tanh(0), Delta);
+        Assert.AreEqual(1.0, trig.Sech(0), Delta); // sech(0) = 1/cosh(0) = 1
+    }
+
+    [TestMethod]
+    public void Radian_InverseHyperbolic_KnownValues()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(0.0, trig.Asinh(0), Delta);
+        Assert.AreEqual(0.0, trig.Acosh(1), Delta);
+        Assert.AreEqual(0.0, trig.Atanh(0), Delta);
+    }
+
+    // ── Radian — normalisation et arithmétique angulaire ────────────────────
+
+    [TestMethod]
+    public void Radian_Normalize0To2Max_ReducesMod2Pi()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(Math.PI,     trig.Normalize0To2Max(3 * Math.PI),      Delta);
+        Assert.AreEqual(Math.PI / 2, trig.Normalize0To2Max(5 * Math.PI / 2),  Delta);
+        Assert.AreEqual(0.0,         trig.Normalize0To2Max(0),                 Delta);
+        Assert.AreEqual(0.0,         trig.Normalize0To2Max(2 * Math.PI),       Delta);
+    }
+
+    [TestMethod]
+    public void Radian_AddAngles_WrapsAround()
+    {
+        var trig = Trigonometry<double>.Radian;
+        // 3π/2 + π = 5π/2 → mod 2π = π/2
+        Assert.AreEqual(Math.PI / 2, trig.AddAngles(3 * Math.PI / 2, Math.PI), Delta);
+    }
+
+    [TestMethod]
+    public void Radian_SubtractAngles_WrapsAround()
+    {
+        var trig = Trigonometry<double>.Radian;
+        // π/4 - π/2 = -π/4 → mod 2π = 7π/4
+        Assert.AreEqual(7 * Math.PI / 4, trig.SubtractAngles(Math.PI / 4, Math.PI / 2), Delta);
+    }
+
+    [TestMethod]
+    public void Radian_FromRadian_ToRadian_AreIdentity()
+    {
+        var trig = Trigonometry<double>.Radian;
+        Assert.AreEqual(1.5, trig.FromRadian(1.5), Delta);
+        Assert.AreEqual(1.5, trig.ToRadian(1.5),   Delta);
+    }
+
+    // ── Degrés ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Degree_Sin_KnownValues()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(0.0,  trig.Sin(0),   Delta);
+        Assert.AreEqual(1.0,  trig.Sin(90),  Delta);
+        Assert.AreEqual(0.0,  trig.Sin(180), Delta);
+        Assert.AreEqual(-1.0, trig.Sin(270), Delta);
+    }
+
+    [TestMethod]
+    public void Degree_Cos_KnownValues()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(1.0,  trig.Cos(0),   Delta);
+        Assert.AreEqual(0.0,  trig.Cos(90),  Delta);
+        Assert.AreEqual(-1.0, trig.Cos(180), Delta);
+    }
+
+    [TestMethod]
+    public void Degree_Tan_KnownValues()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(0.0, trig.Tan(0),  Delta);
+        Assert.AreEqual(1.0, trig.Tan(45), Delta);
+    }
+
+    [TestMethod]
+    public void Degree_NormalizeMinToMax_ReducesToMinus180_180()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(-90.0, trig.NormalizeMinToMax(270),  Delta);
+        Assert.AreEqual(90.0,  trig.NormalizeMinToMax(-270), Delta);
+        Assert.AreEqual(0.0,   trig.NormalizeMinToMax(360),  Delta);
+        Assert.AreEqual(0.0,   trig.NormalizeMinToMax(0),    Delta);
+    }
+
+    [TestMethod]
+    public void Degree_Normalize0To2Max_ReducesTo0_360()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(90.0, trig.Normalize0To2Max(450), Delta);
+        Assert.AreEqual(0.0,  trig.Normalize0To2Max(360), Delta);
+        Assert.AreEqual(0.0,  trig.Normalize0To2Max(0),   Delta);
+    }
+
+    [TestMethod]
+    public void Degree_AddAngles_WrapsAround()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(10.0, trig.AddAngles(350, 20), Delta);
+    }
+
+    [TestMethod]
+    public void Degree_SubtractAngles_WrapsAround()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(350.0, trig.SubtractAngles(10, 20), Delta);
+    }
+
+    [TestMethod]
+    public void Degree_FromRadian_ToRadian()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(180.0,    trig.FromRadian(Math.PI), Delta);
+        Assert.AreEqual(Math.PI,  trig.ToRadian(180),       Delta);
+    }
+
+    // ── Grades ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Grade_Sin_KnownValues()
+    {
+        var trig = Trigonometry<double>.Grade;
+        Assert.AreEqual(0.0,  trig.Sin(0),   Delta); // 0 gr = 0°
+        Assert.AreEqual(1.0,  trig.Sin(100), Delta); // 100 gr = 90°
+        Assert.AreEqual(0.0,  trig.Sin(200), Delta); // 200 gr = 180°
+        Assert.AreEqual(-1.0, trig.Sin(300), Delta); // 300 gr = 270°
+    }
+
+    [TestMethod]
+    public void Grade_Cos_KnownValues()
+    {
+        var trig = Trigonometry<double>.Grade;
+        Assert.AreEqual(1.0,  trig.Cos(0),   Delta);
+        Assert.AreEqual(-1.0, trig.Cos(200), Delta); // 200 gr = 180°
+    }
+
+    // ── Trigonometry.Get() — cache ───────────────────────────────────────────
+
+    [TestMethod]
+    public void Get_SamePerigon_ReturnsSameInstance()
+    {
+        var a = Trigonometry<double>.Get(360);
+        var b = Trigonometry<double>.Get(360);
+        Assert.AreSame(a, b);
+    }
+
+    [TestMethod]
+    public void Get_Degree_ReturnsSameInstanceAsProperty()
+    {
+        Assert.AreSame(Trigonometry<double>.Degree, Trigonometry<double>.Get(360));
+    }
+
+    [TestMethod]
+    public void Get_Radian_ReturnsSameInstanceAsProperty()
+    {
+        Assert.AreSame(Trigonometry<double>.Radian, Trigonometry<double>.Get(2 * Math.PI));
+    }
+
+    [TestMethod]
+    public void Get_Grade_ReturnsSameInstanceAsProperty()
+    {
+        Assert.AreSame(Trigonometry<double>.Grade, Trigonometry<double>.Get(400));
+    }
+}

--- a/UtilsTest/Mathematics/TrigonometryTests.cs
+++ b/UtilsTest/Mathematics/TrigonometryTests.cs
@@ -214,6 +214,46 @@ public class TrigonometryTests
         Assert.AreEqual(-1.0, trig.Cos(200), Delta); // 200 gr = 180°
     }
 
+    // ── Degrés — trigonométrie inverse ──────────────────────────────────────
+
+    [TestMethod]
+    public void Degree_InverseTrig_KnownValues()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(30.0, trig.Asin(0.5), Delta); // arcsin(1/2) = 30°
+        Assert.AreEqual(60.0, trig.Acos(0.5), Delta); // arccos(1/2) = 60°
+        Assert.AreEqual(45.0, trig.Atan(1.0), Delta); // arctan(1)   = 45°
+    }
+
+    [TestMethod]
+    public void Degree_InverseTrig_Boundary()
+    {
+        var trig = Trigonometry<double>.Degree;
+        Assert.AreEqual(90.0,  trig.Asin(1.0),  Delta);  // arcsin(1)  = 90°
+        Assert.AreEqual(0.0,   trig.Acos(1.0),  Delta);  // arccos(1)  = 0°
+        Assert.AreEqual(0.0,   trig.Atan(0.0),  Delta);  // arctan(0)  = 0°
+    }
+
+    // ── Grades — trigonométrie inverse ──────────────────────────────────────
+
+    [TestMethod]
+    public void Grade_InverseTrig_KnownValues()
+    {
+        var trig = Trigonometry<double>.Grade;
+        // 30° = 33.333... grad, 60° = 66.666... grad, 45° = 50 grad
+        Assert.AreEqual(100.0 / 3.0, trig.Asin(0.5), Delta);
+        Assert.AreEqual(200.0 / 3.0, trig.Acos(0.5), Delta);
+        Assert.AreEqual(50.0,        trig.Atan(1.0),  Delta);
+    }
+
+    [TestMethod]
+    public void Grade_InverseTrig_Boundary()
+    {
+        var trig = Trigonometry<double>.Grade;
+        Assert.AreEqual(100.0, trig.Asin(1.0), Delta);  // arcsin(1) = 100 grad
+        Assert.AreEqual(0.0,   trig.Acos(1.0), Delta);  // arccos(1) = 0 grad
+    }
+
     // ── Radian — NormalizeMinToMax ──────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/TrigonometryTests.cs
+++ b/UtilsTest/Mathematics/TrigonometryTests.cs
@@ -214,6 +214,24 @@ public class TrigonometryTests
         Assert.AreEqual(-1.0, trig.Cos(200), Delta); // 200 gr = 180°
     }
 
+    // ── Radian — NormalizeMinToMax ──────────────────────────────────────────
+
+    [TestMethod]
+    public void Radian_NormalizeMinToMax_CorrectlyNormalizesToMinusPiPi()
+    {
+        var trig = Trigonometry<double>.Radian;
+        // Values that should map to themselves (already in [-π, π))
+        Assert.AreEqual(0.0,          trig.NormalizeMinToMax(0),              Delta);
+        Assert.AreEqual(Math.PI / 2,  trig.NormalizeMinToMax(Math.PI / 2),   Delta);
+        Assert.AreEqual(-Math.PI / 2, trig.NormalizeMinToMax(-Math.PI / 2),  Delta);
+        // 2π → 0 (wraps to 0)
+        Assert.AreEqual(0.0,          trig.NormalizeMinToMax(2 * Math.PI),    Delta);
+        // 3π/2 → -π/2  (wraps)
+        Assert.AreEqual(-Math.PI / 2, trig.NormalizeMinToMax(3 * Math.PI / 2), Delta);
+        // -3π/2 → π/2  (wraps negative)
+        Assert.AreEqual(Math.PI / 2,  trig.NormalizeMinToMax(-3 * Math.PI / 2), Delta);
+    }
+
     // ── Trigonometry.Get() — cache ───────────────────────────────────────────
 
     [TestMethod]


### PR DESCRIPTION
## Summary

### FloatingPointComparer
- Removed `IEqualityComparer<T>` (fuzzy equality is semantically incompatible with `GetHashCode`; only `IComparer<T>` makes sense for floats)
- Updated `GeoPoint` / `GeoVector` callers: `comparer.Equals(x, y)` → `comparer.Compare(x, y) == 0`

### NullableIntEx / MathEx
- Renamed `Round`/`Floor`/`Ceiling` parameter `@base` → `step`
- Replaced `Min(a, b, isMin)`/`Max(a, b, isMax)` (boolean flag) with explicit `MinStartpoint`, `MinEndpoint`, `MaxStartpoint`, `MaxEndpoint` (null = -∞ or +∞ depending on context)
- Added `IsPowerOfTwo<T>()` (`IBinaryInteger<T>` constraint)
- Added `Lerp<T>(a, b, t)` (`IFloatingPoint<T>` constraint)
- Wrapped `ComputePascalTriangleLine` cache access in a lock (thread safety)

### IAngleCalculator — adaptive `_invTrigPrecision`
- Was hardcoded `1e-10`; now `T.Max(1e-10, 100 × machine_epsilon)`
- Preserves double at `1e-10`; raises float to `~1.19e-5` (float machine epsilon is `~1.19e-7`, so `1e-10` was below it and broke mod operations)

### FastFourrierTransform
- Converted from an instantiable class to `static class`
- Replaced `start`/`end` index parameters with `Span<Complex>` slices — eliminates a start-offset bug where `Separate` wrote to `array[i<<1]` instead of `array[start + i<<1]`
- Added `InverseTransform`: conjugate → forward FFT → conjugate → divide by N

### FourrierExtensions
- Added `GetAmplitudes(Complex[])` and `GetPhases(Complex[])`
- Added `ArgumentOutOfRangeException` validation for `sampleRate <= 0` in `GetFrequencies`

### ExpressionIntegration
- Renamed `Substract` → `Subtract` (typo)
- Fixed `double.Epsilon` → `1e-10` at 3 locations: `double.Epsilon ≈ 5e-324` is the smallest positive double (NOT machine epsilon), so the comparisons `Abs(n-1) < double.Epsilon` and `Abs(n+1) < double.Epsilon` were effectively always false — the logarithm branches for `∫x^(-1)dx` and `∫c/x dx` never activated

### ExpressionDerivation
- Fixed `Log10` formula: numerator and denominator were swapped (`x/(ln(10)·x')` → `x'/(x·ln(10))`)
- Fixed `DeriveUnknownMethodCall`: `typeof(double)` → `typeof(T)` (broke for `T=float`)
- Fixed finite-difference epsilon: `Expression.Constant(double)` → `ExpressionEx.CreateConstant(T.CreateChecked(...))` (`Expression.Add(float, double)` threw at expression compile time)

### LinearAlgebra
- Added `VectorExtensions.AngleWith<T>` extension method with `ITrigonometricFunctions<T>` constraint (avoids touching `Vector<T>` class signature)

## Tests

78 new tests covering all changes:
- `FloatingPointComparerTests`: removed equality tests, kept compare
- `FastFourrierTransformTests`: corrected expected values (old tests matched buggy output), `InverseTransform` round-trip
- `MathExTests`: `IsPowerOfTwo` (powers, non-powers), `Lerp` (endpoints, midpoint, extrapolation)
- `TrigonometryTests`: inverse trig for Degree (30/60/45°, boundary) and Grade
- `ExpressionDerivationTests`: `Log`, `Log10` (bug fix), `Tan`, `Sinh`/`Cosh`/`Tanh`, quotient rule, constant, float unknown function fallback (bug fix)
- `ExpressionIntegrationTests`: constant, x, x², x^(-1) (bug fix), c/x (bug fix), Sin, Cos, sin(2x), Exp, Log, Log10, scaled sin, sum
- `VectorTests`: `AngleWith` — perpendicular (π/2), parallel (0), opposite (π), 45°, dimension mismatch, zero vector

## Test plan

- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` — 2493 pass, 3 ignored, 0 failures