### PR TITLE
feat(NumberToString): Convert(decimal) overloads — mandatory precision and DecimalFormatOptions

### DIFF
--- a/Utils.NumberToString/DecimalFormatOptions.cs
+++ b/Utils.NumberToString/DecimalFormatOptions.cs
@@ -1,0 +1,34 @@
+namespace Utils.NumberToString;
+
+/// <summary>
+/// Formatting options for the decimal part produced by
+/// <see cref="INumberToStringConverter.Convert(decimal, int, DecimalFormatOptions?, string[])"/>.
+/// </summary>
+public sealed class DecimalFormatOptions
+{
+    /// <summary>
+    /// Overrides the word used as decimal separator between the integer and decimal parts
+    /// (e.g. <c>"euro(s)"</c> instead of the configured <c>"virgule"</c>).
+    /// The <c>"(s)"</c> marker is pluralized against the integer part value.
+    /// When <see langword="null"/>, the converter's configured decimal separator is used.
+    /// </summary>
+    public string? DecimalSeparator { get; init; }
+
+    /// <summary>
+    /// Overrides the denomination suffix appended after the decimal value
+    /// (e.g. <c>"centime(s)"</c> instead of <c>"centième(s)"</c> from the language configuration).
+    /// When set, the decimal value is always converted as a whole number regardless of whether
+    /// a <c>&lt;Fraction&gt;</c> entry is configured for that digit count.
+    /// The <c>"(s)"</c> marker is pluralized against the decimal value.
+    /// When <see langword="null"/>, the configured <c>&lt;Fraction&gt;</c> entry is used when available;
+    /// otherwise the decimal part is read digit by digit.
+    /// </summary>
+    public string? DecimalSuffix { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the decimal part is suppressed when it rounds to zero.
+    /// Useful with a positive <c>mandatoryDecimalDigits</c> to avoid producing
+    /// <c>"vingt et un euros zéro centime"</c> for a whole-number amount.
+    /// </summary>
+    public bool OmitZeroDecimals { get; init; }
+}

--- a/Utils.NumberToString/INumberToStringConverter.cs
+++ b/Utils.NumberToString/INumberToStringConverter.cs
@@ -57,6 +57,60 @@ namespace Utils.NumberToString
         string Convert(decimal number);
 
         /// <summary>
+        /// Converts a decimal value into its string representation, applying the specified
+        /// variant parameters (e.g. <c>"gender=feminin"</c>).
+        /// The default implementation ignores variant parameters and delegates to
+        /// <see cref="Convert(decimal)"/>; implementations that support variants should override.
+        /// </summary>
+        /// <param name="number">The value to convert.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        /// <returns>The formatted number with the requested variants applied.</returns>
+        string Convert(decimal number, params string[] variants) => Convert(number);
+
+        /// <summary>
+        /// Converts a decimal value into its string representation with a mandatory number of
+        /// decimal digits, applying optional variant parameters.
+        /// <para>
+        /// When <paramref name="mandatoryDecimalDigits"/> is negative, the decimal part is shown
+        /// as-is (same as <see cref="Convert(decimal, string[])"/>).
+        /// When zero, the decimal part is suppressed (only the integer part is shown).
+        /// When positive, the value is rounded to that many decimal places and the decimal part
+        /// is always shown with exactly that many digits, padding with zeros if needed.
+        /// </para>
+        /// The default implementation ignores precision and variant parameters and delegates to
+        /// <see cref="Convert(decimal)"/>; implementations should override.
+        /// </summary>
+        /// <param name="number">The value to convert.</param>
+        /// <param name="mandatoryDecimalDigits">
+        /// Number of decimal digits to always show. Negative = natural (as-is), 0 = integer only,
+        /// positive = always show exactly N decimal digits (rounded and zero-padded).
+        /// </param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        /// <returns>The formatted number with the requested precision and variants applied.</returns>
+        string Convert(decimal number, int mandatoryDecimalDigits, params string[] variants) => Convert(number);
+
+        /// <summary>
+        /// Converts a decimal value into its string representation with a mandatory number of
+        /// decimal digits, custom decimal formatting options, and optional variant parameters.
+        /// The default implementation ignores all parameters and delegates to
+        /// <see cref="Convert(decimal)"/>; implementations should override.
+        /// </summary>
+        /// <param name="number">The value to convert.</param>
+        /// <param name="mandatoryDecimalDigits">
+        /// Negative: show the decimal part as-is. Zero: suppress the decimal part entirely.
+        /// Positive: round to N decimal places and always show exactly N digits (zero-padded).
+        /// </param>
+        /// <param name="options">
+        /// Optional overrides for the decimal separator word (<see cref="DecimalFormatOptions.DecimalSeparator"/>),
+        /// the denomination suffix (<see cref="DecimalFormatOptions.DecimalSuffix"/>), and zero-decimal
+        /// suppression (<see cref="DecimalFormatOptions.OmitZeroDecimals"/>).
+        /// Both <c>"(s)"</c> markers are pluralized: the separator against the integer part,
+        /// the suffix against the decimal value.
+        /// </param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        string Convert(decimal number, int mandatoryDecimalDigits, DecimalFormatOptions? options, params string[] variants) => Convert(number);
+
+        /// <summary>
         /// Converts a rational <see cref="Number"/> into its string representation.
         /// The default implementation converts only the integer part; implementations
         /// that support rational conversion should override this.

--- a/Utils.NumberToString/INumberToStringConverter.cs
+++ b/Utils.NumberToString/INumberToStringConverter.cs
@@ -160,6 +160,17 @@ namespace Utils.NumberToString
         string Convert(int number, params string[] variants) => Convert(number);
 
         /// <summary>
+        /// Converts a 32-bit signed integer rounded to <paramref name="significantDigits"/> most
+        /// significant digits into its string representation, applying optional variant parameters.
+        /// The default implementation delegates to <see cref="Convert(BigInteger, int, string[])"/>.
+        /// </summary>
+        /// <param name="number">The value to convert.</param>
+        /// <param name="significantDigits">Number of significant digits to keep. Must be ≥ 1.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        string Convert(int number, int significantDigits, params string[] variants)
+            => Convert((BigInteger)number, significantDigits, variants);
+
+        /// <summary>
         /// Converts a 64-bit signed integer into its string representation,
         /// applying the specified variant parameters.
         /// The default implementation ignores variant parameters and delegates to
@@ -169,6 +180,17 @@ namespace Utils.NumberToString
         /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
         /// <returns>The formatted number with the requested variants applied.</returns>
         string Convert(long number, params string[] variants) => Convert(number);
+
+        /// <summary>
+        /// Converts a 64-bit signed integer rounded to <paramref name="significantDigits"/> most
+        /// significant digits into its string representation, applying optional variant parameters.
+        /// The default implementation delegates to <see cref="Convert(BigInteger, int, string[])"/>.
+        /// </summary>
+        /// <param name="number">The value to convert.</param>
+        /// <param name="significantDigits">Number of significant digits to keep. Must be ≥ 1.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        string Convert(long number, int significantDigits, params string[] variants)
+            => Convert((BigInteger)number, significantDigits, variants);
 
         /// <summary>
         /// Gets a value indicating whether this converter supports ordinal conversion.
@@ -223,6 +245,31 @@ namespace Utils.NumberToString
         /// <returns>The ordinal string for <paramref name="number"/>.</returns>
         string ConvertOrdinal(long number, params string[] variants)
             => ConvertOrdinal(checked((int)number), variants);
+
+        /// <summary>
+        /// Converts a decimal currency amount to words using the supplied currency definition.
+        /// The default implementation throws <see cref="NotSupportedException"/>;
+        /// implementations that support currency conversion should override this.
+        /// </summary>
+        /// <param name="amount">The amount to convert.</param>
+        /// <param name="currency">The currency names and configuration.</param>
+        /// <returns>The amount expressed as words.</returns>
+        string ConvertCurrency(decimal amount, CurrencyDefinition currency)
+            => throw new NotSupportedException("Currency conversion is not supported by this converter.");
+
+        /// <summary>
+        /// Converts a decimal currency amount to words using the supplied currency definition,
+        /// applying morphological variant parameters to the number words
+        /// (e.g. <c>"gender=feminin"</c> for languages that inflect numerals by gender).
+        /// The default implementation ignores variant parameters and delegates to
+        /// <see cref="ConvertCurrency(decimal, CurrencyDefinition)"/>.
+        /// </summary>
+        /// <param name="amount">The amount to convert.</param>
+        /// <param name="currency">The currency names and configuration.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        /// <returns>The amount expressed as words with the requested variants applied.</returns>
+        string ConvertCurrency(decimal amount, CurrencyDefinition currency, params string[] variants)
+            => ConvertCurrency(amount, currency);
 
         /// <summary>
         /// Converts a year number into its spoken string representation.

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -325,6 +325,14 @@ namespace Utils.NumberToString
         /// <returns>The formatted number with the requested variants applied.</returns>
         public string Convert(long number, params string[] variants) => Convert((BigInteger)number, variants);
 
+        /// <inheritdoc cref="INumberToStringConverter.Convert(int, int, string[])"/>
+        public string Convert(int number, int significantDigits, params string[] variants)
+            => Convert((BigInteger)number, significantDigits, variants);
+
+        /// <inheritdoc cref="INumberToStringConverter.Convert(long, int, string[])"/>
+        public string Convert(long number, int significantDigits, params string[] variants)
+            => Convert((BigInteger)number, significantDigits, variants);
+
         /// <summary>
         /// Converts a decimal number to its string representation.
         /// </summary>
@@ -945,13 +953,12 @@ namespace Utils.NumberToString
             return best;
         }
 
