### PR TITLE
feat(NumberToString): Convert(TimeSpan/DateOnly/DateTime), HR/HU, VN linh (items 21-23)

### DIFF
--- a/Utils.NumberToString/INumberToStringConverter.cs
+++ b/Utils.NumberToString/INumberToStringConverter.cs
@@ -355,5 +355,49 @@ namespace Utils.NumberToString
         /// </summary>
         string ConvertMultiplicative(int multiplier, params string[] variants)
             => throw new NotSupportedException("This converter does not support multiplicative forms.");
+
+        /// <summary>
+        /// When <see langword="true"/>, <see cref="Convert(TimeSpan, string[])"/> and
+        /// <see cref="Convert(TimeOnly, string[])"/> produce a result.
+        /// </summary>
+        bool SupportsTimeConversion => false;
+
+        /// <summary>
+        /// When <see langword="true"/>, <see cref="Convert(DateOnly, string[])"/> and
+        /// <see cref="Convert(DateTime, string[])"/> produce a result.
+        /// </summary>
+        bool SupportsDateConversion => false;
+
+        /// <summary>
+        /// Converts a <see cref="TimeSpan"/> duration to its spoken form
+        /// (e.g. "two hours thirty minutes five seconds").
+        /// Requires <c>&lt;TimeUnits&gt;</c> in the XML configuration.
+        /// </summary>
+        string Convert(TimeSpan duration, params string[] variants)
+            => throw new NotSupportedException("Time conversion requires <TimeUnits> in the XML configuration.");
+
+        /// <summary>
+        /// Converts a <see cref="TimeOnly"/> time-of-day to its spoken form
+        /// (e.g. "quatorze heures trente").
+        /// Requires <c>&lt;TimeUnits&gt;</c> in the XML configuration.
+        /// </summary>
+        string Convert(TimeOnly time, params string[] variants)
+            => throw new NotSupportedException("Time conversion requires <TimeUnits> in the XML configuration.");
+
+        /// <summary>
+        /// Converts a <see cref="DateOnly"/> date to its spoken form
+        /// (e.g. "le deux juillet deux mille vingt-six").
+        /// Requires <c>&lt;DateFormat&gt;</c> in the XML configuration.
+        /// Month names are read from <see cref="System.Globalization.CultureInfo"/>.
+        /// </summary>
+        string Convert(DateOnly date, params string[] variants)
+            => throw new NotSupportedException("Date conversion requires <DateFormat> in the XML configuration.");
+
+        /// <summary>
+        /// Converts a <see cref="DateTime"/> to its spoken form by combining
+        /// <see cref="Convert(DateOnly, string[])"/> and <see cref="Convert(TimeOnly, string[])"/>.
+        /// </summary>
+        string Convert(DateTime dateTime, params string[] variants)
+            => throw new NotSupportedException("Date/time conversion requires <DateFormat> and <TimeUnits> in the XML configuration.");
     }
 }

--- a/Utils.NumberToString/NumberConverterConfiguration.cs
+++ b/Utils.NumberToString/NumberConverterConfiguration.cs
@@ -533,6 +533,58 @@ public class FractionListType
 }
 
 /// <summary>
+/// Describes a single time unit (hour, minute, second) with its singular and plural forms.
+/// </summary>
+public class TimeUnitEntry
+{
+    /// <summary>Canonical unit name (e.g. "hour", "minute", "second").</summary>
+    [XmlAttribute("name")]
+    public string Name { get; set; } = "";
+
+    /// <summary>Singular form of the unit (e.g. "heure").</summary>
+    [XmlAttribute("singular")]
+    public string Singular { get; set; } = "";
+
+    /// <summary>Plural form of the unit (e.g. "heures").</summary>
+    [XmlAttribute("plural")]
+    public string Plural { get; set; } = "";
+}
+
+/// <summary>
+/// Holds time-unit configuration for a language (hours, minutes, seconds).
+/// </summary>
+public class TimeUnitsType
+{
+    /// <summary>Gets or sets the list of time unit definitions.</summary>
+    [XmlElement("Unit")]
+    public List<TimeUnitEntry>? Units { get; set; }
+}
+
+/// <summary>
+/// Holds date-format configuration for a language.
+/// </summary>
+public class DateFormatType
+{
+    /// <summary>
+    /// Pattern for rendering a date. Supported tokens: {month}, {ordinal-day}, {cardinal-day}, {year}.
+    /// Example: "{month} {ordinal-day}, {year}" → "July second, twenty twenty-six".
+    /// </summary>
+    [XmlAttribute("pattern")]
+    public string Pattern { get; set; } = "";
+
+    /// <summary>
+    /// Special string used for the first day of the month (e.g. "premier" in French).
+    /// When set, overrides the ordinal form of day 1 in {ordinal-day}.
+    /// </summary>
+    [XmlAttribute("firstDay")]
+    public string? FirstDay { get; set; }
+
+    /// <summary>Connector between the date and the time when converting a DateTime.</summary>
+    [XmlAttribute("dateTimeConnector")]
+    public string? DateTimeConnector { get; set; }
+}
+
+/// <summary>
 /// Holds multiplicative configuration for a language (e.g. 1 → "once", 2 → "twice").
 /// </summary>
 public class MultiplicativesType
@@ -707,6 +759,31 @@ public class LanguageType
     [XmlIgnore]
     public int GroupConnectorThreshold =>
         int.TryParse(GroupConnectorThresholdString, out var n) ? n : 100;
+
+    /// <summary>
+    /// Gets or sets the word inserted inside a group between hundreds and the lower part
+    /// when the lower part is below <see cref="IntraGroupConnectorThreshold"/>.
+    /// Example: "linh" for Vietnamese (101 → "một trăm linh một").
+    /// </summary>
+    [XmlAttribute("intraGroupConnector")]
+    public string? IntraGroupConnector { get; set; }
+
+    /// <summary>Gets or sets the threshold (as string) below which the intra-group connector is inserted.</summary>
+    [XmlAttribute("intraGroupConnectorThreshold")]
+    public string? IntraGroupConnectorThresholdString { get; set; }
+
+    /// <summary>Gets the threshold below which <see cref="IntraGroupConnector"/> is inserted.</summary>
+    [XmlIgnore]
+    public int IntraGroupConnectorThreshold =>
+        int.TryParse(IntraGroupConnectorThresholdString, out var n) ? n : 10;
+
+    /// <summary>Gets or sets the time-unit configuration (hours, minutes, seconds).</summary>
+    [XmlElement(ElementName = "TimeUnits")]
+    public TimeUnitsType? TimeUnits { get; set; }
+
+    /// <summary>Gets or sets the date-format configuration.</summary>
+    [XmlElement(ElementName = "DateFormat")]
+    public DateFormatType? DateFormat { get; set; }
 }
 
 /// <summary>

--- a/Utils.NumberToString/NumberConverterConfiguration.cs
+++ b/Utils.NumberToString/NumberConverterConfiguration.cs
@@ -548,6 +548,14 @@ public class TimeUnitEntry
     /// <summary>Plural form of the unit (e.g. "heures").</summary>
     [XmlAttribute("plural")]
     public string Plural { get; set; } = "";
+
+    /// <summary>
+    /// Optional numeral form to use when count == 1, overriding the standard Convert(1) result.
+    /// Useful when the unit has a grammatical gender that requires a different form of "one"
+    /// (e.g. <c>count1form="eine"</c> for German feminine nouns like "Stunde").
+    /// </summary>
+    [XmlAttribute("count1form")]
+    public string? Count1Form { get; set; }
 }
 
 /// <summary>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
@@ -776,5 +776,11 @@
 		<YearFormat hundredWord="hundert">
 			<SplitRange from="1100" to="1999" />
 		</YearFormat>
+		<TimeUnits>
+			<Unit name="hour"   singular="Stunde"  plural="Stunden"  />
+			<Unit name="minute" singular="Minute"  plural="Minuten"  />
+			<Unit name="second" singular="Sekunde" plural="Sekunden" />
+		</TimeUnits>
+		<DateFormat pattern="{cardinal-day}. {month} {year}" firstDay="ersten" />
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
@@ -777,10 +777,12 @@
 			<SplitRange from="1100" to="1999" />
 		</YearFormat>
 		<TimeUnits>
-			<Unit name="hour"   singular="Stunde"  plural="Stunden"  />
-			<Unit name="minute" singular="Minute"  plural="Minuten"  />
-			<Unit name="second" singular="Sekunde" plural="Sekunden" />
+			<!-- Stunde/Minute/Sekunde are all feminine; count1form="eine" avoids standalone "eins" for count=1 -->
+			<Unit name="hour"   singular="Stunde"  plural="Stunden"  count1form="eine" />
+			<Unit name="minute" singular="Minute"  plural="Minuten"  count1form="eine" />
+			<Unit name="second" singular="Sekunde" plural="Sekunden" count1form="eine" />
 		</TimeUnits>
+		<!-- firstDay="ersten" applies to both {cardinal-day} and {ordinal-day} when day == 1 -->
 		<DateFormat pattern="{cardinal-day}. {month} {year}" firstDay="ersten" />
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.EN.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.EN.xml
@@ -101,5 +101,11 @@
 			<Multiplicative value="2" string="twice" />
 			<Multiplicative value="3" string="thrice" />
 		</Multiplicatives>
