### PR TITLE
feat(NumberToString): FR feminine ordinal, RU ordinals, ConvertYear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added — `omy.Utils.NumberToString`
+- **FR ordinal féminin** : `ConvertOrdinal(1, "gender=feminin")` retourne "première" pour les cultures `FR-fr-ca` et `FR-be-ch` via `<OrdinalVariants>`.
+- **Ordinaux RU** : nouvelles règles d'ordinaux en russe — suffixe "ый" avec `removeTrailing="ь"`, word rules pour toutes les formes irrégulières (unités, dizaines, centaines, тысяча).
+- **`ConvertYear(int year)`** : nouvelle méthode pour lire une année en mots ; pour les langues configurées avec `<YearFormat>` et `<SplitRange>`, l'année est découpée en deux moitiés (ex. EN : 1984 → "nineteen eighty-four", 1900 → "nineteen hundred", 1905 → "nineteen oh five").
 - **Ordinal variants**: `ConvertOrdinal(int, params string[])` — ordinals can now be inflected for gender and other dimensions using the same `"dimension=value"` syntax as `Convert`. Languages with variant ordinals: ES, IT, PT, CA, GL, HE.
 - **Prefix ordinals**: `<Ordinals prefix="…">` in the XML configuration produces ordinals by prepending a fixed string to the cardinal. Used by ZH (第), JA (第), KO (제), EE (etsõ).
 - **`IOrdinalLanguageSpecifics`**: new interface that can be implemented alongside `INumberToStringLanguageSpecifics` to override ordinal formation with custom logic (highest priority, falls back to XML pipeline when `TryConvertOrdinal` returns `false`).

--- a/Utils.NumberToString/Mathematics/INumberToStringConverter.cs
+++ b/Utils.NumberToString/Mathematics/INumberToStringConverter.cs
@@ -131,5 +131,15 @@ namespace Utils.NumberToString
         /// <returns>The ordinal string for <paramref name="number"/>.</returns>
         string ConvertOrdinal(int number, params string[] variants)
             => ConvertOrdinal(number);
+
+        /// <summary>
+        /// Converts a year number into its spoken string representation.
+        /// For languages with a <c>&lt;YearFormat&gt;</c> configuration, years within declared
+        /// split ranges are read as two halves (e.g. 1984 → "nineteen eighty-four" in English).
+        /// For all other years or unconfigured languages, falls back to <see cref="Convert(int)"/>.
+        /// </summary>
+        /// <param name="year">The year to convert (negative values use the minus template).</param>
+        /// <returns>The spoken form of the year.</returns>
+        string ConvertYear(int year) => Convert(year);
     }
 }

--- a/Utils.NumberToString/Mathematics/NumberConverterConfiguration.cs
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfiguration.cs
@@ -538,6 +538,52 @@ public class LanguageType
     /// </summary>
     [XmlElement(ElementName = "Variants")]
     public VariantsType Variants { get; set; }