-        /// <summary>
-        /// Converts a decimal currency amount to words using the supplied currency definition.
-        /// </summary>
-        /// <param name="amount">The amount to convert.</param>
-        /// <param name="currency">The currency names and configuration.</param>
-        /// <returns>The amount expressed as words (e.g. "twenty euros and fifty centimes").</returns>
+        /// <inheritdoc cref="INumberToStringConverter.ConvertCurrency(decimal, CurrencyDefinition)"/>
         public string ConvertCurrency(decimal amount, CurrencyDefinition currency)
+            => ConvertCurrency(amount, currency, []);
+
+        /// <inheritdoc cref="INumberToStringConverter.ConvertCurrency(decimal, CurrencyDefinition, string[])"/>
+        public string ConvertCurrency(decimal amount, CurrencyDefinition currency, params string[] variants)
         {
             ArgumentNullException.ThrowIfNull(currency);
 
@@ -968,12 +975,12 @@ namespace Utils.NumberToString
             subunits %= subunitFactor;
 
             string unitName = units == 1 ? currency.UnitSingular : currency.UnitPlural;
-            string result = Convert(units) + Separator + unitName;
+            string result = Convert(units, variants) + Separator + unitName;
 
             if (subunits > 0)
             {
                 string subunitName = subunits == 1 ? currency.SubunitSingular : currency.SubunitPlural;
-                string subunitsText = Convert(subunits) + Separator + subunitName;
+                string subunitsText = Convert(subunits, variants) + Separator + subunitName;
                 result = result + Separator + currency.Connector + Separator + subunitsText;
             }
 

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -328,25 +328,78 @@ namespace Utils.NumberToString
         /// <summary>
         /// Converts a decimal number to its string representation.
         /// </summary>
-        public string Convert(decimal number)
+        public string Convert(decimal number) => Convert(number, -1, null, []);
+
+        /// <summary>
+        /// Converts a decimal number to its string representation, applying the specified
+        /// morphological variant parameters.
+        /// </summary>
+        public string Convert(decimal number, params string[] variants)
+            => Convert(number, -1, null, variants);
+
+        /// <summary>
+        /// Converts a decimal number to its string representation with a mandatory number of
+        /// decimal digits, applying optional variant parameters.
+        /// </summary>
+        /// <param name="number">The value to convert.</param>
+        /// <param name="mandatoryDecimalDigits">
+        /// Negative: show the decimal part as-is. Zero: suppress the decimal part entirely.
+        /// Positive: round to N decimal places and always show exactly N digits (zero-padded).
+        /// </param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        public string Convert(decimal number, int mandatoryDecimalDigits, params string[] variants)
+            => Convert(number, mandatoryDecimalDigits, null, variants);
+
+        /// <summary>
+        /// Converts a decimal number to its string representation with a mandatory number of
+        /// decimal digits, custom decimal formatting options, and optional variant parameters.
+        /// </summary>
+        /// <param name="number">The value to convert.</param>
+        /// <param name="mandatoryDecimalDigits">
+        /// Negative: show the decimal part as-is. Zero: suppress the decimal part entirely.
+        /// Positive: round to N decimal places and always show exactly N digits (zero-padded).
+        /// </param>
+        /// <param name="options">
+        /// Optional overrides for the decimal separator word, the denomination suffix, and
+        /// zero-decimal suppression. When <see langword="null"/>, the language defaults apply.
+        /// </param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        public string Convert(decimal number, int mandatoryDecimalDigits, DecimalFormatOptions? options, params string[] variants)
         {
             bool isNegative = number < 0;
             if (isNegative) number = -number;
 
+            if (mandatoryDecimalDigits >= 0)
+                number = decimal.Round(number, mandatoryDecimalDigits, MidpointRounding.AwayFromZero);
+
             decimal integerPart = decimal.Truncate(number);
             decimal fraction = number - integerPart;
 
-            var result = new StringBuilder(Convert((BigInteger)integerPart));
+            var result = new StringBuilder(Convert((BigInteger)integerPart, variants));
 
-            if (fraction != 0)
+            string digits = fraction != 0
+                ? fraction.ToString(System.Globalization.CultureInfo.InvariantCulture).Split('.')[1]
+                : string.Empty;
+
+            if (mandatoryDecimalDigits > 0 && digits.Length < mandatoryDecimalDigits)
+                digits = digits.PadRight(mandatoryDecimalDigits, '0');
+
+            bool isZeroDecimal = digits.Length == 0 || BigInteger.Parse(digits) == 0;
+            if (isZeroDecimal && (options?.OmitZeroDecimals ?? false))
+                digits = string.Empty;
+
+            if (digits.Length > 0)
             {
-                string digits = fraction.ToString(System.Globalization.CultureInfo.InvariantCulture).Split('.')[1];
-                result.Append(Separator).Append(DecimalSeparator).Append(Separator);
+                string separatorWord = options?.DecimalSeparator ?? DecimalSeparator;
+                result.Append(Separator).Append(separatorWord.ToPlural((long)integerPart)).Append(Separator);
 
-                if (Fractions.TryGetValue(digits.Length, out var suffix))
+                Fractions.TryGetValue(digits.Length, out var configuredSuffix);
+                string? activeSuffix = options?.DecimalSuffix ?? configuredSuffix;
+
+                if (activeSuffix != null)
                 {
-                    var valueText = Convert(BigInteger.Parse(digits)).Replace("-", " ");
-                    result.Append(valueText).Append(Separator).Append(suffix.ToPlural(long.Parse(digits)));
+                    var valueText = Convert(BigInteger.Parse(digits), variants).Replace("-", " ");
+                    result.Append(valueText).Append(Separator).Append(activeSuffix.ToPlural(long.Parse(digits)));
                 }
                 else
                 {

--- a/Utils.NumberToString/TODO.md
+++ b/Utils.NumberToString/TODO.md
@@ -1,23 +1,102 @@
 # Utils.NumberToString — Améliorations à venir
 
-## Ambitieux
+## Priorité haute — incohérences d'API
 
-### 1. Ordinaux ZU (Zoulou) via `IOrdinalLanguageSpecifics`
+### 1. ~~`Convert(decimal, params string[] variants)` manquant~~ — **implémenté**
+Trois nouvelles surcharges ajoutées dans `INumberToStringConverter` et `NumberToStringConverter` :
+- `Convert(decimal number, params string[] variants)`
+- `Convert(decimal number, int mandatoryDecimalDigits, params string[] variants)`
+- `Convert(decimal number, int mandatoryDecimalDigits, DecimalFormatOptions? options, params string[] variants)`
+
+`mandatoryDecimalDigits` : négatif = afficher les décimales telles quelles, 0 = partie entière
+seulement, positif = arrondir et toujours afficher exactement N chiffres décimaux (zéros inclus).
+
+`DecimalFormatOptions` expose trois propriétés :
+- `DecimalSeparator` : remplace le mot séparateur (ex. `"euro(s)"` à la place de `"virgule"`) ;
+  le marqueur `(s)` est mis au pluriel selon la valeur de la partie entière.
+- `DecimalSuffix` : remplace la dénomination décimale (ex. `"centime(s)"` à la place de
+  `"centième(s)"`) ; le marqueur `(s)` est mis au pluriel selon la valeur de la partie décimale.
+  Quand renseigné, la partie décimale est toujours convertie comme un entier (pas chiffre par chiffre).
+- `OmitZeroDecimals` : supprime la partie décimale si elle vaut zéro après arrondi.
+
+### 2. `ConvertCurrency` sans variants
+`ConvertCurrency(decimal amount, CurrencyDefinition currency)` ne prend pas de variants.
+Or pour le FR/DE la partie entière varie en genre selon la devise (euro est masculin, livre est féminine).
+Il faudrait pouvoir écrire :
+```csharp
+fr.ConvertCurrency(21m, livre, "gender=feminin"); // "vingt et une livres"
+```
+
+### 3. `Convert(long/int, int significantDigits, ...)` manquant dans l'interface
+`Convert(BigInteger, int significantDigits, params string[])` existe dans `INumberToStringConverter`,
+mais pas de surcharges `long`/`int` équivalentes. Les types primitifs passent par un cast implicite
+vers `BigInteger` dans l'implémentation concrète, mais pas depuis l'interface.
+
+## Priorité haute — bugs corrigeables dans les XML
+
+### 4. Formes fusionnées ES et IT (`veintiuno`, `ventiuno`, etc.)
+La règle `LastWord` ne peut pas atteindre `uno`/`una` dans les formes sans espace.
+Solution purement XML : changer les `buildString` de `"treinta*"` → `"treinta y *"` (ES)
+et `"venti*"` → `"venti *"` (IT).
+
+## Priorité moyenne — nouvelles fonctionnalités
+
+### 5. `ConvertOrdinal(BigInteger)` dans l'interface
+`Convert` supporte `BigInteger` illimité, mais `ConvertOrdinal` s'arrête à `long` (et en pratique
+à `int` via cast). Ajouter `ConvertOrdinal(BigInteger)` avec une implémentation par défaut
+`checked((int)number)` garderait la cohérence de surface.
+
+### 6. `ConvertYear` avec variants
+`ConvertYear(int year)` n'accepte pas de variants. Pour les langues où `Convert` varie selon
+le genre (DE: `ConvertYear(2001)` → `"zweitausend eins"` / `"zweitausend eine"`), l'absence
+de variants dans `ConvertYear` crée une inconsistance.
+Signature proposée : `ConvertYear(int year, params string[] variants)`.
+
+### 7. Regex compilées à la construction du converter
+Les `TriggerReplace` et les règles de remplacement avec `regex=true` sont compilées à chaque appel.
+Stocker un `Regex` compilé dans le type `TriggerReplace` au moment de la construction du converter
+éviterait la recompilation à chaque conversion.
+
+### 8. Langues populaires manquantes
+Par ordre d'utilité et de complexité :
+- **TR (Turc)** : agglutinant, harmonie vocalique dans les suffixes numéraux (~90M de locuteurs).
+- **SV/NO/DA (Suédois/Norvégien/Danois)** : langues nordiques, genre commun/neutre, ordinals réguliers.
+- **UK (Ukrainien)** : proche du RU déjà implémenté.
+- **RO (Roumain)** : langue romane comme IT/PT, genre féminin/masculin pour les chiffres.
+
+### 9. Ordinaux ZU (Zoulou) via `IOrdinalLanguageSpecifics`
 Les ordinaux zoulou dépendent de la classe nominale du substantif (morphologie agglutinante),
 ce qui rend l'approche XML insuffisante. Nécessite :
 - Recherche linguistique (classes 1–17, préfixes de classe)
 - Implémentation d'une classe `ZuluOrdinalLanguageSpecifics : IOrdinalLanguageSpecifics`
 
-### 2. Ordinaux PL complets — accord genre × cas via `IOrdinalLanguageSpecifics`
+### 10. Ordinaux PL complets — accord genre × cas via `IOrdinalLanguageSpecifics`
 L'implémentation actuelle couvre le nominatif masculin singulier.
 Pour les formes complètes (féminin/neutre + 7 cas), une classe `PolishOrdinalLanguageSpecifics`
 serait plus appropriée que de multiplier les `<OrdinalVariants>`.
 
-### 3. `ConvertOrdinal` avec accord complet pour AR via `IOrdinalLanguageSpecifics`
+### 11. `ConvertOrdinal` avec accord complet pour AR via `IOrdinalLanguageSpecifics`
 L'arabe inverse le genre de l'ordinal par rapport au cardinal pour 3-10 (règle de polarité),
 et possède une forme duelle. Nécessite une classe `ArabicOrdinalLanguageSpecifics`.
 
-### 4. `ConvertYear` — extension à d'autres langues
+## Priorité basse — robustesse
+
+### 12. `GetConverter` avec codes de culture > 5 caractères
+`culture.Length.ArgMustBeIn([2, 5])` rejette des codes légaux comme `"zh-Hans"` (7)
+ou `"zh-Hans-CN"` (10). `CultureInfo.GetCultureInfo("zh-Hans").Name` retourne `"zh-Hans"`,
+donc passer une `CultureInfo` via l'overload `GetConverter(CultureInfo)` peut lever une exception.
+
+### 13. Thread-safety de `RegisterConfigurations` / `RegisterLanguageSpecifics`
+Ces méthodes statiques modifient `CachedConfigurations` (un `Dictionary` statique).
+En contexte ASP.NET Core où l'appel peut venir de plusieurs threads au démarrage,
+passer à `ConcurrentDictionary` éviterait des races silencieuses.
+
+### 14. `ConvertYear` négatif — années av. J.-C.
+`ConvertYear(-44)` passe par le template `minus` → `"minus forty-four"`.
+Un attribut optionnel `beforeChristSuffix` dans `<YearFormat>` permettrait de produire
+`"forty-four BC"` sans bricoler avec `AdjustFunction`.
+
+### 15. `ConvertYear` — extension à d'autres langues
 Langues candidates pour un format split an :
 - **RU** : « тысяча девятьсот восемьдесят четыре » (pas de split — fallback OK)
 - **FR** : « mille neuf cent quatre-vingt-quatre » (pas de split — fallback OK)

--- a/Utils.NumberToString/TODO.md
+++ b/Utils.NumberToString/TODO.md
@@ -19,18 +19,22 @@ seulement, positif = arrondir et toujours afficher exactement N chiffres décima
   Quand renseigné, la partie décimale est toujours convertie comme un entier (pas chiffre par chiffre).
 - `OmitZeroDecimals` : supprime la partie décimale si elle vaut zéro après arrondi.
 
-### 2. `ConvertCurrency` sans variants
-`ConvertCurrency(decimal amount, CurrencyDefinition currency)` ne prend pas de variants.
-Or pour le FR/DE la partie entière varie en genre selon la devise (euro est masculin, livre est féminine).
-Il faudrait pouvoir écrire :
+### 2. ~~`ConvertCurrency` sans variants~~ — **implémenté**
+Nouvelle surcharge `ConvertCurrency(decimal, CurrencyDefinition, params string[] variants)` ajoutée
+dans `INumberToStringConverter` (avec implémentation par défaut qui lance `NotSupportedException`)
+et dans `NumberToStringConverter` (où l'ancienne implémentation délègue désormais à la nouvelle).
+
+Les `variants` sont transmis aux deux sous-appels `Convert(units, variants)` et
+`Convert(subunits, variants)`, ce qui permet l'inflexion genre/cas des numéraux dans les deux parties :
 ```csharp
-fr.ConvertCurrency(21m, livre, "gender=feminin"); // "vingt et une livres"
+fr.ConvertCurrency(21.01m, livre, "gender=feminin"); // "vingt et une livres et une sous"
 ```
 
-### 3. `Convert(long/int, int significantDigits, ...)` manquant dans l'interface
-`Convert(BigInteger, int significantDigits, params string[])` existe dans `INumberToStringConverter`,
-mais pas de surcharges `long`/`int` équivalentes. Les types primitifs passent par un cast implicite
-vers `BigInteger` dans l'implémentation concrète, mais pas depuis l'interface.
+### 3. ~~`Convert(long/int, int significantDigits, ...)` manquant dans l'interface~~ — **implémenté**
+Deux nouvelles surcharges ajoutées dans `INumberToStringConverter` (implémentations par défaut
+déléguant à `Convert(BigInteger, int, string[])`) et dans `NumberToStringConverter` :
+- `Convert(int number, int significantDigits, params string[] variants)`
+- `Convert(long number, int significantDigits, params string[] variants)`
 
 ## Priorité haute — bugs corrigeables dans les XML
 

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -2384,4 +2384,106 @@ public class NumberToStringConverterImprovementsTests
         Assert.AreEqual(expected, converter.Convert(21.5m, 2, (DecimalFormatOptions?)null, []));
         Assert.AreEqual(expected, converter.Convert(21.5m, 2, new DecimalFormatOptions { OmitZeroDecimals = true }));
     }
+
+    // ─── G1 — Convert(int/long, int significantDigits) ────────────────────────
+
+    [TestMethod]
+    public void Convert_Int_SignificantDigits_MatchesBigInteger()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+
+        Assert.AreEqual(en.Convert((System.Numerics.BigInteger)12345, 3), en.Convert(12345,  3));
+        Assert.AreEqual(en.Convert((System.Numerics.BigInteger)12345, 3), en.Convert(12345L, 3));
+        Assert.AreEqual(en.Convert((System.Numerics.BigInteger)1,     3), en.Convert(1,      3));
+        Assert.AreEqual(en.Convert((System.Numerics.BigInteger)999,   2), en.Convert(999,    2));
+        Assert.AreEqual(en.Convert((System.Numerics.BigInteger)999,   2), en.Convert(999L,   2));
+    }
+
+    [TestMethod]
+    public void Convert_Long_SignificantDigits_WithVariants_MatchesBigInteger()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+
+        // 210 rounded to 1 significant digit → 200 ; 21 rounded to 2 → 21
+        Assert.AreEqual(fr.Convert((System.Numerics.BigInteger)210, 1, "gender=feminin"),
+                        fr.Convert(210L, 1, "gender=feminin"));
+        Assert.AreEqual(fr.Convert((System.Numerics.BigInteger)21, 2, "gender=feminin"),
+                        fr.Convert(21, 2, "gender=feminin"));
+    }
+
+    [TestMethod]
+    public void Convert_Interface_IntLong_SignificantDigits_DelegatesToBigInteger()
+    {
+        INumberToStringConverter iface = NumberToStringConverter.GetConverter("EN");
+
+        Assert.AreEqual(iface.Convert((System.Numerics.BigInteger)12345, 3),
+                        iface.Convert(12345, 3));
+        Assert.AreEqual(iface.Convert((System.Numerics.BigInteger)12345, 3),
+                        iface.Convert(12345L, 3));
+    }
+
+    // ─── G2 — ConvertCurrency avec variants morphologiques ────────────────────
+
+    private static CurrencyDefinition LiveCurrency() => new CurrencyDefinition
+    {
+        UnitSingular    = "livre",
+        UnitPlural      = "livres",
+        SubunitSingular = "sou",
+        SubunitPlural   = "sous",
+        SubunitDigits   = 2,
+        Connector       = "et",
+    };
+
+    [TestMethod]
+    public void ConvertCurrency_FR_DefaultVariant_IsMasculine()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var livre = LiveCurrency();
+
+        // Without variant: masculine numeral (default FR dimension value)
+        Assert.AreEqual("vingt et un livres", fr.ConvertCurrency(21m, livre));
+        Assert.AreEqual("un livre",           fr.ConvertCurrency(1m,  livre));
+    }
+
+    [TestMethod]
+    public void ConvertCurrency_FR_FeminineVariant_InflectsNumeral()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var livre = LiveCurrency();
+
+        // Feminine variant: "un" → "une", "vingt et un" → "vingt et une"
+        Assert.AreEqual("une livre",           fr.ConvertCurrency(1m,  livre, "gender=feminin"));
+        Assert.AreEqual("vingt et une livres", fr.ConvertCurrency(21m, livre, "gender=feminin"));
+        Assert.AreEqual("trente et une livres", fr.ConvertCurrency(31m, livre, "gender=feminin"));
+    }
+
+    [TestMethod]
+    public void ConvertCurrency_FR_FeminineVariant_AppliesToSubunitsAsWell()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var livre = LiveCurrency();
+
+        // 21.01 → "vingt et une livres et un sou" (masculine, sou doesn't inflect un)
+        // With gender=feminin: "vingt et une livres et une sous"… but "une sous" is grammatically
+        // wrong in real French; we test the mechanical inflection, not linguistic correctness.
+        // Compare against the BigInteger sub-conversions to stay independent of locale rendering.
+        string unitsPart    = fr.Convert(21L, "gender=feminin");   // "vingt et une"
+        string subunitsPart = fr.Convert(1L,  "gender=feminin");   // "une"
+        string expected     = $"{unitsPart} livres et {subunitsPart} sou";
+
+        Assert.AreEqual(expected, fr.ConvertCurrency(21.01m, livre, "gender=feminin"));
+    }
+
+    [TestMethod]
+    public void ConvertCurrency_Interface_Variants_DelegatesToConcrete()
+    {
+        INumberToStringConverter iface = NumberToStringConverter.GetConverter("FR");
+        var livre = LiveCurrency();
+
+        // Calling via the interface must reach the concrete implementation (not the default throw).
+        Assert.AreEqual(iface.ConvertCurrency(21m, livre),
+                        iface.ConvertCurrency(21m, livre, []));
+        Assert.AreEqual(iface.ConvertCurrency(21m, livre, "gender=feminin"),
+                        ((NumberToStringConverter)iface).ConvertCurrency(21m, livre, "gender=feminin"));
+    }
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -2162,4 +2162,226 @@ public class NumberToStringConverterImprovementsTests
         string withPrecision = en.Convert((BigInteger)123456789, 20);
         Assert.AreEqual(full, withPrecision);
     }
