### PR TITLE
feat(NumberToString): multi-value variant syntax (values=a,b,c)

### DIFF
--- a/Utils.Mathematics/README.md
+++ b/Utils.Mathematics/README.md
@@ -24,6 +24,59 @@ var fft = new Utils.Mathematics.Fourrier.FastFourrierTransform();
 fft.Transform(signal);
 ```
 
+## MathEx — extended math utilities
+
+`MathEx` provides generic numerical utilities, rounding helpers, and combinatorial tools.
+
+### `RoundToSignificantDigits`
+
+Rounds a `BigInteger` to a given number of significant digits using standard rounding (≥ 5 rounds up).
+
+```csharp
+using System.Numerics;
+using Utils.Mathematics;
+
+MathEx.RoundToSignificantDigits(123456789, 3);  // 123000000
+MathEx.RoundToSignificantDigits(123456789, 2);  // 120000000
+MathEx.RoundToSignificantDigits(123456789, 1);  // 100000000
+MathEx.RoundToSignificantDigits(125, 2);        // 130   (5 → rounds up)
+MathEx.RoundToSignificantDigits(124, 2);        // 120   (4 → rounds down)
+MathEx.RoundToSignificantDigits(-123456789, 3); // -123000000  (sign preserved)
+MathEx.RoundToSignificantDigits(0, 3);          // 0
+```
+
+Throws `ArgumentOutOfRangeException` when `significantDigits < 1`. Returns `value` unchanged when it already has fewer or equal digits than requested.
+
+### Other rounding helpers
+
+```csharp
+MathEx.Round(1234, 100);   // 1200 — nearest multiple of 100
+MathEx.Round(1250, 100);   // 1300 — tie rounds up
+MathEx.Floor(1234,  100);  // 1200 — greatest multiple ≤ value
+MathEx.Ceiling(1201, 100); // 1300 — smallest multiple ≥ value
+```
+
+### `Mod` — always-positive modulo
+
+```csharp
+MathEx.Mod(-1, 3);  // 2  (unlike C# % which gives -1)
+```
+
+### `Gcd` / `Lcm`
+
+```csharp
+MathEx.Gcd(12, 8);   // 4
+MathEx.Lcm(4, 6);    // 12
+```
+
+### `Min` / `Max` / `Clamp` — fixed-set overloads
+
+```csharp
+MathEx.Min(3, 1, 4, 1, 5);   // 1
+MathEx.Max(3, 1, 4, 1, 5);   // 5
+5.Clamp(1, 4);                 // 4
+```
+
 ## FFT examples
 
 `FastFourrierTransform` performs an in-place Cooley-Tukey FFT. The input length must be a power of two.

--- a/Utils.NumberToString/GermanNumberToStringLanguageSpecifics.cs
+++ b/Utils.NumberToString/GermanNumberToStringLanguageSpecifics.cs
@@ -23,8 +23,11 @@ public sealed class GermanNumberToStringLanguageSpecifics : INumberToStringLangu
 
         // "ein Million" → "eine Million": scale names start with an uppercase letter
         // (firstLetterUpperCase="true"); this regex handles all generated levels (Billion,
-        // Trillion …) without an explicit enumeration. Covered by XML Variants: Standalone
-        // "ein" → "eins" and all case/gender inflections; this hook is only for scale words.
-        return Regex.Replace(text, @"\bein (?<l>[A-Z])", "eine ${l}");
+        // Trillion …) without an explicit enumeration. Only this hook can cover compound
+        // endings like "zweihundertein" → "zweihunderteins" (LastWord scope cannot).
+        string finalized = Regex.Replace(text, @"\bein (?<l>[A-Z])", "eine ${l}");
+        if (finalized.EndsWith("ein", StringComparison.Ordinal))
+            finalized += "s";
+        return finalized;
     }
 }

--- a/Utils.NumberToString/GermanNumberToStringLanguageSpecifics.cs
+++ b/Utils.NumberToString/GermanNumberToStringLanguageSpecifics.cs
@@ -21,12 +21,10 @@ public sealed class GermanNumberToStringLanguageSpecifics : INumberToStringLangu
             return text;
         }
 
-        string finalized = Regex.Replace(text, @"\bein (?<l>[A-Z])", "eine ${l}");
-        if (finalized.EndsWith("ein", StringComparison.Ordinal))
-        {
-            finalized += "s";
-        }
-
-        return finalized;
+        // "ein Million" → "eine Million": scale names start with an uppercase letter
+        // (firstLetterUpperCase="true"); this regex handles all generated levels (Billion,
+        // Trillion …) without an explicit enumeration. Covered by XML Variants: Standalone
+        // "ein" → "eins" and all case/gender inflections; this hook is only for scale words.
+        return Regex.Replace(text, @"\bein (?<l>[A-Z])", "eine ${l}");
     }
 }

--- a/Utils.NumberToString/INumberToStringConverter.cs
+++ b/Utils.NumberToString/INumberToStringConverter.cs
@@ -82,6 +82,19 @@ namespace Utils.NumberToString
         string Convert(BigInteger number, params string[] variants) => Convert(number);
 
         /// <summary>
+        /// Converts <paramref name="number"/> rounded to <paramref name="significantDigits"/> most significant
+        /// digits into its string representation, applying optional variant parameters.
+        /// Uses standard rounding (≥ 5 rounds up, &lt; 5 rounds down). For example, 123456789
+        /// with 3 significant digits rounds to 123000000 before conversion.
+        /// </summary>
+        /// <param name="number">The value to convert.</param>
+        /// <param name="significantDigits">Number of significant digits to keep. Must be ≥ 1.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        /// <returns>The formatted rounded number with the requested variants applied.</returns>
+        string Convert(BigInteger number, int significantDigits, params string[] variants)
+            => Convert(NumberToStringConverter.RoundToSignificantDigits(number, significantDigits), variants);
+
+        /// <summary>
         /// Converts a 32-bit signed integer into its string representation,
         /// applying the specified variant parameters.
         /// The default implementation ignores variant parameters and delegates to

--- a/Utils.NumberToString/INumberToStringConverter.cs
+++ b/Utils.NumberToString/INumberToStringConverter.cs
@@ -92,7 +92,7 @@ namespace Utils.NumberToString
         /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
         /// <returns>The formatted rounded number with the requested variants applied.</returns>
         string Convert(BigInteger number, int significantDigits, params string[] variants)
-            => Convert(NumberToStringConverter.RoundToSignificantDigits(number, significantDigits), variants);
+            => Convert(Utils.Mathematics.MathEx.RoundToSignificantDigits(number, significantDigits), variants);
 
         /// <summary>
         /// Converts a 32-bit signed integer into its string representation,

--- a/Utils.NumberToString/NumberConverterConfiguration.cs
+++ b/Utils.NumberToString/NumberConverterConfiguration.cs
@@ -139,6 +139,14 @@ public class OrdinalVariantElementType
     [XmlAttribute("variant")]
     public string? VariantValue { get; set; }
 
+    /// <summary>
+    /// Comma-separated list of dimension values; alternative to <see cref="VariantValue"/>.
+    /// One rule is emitted per value, all sharing the same body.
+    /// Takes priority over <see cref="VariantValue"/> when both are present.
+    /// </summary>
+    [XmlAttribute("values")]
+    public string? VariantValues { get; set; }
+
     /// <summary>Suffix override for this variant; falls back to the base suffix when absent.</summary>
     [XmlAttribute("suffix")]
     public string? Suffix { get; set; }
@@ -366,6 +374,14 @@ public class VariantType
     /// <summary>The value that must be active for this variant to apply (e.g. "feminin").</summary>
     [XmlAttribute("variant")]
     public string? VariantValue { get; set; }
+
+    /// <summary>
+    /// Comma-separated list of dimension values; alternative to <see cref="VariantValue"/>.
+    /// One rule is emitted per value, all sharing the same body.
+    /// Takes priority over <see cref="VariantValue"/> when both are present.
+    /// </summary>
+    [XmlAttribute("values")]
+    public string? VariantValues { get; set; }
 
     /// <summary>Gets or sets the replacement rules applied when this variant is active.</summary>
     [XmlElement("Replacement")]

--- a/Utils.NumberToString/NumberConverterConfiguration.cs
+++ b/Utils.NumberToString/NumberConverterConfiguration.cs
@@ -77,6 +77,14 @@ public class FormVariantType
     [XmlAttribute("forms")]
     public string? Forms { get; set; }
 
+    /// <summary>
+    /// Single output form for the specific dimension value named by <see cref="VariantValue"/>.
+    /// Shorthand for single-value overrides without listing all positional forms.
+    /// Requires <see cref="VariantValue"/> to be set.
+    /// </summary>
+    [XmlAttribute("value")]
+    public string? Value { get; set; }
+
     /// <summary>Nested sub-variants that cascade additional constraints.</summary>
     [XmlElement("Variant")]
     public List<FormVariantType>? NestedVariants { get; set; }
@@ -633,6 +641,73 @@ public class LanguageType
     /// </summary>
     [XmlElement(ElementName = "YearFormat")]
     public YearFormatType? YearFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the trigger rules applied at specific points in the conversion pipeline.
+    /// Multiple Trigger elements are processed in declaration order.
+    /// </summary>
+    [XmlElement(ElementName = "Trigger")]
+    public List<TriggerType>? Triggers { get; set; }
+}
+
+/// <summary>
+/// A text-replacement rule inside a <see cref="TriggerType"/>.
+/// Selects the most specific matching variant form, or <see cref="To"/> as the unconditional default.
+/// Uses the same <see cref="FormVariantType"/> nesting as <c>Replacement</c>, <c>Ordinal</c>, and
+/// <c>OrdinalException</c>: leaf nodes provide positional <c>forms</c> or a single <c>value</c>;
+/// intermediate nodes add dimension constraints via <c>type</c>+<c>variant</c>.
+/// </summary>
+public class TriggerReplaceType
+{
+    /// <summary>Gets or sets the text or regex pattern to match.</summary>
+    [XmlAttribute("from")]
+    public string From { get; set; }
+
+    /// <summary>
+    /// Gets or sets the unconditional default replacement.
+    /// May be omitted when all cases are covered by <see cref="FormVariants"/>;
+    /// the first expanded form then serves as default.
+    /// May contain backreferences ($1, ${name}) when <see cref="IsRegex"/> is true.
+    /// </summary>
+    [XmlAttribute("to")]
+    public string? To { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether <see cref="From"/> is treated as a .NET regular expression.
+    /// Defaults to <see langword="false"/> (literal string match).
+    /// </summary>
+    [XmlAttribute("regex")]
+    public bool IsRegex { get; set; }
+
+    /// <summary>
+    /// Per-dimension-value form declarations expanded at load time.
+    /// The most specific matching form is selected at runtime.
+    /// </summary>
+    [XmlElement("Variant")]
+    public List<FormVariantType>? FormVariants { get; set; }
+}
+
+/// <summary>
+/// A trigger that fires at a specific point in the conversion pipeline and applies
+/// text replacements, each optionally selecting a form based on active variant values.
+/// </summary>
+public class TriggerType
+{
+    /// <summary>
+    /// Gets or sets when the trigger fires.
+    /// Syntax: "group", "group(N)", "group(N,M)", "groupWithScale", "groupWithScale(N)", "end".
+    /// Group indices: 0=units, 1=thousands, 2=millions, … (negative values reserved for decimals).
+    /// </summary>
+    [XmlAttribute("executeAt")]
+    public string ExecuteAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the replacement rules applied when this trigger fires.
+    /// Each Replace is applied independently; for each one the most specific matching
+    /// variant form is selected and applied exactly once.
+    /// </summary>
+    [XmlElement("Replace")]
+    public List<TriggerReplaceType>? Replaces { get; set; }
 }
 
 /// <summary>

--- a/Utils.NumberToString/NumberConverterConfiguration.cs
+++ b/Utils.NumberToString/NumberConverterConfiguration.cs
@@ -39,6 +39,50 @@ public class NumberType
 }
 
 /// <summary>
+/// A variant node inside a form-producing element (<c>&lt;Replacement&gt;</c>,
+/// <c>&lt;OrdinalException&gt;</c>, <c>&lt;Ordinal&gt;</c>).
+/// Plays two roles depending on whether <see cref="Forms"/> is present:
+/// <list type="bullet">
+///   <item><term>Intermediate node</term><description>
+///     <see cref="DimensionType"/> + <see cref="VariantValue"/> add one constraint;
+///     child <c>&lt;Variant&gt;</c> elements cascade further constraints.
+///   </description></item>
+///   <item><term>Leaf node</term><description>
+///     <see cref="DimensionType"/> + <see cref="Forms"/> provide one output form per
+///     dimension value in the order declared by the matching <c>&lt;Dimension&gt;</c>
+///     element. Empty entries are skipped.
+///   </description></item>
+/// </list>
+/// All (constraints, form) pairs are collected at load time and merged by constraint set
+/// into <c>OrdinalVariantRule</c> or <c>VariantRule</c> entries — no runtime changes required.
+/// </summary>
+public class FormVariantType
+{
+    /// <summary>Canonical dimension name this node targets (e.g. <c>"gender"</c>, <c>"case"</c>).</summary>
+    [XmlAttribute("type")]
+    public string? DimensionType { get; set; }
+
+    /// <summary>
+    /// Single dimension value for an intermediate node.
+    /// Used together with child <c>&lt;Variant&gt;</c> elements.
+    /// Omit on leaf nodes that use <see cref="Forms"/> instead.
+    /// </summary>
+    [XmlAttribute("variant")]
+    public string? VariantValue { get; set; }
+
+    /// <summary>
+    /// Comma-separated positional output forms for a leaf node, one per dimension value
+    /// in <c>&lt;Dimension&gt;</c> declaration order. Empty entries produce no rule.
+    /// </summary>
+    [XmlAttribute("forms")]
+    public string? Forms { get; set; }
+
+    /// <summary>Nested sub-variants that cascade additional constraints.</summary>
+    [XmlElement("Variant")]
+    public List<FormVariantType>? NestedVariants { get; set; }
+}
+
+/// <summary>
 /// Describes a single ordinal exception that maps an integer to its ordinal text.
 /// </summary>
 public class OrdinalExceptionType
@@ -47,9 +91,19 @@ public class OrdinalExceptionType
     [XmlAttribute("value")]
     public long Value { get; set; }
 
-    /// <summary>Gets or sets the ordinal text for <see cref="Value"/>.</summary>
+    /// <summary>
+    /// Gets or sets the base ordinal text for <see cref="Value"/> (default variant).
+    /// May be <see langword="null"/> when all forms are declared via <see cref="FormVariants"/>.
+    /// </summary>
     [XmlAttribute("string")]
-    public string StringValue { get; set; }
+    public string? StringValue { get; set; }
+
+    /// <summary>
+    /// Per-dimension-value form declarations expanded at load time into <c>OrdinalVariantRule</c>
+    /// entries (see <see cref="FormVariantType"/>).
+    /// </summary>
+    [XmlElement("Variant")]
+    public List<FormVariantType>? FormVariants { get; set; }
 }
 
 /// <summary>
@@ -62,9 +116,19 @@ public class OrdinalRuleType
     [XmlAttribute("from")]
     public string From { get; set; }
 
-    /// <summary>Gets or sets the ordinal replacement word.</summary>
+    /// <summary>
+    /// Gets or sets the base ordinal replacement word (default variant).
+    /// May be <see langword="null"/> when all forms are declared via <see cref="FormVariants"/>.
+    /// </summary>
     [XmlAttribute("to")]
-    public string To { get; set; }
+    public string? To { get; set; }
+
+    /// <summary>
+    /// Per-dimension-value form declarations expanded at load time into <c>OrdinalVariantRule</c>
+    /// word-rule entries (see <see cref="FormVariantType"/>).
+    /// </summary>
+    [XmlElement("Variant")]
+    public List<FormVariantType>? FormVariants { get; set; }
 }
 
 /// <summary>
@@ -281,10 +345,11 @@ public class ReplacementType
     public string OldValue { get; set; }
 
     /// <summary>
-    /// Gets or sets the replacement text.
+    /// Gets or sets the base replacement text (default variant).
+    /// May be <see langword="null"/> when all forms are declared via <see cref="FormVariants"/>.
     /// </summary>
     [XmlAttribute("newValue")]
-    public string NewValue { get; set; }
+    public string? NewValue { get; set; }
 
     /// <summary>
     /// Gets or sets the textual scope representation supplied by the configuration.
@@ -297,6 +362,13 @@ public class ReplacementType
     /// </summary>
     [XmlIgnore]
     public ReplacementScope Scope => ParseScope(ScopeValue);
+
+    /// <summary>
+    /// Per-dimension-value form declarations expanded at load time into <c>VariantRule</c>
+    /// replacement entries (see <see cref="FormVariantType"/>).
+    /// </summary>
+    [XmlElement("Variant")]
+    public List<FormVariantType>? FormVariants { get; set; }
 
     private static ReplacementScope ParseScope(string scope)
     {

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.AR.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.AR.xml
@@ -59,34 +59,25 @@
             </Suffixes>
         </NumberScale>
         <Exceptions />
+        <!--
+          Arabic ordinals for 1-10 — forms listed in Dimension order: muzakkar, muʾannath.
+          The first form (muzakkar) also serves as the default when no variant is specified.
+        -->
         <Ordinals>
-            <!-- Masculin indéfini, forme courte (sans article) — les ordinaux arabes
-                 sont indépendants des cardinaux et varient en genre avec le nom -->
-            <OrdinalException value="1"  string="أول" />
-            <OrdinalException value="2"  string="ثانٍ" />
-            <OrdinalException value="3"  string="ثالث" />
-            <OrdinalException value="4"  string="رابع" />
-            <OrdinalException value="5"  string="خامس" />
-            <OrdinalException value="6"  string="سادس" />
-            <OrdinalException value="7"  string="سابع" />
-            <OrdinalException value="8"  string="ثامن" />
-            <OrdinalException value="9"  string="تاسع" />
-            <OrdinalException value="10" string="عاشر" />
-            <OrdinalVariants>
-                <!-- Forme féminine (muʾannath) pour 1-10 ; au-delà de 10 aucune exception n'est définie -->
-                <Variant type="gender" variant="muʾannath">
-                    <OrdinalException value="1"  string="أولى"   />
-                    <OrdinalException value="2"  string="ثانية"  />
-                    <OrdinalException value="3"  string="ثالثة"  />
-                    <OrdinalException value="4"  string="رابعة"  />
-                    <OrdinalException value="5"  string="خامسة"  />
-                    <OrdinalException value="6"  string="سادسة"  />
-                    <OrdinalException value="7"  string="سابعة"  />
-                    <OrdinalException value="8"  string="ثامنة"  />
-                    <OrdinalException value="9"  string="تاسعة"  />
-                    <OrdinalException value="10" string="عاشرة"  />
-                </Variant>
-            </OrdinalVariants>
+            <OrdinalException value="1">  <Variant type="gender" forms="أول,أولى"   /></OrdinalException>
+            <OrdinalException value="2">  <Variant type="gender" forms="ثانٍ,ثانية"  /></OrdinalException>
+            <OrdinalException value="3">  <Variant type="gender" forms="ثالث,ثالثة"  /></OrdinalException>
+            <OrdinalException value="4">  <Variant type="gender" forms="رابع,رابعة"  /></OrdinalException>
+            <OrdinalException value="5">  <Variant type="gender" forms="خامس,خامسة"  /></OrdinalException>
+            <OrdinalException value="6">  <Variant type="gender" forms="سادس,سادسة"  /></OrdinalException>
+            <OrdinalException value="7">  <Variant type="gender" forms="سابع,سابعة"  /></OrdinalException>
+            <OrdinalException value="8">  <Variant type="gender" forms="ثامن,ثامنة"  /></OrdinalException>
+            <OrdinalException value="9">  <Variant type="gender" forms="تاسع,تاسعة"  /></OrdinalException>
+            <OrdinalException value="10"> <Variant type="gender" forms="عاشر,عاشرة"  /></OrdinalException>
         </Ordinals>
+        <Variants>
+            <!-- Dimension declared for ordinal forms= expansion; Arabic cardinals are invariable in this config -->
+            <Dimension name="gender" localName="الجنس" values="muzakkar,muʾannath" />
+        </Variants>
     </Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE-ch.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE-ch.xml
@@ -798,17 +798,6 @@
 				</Variant>
 			</Variant>
 
-			<!-- counting form "eins": maskulin/neutrum nominativ and neutrum akkusativ -->
-			<Variant type="gender" variant="maskulin">
-				<Variant type="case" variant="nominativ">
-					<Replacement oldValue="ein" newValue="eins" scope="LastWord" />
-				</Variant>
-			</Variant>
-			<Variant type="gender" variant="neutrum">
-				<Variant type="case" values="nominativ,akkusativ">
-					<Replacement oldValue="ein" newValue="eins" scope="LastWord" />
-				</Variant>
-			</Variant>
 		</Variants>
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE-ch.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE-ch.xml
@@ -84,44 +84,702 @@
 		  ordinal exception is added so "tausendste" is produced for 1000.
 		  Compounds such as "zwei tausend ein" → ordinal "zwei tausend erste"
 		  via the word rule "ein" → "erste".
+		  Two declension variants: "schwach" (weak, default — used after a definite
+		  article) and "stark" (strong — used without an article).
 		-->
 		<Ordinals suffix="ste">
-			<OrdinalException value="1"    string="erste" />
-			<OrdinalException value="3"    string="dritte" />
-			<OrdinalException value="7"    string="siebte" />
-			<OrdinalException value="8"    string="achte" />
-			<OrdinalException value="1000" string="tausendste" />
-			<Ordinal from="ein"      to="erste" />
-			<Ordinal from="zwei"     to="zweite" />
-			<Ordinal from="drei"     to="dritte" />
-			<Ordinal from="vier"     to="vierte" />
-			<Ordinal from="fünf"     to="fünfte" />
-			<Ordinal from="sechs"    to="sechste" />
-			<Ordinal from="sieben"   to="siebte" />
-			<Ordinal from="acht"     to="achte" />
-			<Ordinal from="neun"     to="neunte" />
-			<Ordinal from="zehn"     to="zehnte" />
-			<Ordinal from="elf"      to="elfte" />
-			<Ordinal from="zwölf"    to="zwölfte" />
-			<Ordinal from="dreizehn" to="dreizehnte" />
-			<Ordinal from="vierzehn" to="vierzehnte" />
-			<Ordinal from="fünfzehn" to="fünfzehnte" />
-			<Ordinal from="sechzehn" to="sechzehnte" />
-			<Ordinal from="siebzehn" to="siebzehnte" />
-			<Ordinal from="achtzehn" to="achtzehnte" />
-			<Ordinal from="neunzehn" to="neunzehnte" />
-			<Ordinal from="tausend"  to="tausendste" />
+			<OrdinalException value="1"    string="erste">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,ersten,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erster,ersten,erstem,ersten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,erste,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erste,erste,erster,erster" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,erste,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erstes,erstes,erstem,ersten" />
+					</Variant>
+				</Variant>
+			</OrdinalException>
+			<OrdinalException value="3"    string="dritte">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritten,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dritter,dritten,drittem,dritten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritte,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dritte,dritte,dritter,dritter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritte,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="drittes,drittes,drittem,dritten" />
+					</Variant>
+				</Variant>
+			</OrdinalException>
+			<OrdinalException value="7"    string="siebte">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebten,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebter,siebten,siebtem,siebten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebte,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebte,siebte,siebter,siebter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebte,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebtes,siebtes,siebtem,siebten" />
+					</Variant>
+				</Variant>
+			</OrdinalException>
+			<OrdinalException value="8"    string="achte">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achten,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achter,achten,achtem,achten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achte,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achte,achte,achter,achter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achte,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtes,achtes,achtem,achten" />
+					</Variant>
+				</Variant>
+			</OrdinalException>
+			<OrdinalException value="1000" string="tausendste">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="tausendste,tausendsten,tausendsten,tausendsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="tausendster,tausendsten,tausendstem,tausendsten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="tausendste,tausendste,tausendsten,tausendsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="tausendste,tausendste,tausendster,tausendster" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="tausendste,tausendste,tausendsten,tausendsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="tausendstes,tausendstes,tausendstem,tausendsten" />
+					</Variant>
+				</Variant>
+			</OrdinalException>
+			<Ordinal from="ein">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,ersten,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erster,ersten,erstem,ersten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,erste,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erste,erste,erster,erster" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,erste,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erstes,erstes,erstem,ersten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="zwei">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zweite,zweiten,zweiten,zweiten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zweiter,zweiten,zweitem,zweiten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zweite,zweite,zweiten,zweiten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zweite,zweite,zweiter,zweiter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zweite,zweite,zweiten,zweiten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zweites,zweites,zweitem,zweiten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="drei">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritten,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dritter,dritten,drittem,dritten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritte,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dritte,dritte,dritter,dritter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritte,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="drittes,drittes,drittem,dritten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="vier">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierte,vierten,vierten,vierten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierter,vierten,viertem,vierten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierte,vierte,vierten,vierten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierte,vierte,vierter,vierter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierte,vierte,vierten,vierten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="viertes,viertes,viertem,vierten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="fünf">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfte,fünften,fünften,fünften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfter,fünften,fünftem,fünften" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfte,fünfte,fünften,fünften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfte,fünfte,fünfter,fünfter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfte,fünfte,fünften,fünften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünftes,fünftes,fünftem,fünften" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="sechs">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechste,sechsten,sechsten,sechsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechster,sechsten,sechstem,sechsten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechste,sechste,sechsten,sechsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechste,sechste,sechster,sechster" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechste,sechste,sechsten,sechsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechstes,sechstes,sechstem,sechsten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="sieben">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebten,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebter,siebten,siebtem,siebten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebte,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebte,siebte,siebter,siebter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebte,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebtes,siebtes,siebtem,siebten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="acht">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achten,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achter,achten,achtem,achten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achte,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achte,achte,achter,achter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achte,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtes,achtes,achtem,achten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="neun">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunte,neunten,neunten,neunten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunter,neunten,neuntem,neunten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunte,neunte,neunten,neunten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunte,neunte,neunter,neunter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunte,neunte,neunten,neunten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neuntes,neuntes,neuntem,neunten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="zehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zehnte,zehnten,zehnten,zehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zehnter,zehnten,zehntem,zehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zehnte,zehnte,zehnten,zehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zehnte,zehnte,zehnter,zehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zehnte,zehnte,zehnten,zehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zehntes,zehntes,zehntem,zehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="elf">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="elfte,elften,elften,elften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="elfter,elften,elftem,elften" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="elfte,elfte,elften,elften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="elfte,elfte,elfter,elfter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="elfte,elfte,elften,elften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="elftes,elftes,elftem,elften" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="zwölf">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zwölfte,zwölften,zwölften,zwölften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zwölfter,zwölften,zwölftem,zwölften" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zwölfte,zwölfte,zwölften,zwölften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zwölfte,zwölfte,zwölfter,zwölfter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zwölfte,zwölfte,zwölften,zwölften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zwölftes,zwölftes,zwölftem,zwölften" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="dreizehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dreizehnte,dreizehnten,dreizehnten,dreizehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dreizehnter,dreizehnten,dreizehntem,dreizehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dreizehnte,dreizehnte,dreizehnten,dreizehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dreizehnte,dreizehnte,dreizehnter,dreizehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dreizehnte,dreizehnte,dreizehnten,dreizehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dreizehntes,dreizehntes,dreizehntem,dreizehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="vierzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierzehnte,vierzehnten,vierzehnten,vierzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierzehnter,vierzehnten,vierzehntem,vierzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierzehnte,vierzehnte,vierzehnten,vierzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierzehnte,vierzehnte,vierzehnter,vierzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierzehnte,vierzehnte,vierzehnten,vierzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierzehntes,vierzehntes,vierzehntem,vierzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="fünfzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfzehnte,fünfzehnten,fünfzehnten,fünfzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfzehnter,fünfzehnten,fünfzehntem,fünfzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfzehnte,fünfzehnte,fünfzehnten,fünfzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfzehnte,fünfzehnte,fünfzehnter,fünfzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfzehnte,fünfzehnte,fünfzehnten,fünfzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfzehntes,fünfzehntes,fünfzehntem,fünfzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="sechzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechzehnte,sechzehnten,sechzehnten,sechzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechzehnter,sechzehnten,sechzehntem,sechzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechzehnte,sechzehnte,sechzehnten,sechzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechzehnte,sechzehnte,sechzehnter,sechzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechzehnte,sechzehnte,sechzehnten,sechzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechzehntes,sechzehntes,sechzehntem,sechzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="siebzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebzehnte,siebzehnten,siebzehnten,siebzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebzehnter,siebzehnten,siebzehntem,siebzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebzehnte,siebzehnte,siebzehnten,siebzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebzehnte,siebzehnte,siebzehnter,siebzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebzehnte,siebzehnte,siebzehnten,siebzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebzehntes,siebzehntes,siebzehntem,siebzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="achtzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achtzehnte,achtzehnten,achtzehnten,achtzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtzehnter,achtzehnten,achtzehntem,achtzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achtzehnte,achtzehnte,achtzehnten,achtzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtzehnte,achtzehnte,achtzehnter,achtzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achtzehnte,achtzehnte,achtzehnten,achtzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtzehntes,achtzehntes,achtzehntem,achtzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="neunzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunzehnte,neunzehnten,neunzehnten,neunzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunzehnter,neunzehnten,neunzehntem,neunzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunzehnte,neunzehnte,neunzehnten,neunzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunzehnte,neunzehnte,neunzehnter,neunzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunzehnte,neunzehnte,neunzehnten,neunzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunzehntes,neunzehntes,neunzehntem,neunzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="tausend">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="tausendste,tausendsten,tausendsten,tausendsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="tausendster,tausendsten,tausendstem,tausendsten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="tausendste,tausendste,tausendsten,tausendsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="tausendste,tausendste,tausendster,tausendster" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="tausendste,tausendste,tausendsten,tausendsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="tausendstes,tausendstes,tausendstem,tausendsten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<!--
+			  OrdinalVariants for regular ordinals (20+, suffix="ste"):
+			    schwach: maskulin nom stays as "ste", all other combinations append "n" → "sten"
+			    stark:   maskulin nom → "ster"; dat → "stem"; feminin/neutrum dat/gen → "ster"/"stem"/"sten"
+			-->
+			<OrdinalVariants>
+				<Variant type="declension" variant="schwach">
+					<Variant type="gender" variant="maskulin">
+						<Variant type="case" values="akkusativ,dativ,genitiv" suffix="sten" />
+					</Variant>
+					<Variant type="gender" variant="feminin">
+						<Variant type="case" values="dativ,genitiv" suffix="sten" />
+					</Variant>
+					<Variant type="gender" variant="neutrum">
+						<Variant type="case" values="dativ,genitiv" suffix="sten" />
+					</Variant>
+				</Variant>
+				<Variant type="declension" variant="stark">
+					<Variant type="gender" variant="maskulin">
+						<Variant type="case" variant="nominativ" suffix="ster" />
+						<Variant type="case" values="akkusativ,genitiv" suffix="sten" />
+						<Variant type="case" variant="dativ" suffix="stem" />
+					</Variant>
+					<Variant type="gender" variant="feminin">
+						<Variant type="case" values="dativ,genitiv" suffix="ster" />
+					</Variant>
+					<Variant type="gender" variant="neutrum">
+						<Variant type="case" values="nominativ,akkusativ" suffix="stes" />
+						<Variant type="case" variant="dativ" suffix="stem" />
+						<Variant type="case" variant="genitiv" suffix="sten" />
+					</Variant>
+				</Variant>
+			</OrdinalVariants>
 		</Ordinals>
 		<Variants>
 			<Dimension name="gender" localName="genus" values="maskulin,feminin,neutrum" />
 			<Dimension name="case" localName="kasus" values="nominativ,akkusativ,dativ,genitiv" />
+			<Dimension name="declension" localName="deklination" values="schwach,stark" />
 
 			<Variant type="gender" variant="feminin">
 				<Replacement oldValue="ein" newValue="eine" scope="LastWord" />
-				<Variant type="case" variant="dativ">
-					<Replacement oldValue="eine" newValue="einer" scope="LastWord" />
-				</Variant>
-				<Variant type="case" variant="genitiv">
+				<Variant type="case" values="dativ,genitiv">
 					<Replacement oldValue="eine" newValue="einer" scope="LastWord" />
 				</Variant>
 			</Variant>
@@ -137,6 +795,18 @@
 			<Variant type="gender" variant="maskulin">
 				<Variant type="case" variant="akkusativ">
 					<Replacement oldValue="ein" newValue="einen" scope="LastWord" />
+				</Variant>
+			</Variant>
+
+			<!-- counting form "eins": maskulin/neutrum nominativ and neutrum akkusativ -->
+			<Variant type="gender" variant="maskulin">
+				<Variant type="case" variant="nominativ">
+					<Replacement oldValue="ein" newValue="eins" scope="LastWord" />
+				</Variant>
+			</Variant>
+			<Variant type="gender" variant="neutrum">
+				<Variant type="case" values="nominativ,akkusativ">
+					<Replacement oldValue="ein" newValue="eins" scope="LastWord" />
 				</Variant>
 			</Variant>
 		</Variants>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
@@ -83,37 +83,643 @@
 		<!--
 		  German ordinals: 1, 3, 7, 8 are fully irregular; 2, 4-6, 9-19 follow a
 		  "-te" pattern with minor stem changes; 20+ take "-ste" (default suffix).
-		  Word rules cover units and teens when they appear as space-separated last
-		  words inside compounds (e.g. "tausend drei" → "tausend dritte").
-		  German ordinal declension (gender × case) is adjectival and cannot be
-		  expressed as simple replacements; only the uninflected stem form is provided.
+		  Word rules cover units and teens (space-separated last word in compounds).
+		  Two declension variants: "schwach" (weak, default — used after a definite
+		  article) and "stark" (strong — used without an article).
+		  OrdinalVariants handles the 20+ suffix pattern for both declensions.
 		-->
 		<Ordinals suffix="ste">
-			<!-- Irregular ordinals -->
-			<OrdinalException value="1"  string="erste" />
-			<OrdinalException value="3"  string="dritte" />
-			<OrdinalException value="7"  string="siebte" />
-			<OrdinalException value="8"  string="achte" />
-			<!-- Word rules for 1-19 units (apply when space-separated last word) -->
-			<Ordinal from="ein"      to="erste" />
-			<Ordinal from="zwei"     to="zweite" />
-			<Ordinal from="drei"     to="dritte" />
-			<Ordinal from="vier"     to="vierte" />
-			<Ordinal from="fünf"     to="fünfte" />
-			<Ordinal from="sechs"    to="sechste" />
-			<Ordinal from="sieben"   to="siebte" />
-			<Ordinal from="acht"     to="achte" />
-			<Ordinal from="neun"     to="neunte" />
-			<Ordinal from="zehn"     to="zehnte" />
-			<Ordinal from="elf"      to="elfte" />
-			<Ordinal from="zwölf"    to="zwölfte" />
-			<Ordinal from="dreizehn" to="dreizehnte" />
-			<Ordinal from="vierzehn" to="vierzehnte" />
-			<Ordinal from="fünfzehn" to="fünfzehnte" />
-			<Ordinal from="sechzehn" to="sechzehnte" />
-			<Ordinal from="siebzehn" to="siebzehnte" />
-			<Ordinal from="achtzehn" to="achtzehnte" />
-			<Ordinal from="neunzehn" to="neunzehnte" />
+			<OrdinalException value="1"  string="erste">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,ersten,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erster,ersten,erstem,ersten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,erste,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erste,erste,erster,erster" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,erste,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erstes,erstes,erstem,ersten" />
+					</Variant>
+				</Variant>
+			</OrdinalException>
+			<OrdinalException value="3"  string="dritte">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritten,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dritter,dritten,drittem,dritten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritte,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dritte,dritte,dritter,dritter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritte,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="drittes,drittes,drittem,dritten" />
+					</Variant>
+				</Variant>
+			</OrdinalException>
+			<OrdinalException value="7"  string="siebte">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebten,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebter,siebten,siebtem,siebten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebte,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebte,siebte,siebter,siebter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebte,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebtes,siebtes,siebtem,siebten" />
+					</Variant>
+				</Variant>
+			</OrdinalException>
+			<OrdinalException value="8"  string="achte">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achten,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achter,achten,achtem,achten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achte,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achte,achte,achter,achter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achte,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtes,achtes,achtem,achten" />
+					</Variant>
+				</Variant>
+			</OrdinalException>
+			<Ordinal from="ein">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,ersten,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erster,ersten,erstem,ersten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,erste,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erste,erste,erster,erster" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="erste,erste,ersten,ersten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="erstes,erstes,erstem,ersten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="zwei">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zweite,zweiten,zweiten,zweiten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zweiter,zweiten,zweitem,zweiten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zweite,zweite,zweiten,zweiten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zweite,zweite,zweiter,zweiter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zweite,zweite,zweiten,zweiten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zweites,zweites,zweitem,zweiten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="drei">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritten,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dritter,dritten,drittem,dritten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritte,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dritte,dritte,dritter,dritter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dritte,dritte,dritten,dritten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="drittes,drittes,drittem,dritten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="vier">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierte,vierten,vierten,vierten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierter,vierten,viertem,vierten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierte,vierte,vierten,vierten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierte,vierte,vierter,vierter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierte,vierte,vierten,vierten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="viertes,viertes,viertem,vierten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="fünf">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfte,fünften,fünften,fünften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfter,fünften,fünftem,fünften" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfte,fünfte,fünften,fünften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfte,fünfte,fünfter,fünfter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfte,fünfte,fünften,fünften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünftes,fünftes,fünftem,fünften" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="sechs">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechste,sechsten,sechsten,sechsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechster,sechsten,sechstem,sechsten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechste,sechste,sechsten,sechsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechste,sechste,sechster,sechster" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechste,sechste,sechsten,sechsten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechstes,sechstes,sechstem,sechsten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="sieben">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebten,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebter,siebten,siebtem,siebten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebte,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebte,siebte,siebter,siebter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebte,siebte,siebten,siebten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebtes,siebtes,siebtem,siebten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="acht">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achten,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achter,achten,achtem,achten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achte,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achte,achte,achter,achter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achte,achte,achten,achten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtes,achtes,achtem,achten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="neun">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunte,neunten,neunten,neunten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunter,neunten,neuntem,neunten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunte,neunte,neunten,neunten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunte,neunte,neunter,neunter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunte,neunte,neunten,neunten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neuntes,neuntes,neuntem,neunten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="zehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zehnte,zehnten,zehnten,zehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zehnter,zehnten,zehntem,zehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zehnte,zehnte,zehnten,zehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zehnte,zehnte,zehnter,zehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zehnte,zehnte,zehnten,zehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zehntes,zehntes,zehntem,zehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="elf">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="elfte,elften,elften,elften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="elfter,elften,elftem,elften" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="elfte,elfte,elften,elften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="elfte,elfte,elfter,elfter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="elfte,elfte,elften,elften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="elftes,elftes,elftem,elften" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="zwölf">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zwölfte,zwölften,zwölften,zwölften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zwölfter,zwölften,zwölftem,zwölften" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zwölfte,zwölfte,zwölften,zwölften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zwölfte,zwölfte,zwölfter,zwölfter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="zwölfte,zwölfte,zwölften,zwölften" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="zwölftes,zwölftes,zwölftem,zwölften" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="dreizehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dreizehnte,dreizehnten,dreizehnten,dreizehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dreizehnter,dreizehnten,dreizehntem,dreizehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dreizehnte,dreizehnte,dreizehnten,dreizehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dreizehnte,dreizehnte,dreizehnter,dreizehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="dreizehnte,dreizehnte,dreizehnten,dreizehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="dreizehntes,dreizehntes,dreizehntem,dreizehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="vierzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierzehnte,vierzehnten,vierzehnten,vierzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierzehnter,vierzehnten,vierzehntem,vierzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierzehnte,vierzehnte,vierzehnten,vierzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierzehnte,vierzehnte,vierzehnter,vierzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="vierzehnte,vierzehnte,vierzehnten,vierzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="vierzehntes,vierzehntes,vierzehntem,vierzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="fünfzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfzehnte,fünfzehnten,fünfzehnten,fünfzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfzehnter,fünfzehnten,fünfzehntem,fünfzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfzehnte,fünfzehnte,fünfzehnten,fünfzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfzehnte,fünfzehnte,fünfzehnter,fünfzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="fünfzehnte,fünfzehnte,fünfzehnten,fünfzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="fünfzehntes,fünfzehntes,fünfzehntem,fünfzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="sechzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechzehnte,sechzehnten,sechzehnten,sechzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechzehnter,sechzehnten,sechzehntem,sechzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechzehnte,sechzehnte,sechzehnten,sechzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechzehnte,sechzehnte,sechzehnter,sechzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="sechzehnte,sechzehnte,sechzehnten,sechzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="sechzehntes,sechzehntes,sechzehntem,sechzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="siebzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebzehnte,siebzehnten,siebzehnten,siebzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebzehnter,siebzehnten,siebzehntem,siebzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebzehnte,siebzehnte,siebzehnten,siebzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebzehnte,siebzehnte,siebzehnter,siebzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="siebzehnte,siebzehnte,siebzehnten,siebzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="siebzehntes,siebzehntes,siebzehntem,siebzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="achtzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achtzehnte,achtzehnten,achtzehnten,achtzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtzehnter,achtzehnten,achtzehntem,achtzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achtzehnte,achtzehnte,achtzehnten,achtzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtzehnte,achtzehnte,achtzehnter,achtzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="achtzehnte,achtzehnte,achtzehnten,achtzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="achtzehntes,achtzehntes,achtzehntem,achtzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<Ordinal from="neunzehn">
+				<Variant type="gender" variant="maskulin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunzehnte,neunzehnten,neunzehnten,neunzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunzehnter,neunzehnten,neunzehntem,neunzehnten" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="feminin">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunzehnte,neunzehnte,neunzehnten,neunzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunzehnte,neunzehnte,neunzehnter,neunzehnter" />
+					</Variant>
+				</Variant>
+				<Variant type="gender" variant="neutrum">
+					<Variant type="declension" variant="schwach">
+						<Variant type="case" forms="neunzehnte,neunzehnte,neunzehnten,neunzehnten" />
+					</Variant>
+					<Variant type="declension" variant="stark">
+						<Variant type="case" forms="neunzehntes,neunzehntes,neunzehntem,neunzehnten" />
+					</Variant>
+				</Variant>
+			</Ordinal>
+			<!--
+			  OrdinalVariants for regular ordinals (20+, suffix="ste"):
+			    schwach: maskulin nom stays as "ste", all other combinations append "n" → "sten"
+			    stark:   maskulin nom → "ster"; dat → "stem"; feminin/neutrum dat/gen → "ster"/"stem"/"sten"
+			-->
+			<OrdinalVariants>
+				<Variant type="declension" variant="schwach">
+					<Variant type="gender" variant="maskulin">
+						<Variant type="case" values="akkusativ,dativ,genitiv" suffix="sten" />
+					</Variant>
+					<Variant type="gender" variant="feminin">
+						<Variant type="case" values="dativ,genitiv" suffix="sten" />
+					</Variant>
+					<Variant type="gender" variant="neutrum">
+						<Variant type="case" values="dativ,genitiv" suffix="sten" />
+					</Variant>
+				</Variant>
+				<Variant type="declension" variant="stark">
+					<Variant type="gender" variant="maskulin">
+						<Variant type="case" variant="nominativ" suffix="ster" />
+						<Variant type="case" values="akkusativ,genitiv" suffix="sten" />
+						<Variant type="case" variant="dativ" suffix="stem" />
+					</Variant>
+					<Variant type="gender" variant="feminin">
+						<Variant type="case" values="dativ,genitiv" suffix="ster" />
+					</Variant>
+					<Variant type="gender" variant="neutrum">
+						<Variant type="case" values="nominativ,akkusativ" suffix="stes" />
+						<Variant type="case" variant="dativ" suffix="stem" />
+						<Variant type="case" variant="genitiv" suffix="sten" />
+					</Variant>
+				</Variant>
+			</OrdinalVariants>
 		</Ordinals>
 		<Variants>
 			<!--
@@ -131,23 +737,19 @@
 			    Dativ     : maskulin=einem,     feminin=einer, neutrum=einem
 			    Genitiv   : maskulin=eines,     feminin=einer, neutrum=eines
 
-			  * GermanNumberToStringLanguageSpecifics converts standalone "ein" → "eins"
-			    (counting form). Adjectival "ein" forms (e.g. Akk Neutr) also become
-			    "eins" as they are indistinguishable without syntactic context.
+			  Maskulin/neutrum nominativ and neutrum akkusativ → "eins" (counting form) via
+			  the Variant rules below. Adjectival neutrum akkusativ also becomes "eins"
+			  as the two are indistinguishable without syntactic context.
 			-->
 			<Dimension name="gender" localName="genus" values="maskulin,feminin,neutrum" />
 			<Dimension name="case" localName="kasus" values="nominativ,akkusativ,dativ,genitiv" />
+			<Dimension name="declension" localName="deklination" values="schwach,stark" />
 
 			<!-- gender=feminin (Nom/Akk) → "eine";
 			     dativ/genitiv sub-variants handle the feminine case overrides -->
 			<Variant type="gender" variant="feminin">
 				<Replacement oldValue="ein" newValue="eine" scope="LastWord" />
-				<!-- Dativ feminin → "einer" (oldValue="eine": parent rule already applied) -->
-				<Variant type="case" variant="dativ">
-					<Replacement oldValue="eine" newValue="einer" scope="LastWord" />
-				</Variant>
-				<!-- Genitiv feminin → "einer" -->
-				<Variant type="case" variant="genitiv">
+				<Variant type="case" values="dativ,genitiv">
 					<Replacement oldValue="eine" newValue="einer" scope="LastWord" />
 				</Variant>
 			</Variant>
@@ -167,6 +769,20 @@
 			<Variant type="gender" variant="maskulin">
 				<Variant type="case" variant="akkusativ">
 					<Replacement oldValue="ein" newValue="einen" scope="LastWord" />
+				</Variant>
+			</Variant>
+
+			<!-- counting form "eins": maskulin/neutrum nominativ and neutrum akkusativ.
+			     These are the only positions where "ein" is not transformed by the rules
+			     above, so this pair completes the full inflection table. -->
+			<Variant type="gender" variant="maskulin">
+				<Variant type="case" variant="nominativ">
+					<Replacement oldValue="ein" newValue="eins" scope="LastWord" />
+				</Variant>
+			</Variant>
+			<Variant type="gender" variant="neutrum">
+				<Variant type="case" values="nominativ,akkusativ">
+					<Replacement oldValue="ein" newValue="eins" scope="LastWord" />
 				</Variant>
 			</Variant>
 		</Variants>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
@@ -737,9 +737,9 @@
 			    Dativ     : maskulin=einem,     feminin=einer, neutrum=einem
 			    Genitiv   : maskulin=eines,     feminin=einer, neutrum=eines
 
-			  Maskulin/neutrum nominativ and neutrum akkusativ → "eins" (counting form) via
-			  the Variant rules below. Adjectival neutrum akkusativ also becomes "eins"
-			  as the two are indistinguishable without syntactic context.
+			  * GermanNumberToStringLanguageSpecifics converts standalone or trailing "ein" → "eins"
+			    (counting form). It also handles compounds like "zweihundertein" → "zweihunderteins"
+			    because LastWord-scoped Variant rules cannot match non-final embedded words.
 			-->
 			<Dimension name="gender" localName="genus" values="maskulin,feminin,neutrum" />
 			<Dimension name="case" localName="kasus" values="nominativ,akkusativ,dativ,genitiv" />
@@ -772,19 +772,6 @@
 				</Variant>
 			</Variant>
 
-			<!-- counting form "eins": maskulin/neutrum nominativ and neutrum akkusativ.
-			     These are the only positions where "ein" is not transformed by the rules
-			     above, so this pair completes the full inflection table. -->
-			<Variant type="gender" variant="maskulin">
-				<Variant type="case" variant="nominativ">
-					<Replacement oldValue="ein" newValue="eins" scope="LastWord" />
-				</Variant>
-			</Variant>
-			<Variant type="gender" variant="neutrum">
-				<Variant type="case" values="nominativ,akkusativ">
-					<Replacement oldValue="ein" newValue="eins" scope="LastWord" />
-				</Variant>
-			</Variant>
 		</Variants>
 		<YearFormat hundredWord="hundert">
 			<SplitRange from="1100" to="1999" />

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.EL.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.EL.xml
@@ -71,23 +71,28 @@
 			<Number value="18" string="δεκαοκτώ" />
 			<Number value="19" string="δεκαεννέα" />
 		</Exceptions>
+		<!--
+		  Forms are listed in Dimension order: αρσενικό, θηλυκό, ουδέτερο.
+		  The first form (αρσενικό) also serves as the default when no variant is specified.
+		  13-19 have masculine forms only (no explicit gender variants in common use).
+		-->
 		<Ordinals>
-			<!-- Unités — stems complètement différents des cardinaux -->
-			<Ordinal from="ένα"        to="πρώτος" />
-			<Ordinal from="δύο"        to="δεύτερος" />
-			<Ordinal from="τρία"       to="τρίτος" />
-			<Ordinal from="τέσσερα"    to="τέταρτος" />
-			<Ordinal from="πέντε"      to="πέμπτος" />
-			<Ordinal from="έξι"        to="έκτος" />
-			<Ordinal from="επτά"       to="έβδομος" />
-			<Ordinal from="οκτώ"       to="όγδοος" />
-			<Ordinal from="εννέα"      to="ένατος" />
-			<!-- Dizaine -->
-			<Ordinal from="δέκα"       to="δέκατος" />
+			<!-- Unités 1-9 — stems complètement différents des cardinaux -->
+			<Ordinal from="ένα">     <Variant type="gender" forms="πρώτος,πρώτη,πρώτο"           /></Ordinal>
+			<Ordinal from="δύο">     <Variant type="gender" forms="δεύτερος,δεύτερη,δεύτερο"     /></Ordinal>
+			<Ordinal from="τρία">    <Variant type="gender" forms="τρίτος,τρίτη,τρίτο"           /></Ordinal>
+			<Ordinal from="τέσσερα"> <Variant type="gender" forms="τέταρτος,τέταρτη,τέταρτο"     /></Ordinal>
+			<Ordinal from="πέντε">   <Variant type="gender" forms="πέμπτος,πέμπτη,πέμπτο"       /></Ordinal>
+			<Ordinal from="έξι">     <Variant type="gender" forms="έκτος,έκτη,έκτο"             /></Ordinal>
+			<Ordinal from="επτά">    <Variant type="gender" forms="έβδομος,έβδομη,έβδομο"       /></Ordinal>
+			<Ordinal from="οκτώ">    <Variant type="gender" forms="όγδοος,όγδοη,όγδοο"         /></Ordinal>
+			<Ordinal from="εννέα">   <Variant type="gender" forms="ένατος,ένατη,ένατο"           /></Ordinal>
+			<!-- Dizaine 10 -->
+			<Ordinal from="δέκα">    <Variant type="gender" forms="δέκατος,δέκατη,δέκατο"       /></Ordinal>
 			<!-- Exceptions 11-12 (stems irréguliers, non déductibles depuis les cardinaux) -->
-			<OrdinalException value="11" string="ενδέκατος" />
-			<OrdinalException value="12" string="δωδέκατος" />
-			<!-- Exceptions 13-19 : ordinaux composés depuis les exceptions cardinales -->
+			<OrdinalException value="11"> <Variant type="gender" forms="ενδέκατος,ενδέκατη,ενδέκατο"   /></OrdinalException>
+			<OrdinalException value="12"> <Variant type="gender" forms="δωδέκατος,δωδέκατη,δωδέκατο"   /></OrdinalException>
+			<!-- Exceptions 13-19 : ordinaux composés (formes αρσενικό uniquement) -->
 			<OrdinalException value="13" string="δέκατος τρίτος" />
 			<OrdinalException value="14" string="δέκατος τέταρτος" />
 			<OrdinalException value="15" string="δέκατος πέμπτος" />
@@ -95,62 +100,31 @@
 			<OrdinalException value="17" string="δέκατος έβδομος" />
 			<OrdinalException value="18" string="δέκατος όγδοος" />
 			<OrdinalException value="19" string="δέκατος ένατος" />
-			<!-- Dizaines -->
-			<Ordinal from="είκοσι"     to="εικοστός" />
-			<Ordinal from="τριάντα"    to="τριακοστός" />
-			<Ordinal from="σαράντα"    to="τεσσαρακοστός" />
-			<Ordinal from="πενήντα"    to="πεντηκοστός" />
-			<Ordinal from="εξήντα"     to="εξηκοστός" />
-			<Ordinal from="εβδομήντα"  to="εβδομηκοστός" />
-			<Ordinal from="ογδόντα"    to="ογδοηκοστός" />
-			<Ordinal from="ενενήντα"   to="ενενηκοστός" />
+			<!-- Dizaines 20-90 -->
+			<Ordinal from="είκοσι">    <Variant type="gender" forms="εικοστός,εικοστή,εικοστό"               /></Ordinal>
+			<Ordinal from="τριάντα">   <Variant type="gender" forms="τριακοστός,τριακοστή,τριακοστό"         /></Ordinal>
+			<Ordinal from="σαράντα">   <Variant type="gender" forms="τεσσαρακοστός,τεσσαρακοστή,τεσσαρακοστό"/></Ordinal>
+			<Ordinal from="πενήντα">   <Variant type="gender" forms="πεντηκοστός,πεντηκοστή,πεντηκοστό"     /></Ordinal>
+			<Ordinal from="εξήντα">    <Variant type="gender" forms="εξηκοστός,εξηκοστή,εξηκοστό"           /></Ordinal>
+			<Ordinal from="εβδομήντα"> <Variant type="gender" forms="εβδομηκοστός,εβδομηκοστή,εβδομηκοστό" /></Ordinal>
+			<Ordinal from="ογδόντα">   <Variant type="gender" forms="ογδοηκοστός,ογδοηκοστή,ογδοηκοστό"     /></Ordinal>
+			<Ordinal from="ενενήντα">  <Variant type="gender" forms="ενενηκοστός,ενενηκοστή,ενενηκοστό"     /></Ordinal>
 			<!-- Centaines -->
-			<Ordinal from="εκατό"      to="εκατοστός" />
-			<Ordinal from="διακόσια"   to="διακοσιοστός" />
-			<Ordinal from="τριακόσια"  to="τριακοσιοστός" />
-			<Ordinal from="τετρακόσια" to="τετρακοσιοστός" />
-			<Ordinal from="πεντακόσια" to="πεντακοσιοστός" />
-			<Ordinal from="εξακόσια"   to="εξακοσιοστός" />
-			<Ordinal from="επτακόσια"  to="επτακοσιοστός" />
-			<Ordinal from="οκτακόσια"  to="οκτακοσιοστός" />
-			<Ordinal from="εννιακόσια" to="εννιακοσιοστός" />
+			<Ordinal from="εκατό">      <Variant type="gender" forms="εκατοστός,εκατοστή,εκατοστό"             /></Ordinal>
+			<Ordinal from="διακόσια">   <Variant type="gender" forms="διακοσιοστός,διακοσιοστή,διακοσιοστό"   /></Ordinal>
+			<Ordinal from="τριακόσια">  <Variant type="gender" forms="τριακοσιοστός,τριακοσιοστή,τριακοσιοστό"/></Ordinal>
+			<Ordinal from="τετρακόσια"> <Variant type="gender" forms="τετρακοσιοστός,τετρακοσιοστή,τετρακοσιοστό"/></Ordinal>
+			<Ordinal from="πεντακόσια"> <Variant type="gender" forms="πεντακοσιοστός,πεντακοσιοστή,πεντακοσιοστό"/></Ordinal>
+			<Ordinal from="εξακόσια">   <Variant type="gender" forms="εξακοσιοστός,εξακοσιοστή,εξακοσιοστό"   /></Ordinal>
+			<Ordinal from="επτακόσια">  <Variant type="gender" forms="επτακοσιοστός,επτακοσιοστή,επτακοσιοστό"/></Ordinal>
+			<Ordinal from="οκτακόσια">  <Variant type="gender" forms="οκτακοσιοστός,οκτακοσιοστή,οκτακοσιοστό"/></Ordinal>
+			<Ordinal from="εννιακόσια"> <Variant type="gender" forms="εννιακοσιοστός,εννιακοσιοστή,εννιακοσιοστό"/></Ordinal>
 			<!-- Millier -->
-			<Ordinal from="χίλια"      to="χιλιοστός" />
-			<!-- Variantes de genre nominatif singulier pour 1-12 + dizaines + centaines -->
-			<OrdinalVariants>
-				<Variant type="gender" variant="θηλυκό">
-					<OrdinalException value="1"   string="πρώτη" />
-					<OrdinalException value="2"   string="δεύτερη" />
-					<OrdinalException value="3"   string="τρίτη" />
-					<OrdinalException value="4"   string="τέταρτη" />
-					<OrdinalException value="5"   string="πέμπτη" />
-					<OrdinalException value="6"   string="έκτη" />
-					<OrdinalException value="7"   string="έβδομη" />
-					<OrdinalException value="8"   string="όγδοη" />
-					<OrdinalException value="9"   string="ένατη" />
-					<OrdinalException value="10"  string="δέκατη" />
-					<OrdinalException value="11"  string="ενδέκατη" />
-					<OrdinalException value="12"  string="δωδέκατη" />
-					<OrdinalException value="20"  string="εικοστή" />
-					<OrdinalException value="100" string="εκατοστή" />
-				</Variant>
-				<Variant type="gender" variant="ουδέτερο">
-					<OrdinalException value="1"   string="πρώτο" />
-					<OrdinalException value="2"   string="δεύτερο" />
-					<OrdinalException value="3"   string="τρίτο" />
-					<OrdinalException value="4"   string="τέταρτο" />
-					<OrdinalException value="5"   string="πέμπτο" />
-					<OrdinalException value="6"   string="έκτο" />
-					<OrdinalException value="7"   string="έβδομο" />
-					<OrdinalException value="8"   string="όγδοο" />
-					<OrdinalException value="9"   string="ένατο" />
-					<OrdinalException value="10"  string="δέκατο" />
-					<OrdinalException value="11"  string="ενδέκατο" />
-					<OrdinalException value="12"  string="δωδέκατο" />
-					<OrdinalException value="20"  string="εικοστό" />
-					<OrdinalException value="100" string="εκατοστό" />
-				</Variant>
-			</OrdinalVariants>
+			<Ordinal from="χίλια"> <Variant type="gender" forms="χιλιοστός,χιλιοστή,χιλιοστό" /></Ordinal>
 		</Ordinals>
+		<Variants>
+			<!-- Dimension declared for ordinal forms= expansion; Greek cardinals are invariable in this config -->
+			<Dimension name="gender" localName="γένος" values="αρσενικό,θηλυκό,ουδέτερο" />
+		</Variants>
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.ES.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.ES.xml
@@ -106,115 +106,63 @@
 		    - Compound units (31-99, last word "uno"/"dos"…): word rule on the unit word.
 		    - 100, 1000: word rule on the scale word.
 		    - Other compounds (e.g. 31-99 non-round) fall back to the cardinal (no suffix).
-		  The feminine variant mirrors all of the above with feminine ordinal forms.
+		  Forms are listed in Dimension order: masculino, femenino.
+		  The first form also serves as the default when no variant is specified.
 		-->
 		<Ordinals>
-			<!-- Masculine irregulars 1-12 -->
-			<OrdinalException value="1"  string="primero" />
-			<OrdinalException value="2"  string="segundo" />
-			<OrdinalException value="3"  string="tercero" />
-			<OrdinalException value="4"  string="cuarto" />
-			<OrdinalException value="5"  string="quinto" />
-			<OrdinalException value="6"  string="sexto" />
-			<OrdinalException value="7"  string="séptimo" />
-			<OrdinalException value="8"  string="octavo" />
-			<OrdinalException value="9"  string="noveno" />
-			<OrdinalException value="10" string="décimo" />
-			<OrdinalException value="11" string="undécimo" />
-			<OrdinalException value="12" string="duodécimo" />
+			<!-- Irregulars 1-12 — forms: masculino, femenino -->
+			<OrdinalException value="1">   <Variant type="gender" forms="primero,primera"     /></OrdinalException>
+			<OrdinalException value="2">   <Variant type="gender" forms="segundo,segunda"     /></OrdinalException>
+			<OrdinalException value="3">   <Variant type="gender" forms="tercero,tercera"     /></OrdinalException>
+			<OrdinalException value="4">   <Variant type="gender" forms="cuarto,cuarta"       /></OrdinalException>
+			<OrdinalException value="5">   <Variant type="gender" forms="quinto,quinta"       /></OrdinalException>
+			<OrdinalException value="6">   <Variant type="gender" forms="sexto,sexta"         /></OrdinalException>
+			<OrdinalException value="7">   <Variant type="gender" forms="séptimo,séptima"     /></OrdinalException>
+			<OrdinalException value="8">   <Variant type="gender" forms="octavo,octava"       /></OrdinalException>
+			<OrdinalException value="9">   <Variant type="gender" forms="noveno,novena"       /></OrdinalException>
+			<OrdinalException value="10">  <Variant type="gender" forms="décimo,décima"       /></OrdinalException>
+			<OrdinalException value="11">  <Variant type="gender" forms="undécimo,undécima"   /></OrdinalException>
+			<OrdinalException value="12">  <Variant type="gender" forms="duodécimo,duodécima" /></OrdinalException>
 			<!-- Teens 13-19 (last word = cardinal exception word) -->
-			<Ordinal from="trece"      to="decimotercero" />
-			<Ordinal from="catorce"    to="decimocuarto" />
-			<Ordinal from="quince"     to="decimoquinto" />
-			<Ordinal from="dieciséis"  to="decimosexto" />
-			<Ordinal from="diecisiete" to="decimoséptimo" />
-			<Ordinal from="dieciocho"  to="decimoctavo" />
-			<Ordinal from="diecinueve" to="decimonoveno" />
+			<Ordinal from="trece">      <Variant type="gender" forms="decimotercero,decimotercera"   /></Ordinal>
+			<Ordinal from="catorce">    <Variant type="gender" forms="decimocuarto,decimocuarta"     /></Ordinal>
+			<Ordinal from="quince">     <Variant type="gender" forms="decimoquinto,decimoquinta"     /></Ordinal>
+			<Ordinal from="dieciséis">  <Variant type="gender" forms="decimosexto,decimosexta"       /></Ordinal>
+			<Ordinal from="diecisiete"> <Variant type="gender" forms="decimoséptimo,decimoséptima"   /></Ordinal>
+			<Ordinal from="dieciocho">  <Variant type="gender" forms="decimoctavo,decimoctava"       /></Ordinal>
+			<Ordinal from="diecinueve"> <Variant type="gender" forms="decimonoveno,decimonovena"     /></Ordinal>
 			<!-- Round tens 20-90 -->
-			<Ordinal from="veinte"    to="vigésimo" />
-			<Ordinal from="treinta"   to="trigésimo" />
-			<Ordinal from="cuarenta"  to="cuadragésimo" />
-			<Ordinal from="cincuenta" to="quincuagésimo" />
-			<Ordinal from="sesenta"   to="sexagésimo" />
-			<Ordinal from="setenta"   to="septuagésimo" />
-			<Ordinal from="ochenta"   to="octogésimo" />
-			<Ordinal from="noventa"   to="nonagésimo" />
+			<Ordinal from="veinte">    <Variant type="gender" forms="vigésimo,vigésima"          /></Ordinal>
+			<Ordinal from="treinta">   <Variant type="gender" forms="trigésimo,trigésima"         /></Ordinal>
+			<Ordinal from="cuarenta">  <Variant type="gender" forms="cuadragésimo,cuadragésima"   /></Ordinal>
+			<Ordinal from="cincuenta"> <Variant type="gender" forms="quincuagésimo,quincuagésima" /></Ordinal>
+			<Ordinal from="sesenta">   <Variant type="gender" forms="sexagésimo,sexagésima"       /></Ordinal>
+			<Ordinal from="setenta">   <Variant type="gender" forms="septuagésimo,septuagésima"   /></Ordinal>
+			<Ordinal from="ochenta">   <Variant type="gender" forms="octogésimo,octogésima"       /></Ordinal>
+			<Ordinal from="noventa">   <Variant type="gender" forms="nonagésimo,nonagésima"       /></Ordinal>
 			<!-- Fused 21-29 (config produces "veintiuno", "veintidós"…) -->
-			<Ordinal from="veintiuno"    to="vigesimoprimero" />
-			<Ordinal from="veintidós"    to="vigesimosegundo" />
-			<Ordinal from="veintitrés"   to="vigesimotercero" />
-			<Ordinal from="veinticuatro" to="vigesimocuarto" />
-			<Ordinal from="veinticinco"  to="vigesimoquinto" />
-			<Ordinal from="veintiséis"   to="vigesimosexto" />
-			<Ordinal from="veintisiete"  to="vigesimoseptimo" />
-			<Ordinal from="veintiocho"   to="vigesimooctavo" />
-			<Ordinal from="veintinueve"  to="vigesimonoveno" />
+			<Ordinal from="veintiuno">    <Variant type="gender" forms="vigesimoprimero,vigesimoprimera" /></Ordinal>
+			<Ordinal from="veintidós">    <Variant type="gender" forms="vigesimosegundo,vigesimosegunda" /></Ordinal>
+			<Ordinal from="veintitrés">   <Variant type="gender" forms="vigesimotercero,vigesimatercera" /></Ordinal>
+			<Ordinal from="veinticuatro"> <Variant type="gender" forms="vigesimocuarto,vigesimacuarta"   /></Ordinal>
+			<Ordinal from="veinticinco">  <Variant type="gender" forms="vigesimoquinto,vigesimaquinta"   /></Ordinal>
+			<Ordinal from="veintiséis">   <Variant type="gender" forms="vigesimosexto,vigesemasexta"     /></Ordinal>
+			<Ordinal from="veintisiete">  <Variant type="gender" forms="vigesimoseptimo,vigesimoseptima" /></Ordinal>
+			<Ordinal from="veintiocho">   <Variant type="gender" forms="vigesimooctavo,vigesimaoctava"   /></Ordinal>
+			<Ordinal from="veintinueve">  <Variant type="gender" forms="vigesimonoveno,vigesimanovena"   /></Ordinal>
 			<!-- Compound last-word units (covers 31-99 when last word is separated by space in the config) -->
-			<Ordinal from="uno"    to="primero" />
-			<Ordinal from="dos"    to="segundo" />
-			<Ordinal from="tres"   to="tercero" />
-			<Ordinal from="cuatro" to="cuarto" />
-			<Ordinal from="cinco"  to="quinto" />
-			<Ordinal from="seis"   to="sexto" />
-			<Ordinal from="siete"  to="séptimo" />
-			<Ordinal from="ocho"   to="octavo" />
-			<Ordinal from="nueve"  to="noveno" />
+			<Ordinal from="uno">    <Variant type="gender" forms="primero,primera" /></Ordinal>
+			<Ordinal from="dos">    <Variant type="gender" forms="segundo,segunda" /></Ordinal>
+			<Ordinal from="tres">   <Variant type="gender" forms="tercero,tercera" /></Ordinal>
+			<Ordinal from="cuatro"> <Variant type="gender" forms="cuarto,cuarta"   /></Ordinal>
+			<Ordinal from="cinco">  <Variant type="gender" forms="quinto,quinta"   /></Ordinal>
+			<Ordinal from="seis">   <Variant type="gender" forms="sexto,sexta"     /></Ordinal>
+			<Ordinal from="siete">  <Variant type="gender" forms="séptimo,séptima" /></Ordinal>
+			<Ordinal from="ocho">   <Variant type="gender" forms="octavo,octava"   /></Ordinal>
+			<Ordinal from="nueve">  <Variant type="gender" forms="noveno,novena"   /></Ordinal>
 			<!-- Round scale words -->
-			<Ordinal from="cien" to="centésimo" />
-			<Ordinal from="mil"  to="milésimo" />
-
-			<!-- Feminine variant -->
-			<OrdinalVariants>
-				<Variant type="gender" variant="femenino">
-					<OrdinalException value="1"  string="primera" />
-					<OrdinalException value="2"  string="segunda" />
-					<OrdinalException value="3"  string="tercera" />
-					<OrdinalException value="4"  string="cuarta" />
-					<OrdinalException value="5"  string="quinta" />
-					<OrdinalException value="6"  string="sexta" />
-					<OrdinalException value="7"  string="séptima" />
-					<OrdinalException value="8"  string="octava" />
-					<OrdinalException value="9"  string="novena" />
-					<OrdinalException value="10" string="décima" />
-					<OrdinalException value="11" string="undécima" />
-					<OrdinalException value="12" string="duodécima" />
-					<Ordinal from="trece"      to="decimotercera" />
-					<Ordinal from="catorce"    to="decimocuarta" />
-					<Ordinal from="quince"     to="decimoquinta" />
-					<Ordinal from="dieciséis"  to="decimosexta" />
-					<Ordinal from="diecisiete" to="decimoséptima" />
-					<Ordinal from="dieciocho"  to="decimoctava" />
-					<Ordinal from="diecinueve" to="decimonovena" />
-					<Ordinal from="veinte"    to="vigésima" />
-					<Ordinal from="treinta"   to="trigésima" />
-					<Ordinal from="cuarenta"  to="cuadragésima" />
-					<Ordinal from="cincuenta" to="quincuagésima" />
-					<Ordinal from="sesenta"   to="sexagésima" />
-					<Ordinal from="setenta"   to="septuagésima" />
-					<Ordinal from="ochenta"   to="octogésima" />
-					<Ordinal from="noventa"   to="nonagésima" />
-					<Ordinal from="veintiuno"    to="vigesimoprimera" />
-					<Ordinal from="veintidós"    to="vigesimosegunda" />
-					<Ordinal from="veintitrés"   to="vigesimatercera" />
-					<Ordinal from="veinticuatro" to="vigesimacuarta" />
-					<Ordinal from="veinticinco"  to="vigesimaquinta" />
-					<Ordinal from="veintiséis"   to="vigesemasexta" />
-					<Ordinal from="veintisiete"  to="vigesimoseptima" />
-					<Ordinal from="veintiocho"   to="vigesimaoctava" />
-					<Ordinal from="veintinueve"  to="vigesimanovena" />
-					<Ordinal from="uno"    to="primera" />
-					<Ordinal from="dos"    to="segunda" />
-					<Ordinal from="tres"   to="tercera" />
-					<Ordinal from="cuatro" to="cuarta" />
-					<Ordinal from="cinco"  to="quinta" />
-					<Ordinal from="seis"   to="sexta" />
-					<Ordinal from="siete"  to="séptima" />
-					<Ordinal from="ocho"   to="octava" />
-					<Ordinal from="nueve"  to="novena" />
-					<Ordinal from="cien" to="centésima" />
-					<Ordinal from="mil"  to="milésima" />
-				</Variant>
-			</OrdinalVariants>
+			<Ordinal from="cien"> <Variant type="gender" forms="centésimo,centésima" /></Ordinal>
+			<Ordinal from="mil">  <Variant type="gender" forms="milésimo,milésima"   /></Ordinal>
 		</Ordinals>
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.FR-fr-ca.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.FR-fr-ca.xml
@@ -96,15 +96,12 @@
 			<Fraction digits="3" string="millième(s)" />
 		</Fractions>
 		<Ordinals suffix="ième" removeTrailing="e">
-			<OrdinalException value="1" string="premier" />
+			<OrdinalException value="1">
+				<Variant type="gender" forms="premier,première" />
+			</OrdinalException>
 			<Ordinal from="un" to="unième" />
 			<Ordinal from="cinq" to="cinquième" />
 			<Ordinal from="neuf" to="neuvième" />
-			<OrdinalVariants>
-				<Variant type="gender" variant="feminin">
-					<OrdinalException value="1" string="première" />
-				</Variant>
-			</OrdinalVariants>
 		</Ordinals>
 		<Variants>
 			<Dimension name="gender" localName="genre" values="masculin,feminin" />

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.GL.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.GL.xml
@@ -77,89 +77,55 @@
 		<!--
 		  Galician ordinals: 1-12 use Latin-derived forms; above 12 the system falls
 		  back to the cardinal. Round tens and scale words have explicit word rules.
-		  The feminine variant supplies the feminine ordinal forms for all covered
-		  words, including the feminized unit forms produced by the cardinal variant
-		  ("un→unha", "dous→dúas").
+		  Forms are listed in Dimension order: masculino, feminino.
+		  The first form also serves as the default when no variant is specified.
+		  OrdinalVariants covers only the feminized cardinal forms ("un→unha", "dous→dúas")
+		  which have no corresponding masculine ordinal word rule.
 		-->
 		<Ordinals>
-			<!-- Masculine ordinals 1-12 (irregular) -->
-			<OrdinalException value="1"  string="primeiro" />
-			<OrdinalException value="2"  string="segundo" />
-			<OrdinalException value="3"  string="terceiro" />
-			<OrdinalException value="4"  string="cuarto" />
-			<OrdinalException value="5"  string="quinto" />
-			<OrdinalException value="6"  string="sexto" />
-			<OrdinalException value="7"  string="sétimo" />
-			<OrdinalException value="8"  string="oitavo" />
-			<OrdinalException value="9"  string="noveno" />
-			<OrdinalException value="10" string="décimo" />
-			<OrdinalException value="11" string="undécimo" />
-			<OrdinalException value="12" string="duodécimo" />
+			<!-- Ordinals 1-12 — forms: masculino, feminino -->
+			<OrdinalException value="1">   <Variant type="gender" forms="primeiro,primeira"   /></OrdinalException>
+			<OrdinalException value="2">   <Variant type="gender" forms="segundo,segunda"     /></OrdinalException>
+			<OrdinalException value="3">   <Variant type="gender" forms="terceiro,terceira"   /></OrdinalException>
+			<OrdinalException value="4">   <Variant type="gender" forms="cuarto,cuarta"       /></OrdinalException>
+			<OrdinalException value="5">   <Variant type="gender" forms="quinto,quinta"       /></OrdinalException>
+			<OrdinalException value="6">   <Variant type="gender" forms="sexto,sexta"         /></OrdinalException>
+			<OrdinalException value="7">   <Variant type="gender" forms="sétimo,sétima"       /></OrdinalException>
+			<OrdinalException value="8">   <Variant type="gender" forms="oitavo,oitava"       /></OrdinalException>
+			<OrdinalException value="9">   <Variant type="gender" forms="noveno,novena"       /></OrdinalException>
+			<OrdinalException value="10">  <Variant type="gender" forms="décimo,décima"       /></OrdinalException>
+			<OrdinalException value="11">  <Variant type="gender" forms="undécimo,undécima"   /></OrdinalException>
+			<OrdinalException value="12">  <Variant type="gender" forms="duodécimo,duodécima" /></OrdinalException>
 			<!-- Word rules for units in compounds -->
-			<Ordinal from="un"    to="primeiro" />
-			<Ordinal from="dous"  to="segundo" />
-			<Ordinal from="tres"  to="terceiro" />
-			<Ordinal from="catro" to="cuarto" />
-			<Ordinal from="cinco" to="quinto" />
-			<Ordinal from="seis"  to="sexto" />
-			<Ordinal from="sete"  to="sétimo" />
-			<Ordinal from="oito"  to="oitavo" />
-			<Ordinal from="nove"  to="noveno" />
-			<Ordinal from="dez"   to="décimo" />
+			<Ordinal from="un">    <Variant type="gender" forms="primeiro,primeira" /></Ordinal>
+			<Ordinal from="dous">  <Variant type="gender" forms="segundo,segunda"   /></Ordinal>
+			<Ordinal from="tres">  <Variant type="gender" forms="terceiro,terceira" /></Ordinal>
+			<Ordinal from="catro"> <Variant type="gender" forms="cuarto,cuarta"     /></Ordinal>
+			<Ordinal from="cinco"> <Variant type="gender" forms="quinto,quinta"     /></Ordinal>
+			<Ordinal from="seis">  <Variant type="gender" forms="sexto,sexta"       /></Ordinal>
+			<Ordinal from="sete">  <Variant type="gender" forms="sétimo,sétima"     /></Ordinal>
+			<Ordinal from="oito">  <Variant type="gender" forms="oitavo,oitava"     /></Ordinal>
+			<Ordinal from="nove">  <Variant type="gender" forms="noveno,novena"     /></Ordinal>
+			<Ordinal from="dez">   <Variant type="gender" forms="décimo,décima"     /></Ordinal>
 			<!-- Round tens -->
-			<Ordinal from="vinte"     to="vixésimo" />
-			<Ordinal from="trinta"    to="trixésimo" />
-			<Ordinal from="corenta"   to="cuadragésimo" />
-			<Ordinal from="cincuenta" to="quincuagésimo" />
-			<Ordinal from="sesenta"   to="sexagésimo" />
-			<Ordinal from="setenta"   to="septuagésimo" />
-			<Ordinal from="oitenta"   to="octogésimo" />
-			<Ordinal from="noventa"   to="nonaxésimo" />
+			<Ordinal from="vinte">     <Variant type="gender" forms="vixésimo,vixésima"         /></Ordinal>
+			<Ordinal from="trinta">    <Variant type="gender" forms="trixésimo,trixésima"         /></Ordinal>
+			<Ordinal from="corenta">   <Variant type="gender" forms="cuadragésimo,cuadragésima"   /></Ordinal>
+			<Ordinal from="cincuenta"> <Variant type="gender" forms="quincuagésimo,quincuagésima" /></Ordinal>
+			<Ordinal from="sesenta">   <Variant type="gender" forms="sexagésimo,sexagésima"       /></Ordinal>
+			<Ordinal from="setenta">   <Variant type="gender" forms="septuagésimo,septuagésima"   /></Ordinal>
+			<Ordinal from="oitenta">   <Variant type="gender" forms="octogésimo,octogésima"       /></Ordinal>
+			<Ordinal from="noventa">   <Variant type="gender" forms="nonaxésimo,nonaxésima"       /></Ordinal>
 			<!-- Scale words -->
-			<Ordinal from="cen" to="centésimo" />
-			<Ordinal from="mil" to="milésimo" />
+			<Ordinal from="cen"> <Variant type="gender" forms="centésimo,centésima" /></Ordinal>
+			<Ordinal from="mil"> <Variant type="gender" forms="milésimo,milésima"   /></Ordinal>
 
-			<!-- Feminine variant -->
+			<!-- Feminized cardinal forms not covered by the inline rules above -->
 			<OrdinalVariants>
 				<Variant type="gender" variant="feminino">
-					<OrdinalException value="1"  string="primeira" />
-					<OrdinalException value="2"  string="segunda" />
-					<OrdinalException value="3"  string="terceira" />
-					<OrdinalException value="4"  string="cuarta" />
-					<OrdinalException value="5"  string="quinta" />
-					<OrdinalException value="6"  string="sexta" />
-					<OrdinalException value="7"  string="sétima" />
-					<OrdinalException value="8"  string="oitava" />
-					<OrdinalException value="9"  string="novena" />
-					<OrdinalException value="10" string="décima" />
-					<OrdinalException value="11" string="undécima" />
-					<OrdinalException value="12" string="duodécima" />
-					<!-- Original masculine cardinal forms (for cases not transformed by cardinal variant) -->
-					<Ordinal from="un"    to="primeira" />
-					<Ordinal from="dous"  to="segunda" />
-					<Ordinal from="tres"  to="terceira" />
-					<Ordinal from="catro" to="cuarta" />
-					<Ordinal from="cinco" to="quinta" />
-					<Ordinal from="seis"  to="sexta" />
-					<Ordinal from="sete"  to="sétima" />
-					<Ordinal from="oito"  to="oitava" />
-					<Ordinal from="nove"  to="novena" />
-					<Ordinal from="dez"   to="décima" />
-					<!-- Feminized unit forms (after cardinal "un→unha", "dous→dúas") -->
-					<Ordinal from="unha"  to="primeira" />
-					<Ordinal from="dúas"  to="segunda" />
-					<!-- Round tens (feminine) -->
-					<Ordinal from="vinte"     to="vixésima" />
-					<Ordinal from="trinta"    to="trixésima" />
-					<Ordinal from="corenta"   to="cuadragésima" />
-					<Ordinal from="cincuenta" to="quincuagésima" />
-					<Ordinal from="sesenta"   to="sexagésima" />
-					<Ordinal from="setenta"   to="septuagésima" />
-					<Ordinal from="oitenta"   to="octogésima" />
-					<Ordinal from="noventa"   to="nonaxésima" />
-					<!-- Scale words (feminine) -->
-					<Ordinal from="cen" to="centésima" />
-					<Ordinal from="mil" to="milésima" />
+					<!-- Produced by cardinal variant "un→unha", "dous→dúas" -->
+					<Ordinal from="unha" to="primeira" />
+					<Ordinal from="dúas" to="segunda" />
 				</Variant>
 			</OrdinalVariants>
 		</Ordinals>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.HE.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.HE.xml
@@ -64,33 +64,23 @@
           as cardinals in practice. The default (zachar / standalone) forms are
           masculine; the nekeva variant provides feminine forms.
         -->
+        <!--
+          Ordinals 1-10 — forms listed in Dimension order: standalone, zachar, nekeva.
+          standalone and zachar share the same forms (both use the masculine ordinal);
+          nekeva carries the feminine form. The first entry also serves as the default
+          when ConvertOrdinal is called without an explicit gender variant.
+        -->
         <Ordinals>
-            <!-- Masculine / standalone ordinals 1-10 -->
-            <OrdinalException value="1"  string="ראשון" />
-            <OrdinalException value="2"  string="שני" />
-            <OrdinalException value="3"  string="שלישי" />
-            <OrdinalException value="4"  string="רביעי" />
-            <OrdinalException value="5"  string="חמישי" />
-            <OrdinalException value="6"  string="שישי" />
-            <OrdinalException value="7"  string="שביעי" />
-            <OrdinalException value="8"  string="שמיני" />
-            <OrdinalException value="9"  string="תשיעי" />
-            <OrdinalException value="10" string="עשירי" />
-            <!-- Feminine (nekeva) ordinals 1-10 -->
-            <OrdinalVariants>
-                <Variant type="gender" variant="nekeva">
-                    <OrdinalException value="1"  string="ראשונה" />
-                    <OrdinalException value="2"  string="שנייה" />
-                    <OrdinalException value="3"  string="שלישית" />
-                    <OrdinalException value="4"  string="רביעית" />
-                    <OrdinalException value="5"  string="חמישית" />
-                    <OrdinalException value="6"  string="שישית" />
-                    <OrdinalException value="7"  string="שביעית" />
-                    <OrdinalException value="8"  string="שמינית" />
-                    <OrdinalException value="9"  string="תשיעית" />
-                    <OrdinalException value="10" string="עשירית" />
-                </Variant>
-            </OrdinalVariants>
+            <OrdinalException value="1">  <Variant type="gender" forms="ראשון,ראשון,ראשונה"   /></OrdinalException>
+            <OrdinalException value="2">  <Variant type="gender" forms="שני,שני,שנייה"         /></OrdinalException>
+            <OrdinalException value="3">  <Variant type="gender" forms="שלישי,שלישי,שלישית"   /></OrdinalException>
+            <OrdinalException value="4">  <Variant type="gender" forms="רביעי,רביעי,רביעית"   /></OrdinalException>
+            <OrdinalException value="5">  <Variant type="gender" forms="חמישי,חמישי,חמישית"   /></OrdinalException>
+            <OrdinalException value="6">  <Variant type="gender" forms="שישי,שישי,שישית"       /></OrdinalException>
+            <OrdinalException value="7">  <Variant type="gender" forms="שביעי,שביעי,שביעית"   /></OrdinalException>
+            <OrdinalException value="8">  <Variant type="gender" forms="שמיני,שמיני,שמינית"   /></OrdinalException>
+            <OrdinalException value="9">  <Variant type="gender" forms="תשיעי,תשיעי,תשיעית"   /></OrdinalException>
+            <OrdinalException value="10"> <Variant type="gender" forms="עשירי,עשירי,עשירית"   /></OrdinalException>
         </Ordinals>
         <Variants>
             <!--

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.PL.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.PL.xml
@@ -71,30 +71,209 @@
             <Number value="18" string="osiemnaście" />
             <Number value="19" string="dziewiętnaście" />
         </Exceptions>
+        <!--
+            Ordinal variant dimensions:
+              rodzaj   — maskulin (default), feminin, nijaki, plural_mos, plural
+              przypadek — mianownik (default), dopełniacz, celownik, biernik, narzędnik, miejscownik
+
+            rodzaj "maskulin" uses the inanimate accusative (= mianownik); animate/personal
+            accusative (= dopełniacz) must be requested with rodzaj="maskulin_os" if added later.
+            rodzaj "plural_mos" = plural masculine personal (virile); "plural" = non-virile plural.
+
+            Ordinals 1-10 carry explicit forms via the forms attribute (forms in positional
+            przypadek order). Ordinals 11+ retain the base masculine nominative to= and can be
+            extended with forms= in future revisions.
+        -->
+        <Variants>
+            <Dimension name="rodzaj"   values="maskulin,feminin,nijaki,plural_mos,plural" />
+            <Dimension name="przypadek" values="mianownik,dopełniacz,celownik,biernik,narzędnik,miejscownik" />
+        </Variants>
         <Ordinals>
-            <!-- Nominatif masculin singulier — tous les stems diffèrent des cardinaux -->
-            <!-- Unités -->
-            <Ordinal from="jeden"    to="pierwszy" />
-            <Ordinal from="dwa"      to="drugi" />
-            <Ordinal from="trzy"     to="trzeci" />
-            <Ordinal from="cztery"   to="czwarty" />
-            <Ordinal from="pięć"     to="piąty" />
-            <Ordinal from="sześć"    to="szósty" />
-            <Ordinal from="siedem"   to="siódmy" />
-            <Ordinal from="osiem"    to="ósmy" />
-            <Ordinal from="dziewięć" to="dziewiąty" />
-            <Ordinal from="dziesięć" to="dziesiąty" />
-            <!-- Exceptions 11-19 -->
-            <Ordinal from="jedenaście"    to="jedenasty" />
-            <Ordinal from="dwanaście"     to="dwunasty" />
-            <Ordinal from="trzynaście"    to="trzynasty" />
-            <Ordinal from="czternaście"   to="czternasty" />
-            <Ordinal from="piętnaście"    to="piętnasty" />
-            <Ordinal from="szesnaście"    to="szesnasty" />
-            <Ordinal from="siedemnaście"  to="siedemnasty" />
-            <Ordinal from="osiemnaście"   to="osiemnasty" />
+            <!-- ===== Jednostki (1-9) ===== -->
+            <Ordinal from="jeden">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="pierwszy,pierwszego,pierwszemu,pierwszy,pierwszym,pierwszym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="pierwsza,pierwszej,pierwszej,pierwszą,pierwszą,pierwszej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="pierwsze,pierwszego,pierwszemu,pierwsze,pierwszym,pierwszym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="pierwsi,pierwszych,pierwszym,pierwszych,pierwszymi,pierwszych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="pierwsze,pierwszych,pierwszym,pierwsze,pierwszymi,pierwszych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="dwa">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="drugi,drugiego,drugiemu,drugi,drugim,drugim" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="druga,drugiej,drugiej,drugą,drugą,drugiej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="drugie,drugiego,drugiemu,drugie,drugim,drugim" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="drudzy,drugich,drugim,drugich,drugimi,drugich" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="drugie,drugich,drugim,drugie,drugimi,drugich" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="trzy">
+                <!-- Soft adjective: nom maskulin = plural_mos nom (trzeci) -->
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="trzeci,trzeciego,trzeciemu,trzeci,trzecim,trzecim" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="trzecia,trzeciej,trzeciej,trzecią,trzecią,trzeciej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="trzecie,trzeciego,trzeciemu,trzecie,trzecim,trzecim" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="trzeci,trzecich,trzecim,trzecich,trzecimi,trzecich" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="trzecie,trzecich,trzecim,trzecie,trzecimi,trzecich" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="cztery">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="czwarty,czwartego,czwartemu,czwarty,czwartym,czwartym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="czwarta,czwartej,czwartej,czwartą,czwartą,czwartej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="czwarte,czwartego,czwartemu,czwarte,czwartym,czwartym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="czwarci,czwartych,czwartym,czwartych,czwartymi,czwartych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="czwarte,czwartych,czwartym,czwarte,czwartymi,czwartych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="pięć">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="piąty,piątego,piątemu,piąty,piątym,piątym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="piąta,piątej,piątej,piątą,piątą,piątej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="piąte,piątego,piątemu,piąte,piątym,piątym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="piąci,piątych,piątym,piątych,piątymi,piątych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="piąte,piątych,piątym,piąte,piątymi,piątych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="sześć">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="szósty,szóstego,szóstemu,szósty,szóstym,szóstym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="szósta,szóstej,szóstej,szóstą,szóstą,szóstej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="szóste,szóstego,szóstemu,szóste,szóstym,szóstym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="szóści,szóstych,szóstym,szóstych,szóstymi,szóstych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="szóste,szóstych,szóstym,szóste,szóstymi,szóstych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="siedem">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="siódmy,siódmego,siódmemu,siódmy,siódmym,siódmym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="siódma,siódmej,siódmej,siódmą,siódmą,siódmej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="siódme,siódmego,siódmemu,siódme,siódmym,siódmym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="siódmi,siódmych,siódmym,siódmych,siódmymi,siódmych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="siódme,siódmych,siódmym,siódme,siódmymi,siódmych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="osiem">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="ósmy,ósmego,ósmemu,ósmy,ósmym,ósmym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="ósma,ósmej,ósmej,ósmą,ósmą,ósmej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="ósme,ósmego,ósmemu,ósme,ósmym,ósmym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="ósmi,ósmych,ósmym,ósmych,ósmymi,ósmych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="ósme,ósmych,ósmym,ósme,ósmymi,ósmych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="dziewięć">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="dziewiąty,dziewiątego,dziewiątemu,dziewiąty,dziewiątym,dziewiątym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="dziewiąta,dziewiątej,dziewiątej,dziewiątą,dziewiątą,dziewiątej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="dziewiąte,dziewiątego,dziewiątemu,dziewiąte,dziewiątym,dziewiątym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="dziewiąci,dziewiątych,dziewiątym,dziewiątych,dziewiątymi,dziewiątych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="dziewiąte,dziewiątych,dziewiątym,dziewiąte,dziewiątymi,dziewiątych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="dziesięć">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="dziesiąty,dziesiątego,dziesiątemu,dziesiąty,dziesiątym,dziesiątym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="dziesiąta,dziesiątej,dziesiątej,dziesiątą,dziesiątą,dziesiątej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="dziesiąte,dziesiątego,dziesiątemu,dziesiąte,dziesiątym,dziesiątym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="dziesiąci,dziesiątych,dziesiątym,dziesiątych,dziesiątymi,dziesiątych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="dziesiąte,dziesiątych,dziesiątym,dziesiąte,dziesiątymi,dziesiątych" />
+                </Variant>
+            </Ordinal>
+
+            <!-- ===== 11-19 (base masculine nominative; same hard-adj. pattern) ===== -->
+            <Ordinal from="jedenaście"     to="jedenasty" />
+            <Ordinal from="dwanaście"      to="dwunasty" />
+            <Ordinal from="trzynaście"     to="trzynasty" />
+            <Ordinal from="czternaście"    to="czternasty" />
+            <Ordinal from="piętnaście"     to="piętnasty" />
+            <Ordinal from="szesnaście"     to="szesnasty" />
+            <Ordinal from="siedemnaście"   to="siedemnasty" />
+            <Ordinal from="osiemnaście"    to="osiemnasty" />
             <Ordinal from="dziewiętnaście" to="dziewiętnasty" />
-            <!-- Dizaines -->
+
+            <!-- ===== Dizaines ===== -->
             <Ordinal from="dwadzieścia"    to="dwudziesty" />
             <Ordinal from="trzydzieści"    to="trzydziesty" />
             <Ordinal from="czterdzieści"   to="czterdziesty" />
@@ -103,7 +282,8 @@
             <Ordinal from="siedemdziesiąt" to="siedemdziesiąty" />
             <Ordinal from="osiemdziesiąt"  to="osiemdziesiąty" />
             <Ordinal from="dziewięćdziesiąt" to="dziewięćdziesiąty" />
-            <!-- Centaines -->
+
+            <!-- ===== Centaines ===== -->
             <Ordinal from="sto"         to="setny" />
             <Ordinal from="dwieście"    to="dwusetny" />
             <Ordinal from="trzysta"     to="trzechsetny" />
@@ -113,7 +293,8 @@
             <Ordinal from="siedemset"   to="siedemsetny" />
             <Ordinal from="osiemset"    to="osiemsetny" />
             <Ordinal from="dziewięćset" to="dziewięćsetny" />
-            <!-- Millier -->
+
+            <!-- ===== Millier ===== -->
             <Ordinal from="tysiąc" to="tysięczny" />
         </Ordinals>
     </Language>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.PT.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.PT.xml
@@ -75,102 +75,62 @@
 		  Portuguese ordinals: 1-10 are fully irregular; 11-19 are expressed as
 		  compound ordinals ("décimo primeiro"…). Round tens and scale words have
 		  explicit word rules. Numbers not covered fall back to the cardinal.
-		  The feminine variant mirrors all of the above with feminine forms,
-		  including "uma"/"duas" (produced by the cardinal feminine variant)
-		  mapped to their correct ordinal forms.
+		  Forms are listed in Dimension order: masculino, feminino.
+		  The first form also serves as the default when no variant is specified.
+		  OrdinalVariants covers only "uma"/"duas" (feminized by the cardinal variant)
+		  which have no corresponding masculine ordinal word rule.
 		-->
 		<Ordinals>
-			<!-- Masculine ordinals 1-10 (irregular) -->
-			<OrdinalException value="1"  string="primeiro" />
-			<OrdinalException value="2"  string="segundo" />
-			<OrdinalException value="3"  string="terceiro" />
-			<OrdinalException value="4"  string="quarto" />
-			<OrdinalException value="5"  string="quinto" />
-			<OrdinalException value="6"  string="sexto" />
-			<OrdinalException value="7"  string="sétimo" />
-			<OrdinalException value="8"  string="oitavo" />
-			<OrdinalException value="9"  string="nono" />
-			<OrdinalException value="10" string="décimo" />
-			<!-- Compound teens 11-19 -->
-			<OrdinalException value="11" string="décimo primeiro" />
-			<OrdinalException value="12" string="décimo segundo" />
-			<OrdinalException value="13" string="décimo terceiro" />
-			<OrdinalException value="14" string="décimo quarto" />
-			<OrdinalException value="15" string="décimo quinto" />
-			<OrdinalException value="16" string="décimo sexto" />
-			<OrdinalException value="17" string="décimo sétimo" />
-			<OrdinalException value="18" string="décimo oitavo" />
-			<OrdinalException value="19" string="décimo nono" />
+			<!-- Ordinals 1-10 (irregular) — forms: masculino, feminino -->
+			<OrdinalException value="1">   <Variant type="gender" forms="primeiro,primeira"   /></OrdinalException>
+			<OrdinalException value="2">   <Variant type="gender" forms="segundo,segunda"     /></OrdinalException>
+			<OrdinalException value="3">   <Variant type="gender" forms="terceiro,terceira"   /></OrdinalException>
+			<OrdinalException value="4">   <Variant type="gender" forms="quarto,quarta"       /></OrdinalException>
+			<OrdinalException value="5">   <Variant type="gender" forms="quinto,quinta"       /></OrdinalException>
+			<OrdinalException value="6">   <Variant type="gender" forms="sexto,sexta"         /></OrdinalException>
+			<OrdinalException value="7">   <Variant type="gender" forms="sétimo,sétima"       /></OrdinalException>
+			<OrdinalException value="8">   <Variant type="gender" forms="oitavo,oitava"       /></OrdinalException>
+			<OrdinalException value="9">   <Variant type="gender" forms="nono,nona"           /></OrdinalException>
+			<OrdinalException value="10">  <Variant type="gender" forms="décimo,décima"       /></OrdinalException>
+			<!-- Compound teens 11-19 — forms: masculino, feminino -->
+			<OrdinalException value="11">  <Variant type="gender" forms="décimo primeiro,décima primeira"   /></OrdinalException>
+			<OrdinalException value="12">  <Variant type="gender" forms="décimo segundo,décima segunda"     /></OrdinalException>
+			<OrdinalException value="13">  <Variant type="gender" forms="décimo terceiro,décima terceira"   /></OrdinalException>
+			<OrdinalException value="14">  <Variant type="gender" forms="décimo quarto,décima quarta"       /></OrdinalException>
+			<OrdinalException value="15">  <Variant type="gender" forms="décimo quinto,décima quinta"       /></OrdinalException>
+			<OrdinalException value="16">  <Variant type="gender" forms="décimo sexto,décima sexta"         /></OrdinalException>
+			<OrdinalException value="17">  <Variant type="gender" forms="décimo sétimo,décima sétima"       /></OrdinalException>
+			<OrdinalException value="18">  <Variant type="gender" forms="décimo oitavo,décima oitava"       /></OrdinalException>
+			<OrdinalException value="19">  <Variant type="gender" forms="décimo nono,décima nona"           /></OrdinalException>
 			<!-- Word rules for units in compounds -->
-			<Ordinal from="um"     to="primeiro" />
-			<Ordinal from="dois"   to="segundo" />
-			<Ordinal from="três"   to="terceiro" />
-			<Ordinal from="quatro" to="quarto" />
-			<Ordinal from="cinco"  to="quinto" />
-			<Ordinal from="seis"   to="sexto" />
-			<Ordinal from="sete"   to="sétimo" />
-			<Ordinal from="oito"   to="oitavo" />
-			<Ordinal from="nove"   to="nono" />
+			<Ordinal from="um">     <Variant type="gender" forms="primeiro,primeira" /></Ordinal>
+			<Ordinal from="dois">   <Variant type="gender" forms="segundo,segunda"   /></Ordinal>
+			<Ordinal from="três">   <Variant type="gender" forms="terceiro,terceira" /></Ordinal>
+			<Ordinal from="quatro"> <Variant type="gender" forms="quarto,quarta"     /></Ordinal>
+			<Ordinal from="cinco">  <Variant type="gender" forms="quinto,quinta"     /></Ordinal>
+			<Ordinal from="seis">   <Variant type="gender" forms="sexto,sexta"       /></Ordinal>
+			<Ordinal from="sete">   <Variant type="gender" forms="sétimo,sétima"     /></Ordinal>
+			<Ordinal from="oito">   <Variant type="gender" forms="oitavo,oitava"     /></Ordinal>
+			<Ordinal from="nove">   <Variant type="gender" forms="nono,nona"         /></Ordinal>
 			<!-- Round tens -->
-			<Ordinal from="vinte"     to="vigésimo" />
-			<Ordinal from="trinta"    to="trigésimo" />
-			<Ordinal from="quarenta"  to="quadragésimo" />
-			<Ordinal from="cinquenta" to="quinquagésimo" />
-			<Ordinal from="sessenta"  to="sexagésimo" />
-			<Ordinal from="setenta"   to="septuagésimo" />
-			<Ordinal from="oitenta"   to="octogésimo" />
-			<Ordinal from="noventa"   to="nonagésimo" />
+			<Ordinal from="vinte">     <Variant type="gender" forms="vigésimo,vigésima"         /></Ordinal>
+			<Ordinal from="trinta">    <Variant type="gender" forms="trigésimo,trigésima"        /></Ordinal>
+			<Ordinal from="quarenta">  <Variant type="gender" forms="quadragésimo,quadragésima"  /></Ordinal>
+			<Ordinal from="cinquenta"> <Variant type="gender" forms="quinquagésimo,quinquagésima"/></Ordinal>
+			<Ordinal from="sessenta">  <Variant type="gender" forms="sexagésimo,sexagésima"      /></Ordinal>
+			<Ordinal from="setenta">   <Variant type="gender" forms="septuagésimo,septuagésima"  /></Ordinal>
+			<Ordinal from="oitenta">   <Variant type="gender" forms="octogésimo,octogésima"      /></Ordinal>
+			<Ordinal from="noventa">   <Variant type="gender" forms="nonagésimo,nonagésima"      /></Ordinal>
 			<!-- Scale words -->
-			<Ordinal from="cem" to="centésimo" />
-			<Ordinal from="mil" to="milésimo" />
+			<Ordinal from="cem"> <Variant type="gender" forms="centésimo,centésima" /></Ordinal>
+			<Ordinal from="mil"> <Variant type="gender" forms="milésimo,milésima"   /></Ordinal>
 
-			<!-- Feminine variant -->
+			<!-- Feminized cardinal forms not covered by the inline rules above -->
 			<OrdinalVariants>
 				<Variant type="gender" variant="feminino">
-					<OrdinalException value="1"  string="primeira" />
-					<OrdinalException value="2"  string="segunda" />
-					<OrdinalException value="3"  string="terceira" />
-					<OrdinalException value="4"  string="quarta" />
-					<OrdinalException value="5"  string="quinta" />
-					<OrdinalException value="6"  string="sexta" />
-					<OrdinalException value="7"  string="sétima" />
-					<OrdinalException value="8"  string="oitava" />
-					<OrdinalException value="9"  string="nona" />
-					<OrdinalException value="10" string="décima" />
-					<OrdinalException value="11" string="décima primeira" />
-					<OrdinalException value="12" string="décima segunda" />
-					<OrdinalException value="13" string="décima terceira" />
-					<OrdinalException value="14" string="décima quarta" />
-					<OrdinalException value="15" string="décima quinta" />
-					<OrdinalException value="16" string="décima sexta" />
-					<OrdinalException value="17" string="décima sétima" />
-					<OrdinalException value="18" string="décima oitava" />
-					<OrdinalException value="19" string="décima nona" />
-					<!-- Original cardinal forms (for compounds not transformed by cardinal variant) -->
-					<Ordinal from="um"     to="primeira" />
-					<Ordinal from="dois"   to="segunda" />
-					<Ordinal from="três"   to="terceira" />
-					<Ordinal from="quatro" to="quarta" />
-					<Ordinal from="cinco"  to="quinta" />
-					<Ordinal from="seis"   to="sexta" />
-					<Ordinal from="sete"   to="sétima" />
-					<Ordinal from="oito"   to="oitava" />
-					<Ordinal from="nove"   to="nona" />
-					<!-- Feminized unit forms (after cardinal "um→uma", "dois→duas") -->
+					<!-- Produced by cardinal variant "um→uma", "dois→duas" -->
 					<Ordinal from="uma"  to="primeira" />
 					<Ordinal from="duas" to="segunda" />
-					<!-- Round tens (feminine) -->
-					<Ordinal from="vinte"     to="vigésima" />
-					<Ordinal from="trinta"    to="trigésima" />
-					<Ordinal from="quarenta"  to="quadragésima" />
-					<Ordinal from="cinquenta" to="quinquagésima" />
-					<Ordinal from="sessenta"  to="sexagésima" />
-					<Ordinal from="setenta"   to="septuagésima" />
-					<Ordinal from="oitenta"   to="octogésima" />
-					<Ordinal from="noventa"   to="nonagésima" />
-					<!-- Scale words (feminine) -->
-					<Ordinal from="cem" to="centésima" />
-					<Ordinal from="mil" to="milésima" />
 				</Variant>
 			</OrdinalVariants>
 		</Ordinals>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.RU.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.RU.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
     <Language
         groupSize="3"
@@ -71,35 +71,400 @@
             <Number value="18" string="восемнадцать" />
             <Number value="19" string="девятнадцать" />
         </Exceptions>
+        <!--
+            Ordinal variant dimensions:
+              gender  — maskulin (default), feminin, neutrum, plural
+              case    — именительный (default), родительный, дательный, винительный, творительный, предложный
+
+            Suffix "ый" + removeTrailing "ь" handles regular ordinals (e.g. пятый, девятый, двадцатый).
+            OrdinalVariants overrides the suffix per gender × case for those same regular ordinals.
+            Word-rule ordinals (один → первый, two → второй, etc.) carry explicit forms via the
+            forms attribute, which generates synthetic OrdinalVariantRule entries at load time.
+        -->
+        <Variants>
+            <Dimension name="gender" values="maskulin,feminin,neutrum,plural" />
+            <Dimension name="case"   values="именительный,родительный,дательный,винительный,творительный,предложный" />
+        </Variants>
         <Ordinals suffix="ый" removeTrailing="ь">
-            <OrdinalException value="1" string="первый" />
-            <!-- Unités irrégulières -->
-            <Ordinal from="один"          to="первый" />
-            <Ordinal from="два"           to="второй" />
-            <Ordinal from="три"           to="третий" />
-            <Ordinal from="четыре"        to="четвёртый" />
-            <Ordinal from="шесть"         to="шестой" />
-            <Ordinal from="семь"          to="седьмой" />
-            <Ordinal from="восемь"        to="восьмой" />
+            <!-- Ordinal 1 — exception by value (also handled as word rule below) -->
+            <OrdinalException value="1" string="первый">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="первый,первого,первому,первый,первым,первом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="первая,первой,первой,первую,первой,первой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="первое,первого,первому,первое,первым,первом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="первые,первых,первым,первые,первыми,первых" />
+                </Variant>
+            </OrdinalException>
+
+            <!-- Единицы (irregular) -->
+            <Ordinal from="один">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="первый,первого,первому,первый,первым,первом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="первая,первой,первой,первую,первой,первой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="первое,первого,первому,первое,первым,первом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="первые,первых,первым,первые,первыми,первых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="два">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="второй,второго,второму,второй,вторым,втором" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="вторая,второй,второй,вторую,второй,второй" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="второе,второго,второму,второе,вторым,втором" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="вторые,вторых,вторым,вторые,вторыми,вторых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="три">
+                <!-- Possessive-adjective pattern: gen/dat/inst/prep -его/-ему/-им/-ем -->
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="третий,третьего,третьему,третий,третьим,третьем" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="третья,третьей,третьей,третью,третьей,третьей" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="третье,третьего,третьему,третье,третьим,третьем" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="третьи,третьих,третьим,третьи,третьими,третьих" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="четыре">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="четвёртый,четвёртого,четвёртому,четвёртый,четвёртым,четвёртом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="четвёртая,четвёртой,четвёртой,четвёртую,четвёртой,четвёртой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="четвёртое,четвёртого,четвёртому,четвёртое,четвёртым,четвёртом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="четвёртые,четвёртых,четвёртым,четвёртые,четвёртыми,четвёртых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="шесть">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="шестой,шестого,шестому,шестой,шестым,шестом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="шестая,шестой,шестой,шестую,шестой,шестой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="шестое,шестого,шестому,шестое,шестым,шестом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="шестые,шестых,шестым,шестые,шестыми,шестых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="семь">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="седьмой,седьмого,седьмому,седьмой,седьмым,седьмом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="седьмая,седьмой,седьмой,седьмую,седьмой,седьмой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="седьмое,седьмого,седьмому,седьмое,седьмым,седьмом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="седьмые,седьмых,седьмым,седьмые,седьмыми,седьмых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="восемь">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="восьмой,восьмого,восьмому,восьмой,восьмым,восьмом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="восьмая,восьмой,восьмой,восьмую,восьмой,восьмой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="восьмое,восьмого,восьмому,восьмое,восьмым,восьмом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="восьмые,восьмых,восьмым,восьмые,восьмыми,восьмых" />
+                </Variant>
+            </Ordinal>
+
             <!-- Dizaines irrégulières -->
-            <Ordinal from="сорок"         to="сороковой" />
-            <Ordinal from="пятьдесят"     to="пятидесятый" />
-            <Ordinal from="шестьдесят"    to="шестидесятый" />
-            <Ordinal from="семьдесят"     to="семидесятый" />
-            <Ordinal from="восемьдесят"   to="восьмидесятый" />
-            <Ordinal from="девяносто"     to="девяностый" />
+            <Ordinal from="сорок">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="сороковой,сорокового,сороковому,сороковой,сороковым,сороковом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="сороковая,сороковой,сороковой,сороковую,сороковой,сороковой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="сороковое,сорокового,сороковому,сороковое,сороковым,сороковом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="сороковые,сороковых,сороковым,сороковые,сороковыми,сороковых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="пятьдесят">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="пятидесятый,пятидесятого,пятидесятому,пятидесятый,пятидесятым,пятидесятом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="пятидесятая,пятидесятой,пятидесятой,пятидесятую,пятидесятой,пятидесятой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="пятидесятое,пятидесятого,пятидесятому,пятидесятое,пятидесятым,пятидесятом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="пятидесятые,пятидесятых,пятидесятым,пятидесятые,пятидесятыми,пятидесятых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="шестьдесят">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="шестидесятый,шестидесятого,шестидесятому,шестидесятый,шестидесятым,шестидесятом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="шестидесятая,шестидесятой,шестидесятой,шестидесятую,шестидесятой,шестидесятой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="шестидесятое,шестидесятого,шестидесятому,шестидесятое,шестидесятым,шестидесятом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="шестидесятые,шестидесятых,шестидесятым,шестидесятые,шестидесятыми,шестидесятых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="семьдесят">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="семидесятый,семидесятого,семидесятому,семидесятый,семидесятым,семидесятом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="семидесятая,семидесятой,семидесятой,семидесятую,семидесятой,семидесятой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="семидесятое,семидесятого,семидесятому,семидесятое,семидесятым,семидесятом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="семидесятые,семидесятых,семидесятым,семидесятые,семидесятыми,семидесятых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="восемьдесят">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="восьмидесятый,восьмидесятого,восьмидесятому,восьмидесятый,восьмидесятым,восьмидесятом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="восьмидесятая,восьмидесятой,восьмидесятой,восьмидесятую,восьмидесятой,восьмидесятой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="восьмидесятое,восьмидесятого,восьмидесятому,восьмидесятое,восьмидесятым,восьмидесятом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="восьмидесятые,восьмидесятых,восьмидесятым,восьмидесятые,восьмидесятыми,восьмидесятых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="девяносто">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="девяностый,девяностого,девяностому,девяностый,девяностым,девяностом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="девяностая,девяностой,девяностой,девяностую,девяностой,девяностой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="девяностое,девяностого,девяностому,девяностое,девяностым,девяностом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="девяностые,девяностых,девяностым,девяностые,девяностыми,девяностых" />
+                </Variant>
+            </Ordinal>
+
             <!-- Centaines irrégulières -->
-            <Ordinal from="сто"           to="сотый" />
-            <Ordinal from="двести"        to="двухсотый" />
-            <Ordinal from="триста"        to="трёхсотый" />
-            <Ordinal from="четыреста"     to="четырёхсотый" />
-            <Ordinal from="пятьсот"       to="пятисотый" />
-            <Ordinal from="шестьсот"      to="шестисотый" />
-            <Ordinal from="семьсот"       to="семисотый" />
-            <Ordinal from="восемьсот"     to="восьмисотый" />
-            <Ordinal from="девятьсот"     to="девятисотый" />
+            <Ordinal from="сто">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="сотый,сотого,сотому,сотый,сотым,сотом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="сотая,сотой,сотой,сотую,сотой,сотой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="сотое,сотого,сотому,сотое,сотым,сотом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="сотые,сотых,сотым,сотые,сотыми,сотых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="двести">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="двухсотый,двухсотого,двухсотому,двухсотый,двухсотым,двухсотом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="двухсотая,двухсотой,двухсотой,двухсотую,двухсотой,двухсотой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="двухсотое,двухсотого,двухсотому,двухсотое,двухсотым,двухсотом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="двухсотые,двухсотых,двухсотым,двухсотые,двухсотыми,двухсотых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="триста">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="трёхсотый,трёхсотого,трёхсотому,трёхсотый,трёхсотым,трёхсотом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="трёхсотая,трёхсотой,трёхсотой,трёхсотую,трёхсотой,трёхсотой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="трёхсотое,трёхсотого,трёхсотому,трёхсотое,трёхсотым,трёхсотом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="трёхсотые,трёхсотых,трёхсотым,трёхсотые,трёхсотыми,трёхсотых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="четыреста">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="четырёхсотый,четырёхсотого,четырёхсотому,четырёхсотый,четырёхсотым,четырёхсотом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="четырёхсотая,четырёхсотой,четырёхсотой,четырёхсотую,четырёхсотой,четырёхсотой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="четырёхсотое,четырёхсотого,четырёхсотому,четырёхсотое,четырёхсотым,четырёхсотом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="четырёхсотые,четырёхсотых,четырёхсотым,четырёхсотые,четырёхсотыми,четырёхсотых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="пятьсот">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="пятисотый,пятисотого,пятисотому,пятисотый,пятисотым,пятисотом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="пятисотая,пятисотой,пятисотой,пятисотую,пятисотой,пятисотой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="пятисотое,пятисотого,пятисотому,пятисотое,пятисотым,пятисотом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="пятисотые,пятисотых,пятисотым,пятисотые,пятисотыми,пятисотых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="шестьсот">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="шестисотый,шестисотого,шестисотому,шестисотый,шестисотым,шестисотом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="шестисотая,шестисотой,шестисотой,шестисотую,шестисотой,шестисотой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="шестисотое,шестисотого,шестисотому,шестисотое,шестисотым,шестисотом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="шестисотые,шестисотых,шестисотым,шестисотые,шестисотыми,шестисотых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="семьсот">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="семисотый,семисотого,семисотому,семисотый,семисотым,семисотом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="семисотая,семисотой,семисотой,семисотую,семисотой,семисотой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="семисотое,семисотого,семисотому,семисотое,семисотым,семисотом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="семисотые,семисотых,семисотым,семисотые,семисотыми,семисотых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="восемьсот">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="восьмисотый,восьмисотого,восьмисотому,восьмисотый,восьмисотым,восьмисотом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="восьмисотая,восьмисотой,восьмисотой,восьмисотую,восьмисотой,восьмисотой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="восьмисотое,восьмисотого,восьмисотому,восьмисотое,восьмисотым,восьмисотом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="восьмисотые,восьмисотых,восьмисотым,восьмисотые,восьмисотыми,восьмисотых" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="девятьсот">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="девятисотый,девятисотого,девятисотому,девятисотый,девятисотым,девятисотом" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="девятисотая,девятисотой,девятисотой,девятисотую,девятисотой,девятисотой" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="девятисотое,девятисотого,девятисотому,девятисотое,девятисотым,девятисотом" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="девятисотые,девятисотых,девятисотым,девятисотые,девятисотыми,девятисотых" />
+                </Variant>
+            </Ordinal>
+
             <!-- Mot d'échelle тысяча -->
-            <Ordinal from="тысяча"        to="тысячный" />
+            <Ordinal from="тысяча">
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" forms="тысячный,тысячного,тысячному,тысячный,тысячным,тысячном" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" forms="тысячная,тысячной,тысячной,тысячную,тысячной,тысячной" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" forms="тысячное,тысячного,тысячному,тысячное,тысячным,тысячном" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" forms="тысячные,тысячных,тысячным,тысячные,тысячными,тысячных" />
+                </Variant>
+            </Ordinal>
+
+            <!--
+                OrdinalVariants — suffix overrides for regular ordinals (cardinal ends in "ь":
+                пять, девять, десять, одиннадцать … девятнадцать, двадцать, тридцать).
+                Pattern: strip "ь" from cardinal, append case-specific suffix.
+                Example: десять → десят + ого = десятого (roditelnyj maskulin).
+            -->
+            <OrdinalVariants>
+                <Variant type="gender" variant="maskulin">
+                    <Variant type="case" variant="родительный"   suffix="ого" removeTrailing="ь" />
+                    <Variant type="case" variant="дательный"     suffix="ому" removeTrailing="ь" />
+                    <Variant type="case" variant="творительный"  suffix="ым"  removeTrailing="ь" />
+                    <Variant type="case" variant="предложный"    suffix="ом"  removeTrailing="ь" />
+                </Variant>
+                <Variant type="gender" variant="feminin">
+                    <Variant type="case" variant="именительный"  suffix="ая"  removeTrailing="ь" />
+                    <Variant type="case" values="родительный,дательный,творительный,предложный" suffix="ой" removeTrailing="ь" />
+                    <Variant type="case" variant="винительный"   suffix="ую"  removeTrailing="ь" />
+                </Variant>
+                <Variant type="gender" variant="neutrum">
+                    <Variant type="case" values="именительный,винительный" suffix="ое" removeTrailing="ь" />
+                    <Variant type="case" variant="родительный"   suffix="ого" removeTrailing="ь" />
+                    <Variant type="case" variant="дательный"     suffix="ому" removeTrailing="ь" />
+                    <Variant type="case" variant="творительный"  suffix="ым"  removeTrailing="ь" />
+                    <Variant type="case" variant="предложный"    suffix="ом"  removeTrailing="ь" />
+                </Variant>
+                <Variant type="gender" variant="plural">
+                    <Variant type="case" values="именительный,винительный" suffix="ые" removeTrailing="ь" />
+                    <Variant type="case" values="родительный,предложный"   suffix="ых" removeTrailing="ь" />
+                    <Variant type="case" variant="дательный"     suffix="ым"  removeTrailing="ь" />
+                    <Variant type="case" variant="творительный"  suffix="ыми" removeTrailing="ь" />
+                </Variant>
+            </OrdinalVariants>
         </Ordinals>
     </Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
@@ -317,11 +317,25 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="variant" type="xs:string" use="required">
+        <xs:attribute name="variant" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The dimension value that must be active for this block to apply
+                    The single dimension value that must be active for this block to apply
                     (e.g. "femenino", "femminile", "feminin").
+                    Mutually exclusive with "values": use one or the other.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="values" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Comma-separated list of dimension values — alternative to the single "variant"
+                    attribute. Declares one rule for each listed value, all sharing the same body
+                    (exceptions, word rules, suffix overrides, and nested sub-variants).
+                    By convention, values should be listed in the same order as in the Dimension
+                    declaration; the runtime accepts any order.
+                    "values" takes priority over "variant" when both are present.
+                    Example: values="akkusativ,dativ,genitiv"
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -524,11 +538,25 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="variant" type="xs:string" use="required">
+        <xs:attribute name="variant" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The dimension value that must be active for this variant to apply
+                    The single dimension value that must be active for this variant to apply
                     (e.g. "feminin", "dativ", "partitiivi").
+                    Mutually exclusive with "values": use one or the other.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="values" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Comma-separated list of dimension values — alternative to the single "variant"
+                    attribute. Declares one rule for each listed value, all sharing the same body
+                    (replacements and nested sub-variants).
+                    By convention, values should be listed in the same order as in the Dimension
+                    declaration; the runtime accepts any order.
+                    "values" takes priority over "variant" when both are present.
+                    Example: values="dativ,genitiv"
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
@@ -201,16 +201,33 @@
             <xs:documentation>
                 A single text substitution rule. The scope attribute controls where the
                 replacement is applied; see ReplacementScopeType for semantics.
+
+                Child Variant elements declare per-dimension-value replacements using the
+                forms attribute (see FormVariantType). They are expanded at load time into
+                VariantRule entries merged by constraint set.
+
+                Example — German "ein" with four case forms for masculine:
+                    &lt;Replacement oldValue="ein" scope="lastWord"&gt;
+                        &lt;Variant type="gender" variant="maskulin"&gt;
+                            &lt;Variant type="case" forms="eins,einen,einem,eines" /&gt;
+                        &lt;/Variant&gt;
+                    &lt;/Replacement&gt;
             </xs:documentation>
         </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Variant" type="FormVariantType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
         <xs:attribute name="oldValue" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>The text pattern to search for.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="newValue" type="xs:string" use="required">
+        <xs:attribute name="newValue" type="xs:string" use="optional">
             <xs:annotation>
-                <xs:documentation>The replacement text.</xs:documentation>
+                <xs:documentation>
+                    The base replacement text (default variant).
+                    May be omitted when all forms are covered by child Variant elements.
+                </xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="scope" type="ReplacementScopeType" use="optional">
@@ -231,6 +248,64 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:complexType name="FormVariantType">
+        <xs:annotation>
+            <xs:documentation>
+                A variant node used inside form-producing elements (Replacement, OrdinalException, Ordinal).
+
+                Two roles:
+                  Intermediate node  — type + variant add one constraint; child Variant elements
+                                       cascade further constraints.
+                  Leaf node          — type + forms give one output form per dimension value, in the
+                                       order declared in the matching Dimension element.
+
+                forms (leaf)
+                    Comma-separated list of output strings, one per dimension value in declaration order.
+                    Empty entries are skipped (no rule generated for that position).
+                    Example with Dimension name="case" values="nom,gen,dat,acc,inst,prep":
+                        forms="первый,первого,первому,первый,первым,первом"
+                    creates six ordinal variant rules, one per case value.
+
+                Nesting example — full Russian ordinal for "первый":
+                    &lt;OrdinalException value="1" string="первый"&gt;
+                        &lt;Variant type="gender" variant="maskulin"&gt;
+                            &lt;Variant type="case" forms="первый,первого,первому,первый,первым,первом" /&gt;
+                        &lt;/Variant&gt;
+                        &lt;Variant type="gender" variant="feminin"&gt;
+                            &lt;Variant type="case" forms="первая,первой,первой,первую,первой,первой" /&gt;
+                        &lt;/Variant&gt;
+                    &lt;/OrdinalException&gt;
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Variant" type="FormVariantType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Canonical dimension name (e.g. "gender", "case") or its localName alias.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="variant" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Single dimension value for an intermediate node. Used alongside child Variant elements.
+                    Omit on leaf nodes that use the forms attribute instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="forms" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Comma-separated positional output forms for a leaf node, one per dimension value
+                    in Dimension declaration order. Empty entries produce no rule for that position.
+                    Mutually exclusive with child Variant elements.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
     <xs:complexType name="OrdinalExceptionType">
         <xs:annotation>
             <xs:documentation>
@@ -238,18 +313,35 @@
                 Checked with highest priority in ConvertOrdinal, before word-level rules
                 and before the suffix.
 
+                The string attribute gives the base (default-variant) form.
+                Child Variant elements declare per-dimension-value forms using the forms
+                attribute (see FormVariantType). Forms are expanded at load time into
+                OrdinalVariantRule entries merged by constraint set.
+
                 Example (French): value="1" string="premier"
-                Example (Spanish): value="1" string="primero"
+                Example (Russian with variants):
+                    &lt;OrdinalException value="1" string="первый"&gt;
+                        &lt;Variant type="gender" variant="feminin"&gt;
+                            &lt;Variant type="case" forms="первая,первой,первой,первую,первой,первой" /&gt;
+                        &lt;/Variant&gt;
+                    &lt;/OrdinalException&gt;
             </xs:documentation>
         </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Variant" type="FormVariantType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
         <xs:attribute name="value" type="xs:long" use="required">
             <xs:annotation>
                 <xs:documentation>The integer value this exception applies to.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="string" type="xs:string" use="required">
+        <xs:attribute name="string" type="xs:string" use="optional">
             <xs:annotation>
-                <xs:documentation>The ordinal text for this specific value.</xs:documentation>
+                <xs:documentation>
+                    The base ordinal text for this value (default variant).
+                    May be omitted when all forms are covered by child Variant elements
+                    and dimension defaults guarantee a match.
+                </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -263,22 +355,34 @@
                 Rules are checked after whole-number OrdinalException entries and before
                 the default suffix.
 
-                Example (English): from="one" to="first", from="two" to="second"
-                Example (French):  from="cinq" to="cinquième", from="neuf" to="neuvième"
+                The to attribute gives the base (default-variant) replacement.
+                Child Variant elements declare per-dimension-value replacements using the
+                forms attribute (see FormVariantType). Forms expand at load time into
+                OrdinalVariantRule word-rule entries merged by constraint set.
 
-                The match is applied to the terminal word only (after the last space and
-                the last hyphen), so compound numbers are handled correctly:
-                "twenty-one" → last word = "one" → "twenty-first".
+                Example (English): from="one" to="first", from="two" to="second"
+                Example (Russian with variants):
+                    &lt;Ordinal from="один"&gt;
+                        &lt;Variant type="gender" variant="maskulin"&gt;
+                            &lt;Variant type="case" forms="первый,первого,первому,первый,первым,первом" /&gt;
+                        &lt;/Variant&gt;
+                    &lt;/Ordinal&gt;
             </xs:documentation>
         </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Variant" type="FormVariantType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
         <xs:attribute name="from" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>The cardinal word to match (last word of the cardinal text).</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="to" type="xs:string" use="required">
+        <xs:attribute name="to" type="xs:string" use="optional">
             <xs:annotation>
-                <xs:documentation>The ordinal word that replaces it (the full last word including suffix).</xs:documentation>
+                <xs:documentation>
+                    The base ordinal replacement (default variant).
+                    May be omitted when all forms are covered by child Variant elements.
+                </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
@@ -4,6 +4,8 @@
     targetNamespace="Utils/NumberConvertionConfiguration.xsd"
     xmlns="Utils/NumberConvertionConfiguration.xsd"
     elementFormDefault="qualified"
+    vc:minVersion="1.1"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
 >
 
     <xs:annotation>
@@ -266,6 +268,15 @@
                         forms="первый,первого,первому,первый,первым,первом"
                     creates six ordinal variant rules, one per case value.
 
+                Compact gender example — when the parent element omits string= or to=, the first
+                form in declaration order also serves as the default (no-variant) result:
+                    Dimension name="gender" values="masculino,femenino"
+                    &lt;OrdinalException value="1"&gt;
+                        &lt;Variant type="gender" forms="primero,primera" /&gt;
+                    &lt;/OrdinalException&gt;
+                creates three rules: {gender:masculino}→"primero", {gender:femenino}→"primera",
+                and a default (no variant) rule that also returns "primero".
+
                 Nesting example — full Russian ordinal for "первый":
                     &lt;OrdinalException value="1" string="первый"&gt;
                         &lt;Variant type="gender" variant="maskulin"&gt;
@@ -318,8 +329,16 @@
                 attribute (see FormVariantType). Forms are expanded at load time into
                 OrdinalVariantRule entries merged by constraint set.
 
-                Example (French): value="1" string="premier"
-                Example (Russian with variants):
+                When string is omitted and all forms are expressed via Variant children,
+                the first form in dimension declaration order becomes the default (used
+                when ConvertOrdinal is called without a matching variant).
+
+                Example (French compact): value="1", Dimension gender values="masculin,feminin"
+                    &lt;OrdinalException value="1"&gt;
+                        &lt;Variant type="gender" forms="premier,première" /&gt;
+                    &lt;/OrdinalException&gt;
+                Example (French classic): value="1" string="premier"
+                Example (Russian with nested variants):
                     &lt;OrdinalException value="1" string="первый"&gt;
                         &lt;Variant type="gender" variant="feminin"&gt;
                             &lt;Variant type="case" forms="первая,первой,первой,первую,первой,первой" /&gt;
@@ -360,8 +379,16 @@
                 forms attribute (see FormVariantType). Forms expand at load time into
                 OrdinalVariantRule word-rule entries merged by constraint set.
 
+                When to is omitted and all forms are expressed via Variant children,
+                the first form in dimension declaration order becomes the default (used
+                when ConvertOrdinal is called without a matching variant).
+
                 Example (English): from="one" to="first", from="two" to="second"
-                Example (Russian with variants):
+                Example (Spanish compact): Dimension gender values="masculino,femenino"
+                    &lt;Ordinal from="uno"&gt;
+                        &lt;Variant type="gender" forms="primero,primera" /&gt;
+                    &lt;/Ordinal&gt;
+                Example (Russian with nested variants):
                     &lt;Ordinal from="один"&gt;
                         &lt;Variant type="gender" variant="maskulin"&gt;
                             &lt;Variant type="case" forms="первый,первого,первому,первый,первым,первом" /&gt;
@@ -443,6 +470,16 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:assert test="@variant or @values"
+            xpathDefaultNamespace="##targetNamespace">
+            <xs:annotation>
+                <xs:documentation>
+                    An OrdinalVariant element must declare exactly one selector: either the "variant"
+                    attribute (single value) or the "values" attribute (comma-separated list).
+                    Omitting both would create an unconstrained catch-all rule.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:assert>
         <xs:attribute name="suffix" type="xs:string">
             <xs:annotation>
                 <xs:documentation>
@@ -664,6 +701,16 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:assert test="@variant or @values"
+            xpathDefaultNamespace="##targetNamespace">
+            <xs:annotation>
+                <xs:documentation>
+                    A Variant element must declare exactly one selector: either the "variant"
+                    attribute (single value) or the "values" attribute (comma-separated list).
+                    Omitting both would create an unconstrained catch-all rule.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:assert>
     </xs:complexType>
 
     <xs:complexType name="VariantsType">

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
@@ -311,7 +311,22 @@
                 <xs:documentation>
                     Comma-separated positional output forms for a leaf node, one per dimension value
                     in Dimension declaration order. Empty entries produce no rule for that position.
-                    Mutually exclusive with child Variant elements.
+                    Mutually exclusive with child Variant elements and with "value".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="value" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Single output form for this specific variant value (the value selected by the
+                    "variant" attribute on the same node). Shorthand for the case where only one
+                    dimension value needs an override without listing all positional forms.
+                    Requires "variant" to be set. Mutually exclusive with "forms" and child Variant elements.
+
+                    Example — override feminine only:
+                        &lt;Variant type="genus" variant="feminin" value="eine" /&gt;
+                    creates a single rule: {genus=feminin} → "eine".
+                    Other values (maskulin, neutrum) are unaffected.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -748,6 +763,114 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:complexType name="TriggerReplaceType">
+        <xs:annotation>
+            <xs:documentation>
+                A text-replacement rule inside a Trigger. When the trigger fires, a single
+                replacement is applied — the most specific variant form that matches the active
+                query, or "to" as the unconditional default when no variant matches.
+
+                Variant children use the same FormVariantType syntax as in Replacement, Ordinal,
+                and OrdinalException:
+                  Leaf node  — type + forms: one replacement string per dimension value in
+                               Dimension declaration order.
+                  Intermediate node — type + variant (or values): adds a constraint and
+                               delegates to nested Variant children.
+
+                When "to" is omitted and Variant children are present, the first form in
+                declaration order serves as the unconditional default.
+
+                Example — German "ein" count form, feminine override:
+                    &lt;Replace from="ein$" regex="true"&gt;
+                        &lt;Variant type="genus" forms="eins,eine,eins" /&gt;
+                    &lt;/Replace&gt;
+                creates: maskulin → "eins", feminin → "eine", neutrum → "eins",
+                         default (no variant) → "eins" (first form).
+
+                Selection rule: the most specific matching variant (most constraints) wins.
+                When "to" is provided it is always used as the unconditional default.
+                Only one replacement string is ultimately applied per Replace element.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Variant" type="FormVariantType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The pattern to match. Treated as a .NET regular expression when regex="true",
+                    or as a literal string otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The unconditional default replacement. May be omitted when all cases are
+                    covered by Variant children (the first form then becomes the default).
+                    May contain backreferences ($1, ${name}) when regex="true".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="regex" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    When true, "from" is a .NET regular expression and "to" / variant forms
+                    may contain backreferences. When false (default), literal string replacement.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="TriggerType">
+        <xs:annotation>
+            <xs:documentation>
+                A trigger that fires at a specific point in the conversion pipeline and applies
+                text replacements, each optionally selecting a form based on active variant values.
+
+                executeAt syntax:
+                  "group"               — fires on the digit-only text of each group, before the
+                                          scale name is appended.
+                  "group(N)"            — fires for group N only (0=units, 1=thousands, 2=millions…).
+                  "group(N,M)"          — fires for group N or M.
+                  "groupWithScale"      — fires on the digit+scale text of each group, after the
+                                          existing Replacements are applied for that group.
+                  "groupWithScale(N)"   — fires for group N with its scale name.
+                  "end"                 — fires on the fully assembled number text, after Replacements
+                                          and Variants are applied and before FinalizeWriting.
+
+                Pipeline (cardinal):
+                  ConvertGroup → [group(N) triggers] → append scale → Replacements
+                    → [groupWithScale(N) triggers] → push
+                  Assemble → Replacements → Variants → [end triggers] → FinalizeWriting
+
+                Pipeline (ordinal):
+                  Group triggers fire inside ConvertRaw, same as for cardinals.
+                  End triggers fire after ApplyOrdinalTransform and before FinalizeWriting.
+
+                WARNING: group and groupWithScale triggers fire during ordinal conversion.
+                A trigger that modifies cardinal text (e.g. "ein" → "eins") will prevent
+                ordinal word rules from matching that word. Use end triggers or FinalizeWriting
+                for transformations that must not interfere with ordinal word-rule matching.
+
+                Each Replace element is applied independently: for each one, the most specific
+                matching variant form is selected and applied exactly once.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Replace" type="TriggerReplaceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="executeAt" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    When the trigger fires. Values: "group", "group(N)", "group(N,M,…)",
+                    "groupWithScale", "groupWithScale(N)", "end".
+                    Group indices: 0=units, 1=thousands, 2=millions, … (negative reserved for decimals).
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
     <xs:complexType name="YearFormatSplitRangeType">
         <xs:annotation>
             <xs:documentation>
@@ -1097,6 +1220,18 @@
                                     <xs:attribute name="hundredWord" type="xs:string" use="optional" />
                                     <xs:attribute name="zeroConnector" type="xs:string" use="optional" />
                                 </xs:complexType>
+                            </xs:element>
+
+                            <xs:element name="Trigger" type="TriggerType"
+                                        minOccurs="0" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Text-transformation rule applied at a specific point in the
+                                        conversion pipeline. Multiple Trigger elements are processed
+                                        in declaration order. See TriggerType for the full pipeline
+                                        description and executeAt syntax.
+                                    </xs:documentation>
+                                </xs:annotation>
                             </xs:element>
 
                         </xs:sequence>

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -218,6 +218,10 @@ namespace Utils.NumberToString
                 string? dimType = string.IsNullOrEmpty(variant.DimensionType)
                     ? null : NormalizeDimName(variant.DimensionType);
 
+                if (dimType != null && string.IsNullOrEmpty(variant.VariantValue) && string.IsNullOrEmpty(variant.VariantValues))
+                    throw new InvalidOperationException(
+                        $"Variant with type=\"{variant.DimensionType}\" must declare either a \"variant\" or a \"values\" attribute.");
+
                 // values="a,b,c" expands to one rule per value; variant="x" is the single-value form.
                 IEnumerable<string> dimValues =
                     !string.IsNullOrEmpty(variant.VariantValues)
@@ -326,13 +330,20 @@ namespace Utils.NumberToString
                     return entry;
                 }
 
+                // First forms from elements that omit string=/to= become defaults
+                // (empty-constraint fallback so no-variant calls still resolve correctly).
+                var fallbackExceptions = new Dictionary<long, string>();
+                var fallbackWordRules  = new Dictionary<string, string>();
+
                 foreach (var exc in ordinals?.Exceptions ?? [])
                 {
                     if (exc.FormVariants?.Count > 0)
                     {
+                        bool captureFirst = exc.StringValue == null;
                         foreach (var (c, form) in ExpandFormVariants(exc.FormVariants, parsedDimensions,
                             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)))
                         {
+                            if (captureFirst) { fallbackExceptions.TryAdd(exc.Value, form); captureFirst = false; }
                             var entry = GetOrAddSynthetic(ConstraintKey(c), c);
                             entry.e[exc.Value] = form;
                         }
@@ -343,17 +354,49 @@ namespace Utils.NumberToString
                 {
                     if (rule.FormVariants?.Count > 0)
                     {
+                        bool captureFirst = rule.To == null;
                         foreach (var (c, form) in ExpandFormVariants(rule.FormVariants, parsedDimensions,
                             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)))
                         {
+                            if (captureFirst) { fallbackWordRules.TryAdd(rule.From, form); captureFirst = false; }
                             var entry = GetOrAddSynthetic(ConstraintKey(c), c);
                             entry.w[rule.From] = form;
                         }
                     }
                 }
 
+                // Merge synthetic exceptions/wordRules into any container rule sharing the same
+                // constraint key. Without this, a container rule (suffix=sten, exceptions={}) and
+                // a synthetic rule (exceptions={1:"ersten",...}, suffix=null) both have specificity
+                // 3 and FindBestOrdinalVariant picks whichever appears first, losing the other's data.
+                var containerKeyToIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+                for (int i = 0; i < result.Count; i++)
+                    containerKeyToIndex[ConstraintKey(result[i].Constraints)] = i;
+
                 foreach (var (constraints, exceptions, wordRules) in syntheticByKey.Values)
-                    result.Add(new NumberToStringConverter.OrdinalVariantRule(constraints, exceptions, wordRules, null, null));
+                {
+                    var key = ConstraintKey(constraints);
+                    if (containerKeyToIndex.TryGetValue(key, out var idx))
+                    {
+                        var existing = result[idx];
+                        var mergedExc = new Dictionary<long, string>(existing.Exceptions);
+                        foreach (var kv in exceptions) mergedExc[kv.Key] = kv.Value;
+                        var mergedWr = new Dictionary<string, string>(existing.WordRules);
+                        foreach (var kv in wordRules) mergedWr[kv.Key] = kv.Value;
+                        result[idx] = new NumberToStringConverter.OrdinalVariantRule(
+                            existing.Constraints, mergedExc, mergedWr,
+                            existing.Suffix, existing.RemoveTrailing);
+                    }
+                    else
+                    {
+                        result.Add(new NumberToStringConverter.OrdinalVariantRule(constraints, exceptions, wordRules, null, null));
+                    }
+                }
+
+                if (fallbackExceptions.Count > 0 || fallbackWordRules.Count > 0)
+                    result.Add(new NumberToStringConverter.OrdinalVariantRule(
+                        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                        fallbackExceptions, fallbackWordRules, null, null));
 
                 return result;
             }
@@ -365,6 +408,10 @@ namespace Utils.NumberToString
             {
                 string? dimType = string.IsNullOrEmpty(variant.DimensionType)
                     ? null : NormalizeDimName(variant.DimensionType);
+
+                if (dimType != null && string.IsNullOrEmpty(variant.VariantValue) && string.IsNullOrEmpty(variant.VariantValues))
+                    throw new InvalidOperationException(
+                        $"OrdinalVariant with type=\"{variant.DimensionType}\" must declare either a \"variant\" or a \"values\" attribute.");
 
                 // values="a,b,c" expands to one rule per value; variant="x" is the single-value form.
                 IEnumerable<string> dimValues =

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -183,18 +183,32 @@ namespace Utils.NumberToString
                 Dictionary<string, string> inheritedConstraints,
                 List<NumberToStringConverter.VariantRule> result)
             {
-                var constraints = new Dictionary<string, string>(inheritedConstraints, StringComparer.OrdinalIgnoreCase);
-                if (!string.IsNullOrEmpty(variant.DimensionType) && !string.IsNullOrEmpty(variant.VariantValue))
-                    constraints[NormalizeDimName(variant.DimensionType)] = variant.VariantValue;
+                string? dimType = string.IsNullOrEmpty(variant.DimensionType)
+                    ? null : NormalizeDimName(variant.DimensionType);
 
-                result.Add(new NumberToStringConverter.VariantRule(
-                    constraints,
-                    (variant.Replacements ?? [])
-                        .Select(r => new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue, r.Scope))
-                        .ToList()));
+                // values="a,b,c" expands to one rule per value; variant="x" is the single-value form.
+                IEnumerable<string> dimValues =
+                    !string.IsNullOrEmpty(variant.VariantValues)
+                        ? variant.VariantValues.Split(',').Select(v => v.Trim()).Where(v => v.Length > 0)
+                        : !string.IsNullOrEmpty(variant.VariantValue)
+                            ? [variant.VariantValue]
+                            : [""];
 
-                foreach (var child in variant.NestedVariants ?? [])
-                    CollectVariantRules(child, constraints, result);
+                var replacements = (variant.Replacements ?? [])
+                    .Select(r => new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue, r.Scope))
+                    .ToList();
+
+                foreach (var dimValue in dimValues)
+                {
+                    var constraints = new Dictionary<string, string>(inheritedConstraints, StringComparer.OrdinalIgnoreCase);
+                    if (dimType != null && dimValue.Length > 0)
+                        constraints[dimType] = dimValue;
+
+                    result.Add(new NumberToStringConverter.VariantRule(constraints, replacements));
+
+                    foreach (var child in variant.NestedVariants ?? [])
+                        CollectVariantRules(child, constraints, result);
+                }
             }
 
             IReadOnlyList<NumberToStringConverter.OrdinalVariantRule> ParseOrdinalVariants(OrdinalsType? ordinals)
@@ -214,19 +228,34 @@ namespace Utils.NumberToString
                 Dictionary<string, string> inheritedConstraints,
                 List<NumberToStringConverter.OrdinalVariantRule> result)
             {
-                var constraints = new Dictionary<string, string>(inheritedConstraints, StringComparer.OrdinalIgnoreCase);
-                if (!string.IsNullOrEmpty(variant.DimensionType) && !string.IsNullOrEmpty(variant.VariantValue))
-                    constraints[NormalizeDimName(variant.DimensionType)] = variant.VariantValue;
+                string? dimType = string.IsNullOrEmpty(variant.DimensionType)
+                    ? null : NormalizeDimName(variant.DimensionType);
 
-                result.Add(new NumberToStringConverter.OrdinalVariantRule(
-                    constraints,
-                    variant.Exceptions?.ToDictionary(e => e.Value, e => e.StringValue) ?? new Dictionary<long, string>(),
-                    variant.Rules?.ToDictionary(r => r.From, r => r.To) ?? new Dictionary<string, string>(),
-                    variant.Suffix,
-                    variant.RemoveTrailing));
+                // values="a,b,c" expands to one rule per value; variant="x" is the single-value form.
+                IEnumerable<string> dimValues =
+                    !string.IsNullOrEmpty(variant.VariantValues)
+                        ? variant.VariantValues.Split(',').Select(v => v.Trim()).Where(v => v.Length > 0)
+                        : !string.IsNullOrEmpty(variant.VariantValue)
+                            ? [variant.VariantValue]
+                            : [""];
 
-                foreach (var child in variant.NestedVariants ?? [])
-                    CollectOrdinalVariants(child, constraints, result);
+                var exceptions = variant.Exceptions?.ToDictionary(e => e.Value, e => e.StringValue)
+                    ?? new Dictionary<long, string>();
+                var wordRules = variant.Rules?.ToDictionary(r => r.From, r => r.To)
+                    ?? new Dictionary<string, string>();
+
+                foreach (var dimValue in dimValues)
+                {
+                    var constraints = new Dictionary<string, string>(inheritedConstraints, StringComparer.OrdinalIgnoreCase);
+                    if (dimType != null && dimValue.Length > 0)
+                        constraints[dimType] = dimValue;
+
+                    result.Add(new NumberToStringConverter.OrdinalVariantRule(
+                        constraints, exceptions, wordRules, variant.Suffix, variant.RemoveTrailing));
+
+                    foreach (var child in variant.NestedVariants ?? [])
+                        CollectOrdinalVariants(child, constraints, result);
+                }
             }
 
             var options = new NumberToStringConverterOptions

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -141,7 +141,9 @@ namespace Utils.NumberToString
             );
 
             static IEnumerable<NumberToStringConverter.ReplacementRule> ParseReplacements(ReplacementsListType list) =>
-                list?.Replacements?.Select(r => new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue, r.Scope))
+                list?.Replacements?
+                    .Where(r => r.NewValue != null)
+                    .Select(r => new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue!, r.Scope))
                 ?? [];
 
             static IReadOnlyList<NumberToStringConverter.VariantDimension> ParseVariantDimensions(VariantsType variants) =>
@@ -169,12 +171,42 @@ namespace Utils.NumberToString
 
             IReadOnlyList<NumberToStringConverter.VariantRule> ParseVariantRules(VariantsType variants)
             {
-                if (variants?.Variants == null || variants.Variants.Count == 0)
-                    return new List<NumberToStringConverter.VariantRule>();
-
                 var result = new List<NumberToStringConverter.VariantRule>();
-                foreach (var variant in variants.Variants)
-                    CollectVariantRules(variant, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), result);
+
+                if (variants?.Variants?.Count > 0)
+                {
+                    foreach (var variant in variants.Variants)
+                        CollectVariantRules(variant, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), result);
+                }
+
+                // Expand form-variant replacements into synthetic VariantRule entries.
+                // Multiple <Replacement> elements that share a constraint set are merged so that
+                // one VariantRule entry holds all replacement rules for that combination.
+                var syntheticByKey =
+                    new Dictionary<string, (Dictionary<string, string> Constraints,
+                                            List<NumberToStringConverter.ReplacementRule> Replacements)>(StringComparer.Ordinal);
+
+                foreach (var repl in language.Replacements?.Replacements ?? [])
+                {
+                    if (repl.FormVariants?.Count > 0)
+                    {
+                        foreach (var (c, form) in ExpandFormVariants(repl.FormVariants, parsedDimensions,
+                            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)))
+                        {
+                            var key = ConstraintKey(c);
+                            if (!syntheticByKey.TryGetValue(key, out var entry))
+                            {
+                                entry = (c, []);
+                                syntheticByKey[key] = entry;
+                            }
+                            entry.Replacements.Add(new NumberToStringConverter.ReplacementRule(repl.OldValue, form, repl.Scope));
+                        }
+                    }
+                }
+
+                foreach (var (constraints, replacements) in syntheticByKey.Values)
+                    result.Add(new NumberToStringConverter.VariantRule(constraints, replacements));
+
                 return result;
             }
 
@@ -195,7 +227,8 @@ namespace Utils.NumberToString
                             : [""];
 
                 var replacements = (variant.Replacements ?? [])
-                    .Select(r => new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue, r.Scope))
+                    .Where(r => r.NewValue != null)
+                    .Select(r => new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue!, r.Scope))
                     .ToList();
 
                 foreach (var dimValue in dimValues)
@@ -211,15 +244,117 @@ namespace Utils.NumberToString
                 }
             }
 
+            // Returns a stable string key for a constraint dictionary, used to merge form-variant
+            // rules that share the same (dimension-type, dimension-value) combination.
+            static string ConstraintKey(IReadOnlyDictionary<string, string> c) =>
+                string.Join("|", c.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+                                   .Select(kvp => $"{kvp.Key}={kvp.Value}"));
+
+            // Walks a FormVariantType tree and yields (constraints, form) pairs.
+            // Intermediate nodes (variant attribute present, children present) add one constraint
+            // and recurse; leaf nodes (forms attribute present) expand positional entries using the
+            // matching Dimension declaration order.
+            IEnumerable<(Dictionary<string, string> Constraints, string Form)> ExpandFormVariants(
+                IEnumerable<FormVariantType> nodes,
+                IReadOnlyList<NumberToStringConverter.VariantDimension> dims,
+                IReadOnlyDictionary<string, string> inherited)
+            {
+                foreach (var node in nodes)
+                {
+                    var constraints = new Dictionary<string, string>(inherited, StringComparer.OrdinalIgnoreCase);
+                    if (!string.IsNullOrEmpty(node.DimensionType) && !string.IsNullOrEmpty(node.VariantValue))
+                        constraints[NormalizeDimName(node.DimensionType)] = node.VariantValue;
+
+                    if (!string.IsNullOrEmpty(node.Forms) && !string.IsNullOrEmpty(node.DimensionType))
+                    {
+                        var dimName = NormalizeDimName(node.DimensionType);
+                        var dimValues = dims
+                            .FirstOrDefault(d =>
+                                string.Equals(d.Name, dimName, StringComparison.OrdinalIgnoreCase) ||
+                                string.Equals(d.LocalName, dimName, StringComparison.OrdinalIgnoreCase))
+                            ?.Values ?? (IReadOnlyList<string>)[];
+
+                        var entries = node.Forms.Split(',');
+                        for (int i = 0; i < Math.Min(entries.Length, dimValues.Count); i++)
+                        {
+                            var form = entries[i].Trim();
+                            if (string.IsNullOrEmpty(form)) continue;
+                            var leafConstraints = new Dictionary<string, string>(constraints, StringComparer.OrdinalIgnoreCase)
+                                { [dimName] = dimValues[i] };
+                            yield return (leafConstraints, form);
+                        }
+                    }
+                    else
+                    {
+                        foreach (var pair in ExpandFormVariants(node.NestedVariants ?? [], dims, constraints))
+                            yield return pair;
+                    }
+                }
+            }
+
             IReadOnlyList<NumberToStringConverter.OrdinalVariantRule> ParseOrdinalVariants(OrdinalsType? ordinals)
             {
-                var container = ordinals?.OrdinalVariantsContainer;
-                if (container?.Variants == null || container.Variants.Count == 0)
-                    return new List<NumberToStringConverter.OrdinalVariantRule>();
-
                 var result = new List<NumberToStringConverter.OrdinalVariantRule>();
-                foreach (var variant in container.Variants)
-                    CollectOrdinalVariants(variant, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), result);
+
+                // --- Structural OrdinalVariants container (suffix/removeTrailing/word-rule overrides) ---
+                var container = ordinals?.OrdinalVariantsContainer;
+                if (container?.Variants?.Count > 0)
+                {
+                    foreach (var variant in container.Variants)
+                        CollectOrdinalVariants(variant, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), result);
+                }
+
+                // --- Form-variant expansion from OrdinalException and Ordinal elements ---
+                // Multiple elements can contribute to the same constraint set (e.g. an exception for
+                // value 1 and a word rule for "один" both needing {gender=feminin, case=acc} = "первую").
+                // We merge them into a single OrdinalVariantRule per constraint key so that
+                // FindBestOrdinalVariant returns one rule containing both the exception dict and the
+                // word-rule dict for that combination — preventing priority collisions at runtime.
+                var syntheticByKey =
+                    new Dictionary<string, (Dictionary<string, string> Constraints,
+                                            Dictionary<long, string> Exceptions,
+                                            Dictionary<string, string> WordRules)>(StringComparer.Ordinal);
+
+                (Dictionary<string, string> c, Dictionary<long, string> e, Dictionary<string, string> w)
+                    GetOrAddSynthetic(string key, Dictionary<string, string> constraints)
+                {
+                    if (!syntheticByKey.TryGetValue(key, out var entry))
+                    {
+                        entry = (constraints, new Dictionary<long, string>(), new Dictionary<string, string>());
+                        syntheticByKey[key] = entry;
+                    }
+                    return entry;
+                }
+
+                foreach (var exc in ordinals?.Exceptions ?? [])
+                {
+                    if (exc.FormVariants?.Count > 0)
+                    {
+                        foreach (var (c, form) in ExpandFormVariants(exc.FormVariants, parsedDimensions,
+                            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)))
+                        {
+                            var entry = GetOrAddSynthetic(ConstraintKey(c), c);
+                            entry.e[exc.Value] = form;
+                        }
+                    }
+                }
+
+                foreach (var rule in ordinals?.Rules ?? [])
+                {
+                    if (rule.FormVariants?.Count > 0)
+                    {
+                        foreach (var (c, form) in ExpandFormVariants(rule.FormVariants, parsedDimensions,
+                            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)))
+                        {
+                            var entry = GetOrAddSynthetic(ConstraintKey(c), c);
+                            entry.w[rule.From] = form;
+                        }
+                    }
+                }
+
+                foreach (var (constraints, exceptions, wordRules) in syntheticByKey.Values)
+                    result.Add(new NumberToStringConverter.OrdinalVariantRule(constraints, exceptions, wordRules, null, null));
+
                 return result;
             }
 
@@ -239,9 +374,11 @@ namespace Utils.NumberToString
                             ? [variant.VariantValue]
                             : [""];
 
-                var exceptions = variant.Exceptions?.ToDictionary(e => e.Value, e => e.StringValue)
+                var exceptions = variant.Exceptions?.Where(e => e.StringValue != null)
+                    .ToDictionary(e => e.Value, e => e.StringValue!)
                     ?? new Dictionary<long, string>();
-                var wordRules = variant.Rules?.ToDictionary(r => r.From, r => r.To)
+                var wordRules = variant.Rules?.Where(r => r.To != null)
+                    .ToDictionary(r => r.From, r => r.To!)
                     ?? new Dictionary<string, string>();
 
                 foreach (var dimValue in dimValues)
@@ -281,9 +418,13 @@ namespace Utils.NumberToString
                 FractionSeparator = language.FractionSeparator,
                 OrdinalSuffix = language.Ordinals?.Suffix,
                 OrdinalRemoveTrailing = language.Ordinals?.RemoveTrailing,
-                OrdinalExceptions = language.Ordinals?.Exceptions?.ToDictionary(e => e.Value, e => e.StringValue)
+                OrdinalExceptions = language.Ordinals?.Exceptions?
+                    .Where(e => e.StringValue != null)
+                    .ToDictionary(e => e.Value, e => e.StringValue!)
                     ?? new Dictionary<long, string>(),
-                OrdinalWordRules = language.Ordinals?.Rules?.ToDictionary(r => r.From, r => r.To)
+                OrdinalWordRules = language.Ordinals?.Rules?
+                    .Where(r => r.To != null)
+                    .ToDictionary(r => r.From, r => r.To!)
                     ?? new Dictionary<string, string>(),
                 OrdinalPrefix = language.Ordinals?.Prefix,
                 OrdinalVariants = ParseOrdinalVariants(language.Ordinals),

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -269,7 +269,12 @@ namespace Utils.NumberToString
                     if (!string.IsNullOrEmpty(node.DimensionType) && !string.IsNullOrEmpty(node.VariantValue))
                         constraints[NormalizeDimName(node.DimensionType)] = node.VariantValue;
 
-                    if (!string.IsNullOrEmpty(node.Forms) && !string.IsNullOrEmpty(node.DimensionType))
+                    if (!string.IsNullOrEmpty(node.Value))
+                    {
+                        // Single-value shorthand: variant="X" value="form" — yields exactly one (constraints, form) pair.
+                        yield return (constraints, node.Value);
+                    }
+                    else if (!string.IsNullOrEmpty(node.Forms) && !string.IsNullOrEmpty(node.DimensionType))
                     {
                         var dimName = NormalizeDimName(node.DimensionType);
                         var dimValues = dims
@@ -442,6 +447,70 @@ namespace Utils.NumberToString
                 }
             }
 
+            // Parses "group(0,1,-1)" → (Group, [0,1,-1]), "end" → (End, null), etc.
+            static (NumberToStringConverter.TriggerAt At, int[]? Indices) ParseExecuteAt(string raw)
+            {
+                if (string.IsNullOrWhiteSpace(raw)) return (NumberToStringConverter.TriggerAt.End, null);
+                raw = raw.Trim();
+                int parenIdx = raw.IndexOf('(');
+                string core = parenIdx >= 0 ? raw[..parenIdx].Trim() : raw;
+                string? indexPart = parenIdx >= 0 ? raw[(parenIdx + 1)..].TrimEnd(')').Trim() : null;
+
+                var at = core.ToLowerInvariant() switch
+                {
+                    "group"          => NumberToStringConverter.TriggerAt.Group,
+                    "groupwithscale" => NumberToStringConverter.TriggerAt.GroupWithScale,
+                    _                => NumberToStringConverter.TriggerAt.End,
+                };
+
+                int[]? indices = null;
+                if (indexPart != null)
+                {
+                    indices = indexPart.Split(',')
+                        .Select(s => s.Trim()).Where(s => s.Length > 0)
+                        .Select(s => int.Parse(s, System.Globalization.CultureInfo.InvariantCulture))
+                        .ToArray();
+                    if (indices.Length == 0) indices = null;
+                }
+                return (at, indices);
+            }
+
+            IReadOnlyList<NumberToStringConverter.TriggerRule> ParseTriggers(List<TriggerType>? triggers)
+            {
+                if (triggers == null || triggers.Count == 0) return [];
+
+                var result = new List<NumberToStringConverter.TriggerRule>();
+                foreach (var trigger in triggers)
+                {
+                    var (at, indices) = ParseExecuteAt(trigger.ExecuteAt);
+                    var replaces = new List<NumberToStringConverter.TriggerReplace>();
+
+                    foreach (var replace in trigger.Replaces ?? [])
+                    {
+                        string? defaultTo = replace.To;
+                        var forms = new List<(IReadOnlyDictionary<string, string>, string)>();
+
+                        if (replace.FormVariants?.Count > 0)
+                        {
+                            bool captureFirst = defaultTo == null;
+                            foreach (var (constraints, form) in ExpandFormVariants(
+                                replace.FormVariants, parsedDimensions,
+                                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)))
+                            {
+                                if (captureFirst) { defaultTo = form; captureFirst = false; }
+                                forms.Add((constraints, form));
+                            }
+                        }
+
+                        replaces.Add(new NumberToStringConverter.TriggerReplace(
+                            replace.From, replace.IsRegex, forms, defaultTo));
+                    }
+
+                    result.Add(new NumberToStringConverter.TriggerRule(at, indices, replaces));
+                }
+                return result;
+            }
+
             var options = new NumberToStringConverterOptions
             {
                 Group = language.GroupSize,
@@ -477,6 +546,7 @@ namespace Utils.NumberToString
                 OrdinalVariants = ParseOrdinalVariants(language.Ordinals),
                 VariantDimensions = parsedDimensions,
                 VariantRules = ParseVariantRules(language.Variants),
+                Triggers = ParseTriggers(language.Triggers),
                 YearFormat = language.YearFormat == null ? null : new YearFormatOptions(
                     language.YearFormat.HundredWord,
                     language.YearFormat.ZeroConnector,

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -85,6 +85,7 @@ namespace Utils.NumberToString
 
             VariantDimensions = (options.VariantDimensions ?? []).ToImmutableArray();
             VariantRules = (options.VariantRules ?? []).ToImmutableArray();
+            Triggers = (options.Triggers ?? []).ToImmutableArray();
             _yearFormat = options.YearFormat;
             // Index both canonical name and localName so both are accepted in API calls and XML constraints.
             _dimensionIndex = VariantDimensions
@@ -202,6 +203,12 @@ namespace Utils.NumberToString
         /// </summary>
         public IReadOnlyList<VariantRule> VariantRules { get; }
 
+        /// <summary>
+        /// Trigger rules applied at specific points in the conversion pipeline.
+        /// Processed in declaration order.
+        /// </summary>
+        public IReadOnlyList<TriggerRule> Triggers { get; }
+
         private readonly YearFormatOptions? _yearFormat;
 
         /// <summary>Year-format options, or <see langword="null"/> when not configured.</summary>
@@ -224,6 +231,72 @@ namespace Utils.NumberToString
         /// Used by <see cref="NumberToStringConverterOptions"/> for round-trip cloning.
         /// </summary>
         internal Func<string, string>? RawAdjustFunction => _rawAdjustFunction;
+
+        /// <summary>
+        /// Specifies when a <see cref="TriggerRule"/> fires in the conversion pipeline.
+        /// </summary>
+        public enum TriggerAt
+        {
+            /// <summary>Fires on the digit-only text of a group, before the scale name is appended.</summary>
+            Group,
+            /// <summary>Fires on the digit+scale text of a group, after per-group Replacements are applied.</summary>
+            GroupWithScale,
+            /// <summary>Fires on the fully assembled text, after global Replacements and Variants, before FinalizeWriting.</summary>
+            End,
+        }
+
+        /// <summary>
+        /// A compiled text-replacement rule inside a <see cref="TriggerRule"/>.
+        /// When the trigger fires, the most specific matching variant form is selected and
+        /// applied exactly once; <see cref="DefaultTo"/> is used when nothing matches.
+        /// </summary>
+        public sealed class TriggerReplace
+        {
+            /// <summary>Initializes a new <see cref="TriggerReplace"/>.</summary>
+            public TriggerReplace(
+                string from,
+                bool isRegex,
+                IReadOnlyList<(IReadOnlyDictionary<string, string> Constraints, string To)> forms,
+                string? defaultTo)
+            {
+                From = from;
+                IsRegex = isRegex;
+                Forms = forms;
+                DefaultTo = defaultTo;
+            }
+            /// <summary>Gets the text or regex pattern to match.</summary>
+            public string From { get; }
+            /// <summary>Gets whether <see cref="From"/> is a .NET regular expression.</summary>
+            public bool IsRegex { get; }
+            /// <summary>
+            /// Gets the variant-specific forms ordered by declaration order.
+            /// At runtime the most specific match (most constraints) wins.
+            /// </summary>
+            public IReadOnlyList<(IReadOnlyDictionary<string, string> Constraints, string To)> Forms { get; }
+            /// <summary>Gets the unconditional default replacement used when no variant form matches.</summary>
+            public string? DefaultTo { get; }
+        }
+
+        /// <summary>
+        /// A trigger that fires at a specific position in the conversion pipeline and applies
+        /// one or more text replacements, each optionally variant-conditioned.
+        /// </summary>
+        public sealed class TriggerRule
+        {
+            /// <summary>Initializes a new <see cref="TriggerRule"/>.</summary>
+            public TriggerRule(TriggerAt executeAt, int[]? groupIndices, IReadOnlyList<TriggerReplace> replaces)
+            {
+                ExecuteAt = executeAt;
+                GroupIndices = groupIndices;
+                Replaces = replaces;
+            }
+            /// <summary>Gets when this trigger fires.</summary>
+            public TriggerAt ExecuteAt { get; }
+            /// <summary>Gets the group indices this trigger is restricted to, or <see langword="null"/> for all groups.</summary>
+            public int[]? GroupIndices { get; }
+            /// <summary>Gets the replacement rules applied when this trigger fires.</summary>
+            public IReadOnlyList<TriggerReplace> Replaces { get; }
+        }
 
         /// <summary>
         /// Converts an integer to its string representation.
@@ -345,9 +418,11 @@ namespace Utils.NumberToString
             bool isNegative = number.Sign == -1;
             BigInteger abs = isNegative ? BigInteger.Abs(number) : number;
 
-            string raw = ConvertRaw(abs);
+            var query = BuildVariantQuery(variants);
+            string raw = ConvertRaw(abs, query);
             if (_rawAdjustFunction != null) raw = _rawAdjustFunction(raw);
-            raw = ApplyVariantRules(raw, BuildVariantQuery(variants));
+            raw = ApplyVariantRules(raw, query);
+            raw = ApplyTriggers(raw, TriggerAt.End, null, query);
             string final = LanguageSpecifics.FinalizeWriting(LanguageIdentifier, raw);
 
             return isNegative ? Minus.Replace("*", final) : final;
@@ -356,7 +431,7 @@ namespace Utils.NumberToString
         /// <summary>
         /// Produces the raw text for a positive number without any adjustment or finalization.
         /// </summary>
-        private string ConvertRaw(BigInteger abs)
+        private string ConvertRaw(BigInteger abs, IReadOnlyDictionary<string, string>? variantQuery = null)
         {
             if (abs.Between(long.MinValue, long.MaxValue) && Exceptions.TryGetValue((long)abs, out var exValue))
                 return exValue;
@@ -372,8 +447,13 @@ namespace Utils.NumberToString
                 var group = (long)(remaining % groupValue);
                 if (group != 0)
                 {
-                    string resValue = ConvertGroup(maxGroup, group) + Separator + Scale.GetScaleName(groupNumber).ToPlural(group);
+                    string digits = ConvertGroup(maxGroup, group);
+                    digits = ApplyTriggers(digits, TriggerAt.Group, groupNumber, variantQuery);
+
+                    string resValue = digits + Separator + Scale.GetScaleName(groupNumber).ToPlural(group);
                     resValue = ApplyReplacements(resValue);
+                    resValue = ApplyTriggers(resValue, TriggerAt.GroupWithScale, groupNumber, variantQuery);
+
                     groupsValues.Push(resValue.Trim());
                 }
                 remaining /= groupValue;
@@ -452,6 +532,64 @@ namespace Utils.NumberToString
                 ReplacementScope.LastWord   => ApplyLastWordReplacement(text, replacement.OldValue, replacement.NewValue),
                 _                           => text,
             };
+
+        /// <summary>
+        /// Applies all matching triggers for the given pipeline position to <paramref name="text"/>.
+        /// A trigger matches when its <see cref="TriggerRule.ExecuteAt"/> equals <paramref name="at"/>
+        /// and, if group indices are specified, <paramref name="groupIndex"/> is among them.
+        /// Each Replace within a matching trigger selects the most specific form that satisfies
+        /// <paramref name="query"/>, falling back to <see cref="TriggerReplace.DefaultTo"/>.
+        /// </summary>
+        private string ApplyTriggers(string text, TriggerAt at, int? groupIndex, IReadOnlyDictionary<string, string>? query)
+        {
+            if (Triggers.Count == 0) return text;
+
+            foreach (var trigger in Triggers)
+            {
+                if (trigger.ExecuteAt != at) continue;
+                if (trigger.GroupIndices != null
+                    && (groupIndex == null || !Array.Exists(trigger.GroupIndices, i => i == groupIndex.Value)))
+                    continue;
+
+                foreach (var replace in trigger.Replaces)
+                    text = ApplyTriggerReplace(text, replace, query);
+            }
+            return text;
+        }
+
+        /// <summary>
+        /// Applies a single trigger replace to <paramref name="text"/>, selecting the most specific
+        /// variant form that matches <paramref name="query"/>. Falls back to <see cref="TriggerReplace.DefaultTo"/>.
+        /// Skips the replacement entirely when neither a matching form nor a default exists.
+        /// </summary>
+        private static string ApplyTriggerReplace(string text, TriggerReplace replace, IReadOnlyDictionary<string, string>? query)
+        {
+            string? bestTo = null;
+            int bestScore = -1;
+
+            if (query != null)
+            {
+                foreach (var (constraints, to) in replace.Forms)
+                {
+                    bool matches = constraints.All(c =>
+                        query.TryGetValue(c.Key, out var v) &&
+                        string.Equals(v, c.Value, StringComparison.OrdinalIgnoreCase));
+
+                    if (matches && constraints.Count > bestScore)
+                    {
+                        bestTo = to;
+                        bestScore = constraints.Count;
+                    }
+                }
+            }
+
+            string? effectiveTo = bestTo ?? replace.DefaultTo;
+            if (effectiveTo == null) return text;
+
+            return replace.IsRegex
+                ? Regex.Replace(text, replace.From, effectiveTo)
+                : text.Replace(replace.From, effectiveTo, StringComparison.Ordinal);
+        }
 
         /// <summary>
         /// Replaces <paramref name="oldValue"/> at the end of <paramref name="text"/> when it
@@ -712,10 +850,12 @@ namespace Utils.NumberToString
             if (OrdinalExceptions.TryGetValue(absNumber, out var exception))
                 return isNegative ? Minus.Replace("*", exception) : exception;
 
-            string raw = absNumber == 0 ? Zero : ConvertRaw((BigInteger)absNumber);
+            string raw = absNumber == 0 ? Zero : ConvertRaw((BigInteger)absNumber, activeVariants);
             raw = ApplyVariantRules(raw, activeVariants);
             string ordinal = ApplyOrdinalTransform(raw, activeVariant);
-            string final = AdjustFunction(ordinal);
+            if (_rawAdjustFunction != null) ordinal = _rawAdjustFunction(ordinal);
+            ordinal = ApplyTriggers(ordinal, TriggerAt.End, null, activeVariants);
+            string final = LanguageSpecifics.FinalizeWriting(LanguageIdentifier, ordinal);
             if (!string.IsNullOrEmpty(OrdinalPrefix))
                 final = OrdinalPrefix + final;
             return isNegative ? Minus.Replace("*", final) : final;

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -387,6 +387,35 @@ namespace Utils.NumberToString
         }
 
         /// <summary>
+        /// Rounds <paramref name="value"/> to <paramref name="significantDigits"/> most significant digits
+        /// using standard rounding (≥ 5 rounds up, &lt; 5 rounds down).
+        /// Returns <paramref name="value"/> unchanged when it has fewer or equal digits than requested.
+        /// </summary>
+        /// <param name="value">The value to round (negative values are handled correctly).</param>
+        /// <param name="significantDigits">Number of significant digits to keep. Must be ≥ 1.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="significantDigits"/> is less than 1.
+        /// </exception>
+        public static BigInteger RoundToSignificantDigits(BigInteger value, int significantDigits)
+        {
+            if (significantDigits < 1)
+                throw new ArgumentOutOfRangeException(nameof(significantDigits), "Must be at least 1.");
+            if (value == 0) return 0;
+
+            bool negative = value < 0;
+            BigInteger abs = negative ? BigInteger.Abs(value) : value;
+
+            int numDigits = abs.ToString().Length;
+            if (significantDigits >= numDigits) return value;
+
+            int scaleExp = numDigits - significantDigits;
+            BigInteger scale = BigInteger.Pow(10, scaleExp);
+            BigInteger rounded = (abs + scale / 2) / scale * scale;
+
+            return negative ? -rounded : rounded;
+        }
+
+        /// <summary>
         /// Converts a BigInteger to its string representation using the default variant
         /// (the first declared value of each dimension).
         /// </summary>
@@ -394,6 +423,19 @@ namespace Utils.NumberToString
         /// Thrown when <paramref name="number"/> exceeds <see cref="MaxNumber"/>.
         /// </exception>
         public string Convert(BigInteger number) => Convert(number, []);
+
+        /// <summary>
+        /// Converts <paramref name="number"/> rounded to <paramref name="significantDigits"/> most significant
+        /// digits into its string representation, applying optional variant parameters.
+        /// Uses standard rounding (≥ 5 rounds up). For example, 123456789 with 3 significant digits
+        /// rounds to 123000000 before conversion.
+        /// </summary>
+        /// <param name="number">The value to convert.</param>
+        /// <param name="significantDigits">Number of significant digits to keep. Must be ≥ 1.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        /// <returns>The formatted rounded number with variants applied.</returns>
+        public string Convert(BigInteger number, int significantDigits, params string[] variants)
+            => Convert(RoundToSignificantDigits(number, significantDigits), variants);
 
         /// <summary>
         /// Converts a BigInteger to its string representation, applying the specified morphological

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using System.Text.RegularExpressions;
+using Utils.Mathematics;
 using Utils.Numerics;
 using Utils.Objects;
 using Utils.String;
@@ -387,35 +388,6 @@ namespace Utils.NumberToString
         }
 
         /// <summary>
-        /// Rounds <paramref name="value"/> to <paramref name="significantDigits"/> most significant digits
-        /// using standard rounding (≥ 5 rounds up, &lt; 5 rounds down).
-        /// Returns <paramref name="value"/> unchanged when it has fewer or equal digits than requested.
-        /// </summary>
-        /// <param name="value">The value to round (negative values are handled correctly).</param>
-        /// <param name="significantDigits">Number of significant digits to keep. Must be ≥ 1.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// Thrown when <paramref name="significantDigits"/> is less than 1.
-        /// </exception>
-        public static BigInteger RoundToSignificantDigits(BigInteger value, int significantDigits)
-        {
-            if (significantDigits < 1)
-                throw new ArgumentOutOfRangeException(nameof(significantDigits), "Must be at least 1.");
-            if (value == 0) return 0;
-
-            bool negative = value < 0;
-            BigInteger abs = negative ? BigInteger.Abs(value) : value;
-
-            int numDigits = abs.ToString().Length;
-            if (significantDigits >= numDigits) return value;
-
-            int scaleExp = numDigits - significantDigits;
-            BigInteger scale = BigInteger.Pow(10, scaleExp);
-            BigInteger rounded = (abs + scale / 2) / scale * scale;
-
-            return negative ? -rounded : rounded;
-        }
-
-        /// <summary>
         /// Converts a BigInteger to its string representation using the default variant
         /// (the first declared value of each dimension).
         /// </summary>
@@ -435,7 +407,7 @@ namespace Utils.NumberToString
         /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
         /// <returns>The formatted rounded number with variants applied.</returns>
         public string Convert(BigInteger number, int significantDigits, params string[] variants)
-            => Convert(RoundToSignificantDigits(number, significantDigits), variants);
+            => Convert(MathEx.RoundToSignificantDigits(number, significantDigits), variants);
 
         /// <summary>
         /// Converts a BigInteger to its string representation, applying the specified morphological

--- a/Utils.NumberToString/NumberToStringConverterOptions.cs
+++ b/Utils.NumberToString/NumberToStringConverterOptions.cs
@@ -119,6 +119,12 @@ public sealed class NumberToStringConverterOptions
     /// <summary>Year-format configuration used by <see cref="NumberToStringConverter.ConvertYear"/>.</summary>
     public YearFormatOptions? YearFormat { get; set; }
 
+    /// <summary>
+    /// Trigger rules applied at specific points in the conversion pipeline.
+    /// Processed in declaration order.
+    /// </summary>
+    public IReadOnlyList<NumberToStringConverter.TriggerRule> Triggers { get; set; } = [];
+
     /// <summary>Creates an options object with sensible defaults. Required properties
     /// (<see cref="Zero"/>, <see cref="Minus"/>, <see cref="Groups"/>, <see cref="Scale"/>)
     /// must be set before passing to the constructor.</summary>
@@ -156,6 +162,7 @@ public sealed class NumberToStringConverterOptions
         OrdinalVariants = source.OrdinalVariants;
         VariantDimensions = source.VariantDimensions;
         VariantRules = source.VariantRules;
+        Triggers = source.Triggers;
         YearFormat = source.YearFormat;
     }
 

--- a/Utils.NumberToString/README.md
+++ b/Utils.NumberToString/README.md
@@ -697,13 +697,44 @@ de.Convert(2_000_000);  // "zwei Millionen"
 
 ---
 
+## Significant-digits precision
+
+Round a number to N most significant digits before converting, using standard rounding (≥ 5 rounds up):
+
+```csharp
+NumberToStringConverter fr = NumberToStringConverter.GetConverter("FR");
+
+fr.Convert(123456789);        // "cent vingt trois millions quatre cent cinquante six mille sept cent quatre-vingt-neuf"
+fr.Convert(123456789, 3);     // "cent vingt trois millions"         (→ 123 000 000)
+fr.Convert(123456789, 2);     // "cent vingt millions"               (→ 120 000 000)
+fr.Convert(123456789, 1);     // "cent millions"                     (→ 100 000 000)
+```
+
+The rounding is done by `MathEx.RoundToSignificantDigits` (from `omy.Utils.Mathematics`) and then
+delegates to the normal `Convert` pipeline, so variants work as expected:
+
+```csharp
+fr.Convert(123456789, 3, "gender=feminin"); // "cent vingt trois millions" (no gender change at this scale)
+```
+
+---
+
 ## Conversion pipeline
 
 ```
 number