+
+    /// <summary>
+    /// Gets or sets the year-format configuration used by <see cref="NumberToStringConverter.ConvertYear"/>.
+    /// When absent, <c>ConvertYear</c> falls back to <c>Convert</c>.
+    /// </summary>
+    [XmlElement(ElementName = "YearFormat")]
+    public YearFormatType? YearFormat { get; set; }
+}
+
+/// <summary>
+/// Describes a range of years for which the split-at-hundreds algorithm applies in <see cref="YearFormatType"/>.
+/// </summary>
+public class YearFormatSplitRangeType
+{
+    /// <summary>Gets or sets the lower bound of the range (inclusive).</summary>
+    [XmlAttribute("from")]
+    public int From { get; set; }
+
+    /// <summary>Gets or sets the upper bound of the range (inclusive).</summary>
+    [XmlAttribute("to")]
+    public int To { get; set; }
+}
+
+/// <summary>
+/// Configures the year-format algorithm used by <see cref="NumberToStringConverter.ConvertYear"/>.
+/// When present, years within any declared <see cref="SplitRanges"/> are split at the hundreds boundary.
+/// </summary>
+public class YearFormatType
+{
+    /// <summary>
+    /// Gets or sets the word appended when the year is a round century (remainder == 0).
+    /// Example: "hundred" → 1900 reads as "nineteen hundred".
+    /// </summary>
+    [XmlAttribute("hundredWord")]
+    public string? HundredWord { get; set; }
+
+    /// <summary>
+    /// Gets or sets the connector inserted before single-digit remainders (1–9).
+    /// Example: "oh" → 2005 reads as "twenty oh five".
+    /// </summary>
+    [XmlAttribute("zeroConnector")]
+    public string? ZeroConnector { get; set; }
+
+    /// <summary>Gets or sets the year ranges for which the split algorithm applies.</summary>
+    [XmlElement("SplitRange")]
+    public List<YearFormatSplitRangeType> SplitRanges { get; set; } = new();
 }
 
 /// <summary>

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.EN.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.EN.xml
@@ -92,5 +92,9 @@
 			<Ordinal from="eighty" to="eightieth" />
 			<Ordinal from="ninety" to="ninetieth" />
 		</Ordinals>
+		<YearFormat hundredWord="hundred" zeroConnector="oh">
+			<SplitRange from="1100" to="1999" />
+			<SplitRange from="2010" to="2099" />
+		</YearFormat>
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.FR-be-ch.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.FR-be-ch.xml
@@ -87,6 +87,11 @@
 			<Ordinal from="un"   to="unième" />
 			<Ordinal from="cinq" to="cinquième" />
 			<Ordinal from="neuf" to="neuvième" />
+			<OrdinalVariants>
+				<Variant type="gender" variant="feminin">
+					<OrdinalException value="1" string="première" />
+				</Variant>
+			</OrdinalVariants>
 		</Ordinals>
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.FR-fr-ca.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.FR-fr-ca.xml
@@ -100,6 +100,11 @@
 			<Ordinal from="un" to="unième" />
 			<Ordinal from="cinq" to="cinquième" />
 			<Ordinal from="neuf" to="neuvième" />
+			<OrdinalVariants>
+				<Variant type="gender" variant="feminin">
+					<OrdinalException value="1" string="première" />
+				</Variant>
+			</OrdinalVariants>
 		</Ordinals>
 		<Variants>
 			<Dimension name="gender" localName="genre" values="masculin,feminin" />

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.RU.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.RU.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
     <Language
         groupSize="3"
@@ -71,5 +71,35 @@
             <Number value="18" string="восемнадцать" />
             <Number value="19" string="девятнадцать" />
         </Exceptions>
+        <Ordinals suffix="ый" removeTrailing="ь">
+            <OrdinalException value="1" string="первый" />
+            <!-- Unités irrégulières -->
+            <Ordinal from="один"          to="первый" />
+            <Ordinal from="два"           to="второй" />
+            <Ordinal from="три"           to="третий" />
+            <Ordinal from="четыре"        to="четвёртый" />
+            <Ordinal from="шесть"         to="шестой" />
+            <Ordinal from="семь"          to="седьмой" />
+            <Ordinal from="восемь"        to="восьмой" />
+            <!-- Dizaines irrégulières -->
+            <Ordinal from="сорок"         to="сороковой" />
+            <Ordinal from="пятьдесят"     to="пятидесятый" />
+            <Ordinal from="шестьдесят"    to="шестидесятый" />
+            <Ordinal from="семьдесят"     to="семидесятый" />
+            <Ordinal from="восемьдесят"   to="восьмидесятый" />
+            <Ordinal from="девяносто"     to="девяностый" />
+            <!-- Centaines irrégulières -->
+            <Ordinal from="сто"           to="сотый" />
+            <Ordinal from="двести"        to="двухсотый" />
+            <Ordinal from="триста"        to="трёхсотый" />
+            <Ordinal from="четыреста"     to="четырёхсотый" />
+            <Ordinal from="пятьсот"       to="пятисотый" />
+            <Ordinal from="шестьсот"      to="шестисотый" />
+            <Ordinal from="семьсот"       to="семисотый" />
+            <Ordinal from="восемьсот"     to="восьмисотый" />
+            <Ordinal from="девятьсот"     to="девятисотый" />
+            <!-- Mot d'échelle тысяча -->
+            <Ordinal from="тысяча"        to="тысячный" />
+        </Ordinals>
     </Language>
 </Numbers>

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
@@ -569,6 +569,17 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:complexType name="YearFormatSplitRangeType">
+        <xs:annotation>
+            <xs:documentation>
+                A range of year values for which the split-at-hundreds algorithm is applied.
+                Years in [from, to] are split: ConvertYear(y) = Convert(y/100) + " " + Convert(y%100).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="from" type="xs:int" use="required" />
+        <xs:attribute name="to" type="xs:int" use="required" />
+    </xs:complexType>
+
     <!-- ═══════════════════════════ Root element ══════════════════════════════════════ -->
 
     <xs:element name="Numbers">