+
+    // ─── F1 — Convert(decimal, int mandatoryDecimalDigits) ───────────────────
+
+    [TestMethod]
+    public void ConvertDecimal_MandatoryDigits_Negative_PreservesNaturalBehavior()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // -1 is the internal sentinel for "show as-is"; both paths must produce the same result.
+        Assert.AreEqual(fr.Convert(21.5m), fr.Convert(21.5m, -1, null, []));
+        Assert.AreEqual(fr.Convert(21.5m), fr.Convert(21.5m, []));
+    }
+
+    [TestMethod]
+    public void ConvertDecimal_MandatoryDigits_Zero_SuppressesDecimalPartAfterRounding()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // 21.4m → rounds to 21 (AwayFromZero) → decimal part suppressed
+        Assert.AreEqual("vingt et un", fr.Convert(21.4m, 0));
+        // 21.5m → rounds to 22 (AwayFromZero, midpoint rounds up) → decimal part suppressed
+        Assert.AreEqual(fr.Convert(22), fr.Convert(21.5m, 0));
+    }
+
+    [TestMethod]
+    public void ConvertDecimal_MandatoryDigits_PadsDecimalToRequiredLength_FR()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // "5" padded to "50" → Fractions[2]="centième(s)" → Convert(50)="cinquante" → "centièmes"
+        Assert.AreEqual("vingt et un virgule cinquante centièmes", fr.Convert(21.5m, 2));
+    }
+
+    [TestMethod]
+    public void ConvertDecimal_MandatoryDigits_ShowsZeroWhenDecimalPartIsZero()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // No decimal part → padded to "00" → Convert(0)="zéro" → singular "centième" (0 ∈ [-1,1])
+        Assert.AreEqual("vingt et un virgule zéro centième", fr.Convert(21m, 2));
+    }
+
+    [TestMethod]
+    public void ConvertDecimal_MandatoryDigits_RoundsExtraDecimalDigits()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // 21.567m → decimal.Round(..., 2, AwayFromZero) = 21.57
+        // The decimal sub-value goes through .Replace("-", " "), so hyphens become spaces.
+        Assert.AreEqual("vingt et un virgule cinquante sept centièmes", fr.Convert(21.567m, 2));
+        // 21.564m → 21.56
+        Assert.AreEqual("vingt et un virgule cinquante six centièmes", fr.Convert(21.564m, 2));
+    }
+
+    // ─── F2 — Convert(decimal, params string[] variants) ─────────────────────
+
+    [TestMethod]
+    public void ConvertDecimal_WithVariants_AppliedToIntegerPart_FR()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // gender=feminin: "un" → "une" on the integer part; decimal part unchanged
+        Assert.AreEqual("une virgule cinq dixièmes", fr.Convert(1.5m, "gender=feminin"));
+        // masculine (default) — identical to Convert(1.5m)
+        Assert.AreEqual(fr.Convert(1.5m), fr.Convert(1.5m, "gender=masculin"));
+    }
+
+    [TestMethod]
+    public void ConvertDecimal_WithVariantsAndPrecision_FR()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // Variants and mandatory precision compose: integer "une" + decimal "cinquante centièmes"
+        Assert.AreEqual("une virgule cinquante centièmes", fr.Convert(1.5m, 2, "gender=feminin"));
+    }
+
+    // ─── F3 — DecimalFormatOptions.DecimalSeparator ──────────────────────────
+
+    [TestMethod]
+    public void DecimalFormatOptions_DecimalSeparator_PluralizedAgainstIntegerPart()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var opts = new DecimalFormatOptions { DecimalSeparator = "euro(s)" };
+        // integer = 1 → between(-1,1) → singular "euro"
+        Assert.AreEqual("un euro cinquante centièmes",          fr.Convert(1.50m,  2, opts));
+        // integer = 2 → plural "euros"
+        Assert.AreEqual("deux euros cinquante centièmes",       fr.Convert(2.50m,  2, opts));
+        // integer = 21 → plural "euros"
+        Assert.AreEqual("vingt et un euros cinquante centièmes", fr.Convert(21.50m, 2, opts));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_DecimalSeparator_NoMarker_PassedThrough()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // No "(s)" marker → word is used unchanged regardless of the integer value
+        var opts = new DecimalFormatOptions { DecimalSeparator = "virgule" };
+        Assert.AreEqual("un virgule cinquante centièmes",        fr.Convert(1.50m,  2, opts));
+        Assert.AreEqual("vingt et un virgule cinquante centièmes", fr.Convert(21.50m, 2, opts));
+    }
+
+    // ─── F4 — DecimalFormatOptions.DecimalSuffix ─────────────────────────────
+
+    [TestMethod]
+    public void DecimalFormatOptions_DecimalSuffix_OverridesFractionConfig()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var opts = new DecimalFormatOptions { DecimalSuffix = "centime(s)" };
+        // "centime(s)" replaces the configured "centième(s)" from FR's <Fractions>
+        Assert.AreEqual("vingt et un virgule cinquante centimes", fr.Convert(21.50m, 2, opts));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_DecimalSuffix_PluralizedAgainstDecimalValue()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var opts = new DecimalFormatOptions { DecimalSuffix = "centime(s)" };
+        // decimal value 50 → plural "centimes"
+        Assert.AreEqual("vingt et un virgule cinquante centimes", fr.Convert(21.50m, 2, opts));
+        // decimal value 1 → singular "centime"
+        Assert.AreEqual("un virgule un centime",                  fr.Convert(1.01m,  2, opts));
+        // decimal value 0 → singular "centime" (0 ∈ [-1,1])
+        Assert.AreEqual("vingt et un virgule zéro centime",       fr.Convert(21m,    2, opts));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_DecimalSuffix_ForcesWholeNumberConversionWithoutFractionConfig()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // FR has no <Fraction> entry for 4 digits → without override: digit-by-digit.
+        // With DecimalSuffix: whole-number conversion is forced regardless.
+        var opts = new DecimalFormatOptions { DecimalSuffix = "dix-millième(s)" };
+        // 21.5m with 4 digits → pad "5" to "5000" → Convert(5000)="cinq mille" → plural suffix
+        Assert.AreEqual("vingt et un virgule cinq mille dix-millièmes", fr.Convert(21.5m, 4, opts));
+    }
+
+    // ─── F5 — DecimalFormatOptions.OmitZeroDecimals ──────────────────────────
+
+    [TestMethod]
+    public void DecimalFormatOptions_OmitZeroDecimals_SuppressesZeroDecimalPart()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var opts = new DecimalFormatOptions { OmitZeroDecimals = true };
+        // 21m → mandatory 2 digits → "00" → zero → decimal part (and separator) suppressed
+        Assert.AreEqual("vingt et un", fr.Convert(21m, 2, opts));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_OmitZeroDecimals_DoesNotSuppressNonZeroDecimal()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var opts = new DecimalFormatOptions { OmitZeroDecimals = true };
+        // 21.5m → "50" after padding → not zero → decimal part shown normally
+        Assert.AreEqual("vingt et un virgule cinquante centièmes", fr.Convert(21.5m, 2, opts));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_OmitZeroDecimals_WorksAfterRounding()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var optsOmit = new DecimalFormatOptions { OmitZeroDecimals = true, DecimalSuffix = "centime(s)" };
+        // 21.004m → rounds to 21.00 (4 < 5, rounds down) → zero → suppressed
+        Assert.AreEqual("vingt et un", fr.Convert(21.004m, 2, new DecimalFormatOptions { OmitZeroDecimals = true }));
+        // 21.005m → rounds to 21.01 (5 rounds up, AwayFromZero) → not zero → shown
+        Assert.AreEqual("vingt et un virgule un centime", fr.Convert(21.005m, 2, optsOmit));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_OmitZeroDecimals_FalseShowsZeroDecimalPart()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // Explicitly false → zero decimal part is shown (same as null options)
+        Assert.AreEqual("vingt et un virgule zéro centième", fr.Convert(21m, 2, new DecimalFormatOptions { OmitZeroDecimals = false }));
+        Assert.AreEqual("vingt et un virgule zéro centième", fr.Convert(21m, 2, (DecimalFormatOptions?)null));
+    }
+
+    // ─── F6 — Combined DecimalFormatOptions ──────────────────────────────────
+
+    [TestMethod]
+    public void DecimalFormatOptions_Combined_CurrencyStyle()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var opts = new DecimalFormatOptions
+        {
+            DecimalSeparator = "euro(s)",
+            DecimalSuffix    = "centime(s)",
+            OmitZeroDecimals = true,
+        };
+        Assert.AreEqual("un euro cinquante centimes",           fr.Convert(1.50m,  2, opts));
+        Assert.AreEqual("vingt et un euros cinquante centimes", fr.Convert(21.50m, 2, opts));
+        Assert.AreEqual("un euro un centime",                   fr.Convert(1.01m,  2, opts));
+        // OmitZeroDecimals: separator (unit name) is also omitted when decimal part is zero
+        Assert.AreEqual("vingt et un",                         fr.Convert(21m,    2, opts));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_Combined_NegativeNumber()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var opts = new DecimalFormatOptions { DecimalSeparator = "euro(s)", DecimalSuffix = "centime(s)" };
+        Assert.AreEqual("moins cinq euros cinquante centimes", fr.Convert(-5.50m, 2, opts));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_Combined_WithVariants()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var opts = new DecimalFormatOptions { DecimalSeparator = "euro(s)", DecimalSuffix = "centime(s)" };
+        // gender=feminin: integer "1" → "une", decimal "1" → "une"; separator and suffix unchanged
+        Assert.AreEqual("une euro une centime", fr.Convert(1.01m, 2, opts, "gender=feminin"));
+    }
+
+    // ─── F7 — Interface default implementations for new decimal overloads ─────
+
+    [TestMethod]
+    public void Interface_ConvertDecimal_NewOverloads_DefaultsToConvertDecimal()
+    {
+        // A minimal implementation that only implements the original Convert(decimal)
+        // must compile and produce results from all new overloads via default implementations.
+        INumberToStringConverter converter = new MinimalConverter();
+        // Use Convert(decimal) as the reference value to stay locale-independent.
+        string expected = converter.Convert(21.5m);
+
+        Assert.AreEqual(expected, converter.Convert(21.5m, "gender=feminin"));
+        Assert.AreEqual(expected, converter.Convert(21.5m, 2, []));
+        Assert.AreEqual(expected, converter.Convert(21.5m, 2, (DecimalFormatOptions?)null));
+        Assert.AreEqual(expected, converter.Convert(21.5m, 2, (DecimalFormatOptions?)null, []));
+        Assert.AreEqual(expected, converter.Convert(21.5m, 2, new DecimalFormatOptions { OmitZeroDecimals = true }));
+    }
 }


