### PR TITLE
feat(NumberToString): ordinals for EL, FI, HI, PL, AR, WO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added — `omy.Utils.NumberToString`
+- **Ordinaux EL** : Grec — word rules pour masculin (défaut) + `OrdinalVariants` gender=θηλυκό et gender=ουδέτερο pour 1-12, dizaines et centaines.
+- **Ordinaux FI** : Finnois — word rules exhaustives pour toutes les formes (unités 1-9, exceptions 11-19, dizaines 20-90, centaines, туhat).
+- **Ordinaux HI** : Hindi — suffixe `वाँ` pour 5-9 et 11+ ; exceptions explicites pour 1-4 et word rule pour 6 (छठा).
+- **Ordinaux PL** : Polonais — word rules pour toutes les formes nominatif masculin singulier (unités, 11-19, dizaines, centaines, tysiąc). Pour les ordinaux composés, seul le dernier mot est transformé (limitation XML).
+- **Ordinaux AR** : Arabe — exceptions masculines indéfinies pour 1-10.
+- **Ordinaux WO** : Wolof — suffixe `ël` + exception 1 (`bu njëkk`).
 - **FR ordinal féminin** : `ConvertOrdinal(1, "gender=feminin")` retourne "première" pour les cultures `FR-fr-ca` et `FR-be-ch` via `<OrdinalVariants>`.
 - **Ordinaux RU** : nouvelles règles d'ordinaux en russe — suffixe "ый" avec `removeTrailing="ь"`, word rules pour toutes les formes irrégulières (unités, dizaines, centaines, тысяча).
 - **`ConvertYear(int year)`** : nouvelle méthode pour lire une année en mots ; pour les langues configurées avec `<YearFormat>` et `<SplitRange>`, l'année est découpée en deux moitiés (ex. EN : 1984 → "nineteen eighty-four", 1900 → "nineteen hundred", 1905 → "nineteen oh five").

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.AR.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.AR.xml
@@ -59,5 +59,19 @@
             </Suffixes>
         </NumberScale>
         <Exceptions />
+        <Ordinals>
+            <!-- Masculin indéfini, forme courte (sans article) — les ordinaux arabes
+                 sont indépendants des cardinaux et varient en genre avec le nom -->
+            <OrdinalException value="1"  string="أول" />
+            <OrdinalException value="2"  string="ثانٍ" />
+            <OrdinalException value="3"  string="ثالث" />
+            <OrdinalException value="4"  string="رابع" />
+            <OrdinalException value="5"  string="خامس" />
+            <OrdinalException value="6"  string="سادس" />
+            <OrdinalException value="7"  string="سابع" />
+            <OrdinalException value="8"  string="ثامن" />
+            <OrdinalException value="9"  string="تاسع" />
+            <OrdinalException value="10" string="عاشر" />
+        </Ordinals>
     </Language>
 </Numbers>

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.EL.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.EL.xml
@@ -71,5 +71,86 @@
 			<Number value="18" string="δεκαοκτώ" />
 			<Number value="19" string="δεκαεννέα" />
 		</Exceptions>