-  → ConvertRaw          (digit groups + exceptions + language replacements)
+  → ConvertRaw:
+      for each group (millions, thousands, units, …):
+          ConvertGroup       (digit text for this group)
+          Trigger group      (optional: text-replacements on digit text)
+          append scale name
+          Replacements       (per-language substitutions)
+          Trigger groupWithScale  (optional: replacements on digit+scale text)
+          push to stack
+      assemble all groups
   → AdjustFunction      (optional user-supplied transformation)
   → ApplyVariantRules   (morphological replacements, least to most specific)
+  → Trigger end         (optional: replacements on fully assembled text)
   → FinalizeWriting     (INumberToStringLanguageSpecifics)
   → sign wrapping       (Minus template if negative)
 ```
@@ -713,10 +744,11 @@ number
 ```
 number
   → OrdinalExceptions   (integer-level early exit, e.g. 1 → "premier")
-  → ConvertRaw          (raw cardinal text, no adjustment)
+  → ConvertRaw + Triggers group/groupWithScale
   → ApplyVariantRules   (default variant values)
   → ApplyOrdinalTransform  (word rules + suffix on last word)
   → AdjustFunction      (user transform + FinalizeWriting)
+  → Trigger end
   → sign wrapping
 ```
 
@@ -754,6 +786,7 @@ Language configurations are XML files whose structure is described by
         <Fractions>…</Fractions>               <!-- optional -->
         <Ordinals suffix="…">…</Ordinals>      <!-- optional -->
         <Variants>…</Variants>                 <!-- optional -->
+        <Trigger executeAt="…">…</Trigger>     <!-- optional, one per position -->
 
     </Language>
 </Numbers>
@@ -1140,6 +1173,104 @@ to `Convert(year)`.
 
 ---
 
+### `<Trigger>` — pipeline hooks
+
+`<Trigger>` elements apply text replacements at a specific moment in the conversion pipeline,
+optionally conditioned on active morphological variant values.
+
+#### Execute positions — `executeAt`
+
+| Value | When it fires | Sees |
+|-------|--------------|------|
+| `"group"` | After `ConvertGroup` for each digit group | Digit text only (no scale name yet) |
+| `"group(N)"` | Same, but only for group N (0 = units, 1 = thousands, 2 = millions, …) | Digit text |
+| `"group(N,M,…)"` | Same, restricted to the listed group indices | Digit text |
+| `"groupWithScale"` | After per-group `Replacements`, before pushing | Digit+scale text |
+| `"groupWithScale(N)"` | Same, restricted to group N | Digit+scale text |
+| `"end"` | After full assembly, `AdjustFunction`, and `ApplyVariantRules` | Final assembled text |
+
+> **Warning**: `group` and `groupWithScale` triggers also fire during `ConvertOrdinal`. If the trigger
+> modifies a word that an ordinal word-rule targets (e.g. it replaces `"ein"` with something else),
+> the ordinal transform may not match. Use `"end"` for post-ordinal corrections.
+
+#### `<Replace>` — replacement rule
+
+Each trigger contains one or more `<Replace>` elements. They are applied in declaration order,
+independently of each other — each selects exactly one form and applies it once.
+
+```xml
+<!-- Simple unconditional replacement -->
+<Trigger executeAt="end">
+    <Replace from="et " to="&amp; " />
+</Trigger>
+
+<!-- Regex replacement -->
+<Trigger executeAt="group(0)">
+    <Replace from="^one$" to="uno" regex="true" />
+</Trigger>
+```
+
+#### Variant-conditioned replacements
+
+When a `<Replace>` has `<Variant>` children, the most specific matching form is selected
+(same best-match algorithm as ordinal variants). The `to=` attribute becomes the unconditional
+default used when no form matches the active variant query.
+
+**Positional forms** — one form per dimension value in declaration order:
+
+```xml
+<Trigger executeAt="end">
+    <!-- genus dimension: maskulin=eins, feminin=eine, neutrum=eins -->
+    <Replace from="ein$" regex="true" to="eins">
+        <Variant type="genus" forms="eins,eine,eins" />
+    </Replace>
+</Trigger>
+```
+
+**Single-value shorthand** with `value=` — overrides exactly one dimension value:
+
+```xml
+<Trigger executeAt="end">
+    <!-- default "eins", but feminin → "eine" -->
+    <Replace from="ein$" regex="true" to="eins">
+        <Variant type="genus" variant="feminin" value="eine" />
+    </Replace>
+</Trigger>
+```
+
+**No default** — when `to=` is absent and no variant matches, the replacement is skipped entirely
+(the regex is never evaluated):
+
+```xml
+<Trigger executeAt="group(0)">
+    <!-- fires only for feminin; other variants are untouched -->
+    <Replace from="uno" regex="false">
+        <Variant type="gender" variant="feminin" value="una" />
+    </Replace>
+</Trigger>
+```
+
+#### `<Replace>` attributes
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `from` | ✓ | Text or regex pattern to match. |
+| `to` | | Unconditional default replacement. May contain backreferences (`$1`, `${name}`) when `regex="true"`. When absent, the first expanded `<Variant>` form is used as default. |
+| `regex` | | `"true"` to treat `from` as a .NET regular expression. Default: `"false"` (literal match). |
+
+The `<Variant>` children use the same `FormVariantType` syntax as `<Replacement>`, `<Ordinal>`,
+and `<OrdinalException>`:
+
+| Attribute | Description |
+|-----------|-------------|
+| `type` | Dimension name (canonical or `localName`). |
+| `variant` | Single value — marks this node as a constraint leaf. Used with `value=` or nested children. |
+| `forms` | Positional comma-separated forms, one per dimension value in declaration order. Leaf node syntax. |
+| `value` | Single output form for the specific `variant` named by `variant=`. Shorthand for single-value overrides. |
+
+---
+
 ## Related packages
 
 - `omy.Utils` — contains `NumberToStringConverter`, `NumberToStringConverterOptions`, and all built-in culture XML configurations.
+- `omy.Utils.Mathematics` — provides `MathEx.RoundToSignificantDigits` used by the significant-digits precision overload.

--- a/Utils.NumberToString/README.md
+++ b/Utils.NumberToString/README.md
@@ -27,13 +27,13 @@ dotnet add package omy.Utils.NumberToString
 | PL | Polish | ✓ | — (numbers are invariable in common usage) |
 | NL | Dutch | ✓ | — (numbers are invariable) |
 | RU | Russian | ✓ | — |
-| AR | Arabic | ✓ (1–10 masculine) | — |
+| AR | Arabic | ✓ (1–10) | gender (muzakkar/muʾannath) |
 | HE | Hebrew | ✓ | gender (standalone/zachar/nekeva) |
 | ZH | Chinese | ✓ (prefix 第) | — (no inflection) |
 | JA | Japanese | ✓ (prefix 第) | — (no inflection) |
 | KO | Korean | ✓ (prefix 제) | — (no inflection) |
-| HI | Hindi | ✓ | — |
-| EL | Greek | ✓ | gender (αρσενικό/θηλυκό/ουδέτερο) for 1–12 |
+| HI | Hindi | ✓ | gender (strī) ordinals only |
+| EL | Greek | ✓ | gender (αρσενικό/θηλυκό/ουδέτερο) |
 | FI | Finnish | ✓ | sijamuoto (nominatiivi/partitiivi/genetiivi) |
 | CA | Catalan | ✓ | gender (masculí/femení) |
 | EU | Basque | ✓ | — (no grammatical gender) |
@@ -912,13 +912,19 @@ Allow the decimal part of a number to be expressed with a named denominator.
 
 ### `<Ordinals>` — ordinal conversion
 
-Required to enable `ConvertOrdinal()`. Resolution priority:
-`OrdinalException` → `Ordinal` rule (last word) → suffix (± strip trailing string).
+Required to enable `ConvertOrdinal()`.
+
+**Resolution order** (highest to lowest priority):
+1. Active variant exceptions — from `<OrdinalVariants>`, most-specific constraint first.
+2. Base `<OrdinalException>` — whole-number match.
+3. Active variant word rules — from `<OrdinalVariants>`, most-specific first.
+4. Base `<Ordinal>` word rule — last-word match.
+5. Default suffix (± `removeTrailing` strip).
 
 ```xml
 <Ordinals suffix="ième" removeTrailing="e">
 