### PR DESCRIPTION
## Résumé

- Trois nouvelles surcharges de `Convert(decimal)` dans `INumberToStringConverter` et `NumberToStringConverter`, avec implémentations par défaut backward-compatibles
- Nouveau type `DecimalFormatOptions` avec trois options orthogonales
- 20 tests couvrant tous les cas (sections F1–F7 de `NumberToStringConverterImprovementsTests`)

## Nouvelles surcharges

```csharp
// Variants morphologiques sur la partie entière et décimale
string Convert(decimal number, params string[] variants)

// Précision décimale obligatoire + variants
// mandatoryDecimalDigits < 0 : afficher as-is (comportement existant)
// mandatoryDecimalDigits = 0 : partie entière seulement (arrondi inclus)
// mandatoryDecimalDigits > 0 : arrondir et toujours afficher N chiffres (zero-padded)
string Convert(decimal number, int mandatoryDecimalDigits, params string[] variants)

// Précision + options de formatage + variants
string Convert(decimal number, int mandatoryDecimalDigits, DecimalFormatOptions? options, params string[] variants)
```

## `DecimalFormatOptions`

| Propriété | Type | Effet |
|---|---|---|
| `DecimalSeparator` | `string?` | Remplace le mot séparateur (ex. `"euro(s)"`). `(s)` pluralisé selon la partie entière. |
| `DecimalSuffix` | `string?` | Remplace la dénomination décimale (ex. `"centime(s)"`). `(s)` pluralisé selon la valeur décimale. Force la conversion en entier même sans `<Fraction>` configurée. |
| `OmitZeroDecimals` | `bool` | Supprime la partie décimale (et le séparateur) quand elle vaut zéro après arrondi. |