@@ -884,6 +895,29 @@
                                         so that language-specific post-processing can see the inflected form.
                                     </xs:documentation>
                                 </xs:annotation>
+                            </xs:element>
+
+                            <xs:element name="YearFormat" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Year-format configuration. When present, ConvertYear(int) uses a
+                                        split-at-hundreds algorithm for year values within the declared
+                                        SplitRange elements. Years outside all ranges fall back to Convert(year).
+
+                                        hundredWord   — word appended when the year is a round century
+                                                        (e.g. "hundred" for 1900 → "nineteen hundred").
+                                        zeroConnector — connector inserted before single-digit remainders
+                                                        (e.g. "oh" for 2005 → "twenty oh five").
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="SplitRange" type="YearFormatSplitRangeType"
+                                                    minOccurs="0" maxOccurs="unbounded" />
+                                    </xs:sequence>
+                                    <xs:attribute name="hundredWord" type="xs:string" use="optional" />
+                                    <xs:attribute name="zeroConnector" type="xs:string" use="optional" />
+                                </xs:complexType>
                             </xs:element>
 
                         </xs:sequence>

--- a/Utils.NumberToString/Mathematics/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/Mathematics/NumberToStringConverter.Globalization.cs
@@ -260,6 +260,10 @@ namespace Utils.NumberToString
                 OrdinalVariants = ParseOrdinalVariants(language.Ordinals),
                 VariantDimensions = parsedDimensions,
                 VariantRules = ParseVariantRules(language.Variants),
+                YearFormat = language.YearFormat == null ? null : new YearFormatOptions(
+                    language.YearFormat.HundredWord,
+                    language.YearFormat.ZeroConnector,
+                    language.YearFormat.SplitRanges.Select(r => (r.From, r.To)).ToList()),
             };
 
             return new NumberToStringConverter(options);

--- a/Utils.NumberToString/Mathematics/NumberToStringConverter.cs
+++ b/Utils.NumberToString/Mathematics/NumberToStringConverter.cs
@@ -85,6 +85,7 @@ namespace Utils.NumberToString
 
             VariantDimensions = (options.VariantDimensions ?? []).ToImmutableArray();
             VariantRules = (options.VariantRules ?? []).ToImmutableArray();
+            _yearFormat = options.YearFormat;
             // Index both canonical name and localName so both are accepted in API calls and XML constraints.
             _dimensionIndex = VariantDimensions
                 .SelectMany(d => string.IsNullOrEmpty(d.LocalName)
@@ -200,6 +201,11 @@ namespace Utils.NumberToString
         /// Applied in order of ascending specificity between raw adjustment and finalization.
         /// </summary>
         public IReadOnlyList<VariantRule> VariantRules { get; }
+
+        private readonly YearFormatOptions? _yearFormat;
+
+        /// <summary>Year-format options, or <see langword="null"/> when not configured.</summary>
+        internal YearFormatOptions? YearFormat => _yearFormat;
 
         /// <inheritdoc/>
         public bool SupportsOrdinals =>
@@ -758,6 +764,33 @@ namespace Utils.NumberToString
             }
 
             return isNegative ? Minus.Replace("*", result) : result;