+		<Ordinals>
+			<!-- Unités — stems complètement différents des cardinaux -->
+			<Ordinal from="ένα"        to="πρώτος" />
+			<Ordinal from="δύο"        to="δεύτερος" />
+			<Ordinal from="τρία"       to="τρίτος" />
+			<Ordinal from="τέσσερα"    to="τέταρτος" />
+			<Ordinal from="πέντε"      to="πέμπτος" />
+			<Ordinal from="έξι"        to="έκτος" />
+			<Ordinal from="επτά"       to="έβδομος" />
+			<Ordinal from="οκτώ"       to="όγδοος" />
+			<Ordinal from="εννέα"      to="ένατος" />
+			<!-- Dizaine -->
+			<Ordinal from="δέκα"       to="δέκατος" />
+			<!-- Exceptions 11-12 (stems irréguliers, non déductibles depuis les cardinaux) -->
+			<OrdinalException value="11" string="ενδέκατος" />
+			<OrdinalException value="12" string="δωδέκατος" />
+			<!-- Exceptions 13-19 : ordinaux composés depuis les exceptions cardinales -->
+			<OrdinalException value="13" string="δέκατος τρίτος" />
+			<OrdinalException value="14" string="δέκατος τέταρτος" />
+			<OrdinalException value="15" string="δέκατος πέμπτος" />
+			<OrdinalException value="16" string="δέκατος έκτος" />
+			<OrdinalException value="17" string="δέκατος έβδομος" />
+			<OrdinalException value="18" string="δέκατος όγδοος" />
+			<OrdinalException value="19" string="δέκατος ένατος" />
+			<!-- Dizaines -->
+			<Ordinal from="είκοσι"     to="εικοστός" />
+			<Ordinal from="τριάντα"    to="τριακοστός" />
+			<Ordinal from="σαράντα"    to="τεσσαρακοστός" />
+			<Ordinal from="πενήντα"    to="πεντηκοστός" />
+			<Ordinal from="εξήντα"     to="εξηκοστός" />
+			<Ordinal from="εβδομήντα"  to="εβδομηκοστός" />
+			<Ordinal from="ογδόντα"    to="ογδοηκοστός" />
+			<Ordinal from="ενενήντα"   to="ενενηκοστός" />
+			<!-- Centaines -->
+			<Ordinal from="εκατό"      to="εκατοστός" />
+			<Ordinal from="διακόσια"   to="διακοσιοστός" />
+			<Ordinal from="τριακόσια"  to="τριακοσιοστός" />
+			<Ordinal from="τετρακόσια" to="τετρακοσιοστός" />
+			<Ordinal from="πεντακόσια" to="πεντακοσιοστός" />
+			<Ordinal from="εξακόσια"   to="εξακοσιοστός" />
+			<Ordinal from="επτακόσια"  to="επτακοσιοστός" />
+			<Ordinal from="οκτακόσια"  to="οκτακοσιοστός" />
+			<Ordinal from="εννιακόσια" to="εννιακοσιοστός" />
+			<!-- Millier -->
+			<Ordinal from="χίλια"      to="χιλιοστός" />
+			<!-- Variantes de genre nominatif singulier pour 1-12 + dizaines + centaines -->
+			<OrdinalVariants>
+				<Variant type="gender" variant="θηλυκό">
+					<OrdinalException value="1"   string="πρώτη" />
+					<OrdinalException value="2"   string="δεύτερη" />
+					<OrdinalException value="3"   string="τρίτη" />
+					<OrdinalException value="4"   string="τέταρτη" />
+					<OrdinalException value="5"   string="πέμπτη" />
+					<OrdinalException value="6"   string="έκτη" />
+					<OrdinalException value="7"   string="έβδομη" />
+					<OrdinalException value="8"   string="όγδοη" />
+					<OrdinalException value="9"   string="ένατη" />
+					<OrdinalException value="10"  string="δέκατη" />
+					<OrdinalException value="11"  string="ενδέκατη" />
+					<OrdinalException value="12"  string="δωδέκατη" />
+					<OrdinalException value="20"  string="εικοστή" />
+					<OrdinalException value="100" string="εκατοστή" />
+				</Variant>
+				<Variant type="gender" variant="ουδέτερο">
+					<OrdinalException value="1"   string="πρώτο" />
+					<OrdinalException value="2"   string="δεύτερο" />
+					<OrdinalException value="3"   string="τρίτο" />
+					<OrdinalException value="4"   string="τέταρτο" />
+					<OrdinalException value="5"   string="πέμπτο" />
+					<OrdinalException value="6"   string="έκτο" />
+					<OrdinalException value="7"   string="έβδομο" />
+					<OrdinalException value="8"   string="όγδοο" />
+					<OrdinalException value="9"   string="ένατο" />
+					<OrdinalException value="10"  string="δέκατο" />
+					<OrdinalException value="11"  string="ενδέκατο" />
+					<OrdinalException value="12"  string="δωδέκατο" />
+					<OrdinalException value="20"  string="εικοστό" />
+					<OrdinalException value="100" string="εκατοστό" />
+				</Variant>
+			</OrdinalVariants>
+		</Ordinals>
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.FI.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.FI.xml
@@ -164,5 +164,52 @@
                 <Replacement oldValue="kuusitoista" newValue="kuudentoista" scope="Anywhere" />
             </Variant>
         </Variants>
