### PR TITLE
feat(NumberToString): AR ordinals 11-19, PL full declension plugin, RO cardinals

### DIFF
--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.AR.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.AR.xml
@@ -72,19 +72,38 @@
             <OrdinalException value="8"  string="ثامن" />
             <OrdinalException value="9"  string="تاسع" />
             <OrdinalException value="10" string="عاشر" />
+            <!-- 11-19: [ordinal-root] + عشر (m) / عشرة (f); the root matches 1st-9th ordinals -->
+            <OrdinalException value="11" string="حادي عشر"   />
+            <OrdinalException value="12" string="ثاني عشر"   />
+            <OrdinalException value="13" string="ثالث عشر"   />
+            <OrdinalException value="14" string="رابع عشر"   />
+            <OrdinalException value="15" string="خامس عشر"   />
+            <OrdinalException value="16" string="سادس عشر"   />
+            <OrdinalException value="17" string="سابع عشر"   />
+            <OrdinalException value="18" string="ثامن عشر"   />
+            <OrdinalException value="19" string="تاسع عشر"   />
             <OrdinalVariants>
-                <!-- Forme féminine (muʾannath) pour 1-10 ; au-delà de 10 aucune exception n'est définie -->
+                <!-- Forme féminine (muʾannath) pour 1-19 -->
                 <Variant type="gender" variant="muʾannath">
-                    <OrdinalException value="1"  string="أولى"   />
-                    <OrdinalException value="2"  string="ثانية"  />
-                    <OrdinalException value="3"  string="ثالثة"  />
-                    <OrdinalException value="4"  string="رابعة"  />
-                    <OrdinalException value="5"  string="خامسة"  />
-                    <OrdinalException value="6"  string="سادسة"  />
-                    <OrdinalException value="7"  string="سابعة"  />
-                    <OrdinalException value="8"  string="ثامنة"  />
-                    <OrdinalException value="9"  string="تاسعة"  />
-                    <OrdinalException value="10" string="عاشرة"  />
+                    <OrdinalException value="1"  string="أولى"        />
+                    <OrdinalException value="2"  string="ثانية"       />
+                    <OrdinalException value="3"  string="ثالثة"       />
+                    <OrdinalException value="4"  string="رابعة"       />
+                    <OrdinalException value="5"  string="خامسة"       />
+                    <OrdinalException value="6"  string="سادسة"       />
+                    <OrdinalException value="7"  string="سابعة"       />
+                    <OrdinalException value="8"  string="ثامنة"       />
+                    <OrdinalException value="9"  string="تاسعة"       />
+                    <OrdinalException value="10" string="عاشرة"       />
+                    <OrdinalException value="11" string="حادية عشرة"  />
+                    <OrdinalException value="12" string="ثانية عشرة"  />
+                    <OrdinalException value="13" string="ثالثة عشرة"  />
+                    <OrdinalException value="14" string="رابعة عشرة"  />
+                    <OrdinalException value="15" string="خامسة عشرة"  />
+                    <OrdinalException value="16" string="سادسة عشرة"  />
+                    <OrdinalException value="17" string="سابعة عشرة"  />
+                    <OrdinalException value="18" string="ثامنة عشرة"  />
+                    <OrdinalException value="19" string="تاسعة عشرة"  />
                 </Variant>
             </OrdinalVariants>
         </Ordinals>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.PL.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.PL.xml
@@ -10,6 +10,7 @@
         fractionSeparator="przez"
     >
         <Culture>PL</Culture>
+        <LanguageSpecifics>PolishOrdinalLanguageSpecifics</LanguageSpecifics>
         <Groups>
             <Group level="1">
                 <Digit digit="0" string="" />
@@ -262,17 +263,165 @@
                 </Variant>
             </Ordinal>
 
-            <!-- ===== 11-19 (base masculine nominative; same hard-adj. pattern) ===== -->
-            <Ordinal from="jedenaście"     to="jedenasty" />
-            <Ordinal from="dwanaście"      to="dwunasty" />
-            <Ordinal from="trzynaście"     to="trzynasty" />
-            <Ordinal from="czternaście"    to="czternasty" />
-            <Ordinal from="piętnaście"     to="piętnasty" />
-            <Ordinal from="szesnaście"     to="szesnasty" />
-            <Ordinal from="siedemnaście"   to="siedemnasty" />
-            <Ordinal from="osiemnaście"    to="osiemnasty" />
-            <Ordinal from="dziewiętnaście" to="dziewiętnasty" />
+            <!-- ===== 11-19: full hard-adj. declension (-sty pattern) ===== -->
+            <Ordinal from="jedenaście">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="jedenasty,jedenastego,jedenastemu,jedenasty,jedenastym,jedenastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="jedenasta,jedenastej,jedenastej,jedenastą,jedenastą,jedenastej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="jedenaste,jedenastego,jedenastemu,jedenaste,jedenastym,jedenastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="jedenaści,jedenastych,jedenastym,jedenastych,jedenastymi,jedenastych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="jedenaste,jedenastych,jedenastym,jedenaste,jedenastymi,jedenastych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="dwanaście">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="dwunasty,dwunastego,dwunastemu,dwunasty,dwunastym,dwunastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="dwunasta,dwunastej,dwunastej,dwunastą,dwunastą,dwunastej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="dwunaste,dwunastego,dwunastemu,dwunaste,dwunastym,dwunastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="dwunaści,dwunastych,dwunastym,dwunastych,dwunastymi,dwunastych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="dwunaste,dwunastych,dwunastym,dwunaste,dwunastymi,dwunastych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="trzynaście">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="trzynasty,trzynastego,trzynastemu,trzynasty,trzynastym,trzynastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="trzynasta,trzynastej,trzynastej,trzynastą,trzynastą,trzynastej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="trzynaste,trzynastego,trzynastemu,trzynaste,trzynastym,trzynastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="trzynaści,trzynastych,trzynastym,trzynastych,trzynastymi,trzynastych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="trzynaste,trzynastych,trzynastym,trzynaste,trzynastymi,trzynastych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="czternaście">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="czternasty,czternastego,czternastemu,czternasty,czternastym,czternastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="czternasta,czternastej,czternastej,czternastą,czternastą,czternastej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="czternaste,czternastego,czternastemu,czternaste,czternastym,czternastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="czternaści,czternastych,czternastym,czternastych,czternastymi,czternastych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="czternaste,czternastych,czternastym,czternaste,czternastymi,czternastych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="piętnaście">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="piętnasty,piętnastego,piętnastemu,piętnasty,piętnastym,piętnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="piętnasta,piętnastej,piętnastej,piętnastą,piętnastą,piętnastej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="piętnaste,piętnastego,piętnastemu,piętnaste,piętnastym,piętnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="piętnaści,piętnastych,piętnastym,piętnastych,piętnastymi,piętnastych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="piętnaste,piętnastych,piętnastym,piętnaste,piętnastymi,piętnastych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="szesnaście">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="szesnasty,szesnastego,szesnastemu,szesnasty,szesnastym,szesnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="szesnasta,szesnastej,szesnastej,szesnastą,szesnastą,szesnastej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="szesnaste,szesnastego,szesnastemu,szesnaste,szesnastym,szesnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="szesnaści,szesnastych,szesnastym,szesnastych,szesnastymi,szesnastych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="szesnaste,szesnastych,szesnastym,szesnaste,szesnastymi,szesnastych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="siedemnaście">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="siedemnasty,siedemnastego,siedemnastemu,siedemnasty,siedemnastym,siedemnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="siedemnasta,siedemnastej,siedemnastej,siedemnastą,siedemnastą,siedemnastej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="siedemnaste,siedemnastego,siedemnastemu,siedemnaste,siedemnastym,siedemnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="siedemnaści,siedemnastych,siedemnastym,siedemnastych,siedemnastymi,siedemnastych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="siedemnaste,siedemnastych,siedemnastym,siedemnaste,siedemnastymi,siedemnastych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="osiemnaście">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="osiemnasty,osiemnastego,osiemnastemu,osiemnasty,osiemnastym,osiemnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="osiemnasta,osiemnastej,osiemnastej,osiemnastą,osiemnastą,osiemnastej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="osiemnaste,osiemnastego,osiemnastemu,osiemnaste,osiemnastym,osiemnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="osiemnaści,osiemnastych,osiemnastym,osiemnastych,osiemnastymi,osiemnastych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="osiemnaste,osiemnastych,osiemnastym,osiemnaste,osiemnastymi,osiemnastych" />
+                </Variant>
+            </Ordinal>
+            <Ordinal from="dziewiętnaście">
+                <Variant type="rodzaj" variant="maskulin">
+                    <Variant type="przypadek" forms="dziewiętnasty,dziewiętnastego,dziewiętnastemu,dziewiętnasty,dziewiętnastym,dziewiętnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="feminin">
+                    <Variant type="przypadek" forms="dziewiętnasta,dziewiętnastej,dziewiętnastej,dziewiętnastą,dziewiętnastą,dziewiętnastej" />
+                </Variant>
+                <Variant type="rodzaj" variant="nijaki">
+                    <Variant type="przypadek" forms="dziewiętnaste,dziewiętnastego,dziewiętnastemu,dziewiętnaste,dziewiętnastym,dziewiętnastym" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural_mos">
+                    <Variant type="przypadek" forms="dziewiętnaści,dziewiętnastych,dziewiętnastym,dziewiętnastych,dziewiętnastymi,dziewiętnastych" />
+                </Variant>
+                <Variant type="rodzaj" variant="plural">
+                    <Variant type="przypadek" forms="dziewiętnaste,dziewiętnastych,dziewiętnastym,dziewiętnaste,dziewiętnastymi,dziewiętnastych" />
+                </Variant>
+            </Ordinal>
 