-    <!-- Whole-number exceptions (highest priority) -->
+    <!-- Whole-number exceptions (checked before word rules) -->
     <OrdinalException value="1" string="premier" />
 
     <!-- Rules on the last word of the cardinal -->
@@ -935,15 +941,14 @@ Required to enable `ConvertOrdinal()`. Resolution priority:
 
 | Attribute | Description |
 |-----------|-------------|
-| `suffix` | Suffix added to the last word when no rule matches. |
-| `removeTrailing` | String to strip from the end of the last word before adding `suffix` (only when the word ends with this value). |
-| `prefix` | String prepended to the entire ordinal result (e.g. `"第"` for Chinese, `"etsõ "` for Ewe). When `prefix` is set, suffix and word rules are ignored. |
+| `suffix` | Suffix added to the last word when no word rule matches. |
+| `removeTrailing` | String to strip from the end of the last word before adding `suffix` (only when the word actually ends with this value). |
+| `prefix` | String prepended to the entire ordinal result (e.g. `"第"` for Chinese, `"etsõ "` for Ewe). May be combined with exceptions; suffix and word rules are ignored when `prefix` is set. |
 
 ```xml
 <!-- Prefix-based ordinals (ZH, JA, KO, EE) -->
 <Ordinals prefix="第">
     <!-- All numbers: "第" + cardinal -->
-    <!-- Exception: the prefix is added after AdjustFunction, before sign wrapping -->
 </Ordinals>
 
 <!-- Mixed prefix + exception (EE) -->
@@ -953,9 +958,11 @@ Required to enable `ConvertOrdinal()`. Resolution priority:
 </Ordinals>
 ```
 