+        <Ordinals>
+            <!-- Unités -->
+            <OrdinalException value="1" string="ensimmäinen" />
+            <OrdinalException value="2" string="toinen" />
+            <Ordinal from="yksi"      to="ensimmäinen" />
+            <Ordinal from="kaksi"     to="toinen" />
+            <Ordinal from="kolme"     to="kolmas" />
+            <Ordinal from="neljä"     to="neljäs" />
+            <Ordinal from="viisi"     to="viides" />
+            <Ordinal from="kuusi"     to="kuudes" />
+            <Ordinal from="seitsemän" to="seitsemäs" />
+            <Ordinal from="kahdeksan" to="kahdeksas" />
+            <Ordinal from="yhdeksän"  to="yhdeksäs" />
+            <!-- Dizaine de base -->
+            <Ordinal from="kymmenen"  to="kymmenes" />
+            <!-- Exceptions 11-19 -->
+            <Ordinal from="yksitoista"      to="yhdestoista" />
+            <Ordinal from="kaksitoista"     to="kahdestoista" />
+            <Ordinal from="kolmetoista"     to="kolmastoista" />
+            <Ordinal from="neljätoista"     to="neljästoista" />
+            <Ordinal from="viisitoista"     to="viidestoista" />
+            <Ordinal from="kuusitoista"     to="kuudestoista" />
+            <Ordinal from="seitsemäntoista" to="seitsemästoista" />
+            <Ordinal from="kahdeksantoista" to="kahdeksastoista" />
+            <Ordinal from="yhdeksäntoista"  to="yhdeksästoista" />
+            <!-- Dizaines 20-90 -->
+            <Ordinal from="kaksikymmentä"     to="kahdeskymmenes" />
+            <Ordinal from="kolmekymmentä"     to="kolmaskymmenes" />
+            <Ordinal from="neljäkymmentä"     to="neljäskymmenes" />
+            <Ordinal from="viisikymmentä"     to="viideskymmenes" />
+            <Ordinal from="kuusikymmentä"     to="kuudeskymmenes" />
+            <Ordinal from="seitsemänkymmentä" to="seitsemäskymmenes" />
+            <Ordinal from="kahdeksankymmentä" to="kahdeksaskymmenes" />
+            <Ordinal from="yhdeksänkymmentä"  to="yhdeksäskymmenes" />
+            <!-- Centaines -->
+            <Ordinal from="sata"           to="sadas" />
+            <Ordinal from="kaksisataa"     to="kahdessadas" />
+            <Ordinal from="kolmesataa"     to="kolmassadas" />
+            <Ordinal from="neljäsataa"     to="neljässadas" />
+            <Ordinal from="viisisataa"     to="viidessadas" />
+            <Ordinal from="kuusisataa"     to="kuudessadas" />
+            <Ordinal from="seitsemänsataa" to="seitsemässadas" />
+            <Ordinal from="kahdeksansataa" to="kahdeksassadas" />
+            <Ordinal from="yhdeksänsataa"  to="yhdeksässadas" />
+            <!-- Millier -->
+            <Ordinal from="tuhat" to="tuhannes" />
+        </Ordinals>
     </Language>
 </Numbers>

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.HI.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.HI.xml
@@ -71,5 +71,15 @@
             <Number value="18" string="अठारह" />
             <Number value="19" string="उन्नीस" />
         </Exceptions>