+		<TimeUnits>
+			<Unit name="hour"   singular="hour"   plural="hours"   />
+			<Unit name="minute" singular="minute" plural="minutes" />
+			<Unit name="second" singular="second" plural="seconds" />
+		</TimeUnits>
+		<DateFormat pattern="{month} {ordinal-day}, {year}" />
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.FR-fr-ca.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.FR-fr-ca.xml
@@ -114,5 +114,11 @@
 			<Multiplicative value="2" string="deux fois" />
 			<Multiplicative value="3" string="trois fois" />
 		</Multiplicatives>
+		<TimeUnits>
+			<Unit name="hour"   singular="heure"   plural="heures"   />
+			<Unit name="minute" singular="minute"  plural="minutes"  />
+			<Unit name="second" singular="seconde" plural="secondes" />
+		</TimeUnits>
+		<DateFormat pattern="{cardinal-day} {month} {year}" firstDay="premier" />
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.HR.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.HR.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
+    <Language
+        groupSize="3"
+        separator=" "
+        groupSeparator=""
+        zero="nula"
+        minus="minus *"
+        decimalSeparator="zarez"
+        fractionSeparator="nad"
+    >
+        <Culture>HR</Culture>
+        <Culture>HR-HR</Culture>
+        <Groups>
+            <Group level="1">
+                <Digit digit="0" string="" />
+                <Digit digit="1" string="jedan" />
+                <Digit digit="2" string="dva" />
+                <Digit digit="3" string="tri" />
+                <Digit digit="4" string="četiri" />
+                <Digit digit="5" string="pet" />
+                <Digit digit="6" string="šest" />
+                <Digit digit="7" string="sedam" />
+                <Digit digit="8" string="osam" />
+                <Digit digit="9" string="devet" />
+            </Group>
+            <Group level="2">
+                <Digit digit="0" string=""            buildString="*" />
+                <Digit digit="1" string="deset"       buildString="deset *" />
+                <Digit digit="2" string="dvadeset"    buildString="dvadeset *" />
+                <Digit digit="3" string="trideset"    buildString="trideset *" />
+                <Digit digit="4" string="četrdeset"   buildString="četrdeset *" />
+                <Digit digit="5" string="pedeset"     buildString="pedeset *" />
+                <Digit digit="6" string="šezdeset"    buildString="šezdeset *" />
+                <Digit digit="7" string="sedamdeset"  buildString="sedamdeset *" />
+                <Digit digit="8" string="osamdeset"   buildString="osamdeset *" />
+                <Digit digit="9" string="devedeset"   buildString="devedeset *" />
+            </Group>
+            <Group level="3">
+                <Digit digit="0" string=""            buildString="*" />
+                <Digit digit="1" string="sto"         buildString="sto *" />
+                <Digit digit="2" string="dvjesto"     buildString="dvjesto *" />
+                <Digit digit="3" string="tristo"      buildString="tristo *" />
+                <Digit digit="4" string="četiristo"   buildString="četiristo *" />
+                <Digit digit="5" string="petsto"      buildString="petsto *" />
+                <Digit digit="6" string="šeststo"     buildString="šeststo *" />
+                <Digit digit="7" string="sedamsto"    buildString="sedamsto *" />
+                <Digit digit="8" string="osamsto"     buildString="osamsto *" />
+                <Digit digit="9" string="devetsto"    buildString="devetsto *" />
+            </Group>
+        </Groups>
+        <!-- Croatian long scale: milijun / milijarda / bilijun / bilijarda …
+             groupSeparator="li": mi+li+jun=milijun, mi+li+jarda=milijarda -->
+        <NumberScale firstLetterUpperCase="false" groupSeparator="li">
+            <StaticNames>
+                <Scale value="0" string="" />
+                <Scale value="1" string="tisuća" />
+            </StaticNames>
+            <Suffixes>
+                <Suffix>jun</Suffix>
+                <Suffix>jarda</Suffix>
+            </Suffixes>
+        </NumberScale>
+        <Replacements>
+            <!-- 1000 = "tisuća", not "jedan tisuća" -->
+            <Replacement oldValue="jedan tisuća" newValue="tisuća" />
+        </Replacements>
+        <Exceptions>
+            <Number value="11" string="jedanaest" />
+            <Number value="12" string="dvanaest" />
+            <Number value="13" string="trinaest" />
+            <Number value="14" string="četrnaest" />
+            <Number value="15" string="petnaest" />
+            <Number value="16" string="šesnaest" />
+            <Number value="17" string="sedamnaest" />
+            <Number value="18" string="osamnaest" />
+            <Number value="19" string="devetnaest" />
+        </Exceptions>
+        <Ordinals suffix="i">
+            <OrdinalException value="1" string="prvi" />
+            <OrdinalException value="2" string="drugi" />
+            <OrdinalException value="3" string="treći" />
+        </Ordinals>
+    </Language>
+</Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.HU.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.HU.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
+    <Language
+        groupSize="3"
+        separator=""
+        groupSeparator=""
+        zero="nulla"
+        minus="mínusz *"
+        decimalSeparator="egész"
+        fractionSeparator="per"
+    >
+        <Culture>HU</Culture>
+        <Culture>HU-HU</Culture>
+        <Groups>
+            <Group level="1">
+                <Digit digit="0" string="" />
+                <Digit digit="1" string="egy" />
+                <!-- "két" is the combining form; standalone 2 = "kettő" via Exception -->
+                <Digit digit="2" string="két" />
+                <Digit digit="3" string="három" />
+                <Digit digit="4" string="négy" />
+                <Digit digit="5" string="öt" />
+                <Digit digit="6" string="hat" />
+                <Digit digit="7" string="hét" />
+                <Digit digit="8" string="nyolc" />
+                <Digit digit="9" string="kilenc" />
+            </Group>
+            <Group level="2">
+                <Digit digit="0" string=""          buildString="*" />
+                <!-- tíz standalone, tizen* for 11–19 -->
+                <Digit digit="1" string="tíz"       buildString="tizen*" />
+                <!-- húsz standalone, huszon* for 21–29 -->
+                <Digit digit="2" string="húsz"      buildString="huszon*" />
+                <Digit digit="3" string="harminc"   buildString="harminc*" />
+                <Digit digit="4" string="negyven"   buildString="negyven*" />
+                <Digit digit="5" string="ötven"     buildString="ötven*" />
+                <Digit digit="6" string="hatvan"    buildString="hatvan*" />
+                <Digit digit="7" string="hetven"    buildString="hetven*" />
+                <Digit digit="8" string="nyolcvan"  buildString="nyolcvan*" />
+                <Digit digit="9" string="kilencven" buildString="kilencven*" />
+            </Group>
+            <Group level="3">
+                <Digit digit="0" string=""            buildString="*" />
+                <!-- 100 = "száz", "egyszáz" → "száz" via Replacement -->
+                <Digit digit="1" string="száz"        buildString="száz*" />
+                <Digit digit="2" string="kétszáz"     buildString="kétszáz*" />
+                <Digit digit="3" string="háromszáz"   buildString="háromszáz*" />
+                <Digit digit="4" string="négyszáz"    buildString="négyszáz*" />
+                <Digit digit="5" string="ötszáz"      buildString="ötszáz*" />
+                <Digit digit="6" string="hatszáz"     buildString="hatszáz*" />
+                <Digit digit="7" string="hétszáz"     buildString="hétszáz*" />
+                <Digit digit="8" string="nyolcszáz"   buildString="nyolcszáz*" />
+                <Digit digit="9" string="kilencszáz"  buildString="kilencszáz*" />
+            </Group>
+        </Groups>
+        <!-- Hungarian long scale: millió / milliárd / billió / billiárd …
+             groupSeparator="ll": mi+ll+ió=millió, mi+ll+iárd=milliárd
+             startIndex="2": scale 4 → prefix index 2+1=3 (bi) → billió ✓ -->
+        <NumberScale firstLetterUpperCase="false" groupSeparator="ll" startIndex="2">
+            <StaticNames>
+                <Scale value="0" string="" />
+                <Scale value="1" string="ezer" />
+                <Scale value="2" string="millió" />
+                <Scale value="3" string="milliárd" />
+            </StaticNames>
+            <Suffixes>
+                <Suffix>ió</Suffix>
+                <Suffix>iárd</Suffix>
+            </Suffixes>
+        </NumberScale>
+        <Replacements>
+            <!-- Drop "egy" before scale names: "egyezer" → "ezer", "egyszáz" → "száz" -->
+            <Replacement oldValue="egyezer" newValue="ezer" scope="Anywhere" />
+            <Replacement oldValue="egyszáz" newValue="száz" scope="Anywhere" />
+            <Replacement oldValue="egymillió" newValue="millió" scope="Anywhere" />
+            <Replacement oldValue="egymilliárd" newValue="milliárd" scope="Anywhere" />
+            <!-- Same for generated long-scale names (billió, billiárd, …) -->
+            <Replacement oldValue="egybillió" newValue="billió" scope="Anywhere" />
+            <Replacement oldValue="egybilliárd" newValue="billiárd" scope="Anywhere" />
+            <!-- Exception[2]="kettő" fires in ConvertGroup when chunk=2; replace back to "két" before scale names -->
+            <Replacement oldValue="kettőezer" newValue="kétezer" scope="Anywhere" />
+            <Replacement oldValue="kettőmillió" newValue="kétmillió" scope="Anywhere" />
+            <Replacement oldValue="kettőmilliárd" newValue="kétmilliárd" scope="Anywhere" />
+            <Replacement oldValue="kettőbillió" newValue="kétbillió" scope="Anywhere" />
+            <Replacement oldValue="kettőbilliárd" newValue="kétbilliárd" scope="Anywhere" />
+        </Replacements>
+        <Exceptions>
+            <!-- Standalone 2 = "kettő" (compound uses "két" from Groups) -->
+            <Number value="2" string="kettő" />
+        </Exceptions>
+        <Ordinals suffix=".">
+            <!-- Hungarian ordinals are formed by appending "." (e.g. 1. = "első")
+                 but the full word forms require specific lexical forms.
+                 This minimal configuration appends "." to the cardinal. -->
+            <OrdinalException value="1"  string="első" />
+            <OrdinalException value="2"  string="második" />
+            <OrdinalException value="3"  string="harmadik" />
+            <OrdinalException value="4"  string="negyedik" />
+            <OrdinalException value="5"  string="ötödik" />
+            <OrdinalException value="6"  string="hatodik" />
+            <OrdinalException value="7"  string="hetedik" />
+            <OrdinalException value="8"  string="nyolcadik" />
+            <OrdinalException value="9"  string="kilencedik" />
+            <OrdinalException value="10" string="tizedik" />
+            <OrdinalException value="20" string="huszadik" />
+            <OrdinalException value="30" string="harmincadik" />
+            <OrdinalException value="100" string="századik" />
+            <OrdinalException value="1000" string="ezredik" />
+        </Ordinals>
+    </Language>
+</Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.VN.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.VN.xml
@@ -9,6 +9,8 @@
         decimalSeparator="phẩy"
         fractionSeparator="trên"
         maxNumber="999999999999"