-Variant-specific ordinal rules (`<OrdinalVariants>`) allow a single ordinal configuration to
-produce gender- or case-inflected ordinals. Resolution order: **variant exceptions → base
-exceptions → cardinal → variant word rules → base word rules → suffix/prefix**.
+#### Variant-specific ordinal rules — `<OrdinalVariants>`
+
+`<OrdinalVariants>` lets a single ordinal configuration produce gender- or case-inflected forms.
+Each `<Variant>` block targets one dimension value via `type=` (dimension name) and `variant=`
+(value). The most-specific matching variant (most constraints) wins.
 
 ```xml
 <Ordinals suffix="ième" removeTrailing="e">
@@ -963,13 +970,80 @@ exceptions → cardinal → variant word rules → base word rules → suffix/pr
     <Ordinal from="cinq" to="cinquième" />
 
     <OrdinalVariants>
-        <Variant type="gender" variant="féminin">
+        <Variant type="gender" variant="feminin">
             <OrdinalException value="1" string="première" />
-            <Ordinal from="cinq" to="cinquième" />  <!-- suffix -e for feminine -->
+            <!-- overrides suffix for this variant only -->
+            <!-- <suffix override> / <removeTrailing override> also available -->
         </Variant>
     </OrdinalVariants>
 </Ordinals>
 ```
