### PR TITLE
feat(docs): DocFX API documentation + GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Documentation
+
+on:
+    push:
+        branches:
+            - master
+            - release
+    workflow_dispatch:
+
+permissions:
+    contents: write
+
+jobs:
+    build-and-deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup .NET 9.0.x
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: '9.0.x'
+
+            - name: Restore
+              run: dotnet restore
+
+            - name: Build (generate XML docs)
+              run: dotnet build --configuration Release --no-restore
+
+            - name: Install DocFX
+              run: dotnet tool install -g docfx
+
+            - name: Build documentation
+              run: docfx docfx.json
+
+            - name: Deploy to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v4
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: ./_site
+                  force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,21 +21,124 @@ jobs:
               with:
                   dotnet-version: '9.0.x'
 
-            - name: Restore
-              run: dotnet restore
-
-            - name: Build (generate XML docs)
-              run: dotnet build --configuration Release --no-restore
+            - name: Restore and build (generates XML docs)
+              run: |
+                  dotnet restore
+                  dotnet build --configuration Release --no-restore
 
             - name: Install DocFX
               run: dotnet tool install -g docfx
+
+            - name: Determine version label
+              id: ver
+              run: |
+                  if [ "$GITHUB_REF" = "refs/heads/release" ]; then
+                      V=$(grep -oP '(?<=<Version>)[^<]+' Utils/Utils.csproj | head -1)
+                      echo "label=v$V" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "label=latest" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Build documentation
               run: docfx docfx.json
 
             - name: Deploy to GitHub Pages
-              uses: peaceiris/actions-gh-pages@v4
-              with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  publish_dir: ./_site
-                  force_orphan: true
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  LABEL: ${{ steps.ver.outputs.label }}
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Clone gh-pages or initialise an orphan branch
+                  if git ls-remote --exit-code origin gh-pages > /dev/null 2>&1; then
+                      git clone --branch gh-pages --depth 1 \
+                          "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+                          gh-pages-out
+                  else
+                      mkdir gh-pages-out
+                      cd gh-pages-out
+                      git init
+                      git remote add origin \
+                          "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+                      git checkout --orphan gh-pages
+                      cd ..
+                  fi
+
+                  # Prevent Jekyll processing of DocFX assets (_static, etc.)
+                  touch gh-pages-out/.nojekyll
+
+                  # Deploy this version's docs into its own subdirectory
+                  rm -rf "gh-pages-out/${LABEL}"
+                  cp -r _site/. "gh-pages-out/${LABEL}/"
+
+                  # Regenerate root index listing all available versions
+                  python3 - <<'PYEOF'
+                  import os, re
+
+                  out = "gh-pages-out"
+                  versions = sorted(
+                      [d for d in os.listdir(out) if re.match(r'^v\d', d) and os.path.isdir(f"{out}/{d}")],
+                      key=lambda v: [int(x) for x in re.findall(r'\d+', v)],
+                      reverse=True,
+                  )
+                  has_latest = os.path.isdir(f"{out}/latest")
+
+                  lines = [
+                      '<!DOCTYPE html>',
+                      '<html lang="en">',
+                      '<head>',
+                      '  <meta charset="utf-8">',
+                      '  <meta name="viewport" content="width=device-width, initial-scale=1">',
+                      '  <title>omy.Utils Documentation</title>',
+                      '  <style>',
+                      '    body { font-family: system-ui, sans-serif; max-width: 600px; margin: 4rem auto; padding: 0 1rem; }',
+                      '    h1 { color: #24292f; }',
+                      '    a { color: #0969da; text-decoration: none; }',
+                      '    a:hover { text-decoration: underline; }',
+                      '    ul { padding: 0; list-style: none; }',
+                      '    li { margin: .6rem 0; font-size: 1.1rem; }',
+                      '    .badge { font-size: .75rem; background: #ddf4ff; color: #0550ae;',
+                      '             border-radius: 3px; padding: 2px 6px; margin-left: .4rem; }',
+                      '    .dev   { background: #fff8c5; color: #7d4e00; }',
+                      '  </style>',
+                      '</head>',
+                      '<body>',
+                      '  <h1>omy.Utils Documentation</h1>',
+                      '  <p>Focused .NET utility libraries published on NuGet under the <code>omy.Utils</code> prefix.</p>',
+                      '  <ul>',
+                  ]
+
+                  if has_latest:
+                      lines.append('    <li><a href="latest/">latest (master)</a>'
+                                   '<span class="badge dev">dev</span></li>')
+
+                  for i, v in enumerate(versions):
+                      badge = '<span class="badge">latest release</span>' if i == 0 else ''
+                      lines.append(f'    <li><a href="{v}/">{v}</a>{badge}</li>')
+
+                  lines += [
+                      '  </ul>',
+                      '  <p>',
+                      '    <a href="https://github.com/warny/All-purpose-Utilities">GitHub repository</a> ·',
+                      '    <a href="https://www.nuget.org/profiles/warny">NuGet packages</a>',
+                      '  </p>',
+                      '</body>',
+                      '</html>',
+                  ]
+
+                  with open(f"{out}/index.html", "w", encoding="utf-8") as f:
+                      f.write("\n".join(lines) + "\n")
+
+                  print(f"Index generated — versions: {versions}, has_latest: {has_latest}")
+                  PYEOF
+
+                  # Commit and push only when something actually changed
+                  cd gh-pages-out
+                  git add .
+                  if git diff --cached --quiet; then
+                      echo "No changes — skipping push."
+                  else
+                      git commit -m "docs: deploy ${LABEL}"
+                      git push origin gh-pages
+                  fi

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ bld/
 *.VisualState.xml
 TestResult.xml
 