+        intraGroupConnector="linh"
+        intraGroupConnectorThreshold="10"
     >
         <Culture>VN</Culture>
         <Culture>VI</Culture>
@@ -72,12 +74,8 @@
             <!-- "lăm" replaces "năm" after "mười" for 15 -->
             <Replacement oldValue="mười năm" newValue="mười lăm" scope="Anywhere" />
         </Replacements>
-        <!--
-            Simplified implementation. The "linh" connector used between hundreds and
-            units for numbers like 101–109 (e.g. "một trăm linh một") is not implemented
-            here, as it requires engine support for contextual insertion that is not
-            available through static group/replacement rules.
-        -->
+        <!-- The "linh" connector (intraGroupConnector) is now handled by the engine:
+             101–109 → "một trăm linh một" (connector fires when remainder < 10). -->
         <Ordinals prefix="thứ ">
             <!-- 1st is "thứ nhất", not "thứ một" -->
             <OrdinalException value="1" string="thứ nhất" />

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
@@ -1249,6 +1249,73 @@
                                 </xs:annotation>
                             </xs:element>
 
+                            <xs:element name="TimeUnits" minOccurs="0">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Time-unit definitions for Convert(TimeSpan) and Convert(TimeOnly).
+                                        Each Unit element maps a canonical name ("hour", "minute", "second")
+                                        to its singular and plural spoken forms.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="Unit" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:attribute name="name" type="xs:string" use="required">
+                                                    <xs:annotation><xs:documentation>Canonical name: "hour", "minute", or "second".</xs:documentation></xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="singular" type="xs:string" use="required">
+                                                    <xs:annotation><xs:documentation>Singular form (e.g. "hour", "heure").</xs:documentation></xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="plural" type="xs:string" use="required">
+                                                    <xs:annotation><xs:documentation>Plural form (e.g. "hours", "heures").</xs:documentation></xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+
+                            <xs:element name="DateFormat" minOccurs="0">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Date-format configuration for Convert(DateOnly) and Convert(DateTime).
+                                        The pattern supports tokens: {month}, {ordinal-day}, {cardinal-day}, {year}.
+                                        Month names are read from System.Globalization.CultureInfo — no XML needed.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="pattern" type="xs:string" use="required">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Composition pattern. Tokens: {month} (month name from CultureInfo),
+                                                {ordinal-day} (day as ordinal, e.g. "second"), {cardinal-day} (day as
+                                                cardinal, e.g. "two"), {year} (via ConvertYear).
+                                                Example EN: "{month} {ordinal-day}, {year}"
+                                                Example FR: "{cardinal-day} {month} {year}"
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="firstDay" type="xs:string" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Special string for the first day of the month used in {ordinal-day}
+                                                (e.g. "premier" in French, "ersten" in German).
+                                                When absent, the ordinal form of 1 is used.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="dateTimeConnector" type="xs:string" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Connector inserted between date and time in Convert(DateTime).
+                                                Defaults to the language separator when omitted.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+
                             <xs:element name="Multiplicatives" minOccurs="0">
                                 <xs:annotation>
                                     <xs:documentation>
@@ -1358,6 +1425,24 @@
                                 <xs:documentation>
                                     Threshold below which groupConnector is used instead of groupSeparator.
                                     Defaults to 100 when omitted.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="intraGroupConnector" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Word inserted inside a digit group between the hundreds and the lower part
+                                    (tens + units) when that lower part is below intraGroupConnectorThreshold.
+                                    Example: "linh" for Vietnamese — 101 → "một trăm linh một".
+                                    Omit when no connector is needed within a group.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="intraGroupConnectorThreshold" type="xs:nonNegativeInteger" use="optional">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Threshold below which intraGroupConnector is inserted.
+                                    Defaults to 10 when omitted (connector fires for remainder 1–9).
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
@@ -1249,12 +1249,34 @@
                                 </xs:annotation>
                             </xs:element>
 
+                            <xs:element name="Multiplicatives" minOccurs="0">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Named multiplicative forms (e.g. 1 → "once", 2 → "twice").
+                                        When present, ConvertMultiplicative(int) is supported.
+                                        Named entries take priority; the suffix is used for unnamed values.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="Multiplicative" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:attribute name="value" type="xs:int" use="required" />
+                                                <xs:attribute name="string" type="xs:string" use="required" />
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="suffix" type="xs:string" />
+                                </xs:complexType>
+                            </xs:element>
+
                             <xs:element name="TimeUnits" minOccurs="0">
                                 <xs:annotation>
                                     <xs:documentation>
                                         Time-unit definitions for Convert(TimeSpan) and Convert(TimeOnly).
                                         Each Unit element maps a canonical name ("hour", "minute", "second")
-                                        to its singular and plural spoken forms.
+                                        to its singular and plural spoken forms, with an optional count1form
+                                        override for the numeral "one" when the unit has grammatical gender.
                                     </xs:documentation>
                                 </xs:annotation>
                                 <xs:complexType>
@@ -1269,6 +1291,13 @@
                                                 </xs:attribute>
                                                 <xs:attribute name="plural" type="xs:string" use="required">
                                                     <xs:annotation><xs:documentation>Plural form (e.g. "hours", "heures").</xs:documentation></xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="count1form" type="xs:string" use="optional">
+                                                    <xs:annotation><xs:documentation>
+                                                        Numeral to use when count == 1, overriding Convert(1).
+                                                        Use when the unit requires a gendered or irregular form of "one"
+                                                        (e.g. count1form="eine" for German feminine nouns like "Stunde").
+                                                    </xs:documentation></xs:annotation>
                                                 </xs:attribute>
                                             </xs:complexType>
                                         </xs:element>
@@ -1293,15 +1322,17 @@
                                                 cardinal, e.g. "two"), {year} (via ConvertYear).
                                                 Example EN: "{month} {ordinal-day}, {year}"
                                                 Example FR: "{cardinal-day} {month} {year}"
+                                                Example DE: "{cardinal-day}. {month} {year}"
                                             </xs:documentation>
                                         </xs:annotation>
                                     </xs:attribute>
                                     <xs:attribute name="firstDay" type="xs:string" use="optional">
                                         <xs:annotation>
                                             <xs:documentation>
-                                                Special string for the first day of the month used in {ordinal-day}
+                                                Special string for the first day of the month, applied to both
+                                                {ordinal-day} and {cardinal-day} when day == 1
                                                 (e.g. "premier" in French, "ersten" in German).
-                                                When absent, the ordinal form of 1 is used.
+                                                When absent, the standard ordinal or cardinal form of 1 is used.
                                             </xs:documentation>
                                         </xs:annotation>
                                     </xs:attribute>
@@ -1313,27 +1344,6 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                     </xs:attribute>
-                                </xs:complexType>
-                            </xs:element>
-
-                            <xs:element name="Multiplicatives" minOccurs="0">
-                                <xs:annotation>
-                                    <xs:documentation>
-                                        Named multiplicative forms (e.g. 1 → "once", 2 → "twice").
-                                        When present, ConvertMultiplicative(int) is supported.
-                                        Named entries take priority; the suffix is used for unnamed values.
-                                    </xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element name="Multiplicative" minOccurs="0" maxOccurs="unbounded">
-                                            <xs:complexType>
-                                                <xs:attribute name="value" type="xs:int" use="required" />
-                                                <xs:attribute name="string" type="xs:string" use="required" />
-                                            </xs:complexType>
-                                        </xs:element>
-                                    </xs:sequence>
-                                    <xs:attribute name="suffix" type="xs:string" />
                                 </xs:complexType>
                             </xs:element>
 

--- a/Utils.NumberToString/NumberConverterResources.Designer.cs
+++ b/Utils.NumberToString/NumberConverterResources.Designer.cs
@@ -458,7 +458,21 @@ namespace Utils {
                 return ResourceManager.GetString("NumberConvertionConfiguration.HE", resourceCulture);
             }
         }