+
+`<Variant>` attributes inside `<OrdinalVariants>`:
+
+| Attribute | Description |
+|-----------|-------------|
+| `type` | Dimension name (e.g. `"gender"`, `"case"`) or its `localName` alias. |
+| `variant` | Single dimension value this block applies to. |
+| `values` | Comma-separated list of values — shorthand for declaring several identical blocks. |
+| `suffix` | Suffix override for this variant (replaces the `<Ordinals>` base suffix). |
+| `removeTrailing` | `removeTrailing` override for this variant. |
+
+Nested `<Variant>` children inherit the parent constraint and add their own (cascade):
+
+```xml
+<OrdinalVariants>
+    <Variant type="gender" variant="feminin">
+        <OrdinalException value="1" string="prima" />
+        <Variant type="case" variant="accusative">
+            <OrdinalException value="1" string="primam" />  <!-- {gender=feminin, case=accusative} -->
+        </Variant>
+    </Variant>
+</OrdinalVariants>
+```
+
+#### Compact multi-gender ordinals with `forms=`
+
+When all dimension values share the same exception or word rule structure, write both forms inline
+instead of duplicating them in `<OrdinalVariants>`. The `<Variant>` child uses the `forms=`
+attribute with one form per dimension value **in declaration order**:
+
+```xml
+<Variants>
+    <Dimension name="gender" values="masculin,feminin" />
+    <!-- cardinal rules, if any -->
+</Variants>
+<Ordinals suffix="ième" removeTrailing="e">
+    <!-- forms are positionally matched to Dimension/@values: masculin, feminin -->
+    <OrdinalException value="1">
+        <Variant type="gender" forms="premier,première" />
+    </OrdinalException>
+    <!-- gender-neutral rules stay as-is -->
+    <Ordinal from="un" to="unième" />
+</Ordinals>
+```
+
+The same syntax applies to word-level rules:
+
+```xml
+<Ordinals>
+    <Ordinal from="uno">
+        <Variant type="gender" forms="primero,primera" />
+    </Ordinal>
+</Ordinals>
+```
+
+**Default form**: when `string=` is absent from `<OrdinalException>` (or `to=` from `<Ordinal>`),
+the **first form** in `forms=` order is automatically registered as the no-variant default.
+`ConvertOrdinal(1)` (no gender) returns `"premier"` without any extra configuration.
+
+**Empty entries**: an empty slot (e.g. `forms=",première"`) skips the corresponding dimension
+value — no rule is generated for that position.
+
+**When to use `<OrdinalVariants>` instead**: use it when a variant requires a suffix override,
+or when some variants need word-form mappings that do not align position-for-position with the
+dimension values (e.g. feminine-only cardinals `"una"/"duas"` that have no masculine counterpart
+among the ordinal word rules).
 
 ---
 