+        <Ordinals suffix="वाँ">
+            <!-- 1-4 : formes entièrement irrégulières -->
+            <OrdinalException value="1" string="पहला" />
+            <OrdinalException value="2" string="दूसरा" />
+            <OrdinalException value="3" string="तीसरा" />
+            <OrdinalException value="4" string="चौथा" />
+            <!-- 6 : forme irrégulière (छह → छठा, le suffixe वाँ ne s'applique pas) -->
+            <Ordinal from="छह" to="छठा" />
+            <!-- 5, 7-9 et tous les nombres suivants reçoivent le suffixe वाँ directement -->
+        </Ordinals>
     </Language>
 </Numbers>

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.PL.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.PL.xml
@@ -71,5 +71,50 @@
             <Number value="18" string="osiemnaście" />
             <Number value="19" string="dziewiętnaście" />
         </Exceptions>
+        <Ordinals>
+            <!-- Nominatif masculin singulier — tous les stems diffèrent des cardinaux -->
+            <!-- Unités -->
+            <Ordinal from="jeden"    to="pierwszy" />
+            <Ordinal from="dwa"      to="drugi" />
+            <Ordinal from="trzy"     to="trzeci" />
+            <Ordinal from="cztery"   to="czwarty" />
+            <Ordinal from="pięć"     to="piąty" />
+            <Ordinal from="sześć"    to="szósty" />
+            <Ordinal from="siedem"   to="siódmy" />
+            <Ordinal from="osiem"    to="ósmy" />
+            <Ordinal from="dziewięć" to="dziewiąty" />
+            <Ordinal from="dziesięć" to="dziesiąty" />
+            <!-- Exceptions 11-19 -->
+            <Ordinal from="jedenaście"    to="jedenasty" />
+            <Ordinal from="dwanaście"     to="dwunasty" />
+            <Ordinal from="trzynaście"    to="trzynasty" />
+            <Ordinal from="czternaście"   to="czternasty" />
+            <Ordinal from="piętnaście"    to="piętnasty" />
+            <Ordinal from="szesnaście"    to="szesnasty" />
+            <Ordinal from="siedemnaście"  to="siedemnasty" />
+            <Ordinal from="osiemnaście"   to="osiemnasty" />
+            <Ordinal from="dziewiętnaście" to="dziewiętnasty" />
+            <!-- Dizaines -->
+            <Ordinal from="dwadzieścia"    to="dwudziesty" />
+            <Ordinal from="trzydzieści"    to="trzydziesty" />
+            <Ordinal from="czterdzieści"   to="czterdziesty" />
+            <Ordinal from="pięćdziesiąt"   to="pięćdziesiąty" />
+            <Ordinal from="sześćdziesiąt"  to="sześćdziesiąty" />
+            <Ordinal from="siedemdziesiąt" to="siedemdziesiąty" />
+            <Ordinal from="osiemdziesiąt"  to="osiemdziesiąty" />
+            <Ordinal from="dziewięćdziesiąt" to="dziewięćdziesiąty" />
+            <!-- Centaines -->
+            <Ordinal from="sto"         to="setny" />
+            <Ordinal from="dwieście"    to="dwusetny" />
+            <Ordinal from="trzysta"     to="trzechsetny" />
+            <Ordinal from="czterysta"   to="czterosetny" />
+            <Ordinal from="pięćset"     to="pięćsetny" />
+            <Ordinal from="sześćset"    to="sześćsetny" />
+            <Ordinal from="siedemset"   to="siedemsetny" />
+            <Ordinal from="osiemset"    to="osiemsetny" />
+            <Ordinal from="dziewięćset" to="dziewięćsetny" />
+            <!-- Millier -->
+            <Ordinal from="tysiąc" to="tysięczny" />
+        </Ordinals>
     </Language>
 </Numbers>

--- a/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.WO.xml
+++ b/Utils.NumberToString/Mathematics/NumberConverterConfigurations/NumberConvertionConfiguration.WO.xml
@@ -68,5 +68,10 @@
             <Number value="18" string="fukk ak juróom-ñett" />
             <Number value="19" string="fukk ak juróom-ñent" />
         </Exceptions>
+        <Ordinals suffix="ël">
+            <!-- 1er : forme lexicalisée distincte -->
+            <OrdinalException value="1" string="bu njëkk" />
+            <!-- 2+ : suffixe -ël sur le dernier mot (ñaar → ñaarël, fukk → fukkël, etc.) -->
+        </Ordinals>
     </Language>
 </Numbers>

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -1398,6 +1398,110 @@ public class NumberToStringConverterImprovementsTests
             Assert.AreEqual(expected, converter.ConvertYear(year), $"EN year {year}");
     }
 