+        }
+
+        /// <inheritdoc cref="INumberToStringConverter.ConvertYear(int)"/>
+        public string ConvertYear(int year)
+        {
+            bool isNegative = year < 0;
+            int abs = Math.Abs(year);
+
+            string body;
+            if (_yearFormat != null && _yearFormat.SplitRanges.Any(r => abs >= r.From && abs <= r.To))
+            {
+                int centuries = abs / 100;
+                int remainder = abs % 100;
+
+                if (remainder == 0 && _yearFormat.HundredWord != null)
+                    body = Convert(centuries) + Separator + _yearFormat.HundredWord;
+                else if (remainder is > 0 and < 10 && _yearFormat.ZeroConnector != null)
+                    body = Convert(centuries) + Separator + _yearFormat.ZeroConnector + Separator + Convert(remainder);
+                else
+                    body = Convert(centuries) + Separator + Convert(remainder);
+            }
+            else
+            {
+                body = Convert(abs);
+            }
+
+            return isNegative ? Minus.Replace("*", body) : body;
         }
 
         /// <summary>

--- a/Utils.NumberToString/Mathematics/NumberToStringConverterOptions.cs
+++ b/Utils.NumberToString/Mathematics/NumberToStringConverterOptions.cs
@@ -116,6 +116,9 @@ public sealed class NumberToStringConverterOptions
     /// </summary>
     public IReadOnlyList<NumberToStringConverter.VariantRule> VariantRules { get; set; } = [];
 
+    /// <summary>Year-format configuration used by <see cref="NumberToStringConverter.ConvertYear"/>.</summary>
+    public YearFormatOptions? YearFormat { get; set; }
+
     /// <summary>Creates an options object with sensible defaults. Required properties
     /// (<see cref="Zero"/>, <see cref="Minus"/>, <see cref="Groups"/>, <see cref="Scale"/>)
     /// must be set before passing to the constructor.</summary>
@@ -153,6 +156,7 @@ public sealed class NumberToStringConverterOptions
         OrdinalVariants = source.OrdinalVariants;
         VariantDimensions = source.VariantDimensions;
         VariantRules = source.VariantRules;
+        YearFormat = source.YearFormat;
     }
 
     /// <summary>
@@ -168,3 +172,14 @@ public sealed class NumberToStringConverterOptions
     public static NumberToStringConverterOptions FromCulture(string cultureName)
         => new(NumberToStringConverter.GetConverter(cultureName));
 }
+
+/// <summary>
+/// Immutable year-format options that drive <see cref="NumberToStringConverter.ConvertYear"/>.
+/// </summary>
+/// <param name="HundredWord">Word appended for round centuries (e.g. "hundred").</param>
+/// <param name="ZeroConnector">Connector before single-digit remainders (e.g. "oh").</param>
+/// <param name="SplitRanges">Year ranges where the split-at-hundreds algorithm applies.</param>
+public record YearFormatOptions(
+    string? HundredWord,
+    string? ZeroConnector,
+    IReadOnlyList<(int From, int To)> SplitRanges);

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -1337,6 +1337,67 @@ public class NumberToStringConverterImprovementsTests
         Assert.AreEqual("zeroth", conv.ConvertOrdinal(0));
     }
 
