### PR TITLE
fix(docs): use --global git config to fix deploy identity error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,8 +47,8 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   LABEL: ${{ steps.ver.outputs.label }}
               run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git config --global user.name "github-actions[bot]"
+                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
                   # Clone gh-pages or initialise an orphan branch
                   if git ls-remote --exit-code origin gh-pages > /dev/null 2>&1; then


### PR DESCRIPTION
Hotfix for the docs workflow. git config without --global only applies to the source checkout. When the workflow clones into gh-pages-out, that clone has no user identity configured and git refuses to commit with atal: empty ident name not allowed.

Fix: add --global so the identity is set for all git operations in the runner.

Generated with [Claude Code](https://claude.com/claude-code)