### PR TITLE
feat(collections): SkipListDictionary<K,V> — dictionnaire trié basé sur SkipList

### DIFF
--- a/Utils.Collections/SkipList.cs
+++ b/Utils.Collections/SkipList.cs
@@ -152,6 +152,30 @@ public class SkipList<T> : ICollection<T>
     }
 
     /// <summary>
+    /// Searches for an element that compares equal to <paramref name="item"/> and returns
+    /// the stored instance. This is useful when the comparer considers only a subset of
+    /// the element's fields (e.g. a key), allowing the caller to retrieve the full stored
+    /// object rather than just a membership check.
+    /// </summary>
+    /// <param name="item">The element to locate.</param>
+    /// <param name="found">
+    /// When this method returns <see langword="true"/>, contains the stored element that
+    /// matched <paramref name="item"/>; otherwise the default value.
+    /// </param>
+    /// <returns><see langword="true"/> if a matching element was found; otherwise, <see langword="false"/>.</returns>
+    public bool TryGet(T item, out T found)
+    {
+        var (elementBefore, elementAfter) = FindElementPosition(item);
+        if (elementBefore is not null && elementBefore == elementAfter)
+        {
+            found = elementBefore.Value;
+            return true;
+        }
+        found = default!;
+        return false;
+    }
+
+    /// <summary>
     /// Copies the elements of the skip list to an array, starting at a particular array index.
     /// </summary>
     /// <param name="array">The destination array.</param>