-        
+
+        /// <summary>Croatian number-to-string configuration.</summary>
+        internal static string NumberConvertionConfiguration_HR {
+            get {
+                return ResourceManager.GetString("NumberConvertionConfiguration.HR", resourceCulture);
+            }
+        }
+
+        /// <summary>Hungarian number-to-string configuration.</summary>
+        internal static string NumberConvertionConfiguration_HU {
+            get {
+                return ResourceManager.GetString("NumberConvertionConfiguration.HU", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Recherche une chaîne localisée semblable à &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
         ///&lt;Numbers xmlns=&quot;Utils/NumberConvertionConfiguration.xsd&quot;&gt;

--- a/Utils.NumberToString/NumberConverterResources.resx
+++ b/Utils.NumberToString/NumberConverterResources.resx
@@ -178,6 +178,12 @@
   <data name="NumberConvertionConfiguration.HE" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>NumberConverterConfigurations\NumberConvertionConfiguration.HE.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="NumberConvertionConfiguration.HR" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>NumberConverterConfigurations\NumberConvertionConfiguration.HR.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="NumberConvertionConfiguration.HU" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>NumberConverterConfigurations\NumberConvertionConfiguration.HU.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
   <data name="NumberConvertionConfiguration.HI" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>NumberConverterConfigurations\NumberConvertionConfiguration.HI.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -577,7 +577,7 @@ namespace Utils.NumberToString
                 IntraGroupConnector = language.IntraGroupConnector,
                 IntraGroupConnectorThreshold = language.IntraGroupConnectorThreshold,
                 TimeUnits = language.TimeUnits?.Units?
-                    .ToDictionary(u => u.Name, u => (u.Singular, u.Plural)),
+                    .ToDictionary(u => u.Name, u => (u.Singular, u.Plural, u.Count1Form)),
                 DatePattern = language.DateFormat?.Pattern,
                 DateFirstDay = language.DateFormat?.FirstDay,
                 DateTimeConnector = language.DateFormat?.DateTimeConnector,

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -35,6 +35,8 @@ namespace Utils.NumberToString
                 NumberConverterResources.NumberConvertionConfiguration_FI,
                 NumberConverterResources.NumberConvertionConfiguration_AR,
                 NumberConverterResources.NumberConvertionConfiguration_HE,
+                NumberConverterResources.NumberConvertionConfiguration_HR,
+                NumberConverterResources.NumberConvertionConfiguration_HU,
                 NumberConverterResources.NumberConvertionConfiguration_ZH,
                 NumberConverterResources.NumberConvertionConfiguration_KO,
                 NumberConverterResources.NumberConvertionConfiguration_JA,
@@ -572,6 +574,13 @@ namespace Utils.NumberToString
                 MultiplicativeSuffix = language.Multiplicatives?.Suffix,
                 GroupConnector = language.GroupConnector,
                 GroupConnectorThreshold = language.GroupConnectorThreshold,
+                IntraGroupConnector = language.IntraGroupConnector,
+                IntraGroupConnectorThreshold = language.IntraGroupConnectorThreshold,
+                TimeUnits = language.TimeUnits?.Units?
+                    .ToDictionary(u => u.Name, u => (u.Singular, u.Plural)),
+                DatePattern = language.DateFormat?.Pattern,
+                DateFirstDay = language.DateFormat?.FirstDay,
+                DateTimeConnector = language.DateFormat?.DateTimeConnector,
             };
 
             var converter = new NumberToStringConverter(options);

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -99,6 +99,13 @@ namespace Utils.NumberToString
             MultiplicativeSuffix = options.MultiplicativeSuffix;
             _groupConnector = options.GroupConnector;
             _groupConnectorThreshold = options.GroupConnectorThreshold;
+            _intraGroupConnector = options.IntraGroupConnector;
+            _intraGroupConnectorThreshold = options.IntraGroupConnectorThreshold;
+            _timeUnits = options.TimeUnits?.ToImmutableDictionary()
+                         ?? ImmutableDictionary<string, (string Singular, string Plural)>.Empty;
+            _datePattern = options.DatePattern;
+            _dateFirstDay = options.DateFirstDay;
+            _dateTimeConnector = options.DateTimeConnector;
             // Index both canonical name and localName so both are accepted in API calls and XML constraints.
             _dimensionIndex = VariantDimensions
                 .SelectMany(d => string.IsNullOrEmpty(d.LocalName)
@@ -241,6 +248,30 @@ namespace Utils.NumberToString
         /// <summary>Gets the threshold below which the group connector is used.</summary>
         public int GroupConnectorThreshold => (int)_groupConnectorThreshold;
 
+        /// <summary>Gets the intra-group connector inserted between hundreds and lower parts (e.g. "linh" for VN).</summary>
+        public string? IntraGroupConnector => _intraGroupConnector;
+
+        /// <summary>Gets the threshold below which the intra-group connector is inserted.</summary>
+        public int IntraGroupConnectorThreshold => (int)_intraGroupConnectorThreshold;
+
+        /// <inheritdoc/>
+        public bool SupportsTimeConversion => _timeUnits.Count > 0;
+
+        /// <inheritdoc/>
+        public bool SupportsDateConversion => _datePattern != null;
+
+        /// <summary>Gets the time units for time conversion (hours, minutes, seconds).</summary>
+        public IReadOnlyDictionary<string, (string Singular, string Plural)> TimeUnits => _timeUnits;
+
+        /// <summary>Gets the date pattern string (tokens: {month}, {ordinal-day}, {cardinal-day}, {year}).</summary>
+        public string? DatePattern => _datePattern;
+
+        /// <summary>Gets the special string for day 1 in date ordinal rendering (e.g. "premier" in French).</summary>
+        public string? DateFirstDay => _dateFirstDay;
+
+        /// <summary>Gets the connector inserted between date and time in DateTime conversion.</summary>
+        public string? DateTimeConnector => _dateTimeConnector;
+
         /// <inheritdoc/>
         public bool SupportsOrdinals =>
             OrdinalSuffix != null || OrdinalPrefix != null
@@ -254,6 +285,12 @@ namespace Utils.NumberToString
         private readonly Func<string, string>? _rawAdjustFunction;
         private readonly string? _groupConnector;
         private readonly long _groupConnectorThreshold;
+        private readonly string? _intraGroupConnector;
+        private readonly long _intraGroupConnectorThreshold;
+        private readonly ImmutableDictionary<string, (string Singular, string Plural)> _timeUnits;
+        private readonly string? _datePattern;
+        private readonly string? _dateFirstDay;
+        private readonly string? _dateTimeConnector;
 
         /// <summary>
         /// The raw adjust function before composition with <see cref="LanguageSpecifics"/>.
@@ -937,7 +974,13 @@ namespace Utils.NumberToString
             var leftText = ConvertGroup(groupNumber - 1, remainder);
             var valueText = Groups[groupNumber][groupValue];
 
-            return string.IsNullOrEmpty(leftText) ? valueText.StringValue : valueText.BuildString.Replace("*", leftText);
+            if (string.IsNullOrEmpty(leftText)) return valueText.StringValue;
+
+            // Inject intra-group connector at the hundreds level when there are hundreds AND remainder < threshold
+            if (groupNumber == 3 && _intraGroupConnector != null && groupValue > 0 && remainder > 0 && remainder < _intraGroupConnectorThreshold)
+                return valueText.BuildString.Replace("*", _intraGroupConnector + Separator + leftText);
+
+            return valueText.BuildString.Replace("*", leftText);
         }
 
         /// <summary>
@@ -1117,6 +1160,97 @@ namespace Utils.NumberToString
                 return Convert(multiplier, variants) + MultiplicativeSuffix;
             // No suffix and no named form — fall back to cardinal
             return Convert(multiplier, variants);
+        }
+
+        private string FormatTimeUnit(int count, (string Singular, string Plural) unit, string[] variants)
+        {
+            string word = count == 1 ? unit.Singular : unit.Plural;
+            return Convert(count, variants) + Separator + word;
+        }
+
+        /// <inheritdoc cref="INumberToStringConverter.Convert(TimeSpan, string[])"/>
+        public string Convert(TimeSpan duration, params string[] variants)
+        {
+            if (!SupportsTimeConversion)
+                throw new NotSupportedException($"Language '{LanguageIdentifier}' has no <TimeUnits> configuration.");
+
+            var abs = duration < TimeSpan.Zero ? -duration : duration;
+            var parts = new List<string>();
+            int totalHours = (int)(abs.Days * 24 + abs.Hours);
+
+            if (totalHours > 0 && _timeUnits.TryGetValue("hour", out var h))
+                parts.Add(FormatTimeUnit(totalHours, h, variants));
+            if (abs.Minutes > 0 && _timeUnits.TryGetValue("minute", out var m))
+                parts.Add(FormatTimeUnit(abs.Minutes, m, variants));
+            if (abs.Seconds > 0 && _timeUnits.TryGetValue("second", out var s))
+                parts.Add(FormatTimeUnit(abs.Seconds, s, variants));
+
+            string body = parts.Count > 0 ? string.Join(Separator, parts) : Zero;
+            return duration < TimeSpan.Zero ? Minus.Replace("*", body) : body;
+        }
+
+        /// <inheritdoc cref="INumberToStringConverter.Convert(TimeOnly, string[])"/>
+        public string Convert(TimeOnly time, params string[] variants)
+        {
+            if (!SupportsTimeConversion)
+                throw new NotSupportedException($"Language '{LanguageIdentifier}' has no <TimeUnits> configuration.");
+
+            var parts = new List<string>();
+            if (_timeUnits.TryGetValue("hour", out var h))
+                parts.Add(FormatTimeUnit(time.Hour, h, variants));
+            if (time.Minute > 0 && _timeUnits.TryGetValue("minute", out var m))
+                parts.Add(FormatTimeUnit(time.Minute, m, variants));
+            if (time.Second > 0 && _timeUnits.TryGetValue("second", out var s))
+                parts.Add(FormatTimeUnit(time.Second, s, variants));
+
+            return parts.Count > 0 ? string.Join(Separator, parts) : Zero;
+        }
+
+        private string GetMonthName(int month)
+        {
+            try
+            {
+                return CultureInfo.GetCultureInfo(LanguageIdentifier).DateTimeFormat.MonthNames[month - 1];
+            }
+            catch
+            {
+                return month.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        /// <inheritdoc cref="INumberToStringConverter.Convert(DateOnly, string[])"/>
+        public string Convert(DateOnly date, params string[] variants)
+        {
+            if (!SupportsDateConversion)
+                throw new NotSupportedException($"Language '{LanguageIdentifier}' has no <DateFormat> configuration.");
+
+            string month = GetMonthName(date.Month);
+            string cardinalDay = Convert(date.Day, variants);
+            string ordinalDay = (date.Day == 1 && _dateFirstDay != null)
+                ? _dateFirstDay
+                : (SupportsOrdinals ? ConvertOrdinal(date.Day, variants) : cardinalDay);
+            string year = ConvertYear(date.Year, variants);
+
+            return _datePattern!
+                .Replace("{month}", month)
+                .Replace("{ordinal-day}", ordinalDay)
+                .Replace("{cardinal-day}", cardinalDay)
+                .Replace("{year}", year);
+        }
+
+        /// <inheritdoc cref="INumberToStringConverter.Convert(DateTime, string[])"/>
+        public string Convert(DateTime dateTime, params string[] variants)
+        {
+            if (!SupportsDateConversion && !SupportsTimeConversion)
+                throw new NotSupportedException($"Language '{LanguageIdentifier}' has no <DateFormat> or <TimeUnits> configuration.");
+
+            string connector = _dateTimeConnector ?? Separator;
+
+            if (SupportsDateConversion && SupportsTimeConversion)
+                return Convert(DateOnly.FromDateTime(dateTime), variants) + connector + Convert(TimeOnly.FromDateTime(dateTime), variants);
+            if (SupportsDateConversion)
+                return Convert(DateOnly.FromDateTime(dateTime), variants);
+            return Convert(TimeOnly.FromDateTime(dateTime), variants);
         }
 
         /// <summary>

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -102,7 +102,7 @@ namespace Utils.NumberToString
             _intraGroupConnector = options.IntraGroupConnector;
             _intraGroupConnectorThreshold = options.IntraGroupConnectorThreshold;
             _timeUnits = options.TimeUnits?.ToImmutableDictionary()
-                         ?? ImmutableDictionary<string, (string Singular, string Plural)>.Empty;
+                         ?? ImmutableDictionary<string, (string Singular, string Plural, string? Count1Form)>.Empty;
             _datePattern = options.DatePattern;
             _dateFirstDay = options.DateFirstDay;
             _dateTimeConnector = options.DateTimeConnector;
@@ -261,7 +261,7 @@ namespace Utils.NumberToString
         public bool SupportsDateConversion => _datePattern != null;
 
         /// <summary>Gets the time units for time conversion (hours, minutes, seconds).</summary>
-        public IReadOnlyDictionary<string, (string Singular, string Plural)> TimeUnits => _timeUnits;
+        public IReadOnlyDictionary<string, (string Singular, string Plural, string? Count1Form)> TimeUnits => _timeUnits;
 
         /// <summary>Gets the date pattern string (tokens: {month}, {ordinal-day}, {cardinal-day}, {year}).</summary>
         public string? DatePattern => _datePattern;
@@ -287,7 +287,7 @@ namespace Utils.NumberToString
         private readonly long _groupConnectorThreshold;
         private readonly string? _intraGroupConnector;
         private readonly long _intraGroupConnectorThreshold;
-        private readonly ImmutableDictionary<string, (string Singular, string Plural)> _timeUnits;
+        private readonly ImmutableDictionary<string, (string Singular, string Plural, string? Count1Form)> _timeUnits;
         private readonly string? _datePattern;
         private readonly string? _dateFirstDay;
         private readonly string? _dateTimeConnector;
@@ -1162,10 +1162,11 @@ namespace Utils.NumberToString
             return Convert(multiplier, variants);
         }
 
-        private string FormatTimeUnit(int count, (string Singular, string Plural) unit, string[] variants)
+        private string FormatTimeUnit(int count, (string Singular, string Plural, string? Count1Form) unit, string[] variants)
         {
             string word = count == 1 ? unit.Singular : unit.Plural;
-            return Convert(count, variants) + Separator + word;
+            string numeral = (count == 1 && unit.Count1Form != null) ? unit.Count1Form : Convert(count, variants);
+            return numeral + Separator + word;
         }
 
         /// <inheritdoc cref="INumberToStringConverter.Convert(TimeSpan, string[])"/>
@@ -1225,7 +1226,10 @@ namespace Utils.NumberToString
                 throw new NotSupportedException($"Language '{LanguageIdentifier}' has no <DateFormat> configuration.");
 
             string month = GetMonthName(date.Month);
-            string cardinalDay = Convert(date.Day, variants);
+            // firstDay overrides both {ordinal-day} and {cardinal-day} when day == 1
+            string cardinalDay = (date.Day == 1 && _dateFirstDay != null)
+                ? _dateFirstDay
+                : Convert(date.Day, variants);
             string ordinalDay = (date.Day == 1 && _dateFirstDay != null)
                 ? _dateFirstDay
                 : (SupportsOrdinals ? ConvertOrdinal(date.Day, variants) : cardinalDay);

--- a/Utils.NumberToString/NumberToStringConverterOptions.cs
+++ b/Utils.NumberToString/NumberToStringConverterOptions.cs
@@ -138,6 +138,36 @@ public sealed class NumberToStringConverterOptions
     /// <summary>Threshold below which <see cref="GroupConnector"/> is used instead of the regular group separator.</summary>
     public int GroupConnectorThreshold { get; set; } = 100;
 
+    /// <summary>
+    /// Word inserted inside a group between the hundreds and the lower part when the lower part is
+    /// below <see cref="IntraGroupConnectorThreshold"/> (e.g. "linh" for Vietnamese).
+    /// </summary>
+    public string? IntraGroupConnector { get; set; }
+
+    /// <summary>Threshold below which <see cref="IntraGroupConnector"/> is inserted within a group.</summary>
+    public int IntraGroupConnectorThreshold { get; set; } = 10;
+
+    /// <summary>
+    /// Time units keyed by canonical name ("hour", "minute", "second"),
+    /// each with singular and plural forms. Required for Convert(TimeSpan/TimeOnly).
+    /// </summary>
+    public IReadOnlyDictionary<string, (string Singular, string Plural)>? TimeUnits { get; set; }
+
+    /// <summary>
+    /// Pattern for rendering a date. Supported tokens: {month}, {ordinal-day}, {cardinal-day}, {year}.
+    /// Required for Convert(DateOnly/DateTime).
+    /// </summary>
+    public string? DatePattern { get; set; }
+
+    /// <summary>
+    /// Special string used for the first day of the month (e.g. "premier" in French).
+    /// When set, overrides the ordinal form of day 1 in {ordinal-day}.
+    /// </summary>
+    public string? DateFirstDay { get; set; }
+
+    /// <summary>Connector inserted between date and time when converting a DateTime (defaults to Separator).</summary>
+    public string? DateTimeConnector { get; set; }
+
     /// <summary>Creates an options object with sensible defaults. Required properties
     /// (<see cref="Zero"/>, <see cref="Minus"/>, <see cref="Groups"/>, <see cref="Scale"/>)
     /// must be set before passing to the constructor.</summary>
@@ -181,6 +211,12 @@ public sealed class NumberToStringConverterOptions
         MultiplicativeSuffix = source.MultiplicativeSuffix;
         GroupConnector = source.GroupConnector;
         GroupConnectorThreshold = source.GroupConnectorThreshold;
+        IntraGroupConnector = source.IntraGroupConnector;
+        IntraGroupConnectorThreshold = source.IntraGroupConnectorThreshold;
+        TimeUnits = source.TimeUnits;
+        DatePattern = source.DatePattern;
+        DateFirstDay = source.DateFirstDay;
+        DateTimeConnector = source.DateTimeConnector;
     }
 
     /// <summary>

--- a/Utils.NumberToString/NumberToStringConverterOptions.cs
+++ b/Utils.NumberToString/NumberToStringConverterOptions.cs
@@ -149,9 +149,10 @@ public sealed class NumberToStringConverterOptions
 
     /// <summary>
     /// Time units keyed by canonical name ("hour", "minute", "second"),
-    /// each with singular and plural forms. Required for Convert(TimeSpan/TimeOnly).
+    /// each with singular, plural, and an optional count-1 override for grammatical gender.
+    /// Required for Convert(TimeSpan/TimeOnly).
     /// </summary>
-    public IReadOnlyDictionary<string, (string Singular, string Plural)>? TimeUnits { get; set; }
+    public IReadOnlyDictionary<string, (string Singular, string Plural, string? Count1Form)>? TimeUnits { get; set; }
 
     /// <summary>
     /// Pattern for rendering a date. Supported tokens: {month}, {ordinal-day}, {cardinal-day}, {year}.

--- a/Utils.NumberToString/TODO.md
+++ b/Utils.NumberToString/TODO.md
@@ -104,100 +104,59 @@ RU, FR, IT n'utilisent pas ce format.
 
 ## Prochaines améliorations identifiées
 
-### 16. Scope `StartsWith` pour les remplacements — **indispensable**
-Actuellement les scopes sont `Standalone`, `Anywhere`, `LastWord`. Il manque `StartsWith` (et
-symétrique `EndsWith`) pour affecter le début d'un segment sans contaminer les autres occurrences.
-Cas d'usage typiques :
-- **ID** : "satu belas" → "sebelas" (le préfixe "satu" se contracte en "se" devant "belas")
-- **PL/CS/SK** : contractions de préfixes en début de composé
-- Implémentation : ajouter `StartsWith` / `EndsWith` à `ReplacementScope` (enum) et gérer dans
-  `ApplySubstringReplacements` avec `string.StartsWith` / `string.EndsWith`.
+### 16. ~~Scope `StartsWith` / `EndsWith` pour les remplacements~~ — **implémenté**
+Deux nouveaux scopes ajoutés à `ReplacementScope` : `StartsWith` et `EndsWith`.
+`ApplySubstringReplacements` utilise `string.StartsWith` / `string.EndsWith` selon le scope.
+Utilisés notamment par **ID** ("satu belas" → "sebelas") et **HE** (formes de début de composé).
 
-### 17. Validation des variants au chargement XML — **indispensable**
-Si un `<TriggerReplace>` ou un `<Replacement>` référence un variant non déclaré dans
-`<VariantDimensions>`, l'erreur est silencieuse et le variant est simplement ignoré.
-Il faut lever une `InvalidOperationException` descriptive au moment de `InitializeConfigurations`
-(dans `NumberToStringConverter.Globalization.cs`) pour détecter les fautes de frappe dans les XML.
+### 17. ~~Validation des variants au chargement XML~~ — **implémenté**
+`ValidateVariantReferences` levée dans `ReadConverter` : si un `<TriggerReplace>` référence
+une dimension de variant non déclarée dans `<VariantDimensions>`, une
+`InvalidOperationException` descriptive est levée au chargement. Test de régression ajouté.
 
-### 18. `Convert(double)` / `Convert(float)` — manque d'API évident
-Les surcharges `decimal` existent mais `double`/`float` sont absentes alors que la majorité des
-APIs .NET utilisent `double`. Proposition :
-```csharp
-string Convert(double number, int significantDigits = 15, params string[] variants);
-string Convert(float number, int significantDigits = 7, params string[] variants);
-```
-La précision significative par défaut doit être paramétrable pour éviter les artefacts flottants.
+### 18. ~~`Convert(double)` / `Convert(float)`~~ — **implémenté**
+Méthodes par défaut sur `INumberToStringConverter` : le `double`/`float` est converti via
+`ToString("R")` + `decimal.TryParse` puis délégué à `Convert(decimal, variants)`.
+Précision significative respectée grâce au format round-trip.
 
-### 19. `ConvertFraction(BigInteger, BigInteger)` dans l'interface publique
-`BuildFractionText` est déjà implémenté en interne mais n'est pas exposé via
-`INumberToStringConverter`. Exposer publiquement pour permettre "un tiers", "trois quarts", etc.
+### 19. ~~`ConvertFraction(BigInteger, BigInteger)`~~ — **implémenté**
+Méthode publique `ConvertFraction(numerator, denominator, params string[] variants)` exposée
+sur `INumberToStringConverter` (implémentation par défaut) et `NumberToStringConverter`.
+S'appuie sur `BuildFractionText` interne. Produit "un tiers", "trois quarts", etc.
 
-### 20. `ConvertMultiplicative(int)` — nombres multiplicatifs
-Distinct des ordinaux : `ConvertMultiplicative(2)` → "double"/"deux fois" (FR),
-"twice" (EN), "zweimal" (DE). Supportable via une section `<Multiplicatives>` en XML
-ou `IMultiplicativeLanguageSpecifics`.
+### 20. ~~`ConvertMultiplicative(int)`~~ — **implémenté**
+Section `<Multiplicatives>` en XML avec entrées `<Entry value="…" string="…" />`.
+`ConvertMultiplicative(n)` expose la table ; méthode par défaut sur l'interface lève
+`NotSupportedException` si non configurée.
 
-### 21. Conversion de types temporels — **excellente priorité**
-Exposer des surcharges pour les types temporels standards .NET, en s'appuyant sur le
-`INumberToStringConverter` existant :
+### 21. ~~Conversion de types temporels~~ — **implémenté**
+Quatre nouvelles surcharges ajoutées à `INumberToStringConverter` et `NumberToStringConverter` :
+- `Convert(TimeSpan duration, params string[] variants)` — totalise les heures et concatène
+  heure/minute/seconde non nuls avec leurs formes singulier/pluriel issues de `<TimeUnits>`.
+- `Convert(TimeOnly time, params string[] variants)` — toujours l'heure ; minute/seconde si > 0.
+- `Convert(DateOnly date, params string[] variants)` — patron configurable via `<DateFormat pattern="…">` ;
+  tokens `{month}` (nom via `CultureInfo`), `{ordinal-day}`, `{cardinal-day}`, `{year}` ;
+  attribut `firstDay` pour la forme du 1er du mois (ex. "premier", "ersten").
+- `Convert(DateTime dateTime, params string[] variants)` — combine DateOnly + TimeOnly avec
+  connecteur optionnel `dateTimeConnector`.
 
-#### 21a. `Convert(TimeSpan)` / `ConvertDuration`
-```csharp
-string Convert(TimeSpan duration, params string[] variants);
-```
-Produit "deux heures trente minutes cinq secondes". Nécessite des sections `<TimeUnits>`
-dans le XML (heure/minute/seconde avec pluriel, éventuellement `(s)` via `ToPlural`).
-Les unités non nulles sont concaténées avec le séparateur de la langue.
+Propriétés `SupportsTimeConversion` / `SupportsDateConversion` exposées sur l'interface
+(par défaut `false`). EN, FR et DE configurés avec `<TimeUnits>` et `<DateFormat>`.
 
-#### 21b. `Convert(TimeOnly)`
-```csharp
-string Convert(TimeOnly time, params string[] variants);
-```
-Produit "quatorze heures trente" ou "deux heures et demie" selon le format de la langue.
-Option : format 12h vs 24h via variant ou option dédiée.
+### 22. ~~Connecteur inter-groupes conditionnel~~ — **implémenté**
+Attributs `intraGroupConnector` et `intraGroupConnectorThreshold` sur `<Language>`.
+Injecté dans `ConvertGroup` au niveau 3 quand `groupValue > 0` (centaines présentes)
+et `0 < remainder < threshold`. VN configuré avec `intraGroupConnector="linh" threshold="10"` :
+- 101 → "một trăm linh một" ✓  
+- 110 → "một trăm mười" (pas de connecteur, remainder ≥ threshold) ✓
 
-#### 21c. `Convert(DateOnly)`
-```csharp
-string Convert(DateOnly date, params string[] variants);
-```
-Produit "le deux juillet deux mille vingt-six" (FR), "July second, twenty twenty-six" (EN).
-S'appuie sur `ConvertYear`, `ConvertOrdinal` et des noms de mois en XML (`<Months>`).
-
-#### 21d. `Convert(DateTime)`
-```csharp
-string Convert(DateTime dateTime, params string[] variants);
-```
-Combinaison de `Convert(DateOnly)` + `Convert(TimeOnly)` avec connecteur configurable.
-
-**Note architecturale :** les noms de mois et de jours sont disponibles sans XML supplémentaire via
-`System.Globalization.CultureInfo.GetCultureInfo(lang).DateTimeFormat.MonthNames[month-1]` et
-`.DayNames[dayOfWeek]`. Inutile de les dupliquer dans les fichiers XML — le moteur les lira
-directement depuis le BCL, ce qui garantit leur fiabilité pour toutes les langues supportées
-par .NET. Seules les unités de temps (heure/minute/seconde avec leur pluriel) et le patron de
-composition de la date (ordre jour/mois/an, connecteurs) restent à configurer dans le XML.
-```xml
-<TimeUnits>
-    <Unit name="hour"   singular="heure"  plural="heures"  />
-    <Unit name="minute" singular="minute" plural="minutes" />
-    <Unit name="second" singular="seconde" plural="secondes" />
-</TimeUnits>
-<DateFormat pattern="{ordinal-day} {month} {year}" />
-```
-
-### 22. Connecteur inter-groupes conditionnel (moteur XML)
-Certaines langues insèrent un mot de liaison entre groupes selon le contexte :
-- VN : "linh" entre centaines et unités isolées (101 → "một trăm linh một")
-- EN : "and" entre centaines et dizaines/unités (101 → "one hundred and one")
-- FA : "و" entre chaque groupe
-
-Proposition : attribut `connector="linh"` + `connectorThreshold="10"` sur `<Group level="3">`
-(inséré si le groupe de rang inférieur est < seuil). Résoudrait la limitation documentée dans VN.
-
-### 23. Nouvelles langues — **candidats prioritaires**
-- **HR/SR** (croate/serbe) : Slavique du sud, proches de BG ; serbe en deux alphabets
-- **HU** (hongrois) : agglutinant, suffixes nominaux collant directement au chiffre
-- **RO** (roumain) : genre masculin/féminin, "de" obligatoire devant les grands nombres
-  (ex : "un milion **de** oameni") — complexe mais jouable avec `Variants`
+### 23. ~~Nouvelles langues HR et HU~~ — **implémenté** ; RO **reporté**
+- **HR** (croate) : long scale avec `groupSeparator="li"` → milijun/milijarda/bilijun ;
+  exceptions 11–19 ; remplacement "jedan tisuća" → "tisuća" ; ordinals (prvi/drugi/treći…).
+- **HU** (hongrois) : séparateur vide (agglutination) ; forme liante `két` vs forme isolée
+  `kettő` via `Exception[2]` + Replacements ("kettőezer" → "kétezer") ; `startIndex="2"` pour
+  générer billió/billiárd ; "egyezer" → "ezer" ; ordinals lexicaux (első/második…).
+- **RO** (roumain) : genre m/f + "de" devant grands nombres — reporté, trop complexe.
 
 ### ~~C1. Numéros romains~~ — **hors périmètre**
 `ConvertRoman` doit faire l'objet d'un système de conversion distinct qui pourrait implémenter

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterTimeAndNewLangTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterTimeAndNewLangTests.cs
@@ -1,0 +1,322 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Utils.NumberToString;
+
+namespace UtilsTest.Mathematics.Numbers;
+
+/// <summary>
+/// Tests for: item 21 (Convert TimeSpan/TimeOnly/DateOnly/DateTime),
+/// item 22 (intraGroupConnector — VN "linh"), item 23 (HR, HU new languages).
+/// </summary>
+[TestClass]
+public class NumberToStringConverterTimeAndNewLangTests
+{
+    // ─── Item 22 — VN intraGroupConnector ──────────────────────────────────
+
+    [TestMethod]
+    public void Convert_VN_IntraGroupConnector_101_To_109()
+    {
+        var vn = NumberToStringConverter.GetConverter("VN");
+        Assert.AreEqual("một trăm linh một",  vn.Convert(101));
+        Assert.AreEqual("một trăm linh hai",  vn.Convert(102));
+        Assert.AreEqual("một trăm linh năm",  vn.Convert(105));
+        Assert.AreEqual("một trăm linh chín", vn.Convert(109));
+    }
+
+    [TestMethod]
+    public void Convert_VN_NoConnector_Above_Threshold()
+    {
+        var vn = NumberToStringConverter.GetConverter("VN");
+        // 110 = mười (tens digit = 1) → no linh since remainder=10 >= threshold=10
+        Assert.AreEqual("một trăm mười",           vn.Convert(110));
+        Assert.AreEqual("một trăm hai mươi mốt",   vn.Convert(121));
+        // 200 has no remainder — no connector
+        Assert.AreEqual("hai trăm",                vn.Convert(200));
+    }
+
+    [TestMethod]
+    public void Convert_VN_1To9_NoConnector()
+    {
+        var vn = NumberToStringConverter.GetConverter("VN");
+        // Small numbers (no hundreds) must NOT get the connector
+        Assert.AreEqual("một",  vn.Convert(1));
+        Assert.AreEqual("năm",  vn.Convert(5));
+        Assert.AreEqual("chín", vn.Convert(9));
+    }
+
+    [TestMethod]
+    public void Convert_VN_201_To_209_WithConnector()
+    {
+        var vn = NumberToStringConverter.GetConverter("VN");
+        Assert.AreEqual("hai trăm linh một", vn.Convert(201));
+        Assert.AreEqual("hai trăm linh chín", vn.Convert(209));
+    }
+
+    // ─── Item 21a — Convert(TimeSpan) ──────────────────────────────────────
+
+    [TestMethod]
+    public void Convert_TimeSpan_EN_HoursMinutesSeconds()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.IsTrue(en.SupportsTimeConversion);
+        Assert.AreEqual("two hours thirty minutes five seconds",
+            en.Convert(new TimeSpan(2, 30, 5)));
+    }
+
+    [TestMethod]
+    public void Convert_TimeSpan_EN_HoursOnly()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.AreEqual("one hour", en.Convert(new TimeSpan(1, 0, 0)));
+    }
+
+    [TestMethod]
+    public void Convert_TimeSpan_EN_MinutesSeconds()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.AreEqual("thirty minutes ten seconds", en.Convert(new TimeSpan(0, 30, 10)));
+    }
+
+    [TestMethod]
+    public void Convert_TimeSpan_FR_HoursMinutes()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        Assert.IsTrue(fr.SupportsTimeConversion);
+        Assert.AreEqual("deux heures trente minutes", fr.Convert(new TimeSpan(2, 30, 0)));
+    }
+
+    [TestMethod]
+    public void Convert_TimeSpan_FR_OneHour()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // "heure" is feminine: pass gender variant to get "une" instead of "un"
+        Assert.AreEqual("une heure", fr.Convert(new TimeSpan(1, 0, 0), "gender=feminin"));
+    }
+
+    [TestMethod]
+    public void Convert_TimeSpan_DE_HoursMinutesSeconds()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+        Assert.IsTrue(de.SupportsTimeConversion);
+        Assert.AreEqual("zwei Stunden dreißig Minuten fünf Sekunden",
+            de.Convert(new TimeSpan(2, 30, 5)));
+    }
+
+    // ─── Item 21b — Convert(TimeOnly) ──────────────────────────────────────
+
+    [TestMethod]
+    public void Convert_TimeOnly_EN_Basic()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        // 14:30 → "fourteen hours thirty minutes"
+        Assert.AreEqual("fourteen hours thirty minutes",
+            en.Convert(new TimeOnly(14, 30, 0)));
+    }
+
+    [TestMethod]
+    public void Convert_TimeOnly_FR_Basic()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // 14:30 → "quatorze heures trente minutes"
+        Assert.AreEqual("quatorze heures trente minutes",
+            fr.Convert(new TimeOnly(14, 30, 0)));
+    }
+
+    // ─── Item 21c — Convert(DateOnly) ──────────────────────────────────────
+
+    [TestMethod]
+    public void Convert_DateOnly_EN_Basic()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.IsTrue(en.SupportsDateConversion);
+        // July 2 → "July second, twenty twenty-six" (year via ConvertYear)
+        string result = en.Convert(new DateOnly(2026, 7, 2));
+        Assert.IsTrue(result.StartsWith("July second,"), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Convert_DateOnly_EN_FirstOfMonth()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        // July 1 → "July first, ..."
+        string result = en.Convert(new DateOnly(2026, 7, 1));
+        Assert.IsTrue(result.StartsWith("July first,"), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Convert_DateOnly_FR_Basic()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        Assert.IsTrue(fr.SupportsDateConversion);
+        // 2 juillet 2026 → "deux juillet deux mille vingt-six"
+        string result = fr.Convert(new DateOnly(2026, 7, 2));
+        Assert.IsTrue(result.StartsWith("deux juillet"), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Convert_DateOnly_FR_FirstOfMonth()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // 1er → pattern {cardinal-day} → "un" but firstDay="premier" for {ordinal-day}
+        // FR uses {cardinal-day}, so firstDay doesn't apply here
+        string result = fr.Convert(new DateOnly(2026, 7, 1));
+        Assert.IsTrue(result.StartsWith("un juillet"), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Convert_DateOnly_DE_Basic()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+        Assert.IsTrue(de.SupportsDateConversion);
+        // pattern="{cardinal-day}. {month} {year}", firstDay="ersten"
+        // 2. Juli zweitausendsechsundzwanzig
+        string result = de.Convert(new DateOnly(2026, 7, 2));
+        Assert.IsTrue(result.StartsWith("zwei. Juli"), $"Actual: {result}");
+    }
+
+    // ─── Item 21d — Convert(DateTime) ──────────────────────────────────────
+
+    [TestMethod]
+    public void Convert_DateTime_EN_Basic()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        var dt = new DateTime(2026, 7, 2, 14, 30, 5);
+        string result = en.Convert(dt);
+        // Should contain date part and time part
+        Assert.IsTrue(result.Contains("July"), $"Actual: {result}");
+        Assert.IsTrue(result.Contains("fourteen hours"), $"Actual: {result}");
+    }
+
+    // ─── Item 23 — HR (Croatian) ───────────────────────────────────────────
+
+    [TestMethod]
+    public void Convert_HR_BasicNumbers()
+    {
+        var hr = NumberToStringConverter.GetConverter("HR");
+        Assert.AreEqual("nula",    hr.Convert(0));
+        Assert.AreEqual("jedan",   hr.Convert(1));
+        Assert.AreEqual("dva",     hr.Convert(2));
+        Assert.AreEqual("deset",   hr.Convert(10));
+        Assert.AreEqual("jedanaest", hr.Convert(11));
+        Assert.AreEqual("dvanaest",  hr.Convert(12));
+        Assert.AreEqual("devetnaest", hr.Convert(19));
+        Assert.AreEqual("dvadeset",  hr.Convert(20));
+        Assert.AreEqual("dvadeset jedan", hr.Convert(21));
+        Assert.AreEqual("sto",     hr.Convert(100));
+        Assert.AreEqual("sto jedan", hr.Convert(101));
+        Assert.AreEqual("dvjesto", hr.Convert(200));
+    }
+
+    [TestMethod]
+    public void Convert_HR_Thousands()
+    {
+        var hr = NumberToStringConverter.GetConverter("HR");
+        Assert.AreEqual("tisuća",          hr.Convert(1000));
+        Assert.AreEqual("dva tisuća",      hr.Convert(2000));
+        Assert.AreEqual("deset tisuća",    hr.Convert(10_000));
+        Assert.AreEqual("jedan milijun",   hr.Convert(1_000_000));
+        Assert.AreEqual("dva milijun",     hr.Convert(2_000_000));
+        Assert.AreEqual("jedan milijarda", hr.Convert(1_000_000_000));
+    }
+
+    [TestMethod]
+    public void Convert_HR_LargeScale()
+    {
+        var hr = NumberToStringConverter.GetConverter("HR");
+        Assert.AreEqual("jedan bilijun",   hr.Convert(1_000_000_000_000L));
+    }
+
+    // ─── Item 23 — HU (Hungarian) ─────────────────────────────────────────
+
+    [TestMethod]
+    public void Convert_HU_BasicNumbers()
+    {
+        var hu = NumberToStringConverter.GetConverter("HU");
+        Assert.AreEqual("nulla",    hu.Convert(0));
+        Assert.AreEqual("egy",      hu.Convert(1));
+        Assert.AreEqual("kettő",    hu.Convert(2));   // exception: standalone
+        Assert.AreEqual("három",    hu.Convert(3));
+        Assert.AreEqual("tíz",      hu.Convert(10));
+        Assert.AreEqual("tizenegy", hu.Convert(11));
+        Assert.AreEqual("tizenkét", hu.Convert(12));
+        Assert.AreEqual("húsz",     hu.Convert(20));
+        Assert.AreEqual("huszonegy", hu.Convert(21));
+        Assert.AreEqual("harminc",  hu.Convert(30));
+        Assert.AreEqual("harmincegy", hu.Convert(31));
+    }
+
+    [TestMethod]
+    public void Convert_HU_Hundreds()
+    {
+        var hu = NumberToStringConverter.GetConverter("HU");
+        Assert.AreEqual("száz",        hu.Convert(100));   // "egyszáz" → "száz"
+        Assert.AreEqual("százegy",     hu.Convert(101));
+        Assert.AreEqual("kétszáz",     hu.Convert(200));
+        Assert.AreEqual("háromszáz",   hu.Convert(300));
+        Assert.AreEqual("négyszáz",    hu.Convert(400));
+        Assert.AreEqual("kétszázhuszonegy", hu.Convert(221));
+    }
+
+    [TestMethod]
+    public void Convert_HU_Thousands()
+    {
+        var hu = NumberToStringConverter.GetConverter("HU");
+        Assert.AreEqual("ezer",       hu.Convert(1000));    // "egyezer" → "ezer"
+        Assert.AreEqual("kétezer",    hu.Convert(2000));    // "két" + "ezer"
+        Assert.AreEqual("tízezer",    hu.Convert(10_000));
+        Assert.AreEqual("millió",     hu.Convert(1_000_000));   // "egymillió" → "millió"
+        Assert.AreEqual("kétmillió",  hu.Convert(2_000_000));   // "két" + "millió"
+        Assert.AreEqual("milliárd",   hu.Convert(1_000_000_000L));
+    }
+
+    [TestMethod]
+    public void Convert_HU_LargeScale()
+    {
+        var hu = NumberToStringConverter.GetConverter("HU");
+        // Scale 4: bi+ll+ió = billió
+        Assert.AreEqual("billió", hu.Convert(1_000_000_000_000L));
+    }
+
+    [TestMethod]
+    public void ConvertOrdinal_HU_Exceptions()
+    {
+        var hu = NumberToStringConverter.GetConverter("HU");
+        Assert.IsTrue(hu.SupportsOrdinals);
+        Assert.AreEqual("első",     hu.ConvertOrdinal(1));
+        Assert.AreEqual("második",  hu.ConvertOrdinal(2));
+        Assert.AreEqual("harmadik", hu.ConvertOrdinal(3));
+    }
+
+    // ─── SupportsTimeConversion / SupportsDateConversion feature flags ──────
+
+    [TestMethod]
+    public void SupportsTimeConversion_EN_FR_DE_True()
+    {
+        Assert.IsTrue(NumberToStringConverter.GetConverter("EN").SupportsTimeConversion);
+        Assert.IsTrue(NumberToStringConverter.GetConverter("FR").SupportsTimeConversion);
+        Assert.IsTrue(NumberToStringConverter.GetConverter("DE").SupportsTimeConversion);
+    }
+
+    [TestMethod]
+    public void SupportsTimeConversion_HR_HU_False()
+    {
+        Assert.IsFalse(NumberToStringConverter.GetConverter("HR").SupportsTimeConversion);
+        Assert.IsFalse(NumberToStringConverter.GetConverter("HU").SupportsTimeConversion);
+    }
+
+    [TestMethod]
+    public void SupportsDateConversion_EN_FR_DE_True()
+    {
+        Assert.IsTrue(NumberToStringConverter.GetConverter("EN").SupportsDateConversion);
+        Assert.IsTrue(NumberToStringConverter.GetConverter("FR").SupportsDateConversion);
+        Assert.IsTrue(NumberToStringConverter.GetConverter("DE").SupportsDateConversion);
+    }
+
+    [TestMethod]
+    public void NotSupported_TimeConversion_Throws()
+    {
+        var hr = NumberToStringConverter.GetConverter("HR");
+        Assert.IsFalse(hr.SupportsTimeConversion);
+        Assert.ThrowsException<NotSupportedException>(() => hr.Convert(new TimeSpan(1, 0, 0)));
+    }
+}

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterTimeAndNewLangTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterTimeAndNewLangTests.cs
@@ -102,6 +102,14 @@ public class NumberToStringConverterTimeAndNewLangTests
             de.Convert(new TimeSpan(2, 30, 5)));
     }
 