+# DocFX generated output
+_site/
+api/
+
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ SpecFlow `.feature` files and their step bindings live exclusively in **UtilsTes
 
 ## README  
 - The project’s **README.md** must include an **example snippet**.  
+- Every package **README.md** that accompanies a release must include a link to the versioned API documentation for that release: `https://warny.github.io/All-purpose-Utilities/vX.Y.Z/`  
 
 ---
 

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,68 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "Utils/**/*.csproj",
+            "Utils.Collections/**/*.csproj",
+            "Utils.Data/**/*.csproj",
+            "Utils.DependencyInjection/**/*.csproj",
+            "Utils.Expressions.CLike/**/*.csproj",
+            "Utils.Expressions.CSyntax/**/*.csproj",
+            "Utils.Expressions.VBSyntax/**/*.csproj",
+            "Utils.Fonts/**/*.csproj",
+            "Utils.Geography/**/*.csproj",
+            "Utils.IO/**/*.csproj",
+            "Utils.Imaging/**/*.csproj",
+            "Utils.Mathematics/**/*.csproj",
+            "Utils.Net/**/*.csproj",
+            "Utils.NumberToString/**/*.csproj",
+            "Utils.OData/**/*.csproj",
+            "Utils.Parser/**/*.csproj",
+            "Utils.Parser.Antlr4.Common/**/*.csproj",
+            "Utils.Parser.Diagnostics/**/*.csproj",
+            "Utils.Parser.Expressions/**/*.csproj",
+            "Utils.Parser.Source/**/*.csproj",
+            "Utils.Reflection/**/*.csproj",
+            "Utils.VirtualMachine/**/*.csproj",
+            "Utils.Xml/**/*.csproj"
+          ],
+          "exclude": [
+            "**/bin/**",
+            "**/obj/**"
+          ]
+        }
+      ],
+      "dest": "api",
+      "allowCompilationErrors": true
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": ["api/**.yml", "api/index.md"]
+      },
+      {
+        "files": [
+          "toc.yml",
+          "index.md",
+          "docs/**.md",
+          "docs/toc.yml"
+        ]
+      }
+    ],
+    "globalMetadata": {
+      "_appName": "All-purpose Utilities",
+      "_appTitle": "omy.Utils Documentation",
+      "_enableSearch": true,
+      "_appFooter": "All-purpose Utilities — Apache 2.0",
+      "_gitContribute": {
+        "repo": "https://github.com/warny/All-purpose-Utilities",
+        "branch": "master"
+      }
+    },
+    "dest": "_site",
+    "template": ["default", "modern"]
+  }
+}

--- a/docs/parser/toc.yml
+++ b/docs/parser/toc.yml
@@ -1,0 +1,28 @@
+- name: Overview
+  href: INDEX.md
+- name: ANTLR4 Compatibility
+  href: ANTLRCompatibility.md
+- name: Compatibility Matrix
+  href: Antlr4CompatibilityMatrix.md
+- name: Runtime Architecture
+  href: RuntimeArchitecture.md
+- name: Runtime State Ownership
+  href: RuntimeStateOwnership.md
+- name: Runtime Trace Analysis
+  href: RuntimeTraceAnalysis.md
+- name: Runtime Observation & Export
+  href: RuntimeObservationAndExportContract.md
+- name: Embedded Code Execution Model
+  href: EmbeddedCodeExecutionModel.md
+- name: Embedded Code Transactional State
+  href: EmbeddedCodeTransactionalState.md
+- name: Lexer Inline Actions & Predicates
+  href: LexerInlineActionsAndPredicatesAudit.md
+- name: Continuation Metadata
+  href: ContinuationMetadata.md
+- name: Diagnostics Observation Correlation
+  href: DiagnosticsObservationCorrelation.md
+- name: Parser Metadata & Runtime Limitations
+  href: ParserMetadataAndRuntimeLimitations.md
+- name: Shared LookAhead Preparation
+  href: SharedLookAheadPreparation.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,4 @@
+- name: Getting Started
+  href: getting-started.md
+- name: Parser
+  href: parser/toc.yml

--- a/index.md
+++ b/index.md
@@ -1,0 +1,17 @@
+---
+_layout: landing
+---
+
+# All-purpose Utilities
+
+`All-purpose-Utilities` is a family of focused .NET libraries published on NuGet under the `omy.Utils` prefix.
+
+It is designed for consumers who want small, task-oriented packages (networking, I/O, data mapping, parser tooling, source generators, and more) without adopting a single monolithic framework.
+
+## Quick links
+
+- [Getting started](docs/getting-started.md) — installation and first steps
+- [API Reference](api/) — full generated API documentation
+- [Parser documentation](docs/parser/INDEX.md) — ANTLR4-compatible parser runtime
+- [Changelog](https://github.com/warny/All-purpose-Utilities/blob/master/CHANGELOG.md)
+- [NuGet packages](https://www.nuget.org/profiles/warny)

--- a/toc.yml
+++ b/toc.yml
@@ -1,0 +1,5 @@
+- name: Documentation
+  href: docs/toc.yml
+- name: API Reference
+  href: api/
+  homepage: api/index.md


### PR DESCRIPTION
## Summary

- Ajoute DocFX pour gÃ©nÃ©rer une documentation API complÃ¨te depuis les commentaires XML C#
- Workflow GitHub Actions (docs.yml) qui publie automatiquement sur GitHub Pages Ã  chaque push sur master ou release
- Page d'accueil et navigation structurÃ©e intÃ©grant les docs existantes

## Fichiers ajoutÃ©s

- `docfx.json` : Configuration DocFX, tous les projets Utils.* publics
- `index.md` : Page d'accueil du site de documentation
- `toc.yml` : Navigation racine (Articles / API Reference)
- `docs/toc.yml` : Navigation dans les articles
- `docs/parser/toc.yml` : Navigation dans la documentation parser
- `.github/workflows/docs.yml` : CI/CD â€” build DocFX et dÃ©ploiement sur gh-pages
- `.gitignore` : Exclusion de _site/ et api/ (sorties DocFX)

## Activation requise aprÃ¨s merge

Une seule action manuelle dans les paramÃ¨tres du dÃ©pÃ´t GitHub :

1. Aller dans Settings > Pages
2. Source : Deploy from a branch
3. Branch : gh-pages / root
4. Sauvegarder

La documentation sera ensuite disponible sur https://warny.github.io/All-purpose-Utilities/

## DÃ©clencheurs

Le workflow se dÃ©clenche sur :
- Push sur master (mise Ã  jour de la doc en continu)
- Push sur release (releases NuGet)
- Manuellement via workflow_dispatch

## Test plan

- [ ] Merger la PR
- [ ] VÃ©rifier que le workflow Documentation s'exÃ©cute dans l'onglet Actions
- [ ] Activer GitHub Pages (Settings > Pages > gh-pages branch)
- [ ] Visiter https://warny.github.io/All-purpose-Utilities/ pour vÃ©rifier la documentation

Generated with [Claude Code](https://claude.com/claude-code)