+    // ─── EL — Ordinals ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_EL_WordRulesAndVariants()
+    {
+        var converter = NumberToStringConverter.GetConverter("EL");
+        Assert.AreEqual("πρώτος",    converter.ConvertOrdinal(1));
+        Assert.AreEqual("δεύτερος",  converter.ConvertOrdinal(2));
+        Assert.AreEqual("τρίτος",    converter.ConvertOrdinal(3));
+        Assert.AreEqual("δέκατος",   converter.ConvertOrdinal(10));
+        Assert.AreEqual("ενδέκατος", converter.ConvertOrdinal(11));
+        Assert.AreEqual("εικοστός",  converter.ConvertOrdinal(20));
+        Assert.AreEqual("εκατοστός", converter.ConvertOrdinal(100));
+        Assert.AreEqual("πρώτη",     converter.ConvertOrdinal(1,  "gender=θηλυκό"));
+        Assert.AreEqual("δεύτερη",   converter.ConvertOrdinal(2,  "gender=θηλυκό"));
+        Assert.AreEqual("πρώτο",     converter.ConvertOrdinal(1,  "gender=ουδέτερο"));
+        Assert.AreEqual("εικοστή",   converter.ConvertOrdinal(20, "gender=θηλυκό"));
+    }
+
+    // ─── FI — Ordinals ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_FI_WordRules()
+    {
+        var converter = NumberToStringConverter.GetConverter("FI");
+        (int n, string expected)[] cases =
+        [
+            (1,   "ensimmäinen"),
+            (2,   "toinen"),
+            (3,   "kolmas"),
+            (4,   "neljäs"),
+            (5,   "viides"),
+            (10,  "kymmenes"),
+            (11,  "yhdestoista"),
+            (20,  "kahdeskymmenes"),
+            (100, "sadas"),
+        ];
+        foreach (var (n, expected) in cases)
+            Assert.AreEqual(expected, converter.ConvertOrdinal(n), $"FI ordinal of {n}");
+    }
+
+    // ─── HI — Ordinals ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_HI_SuffixAndExceptions()
+    {
+        var converter = NumberToStringConverter.GetConverter("HI");
+        Assert.AreEqual("पहला",       converter.ConvertOrdinal(1));
+        Assert.AreEqual("दूसरा",      converter.ConvertOrdinal(2));
+        Assert.AreEqual("तीसरा",      converter.ConvertOrdinal(3));
+        Assert.AreEqual("चौथा",       converter.ConvertOrdinal(4));
+        Assert.AreEqual("पांचवाँ",    converter.ConvertOrdinal(5));
+        Assert.AreEqual("छठा",        converter.ConvertOrdinal(6));
+        Assert.AreEqual("सातवाँ",     converter.ConvertOrdinal(7));
+        Assert.AreEqual("ग्यारहवाँ",  converter.ConvertOrdinal(11));
+        Assert.AreEqual("बीसवाँ",     converter.ConvertOrdinal(20));
+    }
+
+    // ─── PL — Ordinals ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_PL_WordRules()
+    {
+        var converter = NumberToStringConverter.GetConverter("PL");
+        (int n, string expected)[] cases =
+        [
+            (1,   "pierwszy"),
+            (2,   "drugi"),
+            (3,   "trzeci"),
+            (5,   "piąty"),
+            (10,  "dziesiąty"),
+            (11,  "jedenasty"),
+            (20,  "dwudziesty"),
+            (21,  "dwadzieścia pierwszy"), // limitation XML : seul le dernier mot est transformé
+            (100, "setny"),
+            (1000, "tysięczny"),
+        ];
+        foreach (var (n, expected) in cases)
+            Assert.AreEqual(expected, converter.ConvertOrdinal(n), $"PL ordinal of {n}");
+    }
+
+    // ─── AR — Ordinals ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_AR_Exceptions()
+    {
+        var converter = NumberToStringConverter.GetConverter("AR");
+        Assert.AreEqual("أول",  converter.ConvertOrdinal(1));
+        Assert.AreEqual("ثانٍ", converter.ConvertOrdinal(2));
+        Assert.AreEqual("ثالث", converter.ConvertOrdinal(3));
+        Assert.AreEqual("عاشر", converter.ConvertOrdinal(10));
+    }
+
+    // ─── WO — Ordinals ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_WO_SuffixAndException()
+    {
+        var converter = NumberToStringConverter.GetConverter("WO");
+        Assert.AreEqual("bu njëkk", converter.ConvertOrdinal(1));
+        Assert.AreEqual("ñaarël",   converter.ConvertOrdinal(2));
+        Assert.AreEqual("fukkël",   converter.ConvertOrdinal(10));
+    }
+
     private sealed class OrdinalPluginSpecifics
         : INumberToStringLanguageSpecifics, IOrdinalLanguageSpecifics
     {


### PR DESCRIPTION
## Summary
- **EL (Grec)** : word rules pour ordinaux masculins (defaut) + `OrdinalVariants` gender=θηλυκό et ουδέτερο pour 1-12, 20, 100
- **FI (Finnois)** : word rules exhaustives — unites 1-9, exceptions 11-19, dizaines 20-90, centaines, tuhat (toutes les formes finnoise ont des stems differents des cardinaux)
- **HI (Hindi)** : suffixe `वाँ` pour 5-9 et 11+, exceptions 1-4, word rule pour 6 (`छठा`)
- **PL (Polonais)** : word rules pour toutes les formes nominatif masculin singulier ; les ordinaux composes ne transforment que le dernier mot (limitation XML, documentee dans les tests)
- **AR (Arabe)** : exceptions masculines indefinies pour 1-10
- **WO (Wolof)** : suffixe `-el` + exception 1 (`bu njekk`)

## Test plan
- [ ] `ConvertOrdinal_EL_WordRulesAndVariants` — 11 assertions (masc + gender variants)
- [ ] `ConvertOrdinal_FI_WordRules` — 9 cas
- [ ] `ConvertOrdinal_HI_SuffixAndExceptions` — 9 assertions
- [ ] `ConvertOrdinal_PL_WordRules` — 10 cas
- [ ] `ConvertOrdinal_AR_Exceptions` — 4 assertions
- [ ] `ConvertOrdinal_WO_SuffixAndException` — 3 assertions
- [ ] Build 0 erreurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