+    [TestMethod]
+    public void Convert_TimeSpan_DE_OneHour_Count1Form()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+        // count1form="eine" prevents "eins Stunde" — should produce "eine Stunde"
+        Assert.AreEqual("eine Stunde", de.Convert(new TimeSpan(1, 0, 0)));
+    }
+
     // ─── Item 21b — Convert(TimeOnly) ──────────────────────────────────────
 
     [TestMethod]
@@ -157,10 +165,9 @@ public class NumberToStringConverterTimeAndNewLangTests
     public void Convert_DateOnly_FR_FirstOfMonth()
     {
         var fr = NumberToStringConverter.GetConverter("FR");
-        // 1er → pattern {cardinal-day} → "un" but firstDay="premier" for {ordinal-day}
-        // FR uses {cardinal-day}, so firstDay doesn't apply here
+        // firstDay="premier" applies to {cardinal-day} too when day == 1
         string result = fr.Convert(new DateOnly(2026, 7, 1));
-        Assert.IsTrue(result.StartsWith("un juillet"), $"Actual: {result}");
+        Assert.IsTrue(result.StartsWith("premier juillet"), $"Actual: {result}");
     }
 
     [TestMethod]
@@ -169,9 +176,18 @@ public class NumberToStringConverterTimeAndNewLangTests
         var de = NumberToStringConverter.GetConverter("DE");
         Assert.IsTrue(de.SupportsDateConversion);
         // pattern="{cardinal-day}. {month} {year}", firstDay="ersten"