+            <!--
+                20+ are handled by PolishOrdinalLanguageSpecifics (C# plugin).
+                The word rules below are kept for reference but the plugin takes priority.
+            -->
             <!-- ===== Dizaines ===== -->
             <Ordinal from="dwadzieścia"    to="dwudziesty" />
             <Ordinal from="trzydzieści"    to="trzydziesty" />

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.RO.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.RO.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
+    <!--
+      Romanian (RO) cardinals.
+
+      Known limitation: Romanian inserts "de" between the multiplier and the scale name
+      when the multiplier is ≥ 20 (e.g. "douăzeci de mii" = 20 000, "o sută de milioane").
+      This requires a scaleConnector/scaleConnectorThreshold engine feature that does not
+      yet exist.  Numbers below 20 × any scale are correct ("o mie", "doisprezece mii",
+      "un milion", "nouăsprezece milioane"); larger multipliers omit "de" for now.
+
+      Gender: "unu/una" (1m/f) and "doi/două" (2m/f) are tracked via the gender variant.
+      The default gender (no variant) is masculine.
+    -->
+    <Language
+        groupSize="3"
+        separator=" "
+        groupSeparator=""
+        zero="zero"
+        minus="minus *"
+        decimalSeparator="virgulă"
+        fractionSeparator="peste"
+    >
+        <Culture>RO</Culture>
+        <Culture>RO-RO</Culture>
+        <Groups>
+            <Group level="1">
+                <Digit digit="0" string="" />
+                <Digit digit="1" string="unu" />
+                <Digit digit="2" string="doi" />
+                <Digit digit="3" string="trei" />
+                <Digit digit="4" string="patru" />
+                <Digit digit="5" string="cinci" />
+                <Digit digit="6" string="șase" />
+                <Digit digit="7" string="șapte" />
+                <Digit digit="8" string="opt" />
+                <Digit digit="9" string="nouă" />
+            </Group>
+            <Group level="2">
+                <Digit digit="0" string="" buildString="*" />
+                <Digit digit="1" string="zece" buildString="zece *" />
+                <Digit digit="2" string="douăzeci" buildString="douăzeci și *" />
+                <Digit digit="3" string="treizeci" buildString="treizeci și *" />
+                <Digit digit="4" string="patruzeci" buildString="patruzeci și *" />
+                <Digit digit="5" string="cincizeci" buildString="cincizeci și *" />
+                <Digit digit="6" string="șaizeci" buildString="șaizeci și *" />
+                <Digit digit="7" string="șaptezeci" buildString="șaptezeci și *" />
+                <Digit digit="8" string="optzeci" buildString="optzeci și *" />
+                <Digit digit="9" string="nouăzeci" buildString="nouăzeci și *" />
+            </Group>
+            <Group level="3">
+                <Digit digit="0" string="" buildString="*" />
+                <Digit digit="1" string="o sută" buildString="o sută *" />
+                <Digit digit="2" string="două sute" buildString="două sute *" />
+                <Digit digit="3" string="trei sute" buildString="trei sute *" />
+                <Digit digit="4" string="patru sute" buildString="patru sute *" />
+                <Digit digit="5" string="cinci sute" buildString="cinci sute *" />
+                <Digit digit="6" string="șase sute" buildString="șase sute *" />
+                <Digit digit="7" string="șapte sute" buildString="șapte sute *" />
+                <Digit digit="8" string="opt sute" buildString="opt sute *" />
+                <Digit digit="9" string="nouă sute" buildString="nouă sute *" />
+            </Group>
+        </Groups>
+        <NumberScale firstLetterUpperCase="false">
+            <StaticNames>
+                <Scale value="0" string="" />
+                <!--
+                  Scale names use the plural form; singular replacements are handled via onScale+onValue.
+                  "o mie"=1 000, "două mii"=2 000 → Replacements below.
+                  "un milion"=1M, "un miliard"=1B → Replacements below.
+                -->
+                <Scale value="1" string="mii" />
+                <Scale value="2" string="milioane" />
+                <Scale value="3" string="miliarde" />
+            </StaticNames>
+        </NumberScale>
+        <Replacements>
+            <!-- Thousands: fix unu/doi before feminine scale "mii/mie" -->
+            <Replacement oldValue="unu mii"  newValue="o mie"    onScale="1" onValue="1" />
+            <Replacement oldValue="doi mii"  newValue="două mii" onScale="1" onValue="2" />
+            <!-- Millions: fix unu/doi before neuter scale "milioane/milion" -->
+            <Replacement oldValue="unu milioane" newValue="un milion"     onScale="2" onValue="1" />
+            <Replacement oldValue="doi milioane" newValue="două milioane" onScale="2" onValue="2" />
+            <!-- Billions: fix unu/doi before neuter scale "miliarde/miliard" -->
+            <Replacement oldValue="unu miliarde" newValue="un miliard"     onScale="3" onValue="1" />
+            <Replacement oldValue="doi miliarde" newValue="două miliarde"  onScale="3" onValue="2" />
+        </Replacements>
+        <Exceptions>
+            <Number value="1"  string="unu" />
+            <Number value="11" string="unsprezece" />
+            <Number value="12" string="doisprezece" />
+            <Number value="13" string="treisprezece" />
+            <Number value="14" string="paisprezece" />
+            <Number value="15" string="cincisprezece" />
+            <Number value="16" string="șaisprezece" />
+            <Number value="17" string="șaptesprezece" />
+            <Number value="18" string="optsprezece" />
+            <Number value="19" string="nouăsprezece" />
+        </Exceptions>
+        <Variants>
+            <Dimension name="gen" values="masculin,feminin" />
+            <Variant type="gen" variant="feminin">
+                <!-- 1f: una; 2f: două -->
+                <Replacement oldValue="unu" newValue="una"  scope="LastWord" />
+                <Replacement oldValue="doi" newValue="două" scope="LastWord" />
+            </Variant>
+        </Variants>
+    </Language>
+</Numbers>

--- a/Utils.NumberToString/NumberConverterResources.Designer.cs
+++ b/Utils.NumberToString/NumberConverterResources.Designer.cs
@@ -691,6 +691,13 @@ namespace Utils {
             }
         }
 