@@ -981,35 +1055,88 @@ Activated by calls to `Convert(number, "dimension=value", …)`.
 ```xml
 <Variants>
 
-    <!-- 1. Dimension declarations (must precede Variant elements) -->
-    <!-- The first value of each dimension is the DEFAULT -->
-    <Dimension name="gender" values="masculin,feminin" />
-    <!-- Multi-dimension example: -->
-    <!-- <Dimension name="kasus" values="nominativ,akkusativ,dativ,genitiv" /> -->
+    <!-- 1. Dimension declarations — must precede all Variant elements.
+            The FIRST value of each dimension is the default. -->
+    <Dimension name="gender" localName="genus" values="maskulin,feminin,neutrum" />
+    <Dimension name="case"   localName="kasus" values="nominativ,akkusativ,dativ,genitiv" />
 
-    <!-- 2. Variant rules -->
-    <!-- Variant with no attributes = wildcard (always applied first) -->
-    <!-- Variant with N attributes = N constraints → higher priority -->
-
-    <Variant gender="feminin">
-        <!-- scope="LastWord": replaces "un" only if it is the last word -->
-        <!-- "un million" → last word = "million" ≠ "un" → no replacement -->
-        <!-- "vingt et un" → last word = "un" → "vingt et une"            -->
-        <Replacement oldValue="un" newValue="une" scope="LastWord" />
+    <!-- 2. One-constraint rule: applied when gender=feminin is active -->
+    <Variant type="gender" variant="feminin">
+        <!-- scope="LastWord": replaces "ein" only at the end of the number text -->
+        <Replacement oldValue="ein" newValue="eine" scope="LastWord" />
     </Variant>
 
-    <!-- 2-constraint example (higher priority than genus alone):
-         see DE configuration for the full genus × kasus implementation -->
-    <!-- <Variant kasus="akkusativ" genus="maskulin">
-        <Replacement oldValue="ein" newValue="einen" scope="LastWord" />
-    </Variant> -->
+    <!-- Multi-value shorthand: both dativ and genitiv share the same body -->
+    <Variant type="case" values="dativ,genitiv">
+        <Replacement oldValue="eine" newValue="einer" scope="LastWord" />
+    </Variant>
+
+    <!-- Nested (2 constraints, higher priority): feminin + dativ -->
+    <Variant type="gender" variant="feminin">
+        <Variant type="case" variant="dativ">
+            <Replacement oldValue="eine" newValue="einer" scope="LastWord" />
+        </Variant>
+    </Variant>
 
 </Variants>
 ```
 
 **Cascade rules**: variants are applied in ascending order of constraint count. A 2-constraint