-        // 2. Juli zweitausendsechsundzwanzig
+        // day 2: cardinal "zwei" → "zwei. Juli ..."
         string result = de.Convert(new DateOnly(2026, 7, 2));
         Assert.IsTrue(result.StartsWith("zwei. Juli"), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Convert_DateOnly_DE_FirstDay_CardinalDay()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+        // firstDay="ersten" must also apply to {cardinal-day} when day == 1
+        string result = de.Convert(new DateOnly(2026, 7, 1));
+        Assert.IsTrue(result.StartsWith("ersten. Juli"), $"Actual: {result}");
     }
 
     // ─── Item 21d — Convert(DateTime) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Item 21 — Types temporels** : `Convert(TimeSpan)`, `Convert(TimeOnly)`, `Convert(DateOnly)`, `Convert(DateTime)` ajoutés à `INumberToStringConverter` et `NumberToStringConverter`. Section XML `<TimeUnits>` (heure/minute/seconde singulier+pluriel) et `<DateFormat pattern="…">` (tokens `{month}`, `{ordinal-day}`, `{cardinal-day}`, `{year}` ; attributs `firstDay`, `dateTimeConnector`). Noms de mois lus depuis `CultureInfo` (.NET BCL). EN, FR, DE configurés.
- **Item 22 — Connecteur inter-groupes** : attributs `intraGroupConnector` et `intraGroupConnectorThreshold` sur `<Language>`. Injecté dans `ConvertGroup` niveau 3 quand `groupValue > 0` et `0 < remainder < threshold`. VN corrigé : 101 → "một trăm linh một".
- **Item 23 — Nouvelles langues** : HR (croate, long scale, exceptions 11-19, ordinals) et HU (hongrois, séparateur vide, `két`/`kettő`, `startIndex="2"` pour billió/billiárd). RO reporté.
- **TODO.md** : items 16-22 marqués implémentés, item 23 mis à jour.

## Test plan

- [x] 389 tests passent, 0 échec
- [x] VN `Convert(101)` → "một trăm linh một", `Convert(1)` → "một" (sans centaines, pas de connecteur)
- [x] EN `Convert(TimeSpan(2,30,5))` → "two hours thirty minutes five seconds"
- [x] FR `Convert(DateOnly(2026,7,2))` commence par "deux juillet"
- [x] HR `Convert(1_000_000)` → "jedan milijun"
- [x] HU `Convert(2000)` → "kétezer", `Convert(1_000_000_000_000)` → "billió"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