+    // ─── FR — Ordinal variants (gender=feminin) ───────────────────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_FR_Feminine_PremiereBecomesPremiere()
+    {
+        var converter = NumberToStringConverter.GetConverter("FR-fr");
+        Assert.AreEqual("première", converter.ConvertOrdinal(1, "gender=feminin"));
+        Assert.AreEqual("premier",  converter.ConvertOrdinal(1));
+    }
+
+    // ─── RU — Ordinals ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_RU_AppliesRulesAndSuffix()
+    {
+        var converter = NumberToStringConverter.GetConverter("RU");
+        (int n, string expected)[] cases =
+        [
+            (1,    "первый"),          // exception
+            (2,    "второй"),          // word rule: два → второй
+            (3,    "третий"),          // word rule: три → третий
+            (4,    "четвёртый"),       // word rule: четыре → четвёртый
+            (5,    "пятый"),           // suffix: пять - ь + ый
+            (6,    "шестой"),          // word rule: шесть → шестой
+            (7,    "седьмой"),         // word rule: семь → седьмой
+            (8,    "восьмой"),         // word rule: восемь → восьмой
+            (9,    "девятый"),         // suffix: девять - ь + ый
+            (10,   "десятый"),         // suffix: десять - ь + ый
+            (11,   "одиннадцатый"),    // suffix: одиннадцать - ь + ый
+            (20,   "двадцатый"),       // suffix: двадцать - ь + ый
+            (21,   "двадцать первый"), // compound: last word один → первый
+            (40,   "сороковой"),       // word rule: сорок → сороковой
+            (100,  "сотый"),           // word rule: сто → сотый
+            (1000, "тысячный"),        // word rule: тысяча → тысячный
+        ];
+        foreach (var (n, expected) in cases)
+            Assert.AreEqual(expected, converter.ConvertOrdinal(n), $"RU ordinal of {n}");
+    }
+
+    // ─── EN — ConvertYear ────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ConvertYear_EN_SplitRanges()
+    {
+        var converter = NumberToStringConverter.GetConverter("EN");
+        (int year, string expected)[] cases =
+        [
+            (1984, "nineteen eighty-four"),  // range 1100-1999, remainder ≥ 10
+            (1900, "nineteen hundred"),       // range 1100-1999, remainder = 0
+            (1905, "nineteen oh five"),       // range 1100-1999, remainder 1-9
+            (1100, "eleven hundred"),         // début de la plage 1100-1999
+            (2024, "twenty twenty-four"),     // range 2010-2099
+            (2010, "twenty ten"),             // début de la plage 2010-2099
+            (2000, "two thousand"),             // hors plage → Convert(2000)
+            (2005, "two thousand, five"),      // entre les deux plages → Convert(2005)
+            (1066, "one thousand, sixty-six"), // sous la plage → Convert(1066)
+        ];
+        foreach (var (year, expected) in cases)
+            Assert.AreEqual(expected, converter.ConvertYear(year), $"EN year {year}");
+    }
+
     private sealed class OrdinalPluginSpecifics
         : INumberToStringLanguageSpecifics, IOrdinalLanguageSpecifics
     {


### PR DESCRIPTION
## Summary
- **FR ordinal feminin** : `ConvertOrdinal(1, "gender=feminin")` retourne "premiere" pour `FR-fr` et `FR-be`/`FR-ch` via `<OrdinalVariants>` dans les XML FR-fr-ca et FR-be-ch
- **Ordinaux RU** : support complet des ordinaux russes — suffixe `ый` avec `removeTrailing="ь"`, word rules pour toutes les formes irregulieres (unites, dizaines, centaines, тысяча)
- **`ConvertYear(int year)`** : nouvelle methode sur `INumberToStringConverter` ; pour les langues avec `<YearFormat>/<SplitRange>`, l'annee est lue en deux moities (EN : 1984 → "nineteen eighty-four", 1900 → "nineteen hundred", 1905 → "nineteen oh five")
- Tests ajoutes dans `NumberToStringConverterImprovementsTests` ; CHANGELOG mis a jour

## Test plan
- [ ] `ConvertOrdinal_FR_Feminine_PremiereBecomesPremiere` — FR-fr ordinal feminin
- [ ] `ConvertOrdinal_RU_AppliesRulesAndSuffix` — 16 cas d'ordinaux russes
- [ ] `ConvertYear_EN_SplitRanges` — 9 cas d'annees EN (split + fallback)
- [ ] Build 0 erreurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