-variant can therefore override the result of a 1-constraint variant. Undeclared dimensions
-and unknown values are silently ignored.
+variant can therefore override the result of a 1-constraint variant. Unrecognised dimension
+names and unknown values are silently ignored.
+
+`<Dimension>` attributes:
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `name` | ✓ | Canonical English identifier used in API calls (`"gender"`, `"case"`). |
+| `localName` | | Optional language-specific alias (e.g. `"genus"`, `"sijamuoto"`). Normalised to `name` internally. |
+| `values` | ✓ | Comma-separated ordered list of valid values. The **first** value is the default. |
+
+`<Variant>` attributes inside `<Variants>`:
+
+| Attribute | Description |
+|-----------|-------------|
+| `type` | Dimension name (canonical or `localName`). |
+| `variant` | Single value that must be active. Mutually exclusive with `values`. |
+| `values` | Comma-separated list of values — shorthand for several identical blocks. |
+
+`<Replacement>` elements inside `<Variant>` support child `<Variant>` nodes with `forms=`
+for multi-dimensional replacements (see `FormVariantType` in the XSD):
+
+```xml
+<!-- German "ein" — four accusative/dative/genitive case forms for masculine -->
+<Replacement oldValue="ein" scope="LastWord">
+    <Variant type="gender" variant="maskulin">
+        <Variant type="case" forms="eins,einen,einem,eines" />
+    </Variant>
+</Replacement>
+```
+
+---
+
+### `<YearFormat>` — year conversion
+
+Optional. When present, `ConvertYear(int)` uses a split-at-hundreds algorithm for year values
+within the declared `<SplitRange>` elements. Years outside all ranges fall back to `Convert(year)`.
+
+```xml
+<YearFormat hundredWord="hundred" zeroConnector="oh">
+    <!-- Years 1100–1999: split at hundreds — "nineteen hundred", "nineteen oh five", ... -->
+    <SplitRange from="1100" to="1999" />
+    <!-- Years 2010–2099: also split — "twenty ten", "twenty twenty-one", ... -->
+    <SplitRange from="2010" to="2099" />
+</YearFormat>
+```
+
+| Attribute | Description |
+|-----------|-------------|
+| `hundredWord` | Word appended when the year is a round century (e.g. `"hundred"` → `"nineteen hundred"`). |
+| `zeroConnector` | Connector inserted before single-digit remainders (e.g. `"oh"` → `"twenty oh five"`). |
+
+`<SplitRange from="N" to="M" />` declares an inclusive range `[N, M]` of year values that
+use the split algorithm. Multiple ranges may be declared; ranges outside the list fall back
+to `Convert(year)`.
 
 ---
 

--- a/Utils/Mathematics/MathEx.cs
+++ b/Utils/Mathematics/MathEx.cs
@@ -51,6 +51,35 @@ public static class MathEx
     #region Round
 
     /// <summary>
+    /// Rounds <paramref name="value"/> to <paramref name="significantDigits"/> most significant digits
+    /// using standard rounding (≥ 5 rounds up, &lt; 5 rounds down).
+    /// Returns <paramref name="value"/> unchanged when it has fewer or equal digits than requested.
+    /// </summary>
+    /// <param name="value">The value to round (negative values are handled correctly).</param>
+    /// <param name="significantDigits">Number of significant digits to keep. Must be ≥ 1.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="significantDigits"/> is less than 1.
+    /// </exception>
+    public static BigInteger RoundToSignificantDigits(BigInteger value, int significantDigits)
+    {
+        if (significantDigits < 1)
+            throw new ArgumentOutOfRangeException(nameof(significantDigits), "Must be at least 1.");
+        if (value == 0) return 0;
+
+        bool negative = value < 0;
+        BigInteger abs = negative ? BigInteger.Abs(value) : value;
+
+        int numDigits = abs.ToString().Length;
+        if (significantDigits >= numDigits) return value;
+
+        int scaleExp = numDigits - significantDigits;
+        BigInteger scale = BigInteger.Pow(10, scaleExp);
+        BigInteger rounded = (abs + scale / 2) / scale * scale;
+
+        return negative ? -rounded : rounded;
+    }
+
+    /// <summary>
     /// Rounds <paramref name="value"/> to the nearest multiple of <paramref name="step"/>.
     /// If <paramref name="value"/> is exactly between two multiples, it is rounded up.
     /// </summary>

--- a/UtilsTest/Mathematics/MathExTests.cs
+++ b/UtilsTest/Mathematics/MathExTests.cs
@@ -386,4 +386,42 @@ public class MathExTests
             Assert.IsTrue(comparer.Equals(test.values, result), $"{{ {string.Join(", ", result)} }} is different from {{ {string.Join(", ", test.values)} }} expected");
         }
     }
+
+    [TestMethod]
+    public void RoundToSignificantDigits_BasicCases()
+    {
+        Assert.AreEqual(123000000, (long)MathEx.RoundToSignificantDigits(123456789, 3));
+        Assert.AreEqual(120000000, (long)MathEx.RoundToSignificantDigits(123456789, 2));
+        Assert.AreEqual(100000000, (long)MathEx.RoundToSignificantDigits(123456789, 1));
+        Assert.AreEqual(123456789, (long)MathEx.RoundToSignificantDigits(123456789, 9));
+        Assert.AreEqual(123456789, (long)MathEx.RoundToSignificantDigits(123456789, 20));
+    }
+
+    [TestMethod]
+    public void RoundToSignificantDigits_StandardRounding()
+    {
+        Assert.AreEqual(130, (long)MathEx.RoundToSignificantDigits(125, 2));   // 5 → round up
+        Assert.AreEqual(120, (long)MathEx.RoundToSignificantDigits(124, 2));   // 4 → round down
+        Assert.AreEqual(160000, (long)MathEx.RoundToSignificantDigits(155000, 2));
+    }
+
+    [TestMethod]
+    public void RoundToSignificantDigits_NegativeValues()
+    {
+        Assert.AreEqual(-123000000, (long)MathEx.RoundToSignificantDigits(-123456789, 3));
+        Assert.AreEqual(-130, (long)MathEx.RoundToSignificantDigits(-125, 2));
+    }
+
+    [TestMethod]
+    public void RoundToSignificantDigits_Zero()
+    {
+        Assert.AreEqual(System.Numerics.BigInteger.Zero, MathEx.RoundToSignificantDigits(0, 3));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentOutOfRangeException))]
+    public void RoundToSignificantDigits_ZeroDigits_Throws()
+    {
+        MathEx.RoundToSignificantDigits(123, 0);
+    }
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Utils.Mathematics;
 using Utils.NumberToString;
 using Utils.Numerics;
 