@@ -172,7 +196,7 @@ public class SkipList<T> : ICollection<T>
     public bool Remove(T item)
     {
         var (elementBefore, elementAfter) = FindElementPosition(item);
-        if (elementBefore != elementAfter) return false;
+        if (elementBefore is null || elementBefore != elementAfter) return false;
         var element = elementBefore;
 
         if (element.Previous is null && element.Next is not null)

--- a/Utils.Collections/SkipListDictionary.cs
+++ b/Utils.Collections/SkipListDictionary.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Utils.Collections;
+
+/// <summary>
+/// A dictionary whose keys are kept in sorted order using a <see cref="SkipList{T}"/>
+/// as the underlying data structure. All keyed operations run in O(log n) time on average.
+/// Iteration yields entries in ascending key order.
+/// </summary>
+/// <typeparam name="K">The type of keys. Must be non-null.</typeparam>
+/// <typeparam name="V">The type of values.</typeparam>
+public class SkipListDictionary<K, V> : IDictionary<K, V>
+    where K : notnull
+{
+    private readonly SkipList<Entry> _skipList;
+
+    /// <summary>
+    /// Initializes a new instance using the default key comparer and a threshold of 10.
+    /// </summary>
+    public SkipListDictionary() : this(Comparer<K>.Default, 10) { }
+
+    /// <summary>
+    /// Initializes a new instance using the default key comparer and the specified threshold.
+    /// </summary>
+    /// <param name="threshold">
+    /// The maximum number of nodes to traverse at a given skip level before creating a
+    /// structure node. Must be &gt;= 2.
+    /// </param>
+    public SkipListDictionary(int threshold) : this(Comparer<K>.Default, threshold) { }
+
+    /// <summary>
+    /// Initializes a new instance using the specified key comparer and threshold.
+    /// </summary>
+    /// <param name="keyComparer">The comparer used to order keys.</param>
+    /// <param name="threshold">
+    /// The maximum number of nodes to traverse at a given skip level before creating a
+    /// structure node. Must be &gt;= 2.
+    /// </param>
+    public SkipListDictionary(IComparer<K> keyComparer, int threshold = 10)
+    {
+        _skipList = new SkipList<Entry>(new EntryComparer(keyComparer ?? throw new ArgumentNullException(nameof(keyComparer))), threshold);
+    }
+
+    /// <inheritdoc />
+    public int Count => _skipList.Count;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc />
+    public ICollection<K> Keys => new KeyCollection(this);
+
+    /// <inheritdoc />
+    public ICollection<V> Values => new ValueCollection(this);
+
+    /// <inheritdoc />
+    public V this[K key]
+    {
+        get
+        {
+            if (!TryGetValue(key, out var value))
+                throw new KeyNotFoundException($"The given key '{key}' was not present in the dictionary.");
+            return value;
+        }
+        set
+        {
+            var probe = Entry.Probe(key);
+            if (_skipList.TryGet(probe, out var found))
+                found.Value = value;
+            else
+                _skipList.Add(new Entry(key, value));
+        }
+    }
+
+    /// <inheritdoc />
+    public void Add(K key, V value)
+    {
+        if (_skipList.Contains(Entry.Probe(key)))
+            throw new ArgumentException("An element with the same key already exists.", nameof(key));
+        _skipList.Add(new Entry(key, value));
+    }
+
+    /// <inheritdoc />
+    public void Add(KeyValuePair<K, V> item) => Add(item.Key, item.Value);
+
+    /// <inheritdoc />
+    public bool ContainsKey(K key) => _skipList.Contains(Entry.Probe(key));
+
+    /// <inheritdoc />
+    public bool Contains(KeyValuePair<K, V> item)
+        => TryGetValue(item.Key, out var value) && EqualityComparer<V>.Default.Equals(value, item.Value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(K key, [MaybeNullWhen(false)] out V value)
+    {
+        if (_skipList.TryGet(Entry.Probe(key), out var found))
+        {
+            value = found.Value;
+            return true;
+        }
+        value = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool Remove(K key) => _skipList.Remove(Entry.Probe(key));
+
+    /// <inheritdoc />
+    public bool Remove(KeyValuePair<K, V> item)
+    {
+        if (!TryGetValue(item.Key, out var value)) return false;
+        if (!EqualityComparer<V>.Default.Equals(value, item.Value)) return false;
+        return Remove(item.Key);
+    }
+
+    /// <inheritdoc />
+    public void Clear() => _skipList.Clear();
+
+    /// <inheritdoc />
+    public void CopyTo(KeyValuePair<K, V>[] array, int arrayIndex)
+    {
+        foreach (var kvp in this)
+            array[arrayIndex++] = kvp;
+    }
+
+    /// <inheritdoc />
+    public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+        => _skipList.Select(e => new KeyValuePair<K, V>(e.Key, e.Value)).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private sealed class Entry
+    {
+        public K Key { get; }
+        public V Value { get; set; }
+
+        public Entry(K key, V value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        /// <summary>Creates a key-only probe used for lookups and removals.</summary>
+        public static Entry Probe(K key) => new(key, default!);
+    }
+
+    private sealed class EntryComparer : IComparer<Entry>
+    {
+        private readonly IComparer<K> _keyComparer;
+
+        public EntryComparer(IComparer<K> keyComparer) => _keyComparer = keyComparer;
+
+        public int Compare(Entry? x, Entry? y) => _keyComparer.Compare(x!.Key, y!.Key);
+    }
+
+    private sealed class KeyCollection : ICollection<K>
+    {
+        private readonly SkipListDictionary<K, V> _owner;
+        public KeyCollection(SkipListDictionary<K, V> owner) => _owner = owner;
+
+        public int Count => _owner.Count;
+        public bool IsReadOnly => true;
+        public bool Contains(K item) => _owner.ContainsKey(item);
+
+        public void CopyTo(K[] array, int arrayIndex)
+        {
+            foreach (var key in this) array[arrayIndex++] = key;
+        }
+
+        public IEnumerator<K> GetEnumerator()
+            => _owner._skipList.Select(e => e.Key).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Add(K item) => throw new NotSupportedException();
+        public void Clear() => throw new NotSupportedException();
+        public bool Remove(K item) => throw new NotSupportedException();
+    }
+
+    private sealed class ValueCollection : ICollection<V>
+    {
+        private readonly SkipListDictionary<K, V> _owner;
+        public ValueCollection(SkipListDictionary<K, V> owner) => _owner = owner;
+
+        public int Count => _owner.Count;
+        public bool IsReadOnly => true;
+        public bool Contains(V item)
+            => _owner._skipList.Any(e => EqualityComparer<V>.Default.Equals(e.Value, item));
+
+        public void CopyTo(V[] array, int arrayIndex)
+        {
+            foreach (var value in this) array[arrayIndex++] = value;
+        }
+
+        public IEnumerator<V> GetEnumerator()
+            => _owner._skipList.Select(e => e.Value).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Add(V item) => throw new NotSupportedException();
+        public void Clear() => throw new NotSupportedException();
+        public bool Remove(V item) => throw new NotSupportedException();
+    }
+}

--- a/UtilsTest/Lists/SkipListDictionaryTests.cs
+++ b/UtilsTest/Lists/SkipListDictionaryTests.cs
@@ -1,0 +1,258 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utils.Collections;
+using Utils.Randomization;
+
+namespace UtilsTest.Lists
+{
+    [TestClass]
+    public class SkipListDictionaryTests
+    {
+        [TestMethod]
+        public void AddAndRetrieve_BasicOperations()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict.Add("b", 2);
+            dict.Add("a", 1);
+            dict.Add("c", 3);
+
+            Assert.AreEqual(3, dict.Count);
+            Assert.AreEqual(1, dict["a"]);
+            Assert.AreEqual(2, dict["b"]);
+            Assert.AreEqual(3, dict["c"]);
+        }
+
+        [TestMethod]
+        public void Keys_AreSortedInAscendingOrder()
+        {
+            var dict = new SkipListDictionary<int, string>();
+            dict.Add(30, "thirty");
+            dict.Add(10, "ten");
+            dict.Add(20, "twenty");
+
+            CollectionAssert.AreEqual(new[] { 10, 20, 30 }, dict.Keys.ToArray());
+        }
+
+        [TestMethod]
+        public void Enumeration_YieldsEntriesInKeyOrder()
+        {
+            var dict = new SkipListDictionary<int, string>();
+            dict.Add(30, "thirty");
+            dict.Add(10, "ten");
+            dict.Add(20, "twenty");
+
+            var pairs = dict.ToArray();
+            Assert.AreEqual(3, pairs.Length);
+            Assert.AreEqual(10, pairs[0].Key);
+            Assert.AreEqual(20, pairs[1].Key);
+            Assert.AreEqual(30, pairs[2].Key);
+            Assert.AreEqual("ten", pairs[0].Value);
+        }
+
+        [TestMethod]
+        public void Indexer_SetUpdatesValueInPlace()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict["a"] = 1;
+            dict["a"] = 42;
+
+            Assert.AreEqual(42, dict["a"]);
+            Assert.AreEqual(1, dict.Count);
+        }
+
+        [TestMethod]
+        public void Indexer_SetAddsIfKeyAbsent()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict["x"] = 99;
+
+            Assert.AreEqual(1, dict.Count);
+            Assert.AreEqual(99, dict["x"]);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(KeyNotFoundException))]
+        public void Indexer_GetMissingKey_Throws()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            _ = dict["missing"];
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Add_DuplicateKey_Throws()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict.Add("a", 1);
+            dict.Add("a", 2);
+        }
+
+        [TestMethod]
+        public void TryGetValue_ExistingKey_ReturnsTrue()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict.Add("a", 42);
+
+            Assert.IsTrue(dict.TryGetValue("a", out var value));
+            Assert.AreEqual(42, value);
+        }
+
+        [TestMethod]
+        public void TryGetValue_MissingKey_ReturnsFalse()
+        {
+            var dict = new SkipListDictionary<string, int>();
+
+            Assert.IsFalse(dict.TryGetValue("z", out _));
+        }
+
+        [TestMethod]
+        public void ContainsKey_ReturnsTrueForExistingKey()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict.Add("hello", 1);
+
+            Assert.IsTrue(dict.ContainsKey("hello"));
+            Assert.IsFalse(dict.ContainsKey("world"));
+        }
+
+        [TestMethod]
+        public void Contains_KeyValuePair_ChecksBothKeyAndValue()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict.Add("a", 1);
+
+            Assert.IsTrue(dict.Contains(new KeyValuePair<string, int>("a", 1)));
+            Assert.IsFalse(dict.Contains(new KeyValuePair<string, int>("a", 99)));
+            Assert.IsFalse(dict.Contains(new KeyValuePair<string, int>("z", 1)));
+        }
+
+        [TestMethod]
+        public void Remove_ByKey_RemovesEntry()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict.Add("a", 1);
+            dict.Add("b", 2);
+
+            Assert.IsTrue(dict.Remove("a"));
+            Assert.AreEqual(1, dict.Count);
+            Assert.IsFalse(dict.ContainsKey("a"));
+            Assert.IsTrue(dict.ContainsKey("b"));
+        }
+
+        [TestMethod]
+        public void Remove_MissingKey_ReturnsFalse()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            Assert.IsFalse(dict.Remove("ghost"));
+        }
+
+        [TestMethod]
+        public void Remove_KeyValuePair_OnlyRemovesWhenValueMatches()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict.Add("a", 1);
+
+            Assert.IsFalse(dict.Remove(new KeyValuePair<string, int>("a", 99)));
+            Assert.IsTrue(dict.ContainsKey("a"));
+
+            Assert.IsTrue(dict.Remove(new KeyValuePair<string, int>("a", 1)));
+            Assert.IsFalse(dict.ContainsKey("a"));
+        }
+
+        [TestMethod]
+        public void Clear_RemovesAllEntries()
+        {
+            var dict = new SkipListDictionary<string, int>();
+            dict.Add("a", 1);
+            dict.Add("b", 2);
+            dict.Clear();
+
+            Assert.AreEqual(0, dict.Count);
+            Assert.IsFalse(dict.ContainsKey("a"));
+            Assert.IsFalse(dict.ContainsKey("b"));
+        }
+
+        [TestMethod]
+        public void CopyTo_CopiesAllEntriesInOrder()
+        {
+            var dict = new SkipListDictionary<int, string>();
+            dict.Add(3, "c");
+            dict.Add(1, "a");
+            dict.Add(2, "b");
+
+            var array = new KeyValuePair<int, string>[3];
+            dict.CopyTo(array, 0);
+
+            Assert.AreEqual(1, array[0].Key);
+            Assert.AreEqual(2, array[1].Key);
+            Assert.AreEqual(3, array[2].Key);
+        }
+
+        [TestMethod]
+        public void Values_ReflectsCurrentState()
+        {
+            var dict = new SkipListDictionary<int, string>();
+            dict.Add(2, "b");
+            dict.Add(1, "a");
+            dict.Add(3, "c");
+
+            CollectionAssert.AreEqual(new[] { "a", "b", "c" }, dict.Values.ToArray());
+        }
+
+        [TestMethod]
+        public void Values_Contains_FindsByEquality()
+        {
+            var dict = new SkipListDictionary<int, string>();
+            dict.Add(1, "hello");
+
+            Assert.IsTrue(dict.Values.Contains("hello"));
+            Assert.IsFalse(dict.Values.Contains("world"));
+        }
+
+        [TestMethod]
+        public void CustomComparer_ReversedOrder()
+        {
+            var dict = new SkipListDictionary<int, string>(Comparer<int>.Create((x, y) => y.CompareTo(x)));
+            dict.Add(1, "one");
+            dict.Add(3, "three");
+            dict.Add(2, "two");
+
+            CollectionAssert.AreEqual(new[] { 3, 2, 1 }, dict.Keys.ToArray());
+        }
+
+        [TestMethod]
+        public void LargeInsert_MaintainsOrder()
+        {
+            var dict = new SkipListDictionary<int, int>(threshold: 5);
+            var rng = new Random(42);
+            var keys = Enumerable.Range(0, 1000).OrderBy(_ => rng.Next()).ToList();
+
+            foreach (var key in keys)
+                dict.Add(key, key * 2);
+
+            var resultKeys = dict.Keys.ToArray();
+            CollectionAssert.AreEqual(Enumerable.Range(0, 1000).ToArray(), resultKeys);
+
+            foreach (var key in keys)
+                Assert.AreEqual(key * 2, dict[key]);
+        }
+
+        [TestMethod]
+        public void LargeInsertAndRemove_MaintainsConsistency()
+        {
+            var dict = new SkipListDictionary<int, int>(threshold: 5);
+            var rng = new Random(0);
+            var keys = rng.RandomArray(500, _ => rng.RandomInt()).Distinct().ToArray();
+
+            foreach (var key in keys)
+                dict.Add(key, key);
+
+            foreach (var key in keys)
+                Assert.IsTrue(dict.Remove(key), $"Remove failed for key {key}");
+
+            Assert.AreEqual(0, dict.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Résumé

- **`SkipListDictionary<K,V>`** : nouveau `IDictionary<K,V>` dont les clés sont maintenues en ordre croissant via un `SkipList` interne. Toutes les opérations par clé s'exécutent en O(log n) en moyenne ; l'itération yield les entrées dans l'ordre des clés.
- **`SkipList<T>.TryGet`** : nouvelle méthode qui retourne l'instance stockée correspondant par comparateur, permettant une mise à jour de valeur en place sans Remove+Add.
- **Bug fix `SkipList<T>.Remove`** : correction d'une `NullReferenceException` lors de la suppression d'un élément absent d'une liste vide (`null != null` était interprété comme « élément trouvé »).

## Détails

### `Utils.Collections/SkipList.cs`
- Ajout de `TryGet(T item, out T found)` — retourne l'objet stocké dont la clé correspond (via le comparateur), indispensable pour mutater la valeur sans perturber la structure.
- Correction du guard dans `Remove` : `if (elementBefore is null || elementBefore != elementAfter)` au lieu de `if (elementBefore != elementAfter)`.

### `Utils.Collections/SkipListDictionary.cs`
- Classe `Entry` privée avec `Key` immuable et `Value` mutable — les nœuds du skip list peuvent être mis à jour en place.
- `EntryComparer` compare uniquement les clés : les sondes (`Entry.Probe(key)`) permettent lookup/suppression sans créer une vraie entrée.
- Implémente `IDictionary<K,V>` intégralement avec `KeyCollection` et `ValueCollection` internes (lecture seule, triées).
- 3 constructeurs : défaut (comparateur par défaut, threshold 10), `(int threshold)`, `(IComparer<K>, int threshold)`.

## Plan de test

- [x] 21 tests unitaires dans `UtilsTest/Lists/SkipListDictionaryTests.cs`
  - CRUD de base (Add, indexeur get/set, Remove, ContainsKey, TryGetValue, Clear, CopyTo)
  - Tri des clés et de l'itération
  - Mise à jour en place via l'indexeur
  - Rejet des clés dupliquées (`ArgumentException`)
  - `KeyNotFoundException` sur accès manquant
  - `Contains(KeyValuePair)` vérifie clé ET valeur
  - Comparateur personnalisé (ordre décroissant)
  - 1 000 insertions aléatoires + vérification de l'ordre
  - 500 insertions + suppressions aléatoires (cohérence finale)
- [x] 13 tests `SkipList` existants toujours au vert (dont le bug fix validé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)