+        /// <summary>Romanian number-to-string configuration.</summary>
+        internal static string NumberConvertionConfiguration_RO {
+            get {
+                return ResourceManager.GetString("NumberConvertionConfiguration.RO", resourceCulture);
+            }
+        }
+
         /// <summary>Swedish number-to-string configuration.</summary>
         internal static string NumberConvertionConfiguration_SV {
             get {

--- a/Utils.NumberToString/NumberConverterResources.resx
+++ b/Utils.NumberToString/NumberConverterResources.resx
@@ -211,6 +211,9 @@
   <data name="NumberConvertionConfiguration.PT" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>NumberConverterConfigurations\NumberConvertionConfiguration.PT.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="NumberConvertionConfiguration.RO" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>NumberConverterConfigurations\NumberConvertionConfiguration.RO.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
   <data name="NumberConvertionConfiguration.RU" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>NumberConverterConfigurations\NumberConvertionConfiguration.RU.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -47,6 +47,7 @@ namespace Utils.NumberToString
                 NumberConverterResources.NumberConvertionConfiguration_EL,
                 NumberConverterResources.NumberConvertionConfiguration_NL,
                 NumberConverterResources.NumberConvertionConfiguration_NO,
+                NumberConverterResources.NumberConvertionConfiguration_RO,
                 NumberConverterResources.NumberConvertionConfiguration_RU,
                 NumberConverterResources.NumberConvertionConfiguration_SV,
                 NumberConverterResources.NumberConvertionConfiguration_SW,

--- a/Utils.NumberToString/PolishOrdinalLanguageSpecifics.cs
+++ b/Utils.NumberToString/PolishOrdinalLanguageSpecifics.cs
@@ -1,0 +1,312 @@
+using System.Collections.Generic;
+
+namespace Utils.NumberToString;
+
+/// <summary>
+/// Handles Polish ordinal conversion for numbers 20 and above, where compound forms
+/// require both the tens and units components to carry ordinal endings — a transformation
+/// the XML word-rule engine cannot perform because it only rewrites the last word.
+/// Numbers 1–19 fall through to the XML pipeline (which carries full case/gender tables).
+/// </summary>
+public sealed class PolishOrdinalLanguageSpecifics : INumberToStringLanguageSpecifics, IOrdinalLanguageSpecifics
+{
+    // rodzaj index: 0=maskulin, 1=feminin, 2=nijaki, 3=plural_mos, 4=plural
+    // przypadek index: 0=mianownik, 1=dopełniacz, 2=celownik, 3=biernik, 4=narzędnik, 5=miejscownik
+    // Flat index = rodzaj * 6 + przypadek
+
+    private static int RodzajIndex(string r) => r switch
+    {
+        "feminin"    => 1,
+        "nijaki"     => 2,
+        "plural_mos" => 3,
+        "plural"     => 4,
+        _            => 0
+    };
+
+    private static int PrzypadekIndex(string p) => p switch
+    {
+        "dopełniacz"  => 1,
+        "celownik"    => 2,
+        "biernik"     => 3,
+        "narzędnik"   => 4,
+        "miejscownik" => 5,
+        _             => 0
+    };
+
+    // Units ordinal forms 1–9 (copied from XML to build compound ordinals).
+    // Outer index = number - 1.  Inner = flat [rodzaj*6 + przypadek].
+    private static readonly string[][] s_units =
+    [
+        // 1: pierwszy
+        [
+            "pierwszy","pierwszego","pierwszemu","pierwszy","pierwszym","pierwszym",
+            "pierwsza","pierwszej","pierwszej","pierwszą","pierwszą","pierwszej",
+            "pierwsze","pierwszego","pierwszemu","pierwsze","pierwszym","pierwszym",
+            "pierwsi","pierwszych","pierwszym","pierwszych","pierwszymi","pierwszych",
+            "pierwsze","pierwszych","pierwszym","pierwsze","pierwszymi","pierwszych",
+        ],
+        // 2: drugi
+        [
+            "drugi","drugiego","drugiemu","drugi","drugim","drugim",
+            "druga","drugiej","drugiej","drugą","drugą","drugiej",
+            "drugie","drugiego","drugiemu","drugie","drugim","drugim",
+            "drudzy","drugich","drugim","drugich","drugimi","drugich",
+            "drugie","drugich","drugim","drugie","drugimi","drugich",
+        ],
+        // 3: trzeci
+        [
+            "trzeci","trzeciego","trzeciemu","trzeci","trzecim","trzecim",
+            "trzecia","trzeciej","trzeciej","trzecią","trzecią","trzeciej",
+            "trzecie","trzeciego","trzeciemu","trzecie","trzecim","trzecim",
+            "trzeci","trzecich","trzecim","trzecich","trzecimi","trzecich",
+            "trzecie","trzecich","trzecim","trzecie","trzecimi","trzecich",
+        ],
+        // 4: czwarty
+        [
+            "czwarty","czwartego","czwartemu","czwarty","czwartym","czwartym",
+            "czwarta","czwartej","czwartej","czwartą","czwartą","czwartej",
+            "czwarte","czwartego","czwartemu","czwarte","czwartym","czwartym",
+            "czwarci","czwartych","czwartym","czwartych","czwartymi","czwartych",
+            "czwarte","czwartych","czwartym","czwarte","czwartymi","czwartych",
+        ],
+        // 5: piąty
+        [
+            "piąty","piątego","piątemu","piąty","piątym","piątym",
+            "piąta","piątej","piątej","piątą","piątą","piątej",
+            "piąte","piątego","piątemu","piąte","piątym","piątym",
+            "piąci","piątych","piątym","piątych","piątymi","piątych",
+            "piąte","piątych","piątym","piąte","piątymi","piątych",
+        ],
+        // 6: szósty
+        [
+            "szósty","szóstego","szóstemu","szósty","szóstym","szóstym",
+            "szósta","szóstej","szóstej","szóstą","szóstą","szóstej",
+            "szóste","szóstego","szóstemu","szóste","szóstym","szóstym",
+            "szóści","szóstych","szóstym","szóstych","szóstymi","szóstych",
+            "szóste","szóstych","szóstym","szóste","szóstymi","szóstych",
+        ],
+        // 7: siódmy
+        [
+            "siódmy","siódmego","siódmemu","siódmy","siódmym","siódmym",
+            "siódma","siódmej","siódmej","siódmą","siódmą","siódmej",
+            "siódme","siódmego","siódmemu","siódme","siódmym","siódmym",
+            "siódmi","siódmych","siódmym","siódmych","siódmymi","siódmych",
+            "siódme","siódmych","siódmym","siódme","siódmymi","siódmych",
+        ],
+        // 8: ósmy
+        [
+            "ósmy","ósmego","ósmemu","ósmy","ósmym","ósmym",
+            "ósma","ósmej","ósmej","ósmą","ósmą","ósmej",
+            "ósme","ósmego","ósmemu","ósme","ósmym","ósmym",
+            "ósmi","ósmych","ósmym","ósmych","ósmymi","ósmych",
+            "ósme","ósmych","ósmym","ósme","ósmymi","ósmych",
+        ],
+        // 9: dziewiąty
+        [
+            "dziewiąty","dziewiątego","dziewiątemu","dziewiąty","dziewiątym","dziewiątym",
+            "dziewiąta","dziewiątej","dziewiątej","dziewiątą","dziewiątą","dziewiątej",
+            "dziewiąte","dziewiątego","dziewiątemu","dziewiąte","dziewiątym","dziewiątym",
+            "dziewiąci","dziewiątych","dziewiątym","dziewiątych","dziewiątymi","dziewiątych",
+            "dziewiąte","dziewiątych","dziewiątym","dziewiąte","dziewiątymi","dziewiątych",
+        ],
+    ];
+
+    // Tens ordinal forms: index 0=20th, 1=30th, …, 7=90th.
+    // Hard-adjective -sty pattern; virile plural (plural_mos): -sty → -ści.
+    private static readonly string[][] s_tens =
+    [
+        // 20: dwudziesty  (virile pl: dwudzieści)
+        [
+            "dwudziesty","dwudziestego","dwudziestemu","dwudziesty","dwudziestym","dwudziestym",
+            "dwudziesta","dwudziestej","dwudziestej","dwudziestą","dwudziestą","dwudziestej",
+            "dwudzieste","dwudziestego","dwudziestemu","dwudzieste","dwudziestym","dwudziestym",
+            "dwudzieści","dwudziestych","dwudziestym","dwudziestych","dwudziestymi","dwudziestych",
+            "dwudzieste","dwudziestych","dwudziestym","dwudzieste","dwudziestymi","dwudziestych",
+        ],
+        // 30: trzydziesty  (virile pl: trzydzieści)
+        [
+            "trzydziesty","trzydziestego","trzydziestemu","trzydziesty","trzydziestym","trzydziestym",
+            "trzydziesta","trzydziestej","trzydziestej","trzydziestą","trzydziestą","trzydziestej",
+            "trzydzieste","trzydziestego","trzydziestemu","trzydzieste","trzydziestym","trzydziestym",
+            "trzydzieści","trzydziestych","trzydziestym","trzydziestych","trzydziestymi","trzydziestych",
+            "trzydzieste","trzydziestych","trzydziestym","trzydzieste","trzydziestymi","trzydziestych",
+        ],
+        // 40: czterdziesty  (virile pl: czterdzieści)
+        [
+            "czterdziesty","czterdziestego","czterdziestemu","czterdziesty","czterdziestym","czterdziestym",
+            "czterdziesta","czterdziestej","czterdziestej","czterdziestą","czterdziestą","czterdziestej",
+            "czterdzieste","czterdziestego","czterdziestemu","czterdzieste","czterdziestym","czterdziestym",
+            "czterdzieści","czterdziestych","czterdziestym","czterdziestych","czterdziestymi","czterdziestych",
+            "czterdzieste","czterdziestych","czterdziestym","czterdzieste","czterdziestymi","czterdziestych",
+        ],
+        // 50: pięćdziesiąty  (virile pl: pięćdziesiąci)
+        [
+            "pięćdziesiąty","pięćdziesiątego","pięćdziesiątemu","pięćdziesiąty","pięćdziesiątym","pięćdziesiątym",
+            "pięćdziesiąta","pięćdziesiątej","pięćdziesiątej","pięćdziesiątą","pięćdziesiątą","pięćdziesiątej",
+            "pięćdziesiąte","pięćdziesiątego","pięćdziesiątemu","pięćdziesiąte","pięćdziesiątym","pięćdziesiątym",
+            "pięćdziesiąci","pięćdziesiątych","pięćdziesiątym","pięćdziesiątych","pięćdziesiątymi","pięćdziesiątych",
+            "pięćdziesiąte","pięćdziesiątych","pięćdziesiątym","pięćdziesiąte","pięćdziesiątymi","pięćdziesiątych",
+        ],
+        // 60: sześćdziesiąty  (virile pl: sześćdziesiąci)
+        [
+            "sześćdziesiąty","sześćdziesiątego","sześćdziesiątemu","sześćdziesiąty","sześćdziesiątym","sześćdziesiątym",
+            "sześćdziesiąta","sześćdziesiątej","sześćdziesiątej","sześćdziesiątą","sześćdziesiątą","sześćdziesiątej",
+            "sześćdziesiąte","sześćdziesiątego","sześćdziesiątemu","sześćdziesiąte","sześćdziesiątym","sześćdziesiątym",
+            "sześćdziesiąci","sześćdziesiątych","sześćdziesiątym","sześćdziesiątych","sześćdziesiątymi","sześćdziesiątych",
+            "sześćdziesiąte","sześćdziesiątych","sześćdziesiątym","sześćdziesiąte","sześćdziesiątymi","sześćdziesiątych",
+        ],
+        // 70: siedemdziesiąty  (virile pl: siedemdziesiąci)
+        [
+            "siedemdziesiąty","siedemdziesiątego","siedemdziesiątemu","siedemdziesiąty","siedemdziesiątym","siedemdziesiątym",
+            "siedemdziesiąta","siedemdziesiątej","siedemdziesiątej","siedemdziesiątą","siedemdziesiątą","siedemdziesiątej",
+            "siedemdziesiąte","siedemdziesiątego","siedemdziesiątemu","siedemdziesiąte","siedemdziesiątym","siedemdziesiątym",
+            "siedemdziesiąci","siedemdziesiątych","siedemdziesiątym","siedemdziesiątych","siedemdziesiątymi","siedemdziesiątych",
+            "siedemdziesiąte","siedemdziesiątych","siedemdziesiątym","siedemdziesiąte","siedemdziesiątymi","siedemdziesiątych",
+        ],
+        // 80: osiemdziesiąty  (virile pl: osiemdziesiąci)
+        [
+            "osiemdziesiąty","osiemdziesiątego","osiemdziesiątemu","osiemdziesiąty","osiemdziesiątym","osiemdziesiątym",
+            "osiemdziesiąta","osiemdziesiątej","osiemdziesiątej","osiemdziesiątą","osiemdziesiątą","osiemdziesiątej",
+            "osiemdziesiąte","osiemdziesiątego","osiemdziesiątemu","osiemdziesiąte","osiemdziesiątym","osiemdziesiątym",
+            "osiemdziesiąci","osiemdziesiątych","osiemdziesiątym","osiemdziesiątych","osiemdziesiątymi","osiemdziesiątych",
+            "osiemdziesiąte","osiemdziesiątych","osiemdziesiątym","osiemdziesiąte","osiemdziesiątymi","osiemdziesiątych",
+        ],
+        // 90: dziewięćdziesiąty  (virile pl: dziewięćdziesiąci)
+        [
+            "dziewięćdziesiąty","dziewięćdziesiątego","dziewięćdziesiątemu","dziewięćdziesiąty","dziewięćdziesiątym","dziewięćdziesiątym",
+            "dziewięćdziesiąta","dziewięćdziesiątej","dziewięćdziesiątej","dziewięćdziesiątą","dziewięćdziesiątą","dziewięćdziesiątej",
+            "dziewięćdziesiąte","dziewięćdziesiątego","dziewięćdziesiątemu","dziewięćdziesiąte","dziewięćdziesiątym","dziewięćdziesiątym",
+            "dziewięćdziesiąci","dziewięćdziesiątych","dziewięćdziesiątym","dziewięćdziesiątych","dziewięćdziesiątymi","dziewięćdziesiątych",
+            "dziewięćdziesiąte","dziewięćdziesiątych","dziewięćdziesiątym","dziewięćdziesiąte","dziewięćdziesiątymi","dziewięćdziesiątych",
+        ],
+    ];
+
+    // Hundreds ordinal forms: index 0=100th, 1=200th, …, 8=900th.
+    // Adjective -ny pattern; virile plural: -ny → -ni.
+    private static readonly string[][] s_hundreds =
+    [
+        // 100: setny  (virile pl: setni)
+        [
+            "setny","setnego","setnemu","setny","setnym","setnym",
+            "setna","setnej","setnej","setną","setną","setnej",
+            "setne","setnego","setnemu","setne","setnym","setnym",
+            "setni","setnych","setnym","setnych","setnymi","setnych",
+            "setne","setnych","setnym","setne","setnymi","setnych",
+        ],
+        // 200: dwusetny
+        [
+            "dwusetny","dwusetnego","dwusetnemu","dwusetny","dwusetnym","dwusetnym",
+            "dwusetna","dwusetnej","dwusetnej","dwusetną","dwusetną","dwusetnej",
+            "dwusetne","dwusetnego","dwusetnemu","dwusetne","dwusetnym","dwusetnym",
+            "dwusetni","dwusetnych","dwusetnym","dwusetnych","dwusetnymi","dwusetnych",
+            "dwusetne","dwusetnych","dwusetnym","dwusetne","dwusetnymi","dwusetnych",
+        ],
+        // 300: trzechsetny
+        [
+            "trzechsetny","trzechsetnego","trzechsetnemu","trzechsetny","trzechsetnym","trzechsetnym",
+            "trzechsetna","trzechsetnej","trzechsetnej","trzechsetną","trzechsetną","trzechsetnej",
+            "trzechsetne","trzechsetnego","trzechsetnemu","trzechsetne","trzechsetnym","trzechsetnym",
+            "trzechsetni","trzechsetnych","trzechsetnym","trzechsetnych","trzechsetnymi","trzechsetnych",
+            "trzechsetne","trzechsetnych","trzechsetnym","trzechsetne","trzechsetnymi","trzechsetnych",
+        ],
+        // 400: czterosetny
+        [
+            "czterosetny","czterosetnego","czterosetnemu","czterosetny","czterosetnym","czterosetnym",
+            "czterosetna","czterosetnej","czterosetnej","czterosetną","czterosetną","czterosetnej",
+            "czterosetne","czterosetnego","czterosetnemu","czterosetne","czterosetnym","czterosetnym",
+            "czterosetni","czterosetnych","czterosetnym","czterosetnych","czterosetnymi","czterosetnych",
+            "czterosetne","czterosetnych","czterosetnym","czterosetne","czterosetnymi","czterosetnych",
+        ],
+        // 500: pięćsetny
+        [
+            "pięćsetny","pięćsetnego","pięćsetnemu","pięćsetny","pięćsetnym","pięćsetnym",
+            "pięćsetna","pięćsetnej","pięćsetnej","pięćsetną","pięćsetną","pięćsetnej",
+            "pięćsetne","pięćsetnego","pięćsetnemu","pięćsetne","pięćsetnym","pięćsetnym",
+            "pięćsetni","pięćsetnych","pięćsetnym","pięćsetnych","pięćsetnymi","pięćsetnych",
+            "pięćsetne","pięćsetnych","pięćsetnym","pięćsetne","pięćsetnymi","pięćsetnych",
+        ],
+        // 600: sześćsetny
+        [
+            "sześćsetny","sześćsetnego","sześćsetnemu","sześćsetny","sześćsetnym","sześćsetnym",
+            "sześćsetna","sześćsetnej","sześćsetnej","sześćsetną","sześćsetną","sześćsetnej",
+            "sześćsetne","sześćsetnego","sześćsetnemu","sześćsetne","sześćsetnym","sześćsetnym",
+            "sześćsetni","sześćsetnych","sześćsetnym","sześćsetnych","sześćsetnymi","sześćsetnych",
+            "sześćsetne","sześćsetnych","sześćsetnym","sześćsetne","sześćsetnymi","sześćsetnych",
+        ],
+        // 700: siedemsetny
+        [
+            "siedemsetny","siedemsetnego","siedemsetnemu","siedemsetny","siedemsetnym","siedemsetnym",
+            "siedemsetna","siedemsetnej","siedemsetnej","siedemsetną","siedemsetną","siedemsetnej",
+            "siedemsetne","siedemsetnego","siedemsetnemu","siedemsetne","siedemsetnym","siedemsetnym",
+            "siedemsetni","siedemsetnych","siedemsetnym","siedemsetnych","siedemsetnymi","siedemsetnych",
+            "siedemsetne","siedemsetnych","siedemsetnym","siedemsetne","siedemsetnymi","siedemsetnych",
+        ],
+        // 800: osiemsetny
+        [
+            "osiemsetny","osiemsetnego","osiemsetnemu","osiemsetny","osiemsetnym","osiemsetnym",
+            "osiemsetna","osiemsetnej","osiemsetnej","osiemsetną","osiemsetną","osiemsetnej",
+            "osiemsetne","osiemsetnego","osiemsetnemu","osiemsetne","osiemsetnym","osiemsetnym",
+            "osiemsetni","osiemsetnych","osiemsetnym","osiemsetnych","osiemsetnymi","osiemsetnych",
+            "osiemsetne","osiemsetnych","osiemsetnym","osiemsetne","osiemsetnymi","osiemsetnych",
+        ],
+        // 900: dziewięćsetny
+        [
+            "dziewięćsetny","dziewięćsetnego","dziewięćsetnemu","dziewięćsetny","dziewięćsetnym","dziewięćsetnym",
+            "dziewięćsetna","dziewięćsetnej","dziewięćsetnej","dziewięćsetną","dziewięćsetną","dziewięćsetnej",
+            "dziewięćsetne","dziewięćsetnego","dziewięćsetnemu","dziewięćsetne","dziewięćsetnym","dziewięćsetnym",
+            "dziewięćsetni","dziewięćsetnych","dziewięćsetnym","dziewięćsetnych","dziewięćsetnymi","dziewięćsetnych",
+            "dziewięćsetne","dziewięćsetnych","dziewięćsetnym","dziewięćsetne","dziewięćsetnymi","dziewięćsetnych",
+        ],
+    ];
+
+    // Cardinal hundreds (used as non-ordinal prefix in compound ordinals: "sto pierwszy").
+    private static readonly string[] s_cardinalHundreds =
+        ["sto", "dwieście", "trzysta", "czterysta", "pięćset", "sześćset", "siedemset", "osiemset", "dziewięćset"];
+
+    /// <inheritdoc />
+    public string FinalizeWriting(string languageIdentifier, string text) => text;
+
+    /// <inheritdoc />
+    public bool TryConvertOrdinal(int number, IReadOnlyDictionary<string, string> activeVariants, out string? result)
+    {
+        if (number < 20) { result = null; return false; }
+
+        int ri = RodzajIndex(activeVariants.TryGetValue("rodzaj", out var r) ? r : "maskulin");
+        int pi = PrzypadekIndex(activeVariants.TryGetValue("przypadek", out var p) ? p : "mianownik");
+
+        result = GetForm(number, ri, pi);
+        return result is not null;
+    }
+
+    private static string? GetForm(int number, int ri, int pi)
+    {
+        if (number is >= 1 and <= 9)
+            return s_units[number - 1][ri * 6 + pi];
+
+        if (number < 20)
+            return null; // 11-19: XML handles
+
+        if (number < 100)
+        {
+            int tensIdx = number / 10 - 2; // 20→0, 30→1, …, 90→7
+            int units   = number % 10;
+            string tensForm = s_tens[tensIdx][ri * 6 + pi];
+            if (units == 0) return tensForm;
+            return tensForm + " " + s_units[units - 1][ri * 6 + pi];
+        }
+
+        if (number < 1000)
+        {
+            int hundredsIdx = number / 100 - 1; // 100→0, …, 900→8
+            int lower       = number % 100;
+            if (lower == 0) return s_hundreds[hundredsIdx][ri * 6 + pi];
+            // Hundreds stays cardinal, remainder takes full ordinal.
+            string cardinal = s_cardinalHundreds[hundredsIdx];
+            string lowerOrdinal = GetForm(lower, ri, pi);
+            return lowerOrdinal is null ? null : cardinal + " " + lowerOrdinal;
+        }
+
+        // 1000+: fall through to XML (tysięczny etc. covered by word rules).
+        return null;
+    }
+}

--- a/Utils.NumberToString/README.md
+++ b/Utils.NumberToString/README.md
@@ -24,10 +24,11 @@ dotnet add package omy.Utils.NumberToString
 | ES | Spanish | ✓ | gender (masculino/femenino) |
 | IT | Italian | ✓ | gender (maschile/femminile) |
 | PT | Portuguese | ✓ | gender (masculino/feminino) |
-| PL | Polish | ✓ | — (numbers are invariable in common usage) |
+| PL | Polish | ✓ | rodzaj (maskulin/feminin/nijaki/plural_mos/plural) × przypadek (mianownik/dopełniacz/…) |
 | NL | Dutch | ✓ | — (numbers are invariable) |
+| RO | Romanian | — | gen (masculin/feminin) |
 | RU | Russian | ✓ | — |
-| AR | Arabic | ✓ (1–10) | gender (muzakkar/muʾannath) |
+| AR | Arabic | ✓ (1–19) | gender (muzakkar/muʾannath) |
 | HE | Hebrew | ✓ | gender (standalone/zachar/nekeva) |
 | ZH | Chinese | ✓ (prefix 第) | — (no inflection) |
 | JA | Japanese | ✓ (prefix 第) | — (no inflection) |
@@ -224,8 +225,9 @@ if (conv.SupportsOrdinals)
 > converter with an uppercase `AdjustFunction` correctly produces `"TWENTY-FIRST"`, not
 > `"TWENTY-ONEth"`.
 
-> **Languages without ordinals**: ZU (Zulu).
+> **Languages without ordinals**: ZU (Zulu), RO (Romanian).
 > Zulu ordinals require noun-class agreement and are not yet implemented.
+> Romanian ordinals are not yet implemented.
 > For languages that have ordinals, `converter.SupportsOrdinals` returns `true`.
 
 ---
@@ -561,7 +563,6 @@ is invariable in common contexts, or because the morphological distinction is no
 | ZH | Chinese | No inflection |
 | JA | Japanese | No inflection |
 | EU | Basque | No grammatical gender (language isolate) |
-| PL | Polish | Numbers are invariable in common usage (nominatif masculin only) |
 | HI | Hindi | Numbers are invariable in common usage |
 | ZU | Zulu | Not yet implemented |
 | EE | Ewe | Not yet implemented |

--- a/Utils.NumberToString/TODO.md
+++ b/Utils.NumberToString/TODO.md
@@ -61,26 +61,32 @@ et dans `NumberToStringConverter`.
 constructeur quand `isRegex=true`. `ApplyTriggerReplace` utilise `CompiledRegex.Replace()`
 au lieu de `Regex.Replace()` à chaque appel.
 
-### 8. ~~Langues populaires manquantes~~ — **implémenté (VN, TR, SV, NO, UK)**
-Cinq nouveaux fichiers XML ajoutés :
+### 8. ~~Langues populaires manquantes~~ — **implémenté (VN, TR, SV, NO, UK, RO)**
+Nouveaux fichiers XML ajoutés :
 - **VN/VI/VI-VN (Vietnamien)** : cardinals avec allomorphes mốt/lăm via remplacement `Anywhere`,
   ordinals `thứ N` avec exception `thứ nhất`. Connecteur *linh* non implémenté (nécessite moteur).
 - **TR/TR-TR (Turc)** : cardinals sans `bir yüz` / `bir bin` (règles nationales respectées).
 - **SV/SV-SE (Suédois)** : cardinals avec fusion 20s (`tjugo*`) et espaces 30s-90s.
 - **NO/NB/NB-NO (Norvégien Bokmål)** : cardinals.
 - **UK/UK-UA (Ukrainien)** : cardinals simplifiés (inflexion тисяч invariante).
-- **RO (Roumain)** : non implémenté (système genre+cas trop complexe → reporté).
+- **RO/RO-RO (Roumain)** : cardinals avec noms d'échelle statiques `mii`/`milioane`/`miliarde` ;
+  remplacements `onScale+onValue` pour l'accord `unu/doi` ; variante `gen=feminin` (una/două).
+  Limitation connue : l'insertion de `de` avant les noms d'échelle pour les multiples ≥ 20
+  (ex. "douăzeci de mii") nécessite un attribut `scaleConnector` non encore implémenté dans le moteur.
 
 ### 9. Ordinaux ZU (Zoulou) via `IOrdinalLanguageSpecifics` — **reporté**
 Nécessite une recherche linguistique approfondie (classes nominales 1–17) et une implémentation
 `ZuluOrdinalLanguageSpecifics`. Hors scope d'un correctif XML.
 
-### 10. Ordinaux PL complets — **reporté**
-L'implémentation actuelle couvre le nominatif masculin singulier.
-Les formes complètes (féminin/neutre + 7 cas) nécessitent `PolishOrdinalLanguageSpecifics`.
+### 10. ~~Ordinaux PL complets~~ — **implémenté**
+`PolishOrdinalLanguageSpecifics` (plugin C#) couvre les ordinals 20–999 avec les 30 formes
+`rodzaj × przypadek` (5 genres × 6 cas) ; le XML couvre 1–19 avec des blocs `<Ordinal>` complets.
+Limitation : les ordinals ≥ 1 000 retombent sur les règles XML simples (tysięczny, etc.).
 
-### 11. `ConvertOrdinal` avec accord complet pour AR — **reporté**
-La règle de polarité de genre arabe (3-10) et la forme duelle nécessitent
+### 11. `ConvertOrdinal` avec accord partiel pour AR — **partiellement implémenté**
+Ordinals 11–19 ajoutés (masculin + féminin via la variante `gender=muʾannath`).
+Restant non implémenté : la règle de polarité de genre arabe (3–10 : le masculin prend
+la forme dérivée du féminin et inversement) et la forme duelle — nécessitent
 `ArabicOrdinalLanguageSpecifics`.
 
 ## Priorité basse — robustesse
@@ -150,13 +156,13 @@ et `0 < remainder < threshold`. VN configuré avec `intraGroupConnector="linh" t
 - 101 → "một trăm linh một" ✓  
 - 110 → "một trăm mười" (pas de connecteur, remainder ≥ threshold) ✓
 
-### 23. ~~Nouvelles langues HR et HU~~ — **implémenté** ; RO **reporté**
+### 23. ~~Nouvelles langues HR et HU~~ — **implémenté** ; RO **implémenté (cardinals, voir item 8)**
 - **HR** (croate) : long scale avec `groupSeparator="li"` → milijun/milijarda/bilijun ;
   exceptions 11–19 ; remplacement "jedan tisuća" → "tisuća" ; ordinals (prvi/drugi/treći…).
 - **HU** (hongrois) : séparateur vide (agglutination) ; forme liante `két` vs forme isolée
   `kettő` via `Exception[2]` + Replacements ("kettőezer" → "kétezer") ; `startIndex="2"` pour
   générer billió/billiárd ; "egyezer" → "ezer" ; ordinals lexicaux (első/második…).
-- **RO** (roumain) : genre m/f + "de" devant grands nombres — reporté, trop complexe.
+- **RO** (roumain) : cardinals implémentés (PR #416). Voir item 8 pour les détails et la limitation "de".
 
 ### ~~C1. Numéros romains~~ — **hors périmètre**
 `ConvertRoman` doit faire l'objet d'un système de conversion distinct qui pourrait implémenter

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -1607,7 +1607,7 @@ public class NumberToStringConverterImprovementsTests
             (10,  "dziesiąty"),
             (11,  "jedenasty"),
             (20,  "dwudziesty"),
-            (21,  "dwadzieścia pierwszy"), // limitation XML : seul le dernier mot est transformé
+            (21,  "dwudziesty pierwszy"),
             (100, "setny"),
             (1000, "tysięczny"),
         ];
@@ -3099,5 +3099,146 @@ public class NumberToStringConverterImprovementsTests
         // group 0 (units) is outside range 1..2 → no replacement
         Assert.AreEqual("un",   c.Convert(1),   "1 — units group not in 1..2");
         Assert.AreEqual("deux", c.Convert(2),   "2 — units group not in 1..2");
+    }
+
+    // ── AR — Ordinals 11-19 ──────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_AR_11To19_Masculine()
+    {
+        var converter = NumberToStringConverter.GetConverter("AR");
+        (int n, string expected)[] cases =
+        [
+            (11, "حادي عشر"),
+            (12, "ثاني عشر"),
+            (13, "ثالث عشر"),
+            (15, "خامس عشر"),
+            (19, "تاسع عشر"),
+        ];
+        foreach (var (n, expected) in cases)
+            Assert.AreEqual(expected, converter.ConvertOrdinal(n), $"AR masc ordinal of {n}");
+    }
+
+    [TestMethod]
+    public void ConvertOrdinal_AR_11To19_Feminine()
+    {
+        var converter = NumberToStringConverter.GetConverter("AR");
+        (int n, string expected)[] cases =
+        [
+            (11, "حادية عشرة"),
+            (12, "ثانية عشرة"),
+            (13, "ثالثة عشرة"),
+            (15, "خامسة عشرة"),
+            (19, "تاسعة عشرة"),
+        ];
+        foreach (var (n, expected) in cases)
+            Assert.AreEqual(expected, converter.ConvertOrdinal(n, "gender=muʾannath"), $"AR fem ordinal of {n}");
+    }
+
+    // ── PL — Ordinals avec variantes (plugin 20+, XML 11-19) ─────────────────
+
+    [TestMethod]
+    public void ConvertOrdinal_PL_11To19_WithVariants()
+    {
+        var converter = NumberToStringConverter.GetConverter("PL");
+
+        Assert.AreEqual("jedenasty",   converter.ConvertOrdinal(11), "11 maskulin mianownik");
+        Assert.AreEqual("jedenasta",   converter.ConvertOrdinal(11, "rodzaj=feminin"), "11 feminin mianownik");
+        Assert.AreEqual("jedenastą",   converter.ConvertOrdinal(11, "rodzaj=feminin", "przypadek=biernik"),
+                         "11 feminin biernik");
+        Assert.AreEqual("jedenaści",   converter.ConvertOrdinal(11, "rodzaj=plural_mos"), "11 pl_mos mianownik");
+        Assert.AreEqual("jedenastych", converter.ConvertOrdinal(11, "rodzaj=plural_mos", "przypadek=dopełniacz"),
+                         "11 pl_mos dopełniacz");
+    }
+
+    [TestMethod]
+    public void ConvertOrdinal_PL_Plugin_Tens()
+    {
+        var converter = NumberToStringConverter.GetConverter("PL");
+
+        Assert.AreEqual("dwudziesty",   converter.ConvertOrdinal(20),                        "20 maskulin nom");
+        Assert.AreEqual("dwudziesta",   converter.ConvertOrdinal(20, "rodzaj=feminin"),       "20 feminin nom");
+        Assert.AreEqual("trzydziesty",  converter.ConvertOrdinal(30),                        "30 maskulin nom");
+        Assert.AreEqual("osiemdziesiąty", converter.ConvertOrdinal(80),                      "80 maskulin nom");
+        Assert.AreEqual("dziewięćdziesiąci",
+                         converter.ConvertOrdinal(90, "rodzaj=plural_mos"),                  "90 pl_mos nom");
+    }
+
+    [TestMethod]
+    public void ConvertOrdinal_PL_Plugin_Compounds()
+    {
+        var converter = NumberToStringConverter.GetConverter("PL");
+
+        Assert.AreEqual("dwudziesty pierwszy",  converter.ConvertOrdinal(21),                       "21 masc nom");
+        Assert.AreEqual("dwudziesta pierwsza",  converter.ConvertOrdinal(21, "rodzaj=feminin"),      "21 fem nom");
+        Assert.AreEqual("dwudziestego pierwszego",
+                         converter.ConvertOrdinal(21, "przypadek=dopełniacz"),                       "21 masc gen");
+        Assert.AreEqual("trzydziesty drugi",    converter.ConvertOrdinal(32),                       "32 masc nom");
+        Assert.AreEqual("pięćdziesiąty piąty",  converter.ConvertOrdinal(55),                       "55 masc nom");
+        Assert.AreEqual("dziewięćdziesiąty dziewiąty", converter.ConvertOrdinal(99),                "99 masc nom");
+    }
+
+    [TestMethod]
+    public void ConvertOrdinal_PL_Plugin_Hundreds()
+    {
+        var converter = NumberToStringConverter.GetConverter("PL");
+
+        Assert.AreEqual("setny",         converter.ConvertOrdinal(100),                     "100 masc nom");
+        Assert.AreEqual("setna",         converter.ConvertOrdinal(100, "rodzaj=feminin"),   "100 fem nom");
+        Assert.AreEqual("dwusetny",      converter.ConvertOrdinal(200),                     "200 masc nom");
+        Assert.AreEqual("sto pierwszy",  converter.ConvertOrdinal(101),                     "101 masc nom");
+        Assert.AreEqual("sto pierwsza",  converter.ConvertOrdinal(101, "rodzaj=feminin"),   "101 fem nom");
+        Assert.AreEqual("dwieście dwudziesty pierwszy", converter.ConvertOrdinal(221),      "221 masc nom");
+    }
+
+    // ── RO — Cardinals ───────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Convert_RO_Cardinals_Basic()
+    {
+        var converter = NumberToStringConverter.GetConverter("RO");
+        (long n, string expected)[] cases =
+        [
+            (0,   "zero"),
+            (1,   "unu"),
+            (2,   "doi"),
+            (10,  "zece"),
+            (11,  "unsprezece"),
+            (12,  "doisprezece"),
+            (19,  "nouăsprezece"),
+            (20,  "douăzeci"),
+            (21,  "douăzeci și unu"),
+            (22,  "douăzeci și doi"),
+            (100, "o sută"),
+            (101, "o sută unu"),
+            (200, "două sute"),
+            (999, "nouă sute nouăzeci și nouă"),
+        ];
+        foreach (var (n, expected) in cases)
+            Assert.AreEqual(expected, converter.Convert(n), $"RO cardinal {n}");
+    }
+
+    [TestMethod]
+    public void Convert_RO_Cardinals_Scale()
+    {
+        var converter = NumberToStringConverter.GetConverter("RO");
+
+        Assert.AreEqual("o mie",        converter.Convert(1_000),       "1 000");
+        Assert.AreEqual("două mii",     converter.Convert(2_000),       "2 000");
+        Assert.AreEqual("zece mii",     converter.Convert(10_000),      "10 000");
+        Assert.AreEqual("un milion",    converter.Convert(1_000_000),   "1 000 000");
+        Assert.AreEqual("două milioane", converter.Convert(2_000_000),  "2 000 000");
+        Assert.AreEqual("un miliard",   converter.Convert(1_000_000_000), "1 000 000 000");
+    }
+
+    [TestMethod]
+    public void Convert_RO_Cardinals_Gender()
+    {
+        var converter = NumberToStringConverter.GetConverter("RO");
+
+        Assert.AreEqual("una",              converter.Convert(1,  "gen=feminin"),  "1f");
+        Assert.AreEqual("două",             converter.Convert(2,  "gen=feminin"),  "2f");
+        Assert.AreEqual("douăzeci și una",  converter.Convert(21, "gen=feminin"),  "21f");
+        Assert.AreEqual("douăzeci și două", converter.Convert(22, "gen=feminin"),  "22f");
     }
 }


### PR DESCRIPTION
## Summary

- AR: OrdinalException 11-19 masculine; full feminine (muannath) variant 11-19 in OrdinalVariants
- PL: New PolishOrdinalLanguageSpecifics C# plugin handling ordinals 20-999 with full rodzaj x przypadek declension (5 genders x 6 cases); XML Ordinal blocks cover 1-19 with all 30 form variants
- RO: New NumberConvertionConfiguration.RO.xml with mii/milioane/miliarde static scale names; onScale+onValue replacements for unu->o mie, doi->doua mii, gender variant gen=feminin

## Test plan

- [ ] ConvertOrdinal_AR_11To19_Masculine -- 5 masculine ordinals 11-19
- [ ] ConvertOrdinal_AR_11To19_Feminine -- 5 feminine ordinals 11-19 with gender=muannath
- [ ] ConvertOrdinal_PL_11To19_WithVariants -- feminin/plural_mos/biernik/dopelniacz forms
- [ ] ConvertOrdinal_PL_Plugin_Tens -- 20-90 via plugin (maskulin + feminin)
- [ ] ConvertOrdinal_PL_Plugin_Compounds -- 21, 21f, 21 gen, 32, 55, 99
- [ ] ConvertOrdinal_PL_Plugin_Hundreds -- 100, 100f, 200, 101, 101f, 221
- [ ] Convert_RO_Cardinals_Basic -- 0-999
- [ ] Convert_RO_Cardinals_Scale -- 1 000 -> 1 miliard
- [ ] Convert_RO_Cardinals_Gender -- gen=feminin (una/doua in compounds)
- [ ] All 424 NumberToString tests pass

Generated with Claude Code