```csharp
var fr = NumberToStringConverter.GetConverter("FR");
var opts = new DecimalFormatOptions
{
    DecimalSeparator = "euro(s)",
    DecimalSuffix    = "centime(s)",
    OmitZeroDecimals = true,
};

fr.Convert(21.50m, 2, opts);  // "vingt et un euros cinquante centimes"
fr.Convert(21.00m, 2, opts);  // "vingt et un"  ← zéro supprimé
fr.Convert(1.01m,  2, opts);  // "un euro un centime"
fr.Convert(1.5m,   2, opts, "gender=feminin");  // variants toujours supportés
```

## Test plan

- [x] 277/277 tests passent
- [x] `F1` — `mandatoryDecimalDigits` : mode naturel, zéro, padding, zéro-décimal, arrondi
- [x] `F2` — variants sur `Convert(decimal)`
- [x] `F3` — `DecimalSeparator` : pluralisation `(s)` singulier/pluriel, sans marqueur
- [x] `F4` — `DecimalSuffix` : remplace Fractions, pluralisation, force entier sans Fractions
- [x] `F5` — `OmitZeroDecimals` : supprime, ne supprime pas, fonctionne après arrondi
- [x] `F6` — Combinaisons : style devise, négatif, avec variants
- [x] `F7` — Implémentations par défaut de l'interface (fallback `Convert(decimal)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)