@@ -2088,47 +2089,47 @@ public class NumberToStringConverterImprovementsTests
     [TestMethod]
     public void RoundToSignificantDigits_BasicCases()
     {
-        Assert.AreEqual(123000000, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 3));
-        Assert.AreEqual(120000000, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 2));
-        Assert.AreEqual(100000000, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 1));
-        Assert.AreEqual(123456789, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 9));
-        Assert.AreEqual(123456789, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 12));
+        Assert.AreEqual(123000000, (long)MathEx.RoundToSignificantDigits(123456789, 3));
+        Assert.AreEqual(120000000, (long)MathEx.RoundToSignificantDigits(123456789, 2));
+        Assert.AreEqual(100000000, (long)MathEx.RoundToSignificantDigits(123456789, 1));
+        Assert.AreEqual(123456789, (long)MathEx.RoundToSignificantDigits(123456789, 9));
+        Assert.AreEqual(123456789, (long)MathEx.RoundToSignificantDigits(123456789, 12));
     }
 
     [TestMethod]
     public void RoundToSignificantDigits_RoundsUp_When5()
     {
         // 125 → precision 2: 125 → scale=10, (125+5)/10*10 = 130
-        Assert.AreEqual(130, (long)NumberToStringConverter.RoundToSignificantDigits(125, 2));
+        Assert.AreEqual(130, (long)MathEx.RoundToSignificantDigits(125, 2));
         // 155000 → precision 2: scale=10000, (155000+5000)/10000*10000 = 160000
-        Assert.AreEqual(160000, (long)NumberToStringConverter.RoundToSignificantDigits(155000, 2));
+        Assert.AreEqual(160000, (long)MathEx.RoundToSignificantDigits(155000, 2));
     }
 
     [TestMethod]
     public void RoundToSignificantDigits_RoundsDown_WhenBelow5()
     {
         // 124 → precision 2: scale=10, (124+5)/10*10 = 120
-        Assert.AreEqual(120, (long)NumberToStringConverter.RoundToSignificantDigits(124, 2));
+        Assert.AreEqual(120, (long)MathEx.RoundToSignificantDigits(124, 2));
     }
 
     [TestMethod]
     public void RoundToSignificantDigits_Zero_ReturnsZero()
     {
-        Assert.AreEqual(BigInteger.Zero, NumberToStringConverter.RoundToSignificantDigits(0, 3));
+        Assert.AreEqual(BigInteger.Zero, MathEx.RoundToSignificantDigits(0, 3));
     }
 
     [TestMethod]
     public void RoundToSignificantDigits_Negative_PreservesSign()
     {
-        Assert.AreEqual(-123000000, (long)NumberToStringConverter.RoundToSignificantDigits(-123456789, 3));
-        Assert.AreEqual(-130, (long)NumberToStringConverter.RoundToSignificantDigits(-125, 2));
+        Assert.AreEqual(-123000000, (long)MathEx.RoundToSignificantDigits(-123456789, 3));
+        Assert.AreEqual(-130, (long)MathEx.RoundToSignificantDigits(-125, 2));
     }
 
     [TestMethod]
     [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void RoundToSignificantDigits_ZeroDigits_Throws()
     {
-        NumberToStringConverter.RoundToSignificantDigits(123, 0);
+        MathEx.RoundToSignificantDigits(123, 0);
     }
 
     [TestMethod]

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -491,7 +491,7 @@ public class NumberToStringConverterImprovementsTests
     {
         var converter = NumberToStringConverter.GetConverter("DE");
 
-        // Without variant: counting form (GermanSpecifics: "ein" → "eins")
+        // Without variant: counting form via XML Variant {maskulin,nominativ} → "eins"
         Assert.AreEqual("eins", converter.Convert(1));
         Assert.AreEqual("eins", converter.Convert(1, "genus=maskulin"));
         Assert.AreEqual("eins", converter.Convert(1, "kasus=nominativ"));
@@ -1136,6 +1136,100 @@ public class NumberToStringConverterImprovementsTests
         Assert.AreEqual("tausend dritte", de.ConvertOrdinal(1003));
     }
 
+    [TestMethod]
+    public void ConvertOrdinal_DE_WithVariants_IrregularForm()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+
+        // schwach (weak) — used after a definite article; case order: nom/akk/dat/gen
+
+        // maskulin schwach: only non-nominativ → "sten"-type endings
+        Assert.AreEqual("erste",  de.ConvertOrdinal(1, "deklination=schwach", "genus=maskulin", "kasus=nominativ"));
+        Assert.AreEqual("ersten", de.ConvertOrdinal(1, "deklination=schwach", "genus=maskulin", "kasus=akkusativ"));
+        Assert.AreEqual("ersten", de.ConvertOrdinal(1, "deklination=schwach", "genus=maskulin", "kasus=dativ"));
+        Assert.AreEqual("ersten", de.ConvertOrdinal(1, "deklination=schwach", "genus=maskulin", "kasus=genitiv"));
+
+        // feminin schwach: nom=akk="erste", dat=gen="ersten"
+        Assert.AreEqual("erste",  de.ConvertOrdinal(1, "deklination=schwach", "genus=feminin", "kasus=nominativ"));
+        Assert.AreEqual("erste",  de.ConvertOrdinal(1, "deklination=schwach", "genus=feminin", "kasus=akkusativ"));
+        Assert.AreEqual("ersten", de.ConvertOrdinal(1, "deklination=schwach", "genus=feminin", "kasus=dativ"));
+        Assert.AreEqual("ersten", de.ConvertOrdinal(1, "deklination=schwach", "genus=feminin", "kasus=genitiv"));
+
+        // neutrum schwach: nom=akk="erste" (same as feminin schwach)
+        Assert.AreEqual("erste",  de.ConvertOrdinal(1, "deklination=schwach", "genus=neutrum", "kasus=nominativ"));
+        Assert.AreEqual("erste",  de.ConvertOrdinal(1, "deklination=schwach", "genus=neutrum", "kasus=akkusativ"));
+
+        // stark (strong) — used without an article
+
+        // maskulin stark: nom="erster", akk=gen="ersten", dat="erstem"
+        Assert.AreEqual("erster", de.ConvertOrdinal(1, "deklination=stark", "genus=maskulin", "kasus=nominativ"));
+        Assert.AreEqual("ersten", de.ConvertOrdinal(1, "deklination=stark", "genus=maskulin", "kasus=akkusativ"));
+        Assert.AreEqual("erstem", de.ConvertOrdinal(1, "deklination=stark", "genus=maskulin", "kasus=dativ"));
+        Assert.AreEqual("ersten", de.ConvertOrdinal(1, "deklination=stark", "genus=maskulin", "kasus=genitiv"));
+
+        // feminin stark: nom=akk="erste", dat=gen="erster"
+        Assert.AreEqual("erste",  de.ConvertOrdinal(1, "deklination=stark", "genus=feminin", "kasus=nominativ"));
+        Assert.AreEqual("erste",  de.ConvertOrdinal(1, "deklination=stark", "genus=feminin", "kasus=akkusativ"));
+        Assert.AreEqual("erster", de.ConvertOrdinal(1, "deklination=stark", "genus=feminin", "kasus=dativ"));
+        Assert.AreEqual("erster", de.ConvertOrdinal(1, "deklination=stark", "genus=feminin", "kasus=genitiv"));
+
+        // neutrum stark: nom=akk="erstes", dat="erstem", gen="ersten"
+        Assert.AreEqual("erstes", de.ConvertOrdinal(1, "deklination=stark", "genus=neutrum", "kasus=nominativ"));
+        Assert.AreEqual("erstes", de.ConvertOrdinal(1, "deklination=stark", "genus=neutrum", "kasus=akkusativ"));
+        Assert.AreEqual("erstem", de.ConvertOrdinal(1, "deklination=stark", "genus=neutrum", "kasus=dativ"));
+        Assert.AreEqual("ersten", de.ConvertOrdinal(1, "deklination=stark", "genus=neutrum", "kasus=genitiv"));
+    }
+
+    [TestMethod]
+    public void ConvertOrdinal_DE_WithVariants_RegularSuffix()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+
+        // 20 has no OrdinalException and no word rule → suffix="ste" from <Ordinals>
+        // OrdinalVariants overrides the suffix per genus × deklination × kasus
+
+        // schwach maskulin: only akk+dat+gen → "sten"; nom stays "ste"
+        Assert.AreEqual("zwanzigste",  de.ConvertOrdinal(20, "deklination=schwach", "genus=maskulin", "kasus=nominativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=schwach", "genus=maskulin", "kasus=akkusativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=schwach", "genus=maskulin", "kasus=dativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=schwach", "genus=maskulin", "kasus=genitiv"));
+
+        // schwach feminin: only dat+gen → "sten"; nom+akk stay "ste"
+        Assert.AreEqual("zwanzigste",  de.ConvertOrdinal(20, "deklination=schwach", "genus=feminin", "kasus=nominativ"));
+        Assert.AreEqual("zwanzigste",  de.ConvertOrdinal(20, "deklination=schwach", "genus=feminin", "kasus=akkusativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=schwach", "genus=feminin", "kasus=dativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=schwach", "genus=feminin", "kasus=genitiv"));
+
+        // schwach neutrum: same as feminin
+        Assert.AreEqual("zwanzigste",  de.ConvertOrdinal(20, "deklination=schwach", "genus=neutrum", "kasus=nominativ"));
+        Assert.AreEqual("zwanzigste",  de.ConvertOrdinal(20, "deklination=schwach", "genus=neutrum", "kasus=akkusativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=schwach", "genus=neutrum", "kasus=dativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=schwach", "genus=neutrum", "kasus=genitiv"));
+
+        // stark maskulin: nom → "ster"; akk+gen → "sten"; dat → "stem"
+        Assert.AreEqual("zwanzigster", de.ConvertOrdinal(20, "deklination=stark", "genus=maskulin", "kasus=nominativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=stark", "genus=maskulin", "kasus=akkusativ"));
+        Assert.AreEqual("zwanzigstem", de.ConvertOrdinal(20, "deklination=stark", "genus=maskulin", "kasus=dativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=stark", "genus=maskulin", "kasus=genitiv"));
+
+        // stark feminin: nom+akk → "ste"; dat+gen → "ster"
+        Assert.AreEqual("zwanzigste",  de.ConvertOrdinal(20, "deklination=stark", "genus=feminin", "kasus=nominativ"));
+        Assert.AreEqual("zwanzigste",  de.ConvertOrdinal(20, "deklination=stark", "genus=feminin", "kasus=akkusativ"));
+        Assert.AreEqual("zwanzigster", de.ConvertOrdinal(20, "deklination=stark", "genus=feminin", "kasus=dativ"));
+        Assert.AreEqual("zwanzigster", de.ConvertOrdinal(20, "deklination=stark", "genus=feminin", "kasus=genitiv"));
+
+        // stark neutrum: nom+akk → "stes"; dat → "stem"; gen → "sten"
+        Assert.AreEqual("zwanzigstes", de.ConvertOrdinal(20, "deklination=stark", "genus=neutrum", "kasus=nominativ"));
+        Assert.AreEqual("zwanzigstes", de.ConvertOrdinal(20, "deklination=stark", "genus=neutrum", "kasus=akkusativ"));
+        Assert.AreEqual("zwanzigstem", de.ConvertOrdinal(20, "deklination=stark", "genus=neutrum", "kasus=dativ"));
+        Assert.AreEqual("zwanzigsten", de.ConvertOrdinal(20, "deklination=stark", "genus=neutrum", "kasus=genitiv"));
+
+        // Compound (21+): suffix variant also applies to word-appended forms
+        Assert.AreEqual("einundzwanzigste",  de.ConvertOrdinal(21));
+        Assert.AreEqual("einundzwanzigster", de.ConvertOrdinal(21, "deklination=stark", "genus=maskulin", "kasus=nominativ"));
+        Assert.AreEqual("einundzwanzigsten", de.ConvertOrdinal(21, "deklination=stark", "genus=maskulin", "kasus=akkusativ"));
+    }
+
     // ── C8d — Ordinals HE ────────────────────────────────────────────────
 
     [TestMethod]
@@ -1677,6 +1771,61 @@ public class NumberToStringConverterImprovementsTests
         Assert.AreEqual("أول",  converter.ConvertOrdinal(1));
         Assert.AreEqual("ثانٍ", converter.ConvertOrdinal(2));
         Assert.AreEqual("عاشر", converter.ConvertOrdinal(10));
+    }
+
+    // ── C15a — Variant without selector throws ───────────────────────────────
+
+    [TestMethod]
+    public void ReadConfiguration_VariantWithoutSelector_Throws()
+    {
+        const string xml = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
+              <Language groupSize="3" separator=" " groupSeparator="" zero="zero" minus="minus *">
+                <Culture>TEST-BAD-VARIANT</Culture>
+                <Groups><Group level="1"><Digit digit="1" string="one" /></Group></Groups>
+                <NumberScale firstLetterUpperCase="false">
+                  <StaticNames><Scale value="0" string="" /></StaticNames>
+                </NumberScale>
+                <Variants>
+                  <Dimension name="case" values="nom,acc" />
+                  <Variant type="case">
+                    <Replacement oldValue="one" newValue="ONE" scope="LastWord" />
+                  </Variant>
+                </Variants>
+              </Language>
+            </Numbers>
+            """;
+
+        Assert.ThrowsException<InvalidOperationException>(() =>
+            NumberToStringConverter.ReadConfiguration(xml));
+    }
+
+    [TestMethod]
+    public void ReadConfiguration_OrdinalVariantWithoutSelector_Throws()
+    {
+        const string xml = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
+              <Language groupSize="3" separator=" " groupSeparator="" zero="zero" minus="minus *">
+                <Culture>TEST-BAD-ORDVARIANT</Culture>
+                <Groups><Group level="1"><Digit digit="1" string="one" /></Group></Groups>
+                <NumberScale firstLetterUpperCase="false">
+                  <StaticNames><Scale value="0" string="" /></StaticNames>
+                </NumberScale>
+                <Ordinals suffix="th">
+                  <OrdinalVariants>
+                    <Variant type="case">
+                      <OrdinalException value="1" string="first" />
+                    </Variant>
+                  </OrdinalVariants>
+                </Ordinals>
+              </Language>
+            </Numbers>
+            """;
+
+        Assert.ThrowsException<InvalidOperationException>(() =>
+            NumberToStringConverter.ReadConfiguration(xml));
     }
 
     // ── C15 — Multi-value variant syntax (values="a,b,c") ───────────────────

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -491,7 +491,7 @@ public class NumberToStringConverterImprovementsTests
     {
         var converter = NumberToStringConverter.GetConverter("DE");
 
-        // Without variant: counting form via XML Variant {maskulin,nominativ} → "eins"
+        // Without variant: counting form (GermanSpecifics EndsWith "ein" → "eins")
         Assert.AreEqual("eins", converter.Convert(1));
         Assert.AreEqual("eins", converter.Convert(1, "genus=maskulin"));
         Assert.AreEqual("eins", converter.Convert(1, "kasus=nominativ"));

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -1935,4 +1935,151 @@ public class NumberToStringConverterImprovementsTests
             return true;
         }
     }
+
+    // ─── Triggers ─────────────────────────────────────────────────────────────
+
+    private static NumberToStringConverter MakeTriggerConverter(
+        IEnumerable<NumberToStringConverter.TriggerRule> triggers)
+    {
+        var options = new NumberToStringConverterOptions(NumberToStringConverter.GetConverter("EN"))
+        {
+            Triggers = triggers.ToList()
+        };
+        return new NumberToStringConverter(options);
+    }
+
+    private static NumberToStringConverter.TriggerReplace SimpleReplace(string from, string to, bool regex = false) =>
+        new(from, regex, [], to);
+
+    private static NumberToStringConverter.TriggerRule EndTrigger(string from, string to, bool regex = false) =>
+        new(NumberToStringConverter.TriggerAt.End, null, [SimpleReplace(from, to, regex)]);
+
+    private static NumberToStringConverter.TriggerRule GroupTrigger(int? groupIndex, string from, string to, bool regex = false) =>
+        new(NumberToStringConverter.TriggerAt.Group,
+            groupIndex.HasValue ? [groupIndex.Value] : null,
+            [SimpleReplace(from, to, regex)]);
+
+    private static NumberToStringConverter.TriggerRule GroupWithScaleTrigger(string from, string to) =>
+        new(NumberToStringConverter.TriggerAt.GroupWithScale, null, [SimpleReplace(from, to)]);
+
+    [TestMethod]
+    public void Trigger_End_Unconditional_LiteralReplace()
+    {
+        var c = MakeTriggerConverter([EndTrigger("one", "ONE")]);
+        Assert.AreEqual("ONE", c.Convert(1));
+        Assert.AreEqual("twenty-ONE", c.Convert(21));
+        Assert.AreEqual("two", c.Convert(2));
+    }
+
+    [TestMethod]
+    public void Trigger_End_Regex()
+    {
+        var c = MakeTriggerConverter([EndTrigger(@"\bone\b", "1", regex: true)]);
+        Assert.AreEqual("1", c.Convert(1));
+        Assert.AreEqual("twenty-1", c.Convert(21));
+        Assert.AreEqual("1 thousand", c.Convert(1_000));
+        Assert.AreEqual("two", c.Convert(2));
+    }
+
+    [TestMethod]
+    public void Trigger_End_VariantConditioned()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        var options = new NumberToStringConverterOptions(en);
+        options.VariantDimensions = [new NumberToStringConverter.VariantDimension("gender", ["masc", "fem"])];
+        // Replace with variant forms: masc="one" (default, first form), fem="una"
+        var forms = new List<(IReadOnlyDictionary<string, string>, string)>
+        {
+            (new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["gender"] = "masc" }, "one"),
+            (new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["gender"] = "fem"  }, "una"),
+        };
+        var replace = new NumberToStringConverter.TriggerReplace("one", false, forms, defaultTo: "one");
+        options.Triggers = [new NumberToStringConverter.TriggerRule(NumberToStringConverter.TriggerAt.End, null, [replace])];
+        var c = new NumberToStringConverter(options);
+
+        Assert.AreEqual("una", c.Convert(1, "gender=fem"));
+        Assert.AreEqual("one", c.Convert(1, "gender=masc"));
+        Assert.AreEqual("one", c.Convert(1));  // default
+    }
+
+    [TestMethod]
+    public void Trigger_End_NoDefaultTo_SkipsWhenNoVariantMatches()
+    {
+        // When no DefaultTo and no variant matches, the replacement is skipped entirely
+        // (the regex is never even evaluated — ApplyTriggerReplace short-circuits)
+        var en = NumberToStringConverter.GetConverter("EN");
+        var options = new NumberToStringConverterOptions(en);
+        options.VariantDimensions = [new NumberToStringConverter.VariantDimension("gender", ["masc", "fem"])];
+        var forms = new List<(IReadOnlyDictionary<string, string>, string)>
+        {
+            (new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["gender"] = "fem" }, "una"),
+        };
+        // No DefaultTo → only fires for fem; masc and no-variant calls are unchanged
+        var replace = new NumberToStringConverter.TriggerReplace("one", false, forms, defaultTo: null);
+        options.Triggers = [new NumberToStringConverter.TriggerRule(NumberToStringConverter.TriggerAt.End, null, [replace])];
+        var c = new NumberToStringConverter(options);
+
+        Assert.AreEqual("una", c.Convert(1, "gender=fem"));
+        Assert.AreEqual("one", c.Convert(1, "gender=masc"));  // no default → skipped
+        Assert.AreEqual("one", c.Convert(1));                  // no default → skipped
+    }
+
+    [TestMethod]
+    public void Trigger_Group0_FiresOnlyForUnitsChunk()
+    {
+        // group(0) transforms digits of the units chunk only — thousands chunk (group 1) is untouched
+        var c = MakeTriggerConverter([GroupTrigger(0, "one", "UNO")]);
+        Assert.AreEqual("UNO", c.Convert(1));
+        Assert.AreEqual("one thousand", c.Convert(1_000));       // group 1 not affected
+        Assert.AreEqual("one thousand, UNO", c.Convert(1_001));  // only units group changes
+    }
+
+    [TestMethod]
+    public void Trigger_Group_AllGroups_FiresForEveryGroup()
+    {
+        // group (no index) fires for all groups, digits-only, before scale
+        var c = MakeTriggerConverter([GroupTrigger(null, "one", "UNO")]);
+        Assert.AreEqual("UNO", c.Convert(1));
+        Assert.AreEqual("UNO thousand", c.Convert(1_000));       // thousands group: "one" → "UNO", then scale appended
+        Assert.AreEqual("UNO thousand, UNO", c.Convert(1_001));
+    }
+
+    [TestMethod]
+    public void Trigger_GroupWithScale_FiresAfterScale()
+    {
+        // groupWithScale fires on "digits + scale" text after ApplyReplacements
+        var c = MakeTriggerConverter([GroupWithScaleTrigger("one thousand", "mille")]);
+        Assert.AreEqual("mille", c.Convert(1_000));
+        Assert.AreEqual("two thousand", c.Convert(2_000));         // not matching
+        Assert.AreEqual("mille, one", c.Convert(1_001));           // units group stays separate
+    }
+
+    [TestMethod]
+    public void Trigger_End_FiresForOrdinals()
+    {
+        // end triggers fire in ConvertOrdinal pipeline (after ApplyOrdinalTransform, before FinalizeWriting)
+        var c = MakeTriggerConverter([EndTrigger("second", "SECOND")]);
+        Assert.AreEqual("SECOND", c.ConvertOrdinal(2));
+        Assert.AreEqual("third", c.ConvertOrdinal(3));  // unrelated ordinal unaffected
+    }
+
+    [TestMethod]
+    public void Trigger_Group0_BreaksOrdinalWordRule_ByDesign()
+    {
+        // group(0) fires inside ConvertRaw, which ordinals call too.
+        // "two" → "TWO" before ordinal rules run → word rule "two"→"second" can't match → suffix "th" used
+        var c = MakeTriggerConverter([GroupTrigger(0, "two", "TWO")]);
+        Assert.AreEqual("TWO", c.Convert(2));
+        Assert.AreEqual("TWOth", c.ConvertOrdinal(2));  // intended: documented side-effect
+    }
+
+    [TestMethod]
+    public void Trigger_MultipleTriggersAppliedInOrder()
+    {
+        var c = MakeTriggerConverter([
+            EndTrigger("one", "eins"),
+            EndTrigger("eins", "EIN"),
+        ]);
+        Assert.AreEqual("EIN", c.Convert(1));
+    }
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -1679,6 +1679,101 @@ public class NumberToStringConverterImprovementsTests
         Assert.AreEqual("عاشر", converter.ConvertOrdinal(10));
     }
 
+    // ── C15 — Multi-value variant syntax (values="a,b,c") ───────────────────
+
+    private const string MultiValueTestConfig = """
+        <?xml version="1.0" encoding="utf-8" ?>
+        <Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
+          <Language groupSize="3" separator=" " groupSeparator="" zero="nul" minus="minus *">
+            <Culture>TEST-MV</Culture>
+            <Groups>
+              <Group level="1">
+                <Digit digit="0" string="" />
+                <Digit digit="1" string="één" />
+                <Digit digit="2" string="twee" />
+                <Digit digit="3" string="drie" />
+              </Group>
+              <Group level="2">
+                <Digit digit="0" string="" buildString="*" />
+                <Digit digit="1" string="tien" buildString="*tien" />
+                <Digit digit="2" string="twintig" buildString="*entwintig" />
+              </Group>
+              <Group level="3">
+                <Digit digit="0" string="" buildString="*" />
+                <Digit digit="1" string="honderd" buildString="honderd *" />
+              </Group>
+            </Groups>
+            <NumberScale firstLetterUpperCase="false">
+              <StaticNames>
+                <Scale value="0" string="" />
+                <Scale value="1" string="duizend" />
+              </StaticNames>
+            </NumberScale>
+            <Ordinals suffix="de">
+              <OrdinalException value="1" string="eerste" />
+              <OrdinalVariants>
+                <Variant type="case" values="genitief,datief,accusatief" suffix="den">
+                  <OrdinalException value="1" string="eersten" />
+                </Variant>
+              </OrdinalVariants>
+            </Ordinals>
+            <Variants>
+              <Dimension name="case" values="nominatief,genitief,datief,accusatief" />
+              <Variant type="case" values="genitief,datief">
+                <Replacement oldValue="één" newValue="ener" scope="LastWord" />
+              </Variant>
+              <Variant type="case" variant="accusatief">
+                <Replacement oldValue="één" newValue="enen" scope="LastWord" />
+              </Variant>
+            </Variants>
+          </Language>
+        </Numbers>
+        """;
+
+    [TestMethod]
+    public void OrdinalVariant_MultiValue_SameExceptionForAllListedCases()
+    {
+        var converters = NumberToStringConverter.ReadConfiguration(MultiValueTestConfig);
+        var c = converters["TEST-MV"];
+
+        // base (no case variant) → exception "eerste"
+        Assert.AreEqual("eerste", c.ConvertOrdinal(1));
+        // the three values listed in values="genitief,datief,accusatief" all apply "eersten"
+        Assert.AreEqual("eersten", c.ConvertOrdinal(1, "case=genitief"),   "genitief");
+        Assert.AreEqual("eersten", c.ConvertOrdinal(1, "case=datief"),     "datief");
+        Assert.AreEqual("eersten", c.ConvertOrdinal(1, "case=accusatief"), "accusatief");
+    }
+
+    [TestMethod]
+    public void OrdinalVariant_MultiValue_SuffixOverrideForAllListedCases()
+    {
+        var converters = NumberToStringConverter.ReadConfiguration(MultiValueTestConfig);
+        var c = converters["TEST-MV"];
+
+        // 2 → no exception → base suffix "de" → "tweede"
+        Assert.AreEqual("tweede", c.ConvertOrdinal(2));
+        // genitief/datief/accusatief → suffix "den" → "tweeden"
+        Assert.AreEqual("tweeden", c.ConvertOrdinal(2, "case=genitief"),   "genitief suffix");
+        Assert.AreEqual("tweeden", c.ConvertOrdinal(2, "case=datief"),     "datief suffix");
+        Assert.AreEqual("tweeden", c.ConvertOrdinal(2, "case=accusatief"), "accusatief suffix");
+    }
+
+    [TestMethod]
+    public void CardinalVariant_MultiValue_SameReplacementForAllListedCases()
+    {
+        var converters = NumberToStringConverter.ReadConfiguration(MultiValueTestConfig);
+        var c = converters["TEST-MV"];
+
+        // base / nominatief: één unchanged
+        Assert.AreEqual("één",  c.Convert(1));
+        Assert.AreEqual("één",  c.Convert(1, "case=nominatief"));
+        // genitief and datief share the same replacement rule via values="genitief,datief"
+        Assert.AreEqual("ener", c.Convert(1, "case=genitief"), "genitief");
+        Assert.AreEqual("ener", c.Convert(1, "case=datief"),   "datief");
+        // accusatief uses the separate single-value rule
+        Assert.AreEqual("enen", c.Convert(1, "case=accusatief"), "accusatief");
+    }
+
     private sealed class OrdinalPluginSpecifics
         : INumberToStringLanguageSpecifics, IOrdinalLanguageSpecifics
     {

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -2082,4 +2082,83 @@ public class NumberToStringConverterImprovementsTests
         ]);
         Assert.AreEqual("EIN", c.Convert(1));
     }
+
+    // ─── Significant-digits precision ─────────────────────────────────────────
+
+    [TestMethod]
+    public void RoundToSignificantDigits_BasicCases()
+    {
+        Assert.AreEqual(123000000, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 3));
+        Assert.AreEqual(120000000, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 2));
+        Assert.AreEqual(100000000, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 1));
+        Assert.AreEqual(123456789, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 9));
+        Assert.AreEqual(123456789, (long)NumberToStringConverter.RoundToSignificantDigits(123456789, 12));
+    }
+
+    [TestMethod]
+    public void RoundToSignificantDigits_RoundsUp_When5()
+    {
+        // 125 → precision 2: 125 → scale=10, (125+5)/10*10 = 130
+        Assert.AreEqual(130, (long)NumberToStringConverter.RoundToSignificantDigits(125, 2));
+        // 155000 → precision 2: scale=10000, (155000+5000)/10000*10000 = 160000
+        Assert.AreEqual(160000, (long)NumberToStringConverter.RoundToSignificantDigits(155000, 2));
+    }
+
+    [TestMethod]
+    public void RoundToSignificantDigits_RoundsDown_WhenBelow5()
+    {
+        // 124 → precision 2: scale=10, (124+5)/10*10 = 120
+        Assert.AreEqual(120, (long)NumberToStringConverter.RoundToSignificantDigits(124, 2));
+    }
+
+    [TestMethod]
+    public void RoundToSignificantDigits_Zero_ReturnsZero()
+    {
+        Assert.AreEqual(BigInteger.Zero, NumberToStringConverter.RoundToSignificantDigits(0, 3));
+    }
+
+    [TestMethod]
+    public void RoundToSignificantDigits_Negative_PreservesSign()
+    {
+        Assert.AreEqual(-123000000, (long)NumberToStringConverter.RoundToSignificantDigits(-123456789, 3));
+        Assert.AreEqual(-130, (long)NumberToStringConverter.RoundToSignificantDigits(-125, 2));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentOutOfRangeException))]
+    public void RoundToSignificantDigits_ZeroDigits_Throws()
+    {
+        NumberToStringConverter.RoundToSignificantDigits(123, 0);
+    }
+
+    [TestMethod]
+    public void Convert_WithPrecision_FR()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // 123456789 → precision 3 → 123000000
+        Assert.AreEqual("cent vingt trois millions", fr.Convert((BigInteger)123456789, 3));
+        // 123456789 → precision 2 → 120000000
+        Assert.AreEqual("cent vingt millions", fr.Convert((BigInteger)123456789, 2));
+        // 123456789 → precision 1 → 100000000
+        Assert.AreEqual("cent millions", fr.Convert((BigInteger)123456789, 1));
+    }
+
+    [TestMethod]
+    public void Convert_WithPrecision_EN()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        // 123456789 → precision 3 → 123000000
+        Assert.AreEqual("one hundred and twenty-three million", en.Convert((BigInteger)123456789, 3));
+        // 123456789 → precision 2 → 120000000
+        Assert.AreEqual("one hundred and twenty million", en.Convert((BigInteger)123456789, 2));
+    }
+
+    [TestMethod]
+    public void Convert_WithPrecision_NoPrecisionLoss_WhenPrecisionLargeEnough()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        string full = en.Convert(123456789);
+        string withPrecision = en.Convert((BigInteger)123456789, 20);
+        Assert.AreEqual(full, withPrecision);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `values="a,b,c"` attribute to `<Variant>` (ordinal and cardinal) as a shorthand for the same rule body across multiple dimension values
- `values` takes priority over `variant` when both are present; existing single-value syntax unchanged
- By convention values should follow the `Dimension` declaration order (documented in XSD); the runtime accepts any order
- Enables concise German ordinal declension (4 cases × 3 genders) and Slavic languages without repeating identical exception/word-rule blocks

## Changes

| File | Change |
|------|--------|
| `NumberConvertionConfiguration.xsd` | `variant` becomes optional; `values` attribute added with documentation |
| `NumberConverterConfiguration.cs` | `VariantValues` property added to `OrdinalVariantElementType` and `VariantType` |
| `NumberToStringConverter.Globalization.cs` | `CollectOrdinalVariants` and `CollectVariantRules` expand `values` into one rule per listed value |
| `NumberToStringConverterImprovementsTests.cs` | 3 new C15 tests with inline XML config |

## Test plan

- [x] `OrdinalVariant_MultiValue_SameExceptionForAllListedCases`
- [x] `OrdinalVariant_MultiValue_SuffixOverrideForAllListedCases`
- [x] `CardinalVariant_MultiValue_SameReplacementForAllListedCases`
- [x] Full suite: 2854 pass, 0 fail (was 2851)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
