### PR TITLE
test+fix+feat(NumberToString): TODO items 24-46 (lang tests, dimension validation, perf, FI/KO/JA thousands, ES/PT/GL/FR-be-ch, coverage, README)

### DIFF
--- a/Utils.NumberToString/INumberToStringConverter.cs
+++ b/Utils.NumberToString/INumberToStringConverter.cs
@@ -112,10 +112,25 @@ namespace Utils.NumberToString
 
         /// <summary>
         /// Converts a double-precision floating-point value into its string representation.
+        /// </summary>
+        /// <param name="number">The value to convert. Must be a finite number.</param>
+        /// <returns>The formatted number.</returns>
+        /// <exception cref="ArgumentException"><paramref name="number"/> is <see cref="double.NaN"/> or infinite.</exception>
+        string Convert(double number) => Convert(number, []);
+
+        /// <summary>
+        /// Converts a double-precision floating-point value into its string representation.
         /// Uses the round-trip format ("R") to convert to decimal, avoiding floating-point artifacts.
         /// </summary>
+        /// <param name="number">The value to convert. Must be a finite number.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        /// <returns>The formatted number with the requested variants applied.</returns>
+        /// <exception cref="ArgumentException"><paramref name="number"/> is <see cref="double.NaN"/> or infinite.</exception>
         string Convert(double number, params string[] variants)
         {
+            if (double.IsNaN(number) || double.IsInfinity(number))
+                throw new ArgumentException($"Cannot convert non-finite value '{number}' to a number in words.", nameof(number));
+
             if (decimal.TryParse(
                     number.ToString("R", System.Globalization.CultureInfo.InvariantCulture),
                     System.Globalization.NumberStyles.Any,
@@ -129,6 +144,18 @@ namespace Utils.NumberToString
         /// <summary>
         /// Converts a single-precision floating-point value into its string representation.
         /// </summary>
+        /// <param name="number">The value to convert. Must be a finite number.</param>
+        /// <returns>The formatted number.</returns>
+        /// <exception cref="ArgumentException"><paramref name="number"/> is <see cref="float.NaN"/> or infinite.</exception>
+        string Convert(float number) => Convert(number, []);
+
+        /// <summary>
+        /// Converts a single-precision floating-point value into its string representation.
+        /// </summary>
+        /// <param name="number">The value to convert. Must be a finite number.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        /// <returns>The formatted number with the requested variants applied.</returns>
+        /// <exception cref="ArgumentException"><paramref name="number"/> is <see cref="float.NaN"/> or infinite.</exception>
         string Convert(float number, params string[] variants)
             => Convert((double)number, variants);
 
@@ -169,6 +196,9 @@ namespace Utils.NumberToString
         /// Unrecognised dimensions or values fall back to the default silently.
         /// </param>
         /// <returns>The formatted number with the requested variants applied.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="number"/> exceeds <see cref="MaxNumber"/> (implementations that declare one).
+        /// </exception>
         string Convert(BigInteger number, params string[] variants) => Convert(number);
 
         /// <summary>
@@ -244,6 +274,7 @@ namespace Utils.NumberToString
         /// </summary>
         /// <param name="number">The value to convert. Negative values use the minus template.</param>
         /// <returns>The ordinal string for <paramref name="number"/>.</returns>
+        /// <exception cref="NotSupportedException">The converter does not support ordinal conversion (<see cref="SupportsOrdinals"/> is <see langword="false"/>).</exception>
         string ConvertOrdinal(int number)
             => throw new NotSupportedException("Ordinal conversion is not supported by this converter.");
 
@@ -255,6 +286,7 @@ namespace Utils.NumberToString
         /// <param name="number">The value to convert. Negative values use the minus template.</param>
         /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
         /// <returns>The ordinal string for <paramref name="number"/>.</returns>
+        /// <exception cref="NotSupportedException">The converter does not support ordinal conversion (<see cref="SupportsOrdinals"/> is <see langword="false"/>).</exception>
         string ConvertOrdinal(int number, params string[] variants)
             => ConvertOrdinal(number);
 
@@ -266,6 +298,8 @@ namespace Utils.NumberToString
         /// </summary>
         /// <param name="number">The value to convert. Negative values use the minus template.</param>
         /// <returns>The ordinal string for <paramref name="number"/>.</returns>
+        /// <exception cref="OverflowException"><paramref name="number"/> is outside the <see cref="int"/> range.</exception>
+        /// <exception cref="NotSupportedException">The converter does not support ordinal conversion (<see cref="SupportsOrdinals"/> is <see langword="false"/>).</exception>
         string ConvertOrdinal(long number)
             => ConvertOrdinal(number, []);
 
@@ -279,6 +313,8 @@ namespace Utils.NumberToString
         /// <param name="number">The value to convert. Negative values use the minus template.</param>
         /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
         /// <returns>The ordinal string for <paramref name="number"/>.</returns>
+        /// <exception cref="OverflowException"><paramref name="number"/> is outside the <see cref="int"/> range.</exception>
+        /// <exception cref="NotSupportedException">The converter does not support ordinal conversion (<see cref="SupportsOrdinals"/> is <see langword="false"/>).</exception>
         string ConvertOrdinal(long number, params string[] variants)
             => ConvertOrdinal(checked((int)number), variants);
 
@@ -289,6 +325,8 @@ namespace Utils.NumberToString
         /// </summary>
         /// <param name="number">The value to convert. Negative values use the minus template.</param>
         /// <returns>The ordinal string for <paramref name="number"/>.</returns>
+        /// <exception cref="OverflowException"><paramref name="number"/> is outside the <see cref="long"/> or <see cref="int"/> range.</exception>
+        /// <exception cref="NotSupportedException">The converter does not support ordinal conversion (<see cref="SupportsOrdinals"/> is <see langword="false"/>).</exception>
         string ConvertOrdinal(BigInteger number)
             => ConvertOrdinal(checked((long)number), []);
 
@@ -301,6 +339,8 @@ namespace Utils.NumberToString
         /// <param name="number">The value to convert. Negative values use the minus template.</param>
         /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
         /// <returns>The ordinal string for <paramref name="number"/>.</returns>
+        /// <exception cref="OverflowException"><paramref name="number"/> is outside the <see cref="long"/> or <see cref="int"/> range.</exception>
+        /// <exception cref="NotSupportedException">The converter does not support ordinal conversion (<see cref="SupportsOrdinals"/> is <see langword="false"/>).</exception>
         string ConvertOrdinal(BigInteger number, params string[] variants)
             => ConvertOrdinal(checked((long)number), variants);
 
@@ -312,6 +352,7 @@ namespace Utils.NumberToString
         /// <param name="amount">The amount to convert.</param>
         /// <param name="currency">The currency names and configuration.</param>
         /// <returns>The amount expressed as words.</returns>
+        /// <exception cref="NotSupportedException">The converter does not support currency conversion.</exception>
         string ConvertCurrency(decimal amount, CurrencyDefinition currency)
             => throw new NotSupportedException("Currency conversion is not supported by this converter.");
 
@@ -326,6 +367,7 @@ namespace Utils.NumberToString
         /// <param name="currency">The currency names and configuration.</param>
         /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
         /// <returns>The amount expressed as words with the requested variants applied.</returns>
+        /// <exception cref="NotSupportedException">The converter does not support currency conversion.</exception>
         string ConvertCurrency(decimal amount, CurrencyDefinition currency, params string[] variants)
             => ConvertCurrency(amount, currency);
 
@@ -358,6 +400,28 @@ namespace Utils.NumberToString
             => $"{Convert(numerator, variants)} / {Convert(denominator, variants)}";
 
         /// <summary>
+        /// Converts the fraction <paramref name="numerator"/>/<paramref name="denominator"/> to its
+        /// string representation. Delegates to <see cref="ConvertFraction(BigInteger, BigInteger, string[])"/>.
+        /// </summary>
+        /// <param name="numerator">The numerator of the fraction.</param>
+        /// <param name="denominator">The denominator of the fraction.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        /// <returns>The textual representation of the fraction.</returns>
+        string ConvertFraction(int numerator, int denominator, params string[] variants)
+            => ConvertFraction((BigInteger)numerator, (BigInteger)denominator, variants);
+
+        /// <summary>
+        /// Converts the fraction <paramref name="numerator"/>/<paramref name="denominator"/> to its
+        /// string representation. Delegates to <see cref="ConvertFraction(BigInteger, BigInteger, string[])"/>.
+        /// </summary>
+        /// <param name="numerator">The numerator of the fraction.</param>
+        /// <param name="denominator">The denominator of the fraction.</param>
+        /// <param name="variants">Zero or more <c>"dimension=value"</c> strings.</param>
+        /// <returns>The textual representation of the fraction.</returns>
+        string ConvertFraction(long numerator, long denominator, params string[] variants)
+            => ConvertFraction((BigInteger)numerator, (BigInteger)denominator, variants);
+
+        /// <summary>
         /// When <see langword="true"/>, <see cref="ConvertMultiplicative"/> produces a result;
         /// when <see langword="false"/>, it throws <see cref="NotSupportedException"/>.
         /// </summary>
@@ -367,6 +431,7 @@ namespace Utils.NumberToString
         /// Converts a multiplier to its spoken multiplicative form (e.g. 2 → "twice", 3 → "trois fois").
         /// Throws <see cref="NotSupportedException"/> when the language has no multiplicative configuration.
         /// </summary>
+        /// <exception cref="NotSupportedException">The converter has no <c>&lt;Multiplicatives&gt;</c> configuration (<see cref="SupportsMultiplicative"/> is <see langword="false"/>).</exception>
         string ConvertMultiplicative(int multiplier, params string[] variants)
             => throw new NotSupportedException("This converter does not support multiplicative forms.");
 
@@ -387,6 +452,7 @@ namespace Utils.NumberToString
         /// (e.g. "two hours thirty minutes five seconds").
         /// Requires <c>&lt;TimeUnits&gt;</c> in the XML configuration.
         /// </summary>
+        /// <exception cref="NotSupportedException">The converter has no <c>&lt;TimeUnits&gt;</c> configuration (<see cref="SupportsTimeConversion"/> is <see langword="false"/>).</exception>
         string Convert(TimeSpan duration, params string[] variants)
             => throw new NotSupportedException("Time conversion requires <TimeUnits> in the XML configuration.");
 
@@ -395,6 +461,7 @@ namespace Utils.NumberToString
         /// (e.g. "quatorze heures trente").
         /// Requires <c>&lt;TimeUnits&gt;</c> in the XML configuration.
         /// </summary>
+        /// <exception cref="NotSupportedException">The converter has no <c>&lt;TimeUnits&gt;</c> configuration (<see cref="SupportsTimeConversion"/> is <see langword="false"/>).</exception>
         string Convert(TimeOnly time, params string[] variants)
             => throw new NotSupportedException("Time conversion requires <TimeUnits> in the XML configuration.");
 
@@ -404,6 +471,7 @@ namespace Utils.NumberToString
         /// Requires <c>&lt;DateFormat&gt;</c> in the XML configuration.
         /// Month names are read from <see cref="System.Globalization.CultureInfo"/>.
         /// </summary>
+        /// <exception cref="NotSupportedException">The converter has no <c>&lt;DateFormat&gt;</c> configuration (<see cref="SupportsDateConversion"/> is <see langword="false"/>).</exception>
         string Convert(DateOnly date, params string[] variants)
             => throw new NotSupportedException("Date conversion requires <DateFormat> in the XML configuration.");
 
@@ -411,6 +479,7 @@ namespace Utils.NumberToString
         /// Converts a <see cref="DateTime"/> to its spoken form by combining
         /// <see cref="Convert(DateOnly, string[])"/> and <see cref="Convert(TimeOnly, string[])"/>.
         /// </summary>
+        /// <exception cref="NotSupportedException">The converter has no <c>&lt;DateFormat&gt;</c> or <c>&lt;TimeUnits&gt;</c> configuration.</exception>
         string Convert(DateTime dateTime, params string[] variants)
             => throw new NotSupportedException("Date/time conversion requires <DateFormat> and <TimeUnits> in the XML configuration.");
     }

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.ES.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.ES.xml
@@ -75,15 +75,19 @@
 			  In Spanish, only "uno" (1) and compound hundreds (-cientos) vary in
 			  gender. The 21-29 compounds are fused words (veintiuno, veintidós…):
 			  LastWord does not transform "uno" inside "veintiuno" because the
-			  preceding character ('i') is neither a space nor a hyphen. Fixing
-			  the buildStrings (adding a space and "y") would extend coverage to
-			  the 31-99 forms.
+			  preceding character ('i') is neither a space nor a hyphen — handled
+			  instead via a whole-word replacement below (item 41). 31-99 already
+			  use a space-separated buildString ("treinta y *"), so LastWord works there.
 			-->
 			<Dimension name="gender" localName="género" values="masculino,femenino" />
 
 			<Variant type="gender" variant="femenino">
 				<!-- Units: "uno" alone or at end of group (preceded by a space or hyphen) -->
 				<Replacement oldValue="uno" newValue="una" scope="LastWord" />
+				<!-- item 41: 21 is a fused word ("veintiuno") that LastWord cannot reach
+				     (no space/hyphen before "uno"); handled with a whole-word replacement instead.
+				     22-29 do not vary in gender ("uno" is the only variable unit). -->
+				<Replacement oldValue="veintiuno" newValue="veintiuna" scope="Anywhere" />
 				<!-- Hundreds: replaces the -cientos form with -cientas everywhere
 				     (safe because these words do not appear in scale names) -->
 				<Replacement oldValue="doscientos"    newValue="doscientas"    scope="Anywhere" />

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.FI.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.FI.xml
@@ -58,6 +58,10 @@
                 <Suffix>miljoona</Suffix>
             </Suffixes>
         </NumberScale>
+        <Replacements>
+            <!-- 1 000 is "tuhat", not "yksi tuhat" (the multiplier 1 is elided before the thousands scale name). -->
+            <Replacement oldValue="yksi tuhat" newValue="tuhat" onScale="1" onValue="1" />
+        </Replacements>
         <Exceptions>
             <Number value="11" string="yksitoista" />
             <Number value="12" string="kaksitoista" />

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.JA.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.JA.xml
@@ -58,6 +58,10 @@
 				<Suffix>万</Suffix>
 			</Suffixes>
 		</NumberScale>
+		<Replacements>
+			<!-- 1 000 is "千", not "一 千" (unlike Chinese, which keeps "一千") -->
+			<Replacement oldValue="一 千" newValue="千" onScale="1" onValue="1" />
+		</Replacements>
 		<Exceptions />
 		<Ordinals prefix="第" />
 	</Language>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.KO.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.KO.xml
@@ -58,6 +58,10 @@
                 <Suffix>만</Suffix>
             </Suffixes>
         </NumberScale>
+        <Replacements>
+            <!-- 1 000 is "천", not "일 천" (the multiplier 1 is elided before the thousands scale name). -->
+            <Replacement oldValue="일 천" newValue="천" onScale="1" onValue="1" />
+        </Replacements>
         <Exceptions />
         <Ordinals prefix="제" />
     </Language>

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -730,39 +730,41 @@ namespace Utils.NumberToString
 
         /// <summary>
         /// Validates that all variant dimension references in VariantRules, OrdinalVariants, and
-        /// TriggerReplace.Forms constraints are declared dimensions for the converter.
-        /// Throws <see cref="InvalidOperationException"/> when an unknown dimension key is found.
+        /// TriggerReplace.Forms constraints are declared dimensions for the converter, and that
+        /// the constraint values used are among the values declared for that dimension.
+        /// Throws <see cref="InvalidOperationException"/> when an unknown dimension key or an
+        /// undeclared value is found.
         /// </summary>
         private static void ValidateVariantReferences(NumberToStringConverter converter, string configSource)
         {
-            var knownDimensions = converter.VariantDimensions
-                .SelectMany(d => new[] { d.Name }.Concat(d.LocalName != null ? [d.LocalName] : []))
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var dimensionsByKey = converter.VariantDimensions
+                .SelectMany(d => new[] { d.Name }.Concat(d.LocalName != null ? [d.LocalName] : [])
+                    .Select(key => (key, dimension: d)))
+                .ToDictionary(t => t.key, t => t.dimension, StringComparer.OrdinalIgnoreCase);
 
             string Declared() =>
                 string.Join(", ", converter.VariantDimensions.Select(d => d.Name));
 
-            foreach (var rule in converter.VariantRules)
+            void ValidateKeyValue(string kind, string key, string value)
             {
-                foreach (var key in rule.Constraints.Keys)
-                {
-                    if (!knownDimensions.Contains(key))
-                        throw new InvalidOperationException(
-                            $"[{configSource}] Variant rule references unknown dimension '{key}'. " +
-                            $"Declared: [{Declared()}].");
-                }
+                if (!dimensionsByKey.TryGetValue(key, out var dimension))
+                    throw new InvalidOperationException(
+                        $"[{configSource}] {kind} references unknown dimension '{key}'. " +
+                        $"Declared: [{Declared()}].");
+
+                if (!dimension.Values.Contains(value, StringComparer.OrdinalIgnoreCase))
+                    throw new InvalidOperationException(
+                        $"[{configSource}] {kind} references unknown value '{value}' for dimension '{key}'. " +
+                        $"Declared values: [{string.Join(", ", dimension.Values)}].");
             }
 
+            foreach (var rule in converter.VariantRules)
+                foreach (var (key, value) in rule.Constraints)
+                    ValidateKeyValue("Variant rule", key, value);
+
             foreach (var rule in converter.OrdinalVariants)
-            {
-                foreach (var key in rule.Constraints.Keys)
-                {
-                    if (!knownDimensions.Contains(key))
-                        throw new InvalidOperationException(
-                            $"[{configSource}] OrdinalVariant rule references unknown dimension '{key}'. " +
-                            $"Declared: [{Declared()}].");
-                }
-            }
+                foreach (var (key, value) in rule.Constraints)
+                    ValidateKeyValue("OrdinalVariant rule", key, value);
 
             foreach (var trigger in converter.Triggers)
             {
@@ -770,13 +772,8 @@ namespace Utils.NumberToString
                 {
                     foreach (var (constraints, _) in replace.Forms)
                     {
-                        foreach (var key in constraints.Keys)
-                        {
-                            if (!knownDimensions.Contains(key))
-                                throw new InvalidOperationException(
-                                    $"[{configSource}] TriggerReplace references unknown dimension '{key}'. " +
-                                    $"Declared: [{Declared()}].");
-                        }
+                        foreach (var (key, value) in constraints)
+                            ValidateKeyValue("TriggerReplace", key, value);
                     }
                 }
             }

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -103,6 +103,7 @@ namespace Utils.NumberToString
 
             VariantDimensions = (options.VariantDimensions ?? []).ToImmutableArray();
             VariantRules = (options.VariantRules ?? []).ToImmutableArray();
+            _sortedVariantRules = VariantRules.OrderBy(r => r.Specificity).ToImmutableArray();
             _hasScaleSpecificVariantRules = VariantRules.Any(r => r.Replacements.Any(rr => rr.OnScale is not null));
             Triggers = (options.Triggers ?? []).ToImmutableArray();
             _yearFormat = options.YearFormat;
@@ -304,6 +305,7 @@ namespace Utils.NumberToString
         private readonly ImmutableArray<ReplacementRule> _valueFilteredGlobalReplacements;
         private readonly ImmutableArray<ReplacementRule> _scaleReplacements;
         private readonly bool _hasScaleSpecificVariantRules;
+        private readonly ImmutableArray<VariantRule> _sortedVariantRules;
         private readonly ImmutableDictionary<string, VariantDimension> _dimensionIndex;
         private readonly Func<string, string>? _rawAdjustFunction;
         private readonly string? _groupConnector;
@@ -711,7 +713,7 @@ namespace Utils.NumberToString
         {
             if (VariantRules.Count == 0 || query.Count == 0) return text;
 
-            foreach (var rule in VariantRules.OrderBy(r => r.Specificity))
+            foreach (var rule in _sortedVariantRules)
             {
                 bool matches = rule.Constraints.All(c =>
                     query.TryGetValue(c.Key, out var v) &&
@@ -744,7 +746,7 @@ namespace Utils.NumberToString
         {
             if (VariantRules.Count == 0 || query.Count == 0) return text;
 
-            foreach (var rule in VariantRules.OrderBy(r => r.Specificity))
+            foreach (var rule in _sortedVariantRules)
             {
                 bool matches = rule.Constraints.All(c =>
                     query.TryGetValue(c.Key, out var v) &&

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -103,7 +103,7 @@ namespace Utils.NumberToString
 
             VariantDimensions = (options.VariantDimensions ?? []).ToImmutableArray();
             VariantRules = (options.VariantRules ?? []).ToImmutableArray();
-            _sortedVariantRules = VariantRules.OrderBy(r => r.Specificity).ToImmutableArray();
+            _sortedVariantRules = [.. VariantRules.OrderBy(r => r.Specificity)];
             _hasScaleSpecificVariantRules = VariantRules.Any(r => r.Replacements.Any(rr => rr.OnScale is not null));
             Triggers = (options.Triggers ?? []).ToImmutableArray();
             _yearFormat = options.YearFormat;
@@ -542,9 +542,15 @@ namespace Utils.NumberToString
             return isNegative ? Minus.Replace("*", adjusted) : adjusted;
         }
 
+        /// <inheritdoc cref="INumberToStringConverter.Convert(double)"/>
+        public string Convert(double number) => Convert(number, []);
+
         /// <inheritdoc cref="INumberToStringConverter.Convert(double, string[])"/>
         public string Convert(double number, params string[] variants)
         {
+            if (double.IsNaN(number) || double.IsInfinity(number))
+                throw new ArgumentException($"Cannot convert non-finite value '{number}' to a number in words.", nameof(number));
+
             if (decimal.TryParse(
                     number.ToString("R", System.Globalization.CultureInfo.InvariantCulture),
                     System.Globalization.NumberStyles.Any,
@@ -553,6 +559,9 @@ namespace Utils.NumberToString
                 return Convert(d, variants);
             return Convert(new System.Numerics.BigInteger(Math.Truncate(number)), variants);
         }
+
+        /// <inheritdoc cref="INumberToStringConverter.Convert(float)"/>
+        public string Convert(float number) => Convert((double)number, []);
 
         /// <inheritdoc cref="INumberToStringConverter.Convert(float, string[])"/>
         public string Convert(float number, params string[] variants)
@@ -701,15 +710,30 @@ namespace Utils.NumberToString
         }
 
         /// <summary>
-        /// Applies variant rules to <paramref name="text"/> in order of ascending specificity.
+        /// Applies variant rules to <paramref name="text"/> in order of ascending specificity
+        /// (pre-sorted once at construction time in <see cref="_sortedVariantRules"/>).
         /// A rule matches when all its dimension constraints are satisfied by <paramref name="query"/>.
+        /// Two mutually exclusive modes are supported via <paramref name="scaleGroupNumber"/>:
+        /// global replacements (no <c>onScale</c>) when <see langword="null"/>, or scale-specific
+        /// replacements for a single group when set (used by <see cref="ApplyVariantRulesForScale"/>).
         /// </summary>
+        /// <param name="text">The already-converted text to apply variant replacements to.</param>
+        /// <param name="query">The active variant dimension values (e.g. gender, case) to match rules against.</param>
         /// <param name="numericValue">
         /// The full absolute number value, used to evaluate <see cref="ReplacementRule.OnValue"/>
-        /// predicates on global (no <c>onScale</c>) variant replacements.
+        /// predicates on global (no <c>onScale</c>) variant replacements. Ignored in scale mode.
         /// <see langword="null"/> suppresses <c>onValue</c> filtering (rule fires regardless).
         /// </param>
-        private string ApplyVariantRules(string text, IReadOnlyDictionary<string, string> query, long? numericValue = null)
+        /// <param name="scaleGroupNumber">
+        /// When set, restricts matching to scale-specific replacements whose <c>onScale</c> range
+        /// contains this group number (scale mode). When <see langword="null"/>, only global
+        /// (non-scale) replacements are applied.
+        /// </param>
+        /// <param name="scaleGroupValue">
+        /// The numeric value of the current group in scale mode (e.g. 1 for the thousands group
+        /// in 1 000), evaluated against <see cref="ReplacementRule.OnValue"/>.
+        /// </param>
+        private string ApplyVariantRules(string text, IReadOnlyDictionary<string, string> query, long? numericValue = null, int? scaleGroupNumber = null, long scaleGroupValue = 0)
         {
             if (VariantRules.Count == 0 || query.Count == 0) return text;
 
@@ -723,9 +747,17 @@ namespace Utils.NumberToString
 
                 foreach (var replacement in rule.Replacements)
                 {
-                    if (_hasScaleSpecificVariantRules && replacement.OnScale is not null) continue;
-                    if (replacement.OnValue is not null && (numericValue is null || !replacement.OnValue.Contains(numericValue.Value)))
-                        continue;
+                    if (scaleGroupNumber is int groupNumber)
+                    {
+                        if (replacement.OnScale is null || !replacement.OnScale.Contains(groupNumber)) continue;
+                        if (replacement.OnValue is not null && !replacement.OnValue.Contains(scaleGroupValue)) continue;
+                    }
+                    else
+                    {
+                        if (_hasScaleSpecificVariantRules && replacement.OnScale is not null) continue;
+                        if (replacement.OnValue is not null && (numericValue is null || !replacement.OnValue.Contains(numericValue.Value)))
+                            continue;
+                    }
                     text = ApplyVariantReplacement(text, replacement);
                 }
             }
@@ -736,35 +768,18 @@ namespace Utils.NumberToString
         /// <summary>
         /// Applies scale-specific variant replacements for <paramref name="groupNumber"/> only.
         /// Called per-group inside <see cref="ConvertRaw"/> when scale-specific variant rules exist.
+        /// Thin wrapper over <see cref="ApplyVariantRules"/> in scale mode.
         /// </summary>
+        /// <param name="text">The already-converted text to apply variant replacements to.</param>
+        /// <param name="query">The active variant dimension values (e.g. gender, case) to match rules against.</param>
+        /// <param name="groupNumber">The scale group number the replacements must target via <c>onScale</c>.</param>
         /// <param name="groupNumericValue">
         /// The numeric value of the current group (e.g. 1 for the thousands group in 1 000).
         /// Used to evaluate <see cref="ReplacementRule.OnValue"/> predicates on scale-specific
         /// variant replacements.
         /// </param>
-        private string ApplyVariantRulesForScale(string text, IReadOnlyDictionary<string, string> query, int groupNumber, long groupNumericValue = 0)
-        {
-            if (VariantRules.Count == 0 || query.Count == 0) return text;
-
-            foreach (var rule in _sortedVariantRules)
-            {
-                bool matches = rule.Constraints.All(c =>
-                    query.TryGetValue(c.Key, out var v) &&
-                    string.Equals(v, c.Value, StringComparison.OrdinalIgnoreCase));
-
-                if (!matches) continue;
-
-                foreach (var replacement in rule.Replacements)
-                {
-                    if (replacement.OnScale is null || !replacement.OnScale.Contains(groupNumber)) continue;
-                    if (replacement.OnValue is not null && !replacement.OnValue.Contains(groupNumericValue))
-                        continue;
-                    text = ApplyVariantReplacement(text, replacement);
-                }
-            }
-
-            return text;
-        }
+        private string ApplyVariantRulesForScale(string text, IReadOnlyDictionary<string, string> query, int groupNumber, long groupNumericValue = 0) =>
+            ApplyVariantRules(text, query, scaleGroupNumber: groupNumber, scaleGroupValue: groupNumericValue);
 
         /// <summary>
         /// Applies a single replacement rule to <paramref name="text"/> according to its scope.
@@ -1180,17 +1195,17 @@ namespace Utils.NumberToString
         /// <param name="numerator">The numerator of the fraction.</param>
         /// <param name="denominator">The denominator of the fraction.</param>
         /// <param name="allowFractionNames">When <see langword="true"/>, uses named fraction suffixes when available.</param>
+        /// <param name="variants">Optional variant dimension values (e.g. gender) forwarded to the numerator/denominator conversions.</param>
         /// <returns>The textual representation of the fraction.</returns>
         private string BuildFractionText(BigInteger numerator, BigInteger denominator, bool allowFractionNames = true, string[]? variants = null)
         {
             if (allowFractionNames &&
                 TryGetBase10FractionDigits(denominator, out int digits) &&
                 Fractions.TryGetValue(digits, out var suffix) &&
-                numerator >= 0 &&
-                numerator <= long.MaxValue)
+                BigInteger.Abs(numerator) <= long.MaxValue)
             {
                 string valueText = (variants is { Length: > 0 } ? Convert(numerator, variants) : Convert(numerator)).Replace("-", " ");
-                return string.Concat(valueText, Separator, suffix.ToPlural((long)numerator)).Trim();
+                return string.Concat(valueText, Separator, suffix.ToPlural((long)BigInteger.Abs(numerator))).Trim();
             }
 
             string numeratorText = (variants is { Length: > 0 } ? Convert(numerator, variants) : Convert(numerator)).Replace("-", " ");
@@ -1334,6 +1349,14 @@ namespace Utils.NumberToString
         public string ConvertFraction(BigInteger numerator, BigInteger denominator, params string[] variants)
             => BuildFractionText(numerator, denominator, allowFractionNames: true, variants);
 
+        /// <inheritdoc cref="INumberToStringConverter.ConvertFraction(int, int, string[])"/>
+        public string ConvertFraction(int numerator, int denominator, params string[] variants)
+            => ConvertFraction((BigInteger)numerator, (BigInteger)denominator, variants);
+
+        /// <inheritdoc cref="INumberToStringConverter.ConvertFraction(long, long, string[])"/>
+        public string ConvertFraction(long numerator, long denominator, params string[] variants)
+            => ConvertFraction((BigInteger)numerator, (BigInteger)denominator, variants);
+
         /// <summary>
         /// Converts a multiplier to its spoken form (e.g. 2 → "twice", 3 → "trois fois").
         /// Named forms are looked up from the configuration; unnamed forms append <see cref="MultiplicativeSuffix"/>
@@ -1402,7 +1425,7 @@ namespace Utils.NumberToString
             {
                 return CultureInfo.GetCultureInfo(LanguageIdentifier).DateTimeFormat.MonthNames[month - 1];
             }
-            catch
+            catch (Exception ex) when (ex is CultureNotFoundException or IndexOutOfRangeException)
             {
                 return month.ToString(CultureInfo.InvariantCulture);
             }

--- a/Utils.NumberToString/README.md
+++ b/Utils.NumberToString/README.md
@@ -42,6 +42,20 @@ dotnet add package omy.Utils.NumberToString
 | ZU | Zulu | — | — (not yet implemented) |
 | EE | Ewe | ✓ (prefix etsõ) | — |
 | WO | Wolof | ✓ | — |
+| HR | Croatian | ✓ | — (numbers are invariable) |
+| HU | Hungarian | ✓ | — (numbers are invariable) |
+| VN, VI, VI-VN | Vietnamese | ✓ | — (numbers are invariable) |
+| TR, TR-TR | Turkish | — | — (numbers are invariable) |
+| SV, SV-SE | Swedish | — | — (numbers are invariable) |
+| NO, NB, NB-NO | Norwegian (Bokmål) | — | — (numbers are invariable) |
+| UK, UK-UA | Ukrainian | — | — (numbers are invariable) |
+| DA, DA-DK | Danish | — | — (numbers are invariable) |
+| CS, CS-CZ | Czech | — | — (numbers are invariable) |
+| SK, SK-SK | Slovak | — | — (numbers are invariable) |
+| BG, BG-BG | Bulgarian | — | — (numbers are invariable) |
+| ID, MS | Indonesian / Malay | — | — (numbers are invariable) |
+| FA, FA-IR | Persian (Farsi) | — | — (numbers are invariable) |
+| SW | Swahili | — | — (numbers are invariable) |
 
 ---
 
@@ -810,6 +824,9 @@ on the same language register the same converter under several codes.
 | `fractionSeparator` | | Connector for fractions (e.g. `"sur"`, `"over"`). |
 | `maxNumber` | | Maximum accepted value; beyond this, `ArgumentOutOfRangeException` is thrown. |
 | `baseOn` | | Culture code of a base language to inherit from. All settings are inherited and can be selectively overridden. Chains (A → B → C) are supported; the base must appear earlier in the same file or in a previously loaded file. An empty element (e.g. `<Replacements />`) explicitly overrides the base with an empty list. |
+| `groupConnector` / `groupConnectorThreshold` | | Word inserted between the last two groups when the lowest group's value is below the threshold (e.g. English "one thousand **and** one" — `groupConnector="and" groupConnectorThreshold="100"`). |
+| `intraGroupConnector` / `intraGroupConnectorThreshold` | | Word inserted between the hundreds digit and the remainder within a group of 3, when hundreds are present and the remainder is below the threshold (e.g. Vietnamese 101 → "một trăm **linh** một" — `intraGroupConnector="linh" intraGroupConnectorThreshold="10"`). |
+| `scaleConnector` / `scaleConnectorThreshold` | | Word inserted between a group's text and its scale name (thousand/million/…) when the group's value is at or above the threshold (e.g. Romanian 20 000 → "douăzeci **de** mii" — `scaleConnector="de" scaleConnectorThreshold="20"`). |
 
 ---
 
@@ -1247,6 +1264,7 @@ within the declared `<SplitRange>` elements. Years outside all ranges fall back 
 |-----------|-------------|
 | `hundredWord` | Word appended when the year is a round century (e.g. `"hundred"` → `"nineteen hundred"`). |
 | `zeroConnector` | Connector inserted before single-digit remainders (e.g. `"oh"` → `"twenty oh five"`). |
+| `beforeChristSuffix` | Suffix appended to negative years instead of the `minus` template (e.g. `"BC"` → `ConvertYear(-44)` → `"forty-four BC"` instead of `"minus forty-four"`). |
 
 `<SplitRange from="N" to="M" />` declares an inclusive range `[N, M]` of year values that
 use the split algorithm. Multiple ranges may be declared; ranges outside the list fall back

--- a/Utils.NumberToString/TODO.md
+++ b/Utils.NumberToString/TODO.md
@@ -211,3 +211,70 @@ itèrent sur ce champ au lieu d'appeler `.OrderBy(r => r.Specificity)` à chaque
 Les tests existants qui attendaient l'ancien comportement (`NumberToStringConverterFITests.cs`,
 `NumberToStringConverterKOTests.cs`, et un cas dans `NumberToStringConverterImprovementsTests.cs`)
 ont été mis à jour en conséquence.
+
+---
+
+## Améliorations identifiées (2026-07-09)
+
+### 29. `GetMonthName` — catch trop large
+
+`NumberToStringConverter.cs:1403` attrape `catch { }` sans type, masquant toute exception
+(pas seulement les erreurs de culture attendues). Même pattern que le fix appliqué à
+`TtfEncoderFactory.cs` en 2026-03-12 : remplacer par les types d'exception réellement
+attendus (ex. `ArgumentOutOfRangeException`).
+
+### 30. `BuildFractionText` ignore les numérateurs négatifs pour les suffixes nommés
+
+`NumberToStringConverter.cs:1182-1192` : le test `numerator >= 0` empêche `-1/3` de
+bénéficier de la forme nommée ("moins un tiers"), elle retombe sur une forme brute
+(numérateur/dénominateur bruts). Extraire la valeur absolue avant le test résoudrait
+l'incohérence.
+
+### 31. `ApplyVariantRules` / `ApplyVariantRulesForScale` dupliquées (~40 lignes)
+
+`NumberToStringConverter.cs:710-732` et `743-765` : même logique d'itération/contrainte/
+remplacement, seul le filtre `OnScale` diffère. À factoriser en une seule méthode
+paramétrée, en même temps que le correctif de tri unique proposé par l'item 27
+(actuellement non implémenté).
+
+### 32. Étendre le fix item 28 (multiplicateur "1" devant mille) à ZH et JA
+
+Le même bug que FI/KO existe potentiellement pour "一千" (ZH) et "一千" (JA) : à vérifier
+et corriger avec le même pattern `<Replacement oldValue="一千" newValue="千" onScale="1" onValue="1" />`
+dans `ZH.xml` et `JA.xml`.
+
+### 33. PT/GL — centaines sans forme féminine
+
+`duzentos`/`trescentos` (PT et GL) n'ont pas d'équivalent féminin contrairement à
+l'espagnol (`doscientas`). À vérifier linguistiquement (le portugais et le galicien
+accordent-ils réellement les centaines en genre comme l'espagnol ?) puis corriger si
+applicable via des `<Variant>` gender=feminino.
+
+### 34. FR-be-ch — connecteur "et" manquant pour 71/81/91
+
+En français de Belgique/Suisse, "septante et un" (71) prend "et" mais "septante-deux" (72)
+n'en prend pas — cette distinction n'est pas modélisée dans `NumberConvertionConfiguration.FR-be-ch.xml`,
+qui n'a pas d'exceptions dédiées pour 71-99 comme le FR standard.
+
+### 35. `Convert(double/float)` et `DecimalFormatOptions` quasi uniquement testés en FR
+
+Ces fonctionnalités (items 1 et 18) ont une couverture de test presque exclusivement FR.
+Étendre à DE/ES/IT pour vérifier l'interaction genre/pluriel avec `DecimalSeparator`,
+`DecimalSuffix` et `OmitZeroDecimals`.
+
+### 36. `Convert(TimeSpan/DateOnly/DateTime)` non testé pour DE
+
+`DE.xml` a pourtant une config complète `<TimeUnits>` + `<DateFormat firstDay="ersten">`,
+mais `NumberToStringConverterTimeAndNewLangTests.cs` ne couvre que EN/FR pour
+`Convert(DateOnly)` et `Convert(DateTime)`.
+
+### 37. `Convert(BigInteger, int significantDigits, ...)` sans test par langue
+
+Ajoutée en item 3, cette surcharge n'a aucun test vérifiant l'arrondi de groupe combiné
+à des variants (ex. genre FR) sur un grand nombre.
+
+### 38. `ConvertYear` négatif (`beforeChristSuffix`) jamais combiné à des variants
+
+Testé uniquement via `ConvertYear(-44)` en EN sans variant ; aucun test ne combine année
+av. J.-C. et variant genre/cas pour une langue où le split par moitié (EN/DE/NL) produit
+des numéraux accordables.

--- a/Utils.NumberToString/TODO.md
+++ b/Utils.NumberToString/TODO.md
@@ -216,79 +216,85 @@ ont été mis à jour en conséquence.
 
 ## Améliorations identifiées (2026-07-09)
 
-### 29. `GetMonthName` — catch trop large
+### ~~29. `GetMonthName` — catch trop large~~ — **implémenté**
 
-`NumberToStringConverter.cs:1403` attrape `catch { }` sans type, masquant toute exception
-(pas seulement les erreurs de culture attendues). Même pattern que le fix appliqué à
-`TtfEncoderFactory.cs` en 2026-03-12 : remplacer par les types d'exception réellement
-attendus (ex. `ArgumentOutOfRangeException`).
+`catch { }` remplacé par `catch (Exception ex) when (ex is CultureNotFoundException or IndexOutOfRangeException)`
+dans `NumberToStringConverter.cs`. Test de régression via réflexion sur la méthode privée
+(mois hors plage → repli sur la valeur numérique au lieu de propager une exception inattendue).
 
-### 30. `BuildFractionText` ignore les numérateurs négatifs pour les suffixes nommés
+### ~~30. `BuildFractionText` ignore les numérateurs négatifs pour les suffixes nommés~~ — **implémenté**
 
-`NumberToStringConverter.cs:1182-1192` : le test `numerator >= 0` empêche `-1/3` de
-bénéficier de la forme nommée ("moins un tiers"), elle retombe sur une forme brute
-(numérateur/dénominateur bruts). Extraire la valeur absolue avant le test résoudrait
-l'incohérence.
+Condition changée en `BigInteger.Abs(numerator) <= long.MaxValue` ; `ToPlural` reçoit aussi
+la valeur absolue. `-1/10` bénéficie désormais de la forme nommée ("moins un dixième" /
+"minus one tenth") au lieu de retomber sur la forme brute numérateur/dénominateur.
 
-### 31. `ApplyVariantRules` / `ApplyVariantRulesForScale` dupliquées (~40 lignes)
+### ~~31. `ApplyVariantRules` / `ApplyVariantRulesForScale` dupliquées~~ — **implémenté**
 
-`NumberToStringConverter.cs:710-732` et `743-765` : même logique d'itération/contrainte/
-remplacement, seul le filtre `OnScale` diffère. À factoriser en une seule méthode
-paramétrée, en même temps que le correctif de tri unique proposé par l'item 27
-(actuellement non implémenté).
+Fusionnées en une seule méthode `ApplyVariantRules(text, query, numericValue?, scaleGroupNumber?, scaleGroupValue)` ;
+`ApplyVariantRulesForScale` devient un wrapper fin. Le tri de l'item 27 a été fait dans la
+foulée (`_sortedVariantRules` trié une fois au constructeur).
 
-### 32. Étendre le fix item 28 (multiplicateur "1" devant mille) à ZH et JA
+### ~~32. Étendre le fix item 28 (multiplicateur "1" devant mille) à ZH et JA~~ — **implémenté (JA seulement)**
 
-Le même bug que FI/KO existe potentiellement pour "一千" (ZH) et "一千" (JA) : à vérifier
-et corriger avec le même pattern `<Replacement oldValue="一千" newValue="千" onScale="1" onValue="1" />`
-dans `ZH.xml` et `JA.xml`.
+Vérification empirique (et non simple supposition) : le mandarin standard **garde** le "一"
+devant 千 ("一千" est correct, confirmé par un test ZH déjà existant) — aucune correction
+apportée à `ZH.xml`. Le japonais, en revanche, omet "一" devant 千 comme devant 百 (déjà
+correct) : `<Replacement oldValue="一 千" newValue="千" onScale="1" onValue="1" />` ajouté
+dans `JA.xml`. Item 28 lui-même (FI/KO) a été implémenté au passage (il ne l'était pas malgré
+un statut antérieur trompeur) — voir tests `NumberToStringConverterFITests.cs`/`KOTests.cs`.
 
-### 33. PT/GL — centaines sans forme féminine
+### ~~33. PT/GL — centaines sans forme féminine~~ — **déjà implémenté (PT) ; GL déjà correct par conception**
 
-`duzentos`/`trescentos` (PT et GL) n'ont pas d'équivalent féminin contrairement à
-l'espagnol (`doscientas`). À vérifier linguistiquement (le portugais et le galicien
-accordent-ils réellement les centaines en genre comme l'espagnol ?) puis corriger si
-applicable via des `<Variant>` gender=feminino.
+Vérification du code : PT a déjà les 8 remplacements -entos→-entas dans `<Variants>` (testé
+dans `Cardinals_Gender_Feminino`). GL a déjà `douscentos→douscentas` (le seul cas variable en
+galicien selon le commentaire du fichier) ; test de régression ajouté pour verrouiller ce
+comportement documenté (200 varie, 300 non).
 
-### 34. FR-be-ch — connecteur "et" manquant pour 71/81/91
+### ~~34. FR-be-ch — connecteur "et" manquant pour 71/81/91~~ — **déjà correct, non un bug**
 
-En français de Belgique/Suisse, "septante et un" (71) prend "et" mais "septante-deux" (72)
-n'en prend pas — cette distinction n'est pas modélisée dans `NumberConvertionConfiguration.FR-be-ch.xml`,
-qui n'a pas d'exceptions dédiées pour 71-99 comme le FR standard.
+Le mécanisme générique (`Group level 1, digit=1 → "et un"`) applique déjà "et" uniquement
+au chiffre 1, quel que soit le mot des dizaines — 71/81/91 en bénéficient automatiquement,
+72-79/82-89/92-99 n'en ont pas besoin. Tests ajoutés (`NumberToStringConverterFRTests.cs`)
+pour verrouiller ce comportement déjà correct mais non testé.
 
-### 35. `Convert(double/float)` et `DecimalFormatOptions` quasi uniquement testés en FR
+### ~~35. `Convert(double/float)` et `DecimalFormatOptions` quasi uniquement testés en FR~~ — **implémenté**
 
-Ces fonctionnalités (items 1 et 18) ont une couverture de test presque exclusivement FR.
-Étendre à DE/ES/IT pour vérifier l'interaction genre/pluriel avec `DecimalSeparator`,
-`DecimalSuffix` et `OmitZeroDecimals`.
+6 tests ajoutés couvrant DE/ES/IT (`Convert(double)` avec variant, `DecimalFormatOptions`
+avec séparateur/suffixe pluralisés) dans `NumberToStringConverterCoverageGapsTests.cs`.
 
-### 36. `Convert(TimeSpan/DateOnly/DateTime)` non testé pour DE
+### ~~36. `Convert(TimeSpan/DateOnly/DateTime)` non testé pour DE~~ — **implémenté**
 
-`DE.xml` a pourtant une config complète `<TimeUnits>` + `<DateFormat firstDay="ersten">`,
-mais `NumberToStringConverterTimeAndNewLangTests.cs` ne couvre que EN/FR pour
-`Convert(DateOnly)` et `Convert(DateTime)`.
+2 tests ajoutés : `Convert(DateTime)` DE (parties date+heure) et `Convert(DateOnly)` DE avec
+`firstDay="ersten"` appliqué à `{ordinal-day}`.
 
-### 37. `Convert(BigInteger, int significantDigits, ...)` sans test par langue
+### ~~37. `Convert(BigInteger, int significantDigits, ...)` sans test par langue~~ — **implémenté**
 
-Ajoutée en item 3, cette surcharge n'a aucun test vérifiant l'arrondi de groupe combiné
-à des variants (ex. genre FR) sur un grand nombre.
+2 tests ajoutés (DE, ES avec variant de genre) vérifiant l'arrondi de groupe combiné aux
+variants sur un grand nombre.
 
-### 38. `ConvertYear` négatif (`beforeChristSuffix`) jamais combiné à des variants
+### ~~38. `ConvertYear` négatif (`beforeChristSuffix`) jamais combiné à des variants~~ — **implémenté**
 
-Testé uniquement via `ConvertYear(-44)` en EN sans variant ; aucun test ne combine année
-av. J.-C. et variant genre/cas pour une langue où le split par moitié (EN/DE/NL) produit
-des numéraux accordables.
+Découverte en écrivant le test : aucune config XML livrée ne déclare `beforeChristSuffix`
+(seul `NumberToStringConverterBatchTests.cs` l'exerçait via un converter construit à la main).
+Nouveau test construit un converter FR (qui a un genre) + `BeforeChristSuffix`, vérifiant que
+le genre est bien transmis au numéral avant append du suffixe ("un av. J.-C." / "une av. J.-C.").
 
 ---
 
 ## Améliorations identifiées (2026-07-09, suite)
 
-### 39. EL (grec) — centaines sans forme féminine
+### 39. EL (grec) — centaines sans forme féminine — **bug linguistique confirmé, bloqué par le moteur**
 
-Les centaines grecques (διακόσια, τριακόσια…) ne sont produites qu'en neutre. Le grec
-moderne accorde les centaines en genre selon le nom compté : "διακόσιες λίρες" (féminin
-pluriel) vs "διακόσια δολάρια" (neutre pluriel). Aucun `<Variant>` gender n'existe dans
-`EL.xml` pour ce cas, contrairement à ES qui gère déjà ce type d'accord pour les centaines.
+Les centaines grecques (διακόσια, τριακόσια…) ne sont produites qu'en neutre alors que le
+grec moderne les accorde en genre. Tentative d'implémentation via `<Variant type="gender"
+variant="αρσενικό/θηλυκό">` : **régression découverte** — la valeur par défaut d'une dimension
+est toujours `Values[0]` (`NumberToStringConverter.cs:1099`, non redéfinissable), et cette
+même dimension `gender` est partagée avec le positionnement des `forms=` des ordinaux
+(qui exige `αρσενικό` en premier). Rendre `ουδέτερο` premier casserait le défaut des ordinaux
+(`ConvertOrdinal(1)` sans variant doit rester "πρώτος", pas "πρώτο"). Fix annulé pour éviter
+de casser `Convert(200)` (devenu silencieusement "διακόσιοι" au lieu de "διακόσια"). Nécessite
+soit une dimension `gender` séparée pour les cardinaux (incohérent avec le reste du projet),
+soit une évolution du moteur permettant une valeur par défaut différente de `Values[0]`.
 
 ### 40. RU/CS/SK/BG — accord numéral slave (nominatif/génitif sg/pl) absent — limitation architecturale
 
@@ -300,50 +306,39 @@ remplacement ponctuel (RU, sans dimension de variant associée). Contrairement a
 moteur ne modélise pas aujourd'hui — **reporté**, à l'instar de l'item 9 (ZU), nécessiterait
 une extension du système de variants côté appelant plutôt qu'un correctif XML.
 
-### 41. ES — composés 21-29 (`veintiuno`) toujours fusionnés sans espace
+### ~~41. ES — composés 21-29 (`veintiuno`) toujours fusionnés sans espace~~ — **implémenté**
 
-L'item 4 a corrigé l'accord féminin pour ES 31-99 (`"treinta y *"`) et IT 21-29
-(`"venti *"`), mais **pas** ES 21-29 : `veintiuno`, `veintidós`… restent fusionnés en un
-seul mot, donc la règle `LastWord` n'atteint jamais le "uno" interne. `Convert(21,
-"gender=femenino")` retourne donc "veintiuno" au lieu de "veintiuna". Nécessite soit un
-espacement (`"veinte y *"` puis remplacement `"veinte y "` → `"veinti"`), soit une règle
-de remplacement dédiée comme pour 31-99.
+Plutôt que d'introduire un espace (qui changerait l'orthographe standard "veintiuno"),
+un remplacement mot-entier dédié a été ajouté : `<Replacement oldValue="veintiuno"
+newValue="veintiuna" scope="Anywhere" />`. 22-29 ne varient pas en genre (seul "uno" varie).
+`Convert(21, "gender=femenino")` → "veintiuna".
 
-### 42. README — 14 langues configurées absentes de la liste des langues supportées
+### ~~42. README — 14 langues configurées absentes de la liste des langues supportées~~ — **implémenté**
 
-`README.md` liste 25 langues alors que 39 fichiers XML existent dans
-`NumberConverterConfigurations/`. Manquent notamment : BG, CS, DA, FA, HR, HU, ID, NO, SK,
-SV, SW, TR, UK, VN — dont plusieurs ajoutées récemment (items 8 et 23) mais jamais
-reportées dans le README.
+Les 14 langues (BG, CS, DA, FA, HR, HU, ID/MS, NO/NB, SK, SV, SW, TR, UK, VN) ajoutées à la
+table des langues supportées, avec leurs codes de culture réels lus dans chaque XML.
 
-### 43. README — connecteurs XML majeurs et `beforeChristSuffix` non documentés
+### ~~43. README — connecteurs XML majeurs et `beforeChristSuffix` non documentés~~ — **implémenté**
 
-La section "XML Configuration" du README ne mentionne pas `groupConnector` /
-`groupConnectorThreshold`, `intraGroupConnector` / `intraGroupConnectorThreshold` (item 22)
-ni `scaleConnector` / `scaleConnectorThreshold` (item 8/RO), bien que ces attributs soient
-dans le XSD et activement utilisés. La section `<YearFormat>` documente `hundredWord` et
-`zeroConnector` mais omet `beforeChristSuffix` (item 14).
+`groupConnector`/`groupConnectorThreshold`, `intraGroupConnector`/`intraGroupConnectorThreshold`,
+`scaleConnector`/`scaleConnectorThreshold` ajoutés à la table `<Language>` attributes ;
+`beforeChristSuffix` ajouté à la table `<YearFormat>` attributes.
 
-### 44. `INumberToStringConverter` — XML docs sans tags `<exception>` structurés
+### ~~44. `INumberToStringConverter` — XML docs sans tags `<exception>` structurés~~ — **implémenté**
 
-Les exceptions levées (`NotSupportedException` selon `SupportsOrdinals`/`SupportsTimeConversion`/
-etc., `OverflowException` sur les conversions BigInteger→long) ne sont mentionnées qu'en
-texte libre dans les `<summary>`, jamais via des tags `<exception cref="...">` dédiés — à
-compléter sur les ~35 membres publics concernés.
+Tags `<exception cref="...">` ajoutés sur `Convert(BigInteger, variants)`, `ConvertOrdinal`
+(int/long/BigInteger, avec/sans variants), `ConvertCurrency` (avec/sans variants),
+`ConvertMultiplicative`, `Convert(TimeSpan/TimeOnly/DateOnly/DateTime)`, et
+`Convert(double/float)` (voir item 45).
 
-### 45. `Convert(double)` / `Convert(float)` — incohérences de surcharge et cas limites non gérés
+### ~~45. `Convert(double)` / `Convert(float)` — incohérences de surcharge et cas limites non gérés~~ — **implémenté**
 
-Deux problèmes distincts sur la même paire de méthodes (`INumberToStringConverter.cs`) :
-- Contrairement à `Convert(int/long/BigInteger/decimal)` qui ont chacune une surcharge sans
-  `variants`, `Convert(double)`/`Convert(float)` n'existent qu'avec `params string[] variants`.
-- `double.NaN` / `double.PositiveInfinity` ne sont jamais interceptés avant le passage par
-  `ToString("R")` + `decimal.TryParse` : le comportement résultant (échec silencieux ou
-  exception peu explicite) n'est pas défini. Ajouter un test explicite `double.IsNaN`/
-  `IsInfinity` avec un message d'erreur clair.
+Surcharges `Convert(double)`/`Convert(float)` sans `variants` ajoutées (interface + implémentation
+concrète, pour un accès direct sans passer par l'interface). `double.IsNaN`/`IsInfinity` (et
+équivalents `float`) interceptés en tête de méthode : lève désormais `ArgumentException` au lieu
+d'un comportement indéfini.
 
-### 46. `ConvertFraction` — pas de surcharge `int`/`long`, uniquement `BigInteger`
+### ~~46. `ConvertFraction` — pas de surcharge `int`/`long`, uniquement `BigInteger`~~ — **implémenté**
 
-`Convert`, `ConvertOrdinal` et `ConvertCurrency` offrent tous des surcharges `int`/`long`/
-`BigInteger` pour la cohérence de l'API. `ConvertFraction(BigInteger, BigInteger, ...)`
-(item 19) n'a pas d'équivalent `int`/`long`, forçant les appelants à convertir manuellement
-et s'exposant à un `OverflowException` évitable.
+Surcharges `ConvertFraction(int, int, ...)` et `ConvertFraction(long, long, ...)` ajoutées
+(interface + implémentation concrète), délégant à la version `BigInteger`.

--- a/Utils.NumberToString/TODO.md
+++ b/Utils.NumberToString/TODO.md
@@ -231,8 +231,8 @@ la valeur absolue. `-1/10` bénéficie désormais de la forme nommée ("moins un
 ### ~~31. `ApplyVariantRules` / `ApplyVariantRulesForScale` dupliquées~~ — **implémenté**
 
 Fusionnées en une seule méthode `ApplyVariantRules(text, query, numericValue?, scaleGroupNumber?, scaleGroupValue)` ;
-`ApplyVariantRulesForScale` devient un wrapper fin. Le tri de l'item 27 a été fait dans la
-foulée (`_sortedVariantRules` trié une fois au constructeur).
+`ApplyVariantRulesForScale` devient un wrapper fin qui délègue à la version unifiée
+(`_sortedVariantRules`, trié une fois au constructeur, cf. item 27 implémenté par ailleurs).
 
 ### ~~32. Étendre le fix item 28 (multiplicateur "1" devant mille) à ZH et JA~~ — **implémenté (JA seulement)**
 
@@ -240,8 +240,8 @@ Vérification empirique (et non simple supposition) : le mandarin standard **gar
 devant 千 ("一千" est correct, confirmé par un test ZH déjà existant) — aucune correction
 apportée à `ZH.xml`. Le japonais, en revanche, omet "一" devant 千 comme devant 百 (déjà
 correct) : `<Replacement oldValue="一 千" newValue="千" onScale="1" onValue="1" />` ajouté
-dans `JA.xml`. Item 28 lui-même (FI/KO) a été implémenté au passage (il ne l'était pas malgré
-un statut antérieur trompeur) — voir tests `NumberToStringConverterFITests.cs`/`KOTests.cs`.
+dans `JA.xml`. Item 28 lui-même (FI/KO) avait déjà été implémenté indépendamment (PR #422,
+commit `918d6e3f`).
 
 ### ~~33. PT/GL — centaines sans forme féminine~~ — **déjà implémenté (PT) ; GL déjà correct par conception**
 

--- a/Utils.NumberToString/TODO.md
+++ b/Utils.NumberToString/TODO.md
@@ -278,3 +278,72 @@ Ajoutée en item 3, cette surcharge n'a aucun test vérifiant l'arrondi de group
 Testé uniquement via `ConvertYear(-44)` en EN sans variant ; aucun test ne combine année
 av. J.-C. et variant genre/cas pour une langue où le split par moitié (EN/DE/NL) produit
 des numéraux accordables.
+
+---
+
+## Améliorations identifiées (2026-07-09, suite)
+
+### 39. EL (grec) — centaines sans forme féminine
+
+Les centaines grecques (διακόσια, τριακόσια…) ne sont produites qu'en neutre. Le grec
+moderne accorde les centaines en genre selon le nom compté : "διακόσιες λίρες" (féminin
+pluriel) vs "διακόσια δολάρια" (neutre pluriel). Aucun `<Variant>` gender n'existe dans
+`EL.xml` pour ce cas, contrairement à ES qui gère déjà ce type d'accord pour les centaines.
+
+### 40. RU/CS/SK/BG — accord numéral slave (nominatif/génitif sg/pl) absent — limitation architecturale
+
+Les quatre langues slaves n'implémentent aucun mécanisme pour l'accord du nom compté selon
+la règle slave classique (1 → nominatif singulier, 2-4 → génitif singulier, 5+ → génitif
+pluriel ; ex. RU "1 книга" / "2 книги" / "5 книг"). Seul le mot d'échelle "тысяча" a un
+remplacement ponctuel (RU, sans dimension de variant associée). Contrairement aux items
+26/33/39 (accord d'un mot isolé), ce cas porterait sur le nom compté externe, ce que le
+moteur ne modélise pas aujourd'hui — **reporté**, à l'instar de l'item 9 (ZU), nécessiterait
+une extension du système de variants côté appelant plutôt qu'un correctif XML.
+
+### 41. ES — composés 21-29 (`veintiuno`) toujours fusionnés sans espace
+
+L'item 4 a corrigé l'accord féminin pour ES 31-99 (`"treinta y *"`) et IT 21-29
+(`"venti *"`), mais **pas** ES 21-29 : `veintiuno`, `veintidós`… restent fusionnés en un
+seul mot, donc la règle `LastWord` n'atteint jamais le "uno" interne. `Convert(21,
+"gender=femenino")` retourne donc "veintiuno" au lieu de "veintiuna". Nécessite soit un
+espacement (`"veinte y *"` puis remplacement `"veinte y "` → `"veinti"`), soit une règle
+de remplacement dédiée comme pour 31-99.
+
+### 42. README — 14 langues configurées absentes de la liste des langues supportées
+
+`README.md` liste 25 langues alors que 39 fichiers XML existent dans
+`NumberConverterConfigurations/`. Manquent notamment : BG, CS, DA, FA, HR, HU, ID, NO, SK,
+SV, SW, TR, UK, VN — dont plusieurs ajoutées récemment (items 8 et 23) mais jamais
+reportées dans le README.
+
+### 43. README — connecteurs XML majeurs et `beforeChristSuffix` non documentés
+
+La section "XML Configuration" du README ne mentionne pas `groupConnector` /
+`groupConnectorThreshold`, `intraGroupConnector` / `intraGroupConnectorThreshold` (item 22)
+ni `scaleConnector` / `scaleConnectorThreshold` (item 8/RO), bien que ces attributs soient
+dans le XSD et activement utilisés. La section `<YearFormat>` documente `hundredWord` et
+`zeroConnector` mais omet `beforeChristSuffix` (item 14).
+
+### 44. `INumberToStringConverter` — XML docs sans tags `<exception>` structurés
+
+Les exceptions levées (`NotSupportedException` selon `SupportsOrdinals`/`SupportsTimeConversion`/
+etc., `OverflowException` sur les conversions BigInteger→long) ne sont mentionnées qu'en
+texte libre dans les `<summary>`, jamais via des tags `<exception cref="...">` dédiés — à
+compléter sur les ~35 membres publics concernés.
+
+### 45. `Convert(double)` / `Convert(float)` — incohérences de surcharge et cas limites non gérés
+
+Deux problèmes distincts sur la même paire de méthodes (`INumberToStringConverter.cs`) :
+- Contrairement à `Convert(int/long/BigInteger/decimal)` qui ont chacune une surcharge sans
+  `variants`, `Convert(double)`/`Convert(float)` n'existent qu'avec `params string[] variants`.
+- `double.NaN` / `double.PositiveInfinity` ne sont jamais interceptés avant le passage par
+  `ToString("R")` + `decimal.TryParse` : le comportement résultant (échec silencieux ou
+  exception peu explicite) n'est pas défini. Ajouter un test explicite `double.IsNaN`/
+  `IsInfinity` avec un message d'erreur clair.
+
+### 46. `ConvertFraction` — pas de surcharge `int`/`long`, uniquement `BigInteger`
+
+`Convert`, `ConvertOrdinal` et `ConvertCurrency` offrent tous des surcharges `int`/`long`/
+`BigInteger` pour la cohérence de l'API. `ConvertFraction(BigInteger, BigInteger, ...)`
+(item 19) n'a pas d'équivalent `int`/`long`, forçant les appelants à convertir manuellement
+et s'exposant à un `OverflowException` évitable.

--- a/Utils.NumberToString/TODO.md
+++ b/Utils.NumberToString/TODO.md
@@ -64,15 +64,18 @@ au lieu de `Regex.Replace()` à chaque appel.
 ### 8. ~~Langues populaires manquantes~~ — **implémenté (VN, TR, SV, NO, UK, RO)**
 Nouveaux fichiers XML ajoutés :
 - **VN/VI/VI-VN (Vietnamien)** : cardinals avec allomorphes mốt/lăm via remplacement `Anywhere`,
-  ordinals `thứ N` avec exception `thứ nhất`. Connecteur *linh* non implémenté (nécessite moteur).
+  ordinals `thứ N` avec exception `thứ nhất`. Connecteur *linh* géré via `intraGroupConnector`
+  (voir item 22 plus bas).
 - **TR/TR-TR (Turc)** : cardinals sans `bir yüz` / `bir bin` (règles nationales respectées).
 - **SV/SV-SE (Suédois)** : cardinals avec fusion 20s (`tjugo*`) et espaces 30s-90s.
 - **NO/NB/NB-NO (Norvégien Bokmål)** : cardinals.
 - **UK/UK-UA (Ukrainien)** : cardinals simplifiés (inflexion тисяч invariante).
 - **RO/RO-RO (Roumain)** : cardinals avec noms d'échelle statiques `mii`/`milioane`/`miliarde` ;
   remplacements `onScale+onValue` pour l'accord `unu/doi` ; variante `gen=feminin` (una/două).
-  Limitation connue : l'insertion de `de` avant les noms d'échelle pour les multiples ≥ 20
-  (ex. "douăzeci de mii") nécessite un attribut `scaleConnector` non encore implémenté dans le moteur.
+  L'insertion de `de` avant les noms d'échelle pour les multiples ≥ 20 (ex. "douăzeci de mii")
+  est gérée via l'attribut `scaleConnector`/`scaleConnectorThreshold`, ajouté sur `<Language>`
+  avec la PR #419. Pas d'ordinaux RO à ce jour (voir item 9/11 : mêmes limites de portée
+  que ZU/AR — nécessiterait un plugin C# dédié).
 
 ### 9. Ordinaux ZU (Zoulou) via `IOrdinalLanguageSpecifics` — **reporté**
 Nécessite une recherche linguistique approfondie (classes nominales 1–17) et une implémentation
@@ -170,43 +173,41 @@ et `0 < remainder < threshold`. VN configuré avec `intraGroupConnector="linh" t
 
 ---
 
-## Améliorations identifiées (2026-07-06)
+## Améliorations identifiées (2026-07-06) — toutes implémentées le 2026-07-09
 
-### 24. Tests manquants : HR, HU, NO, SV, UK, VN
+### 24. ~~Tests manquants : HR, HU, NO, SV, UK, VN~~ — **implémenté**
+Six nouveaux fichiers dédiés créés (`NumberToStringConverterHRTests.cs`,
+`NumberToStringConverterHUTests.cs`, `NumberToStringConverterNOTests.cs`,
+`NumberToStringConverterSVTests.cs`, `NumberToStringConverterUKTests.cs`,
+`NumberToStringConverterVNTests.cs`), 31 tests au total couvrant cardinaux, milliers,
+grande échelle et ordinaux (quand supportés).
 
-Six langues ont une config XML complète mais aucun fichier de test dédié.
-Une régression de config passerait inaperçue. Fichiers à créer :
-`NumberToStringConverterHRTests.cs`, `NumberToStringConverterHUTests.cs`,
-`NumberToStringConverterNOTests.cs`, `NumberToStringConverterSVTests.cs`,
-`NumberToStringConverterUKTests.cs`, `NumberToStringConverterVNTests.cs`.
+### 25. ~~Ordinaux féminins HI non testés~~ — **déjà couvert**
+La couverture existait déjà dans `NumberToStringConverterImprovementsTests.cs`
+(section « C13 — Ordinal HI feminine variant », `ConvertOrdinal_HI_StriiVariant_*`),
+ajoutée avec la PR #419. Seul le fichier dédié `NumberToStringConverterHITests.cs`
+n'en avait pas — pas d'action nécessaire, le comportement est vérifié.
 
-### 25. Ordinaux féminins HI non testés
+### 26. ~~Validation des *valeurs* de dimensions~~ — **implémenté**
+`ValidateVariantReferences` (dans `NumberToStringConverter.Globalization.cs`) vérifie désormais
+aussi que chaque valeur de contrainte figure dans les valeurs déclarées de sa dimension
+(comparaison `OrdinalIgnoreCase`, cohérente avec `ApplyVariantRules`). Un typo de valeur lève
+maintenant une `InvalidOperationException` descriptive au chargement, comme pour les clés
+inconnues. La fonction a été factorisée (une seule vérification clé+valeur pour VariantRules,
+OrdinalVariants et TriggerReplace.Forms).
 
-La PR #419 a dû ajouter `<Dimension name="gender" values="puṃ,strī" />` dans la config HI
-pour corriger un bug de validation. La dimension est désormais déclarée ; `ConvertOrdinal(1, "gender=strī")`
-devrait retourner "पहली", mais `NumberToStringConverterHITests.cs` ne teste que les ordinaux masculins.
+### 27. ~~`VariantRules` pré-triées à la construction~~ — **implémenté**
+Nouveau champ `_sortedVariantRules` (`ImmutableArray<VariantRule>`) calculé une fois dans le
+constructeur de `NumberToStringConverter`. `ApplyVariantRules` et `ApplyVariantRulesForScale`
+itèrent sur ce champ au lieu d'appeler `.OrderBy(r => r.Specificity)` à chaque conversion.
 
-### 26. Validation des *valeurs* de dimensions
+### 28. ~~Config FI et KO : suppression du multiplicateur "1" devant l'unité de mille~~ — **implémenté**
+- **FI** : `<Replacement oldValue="yksi tuhat" newValue="tuhat" onScale="1" onValue="1" />`
+  ajouté dans `FI.xml`. 1 000 → "tuhat" (au lieu de "yksi tuhat").
+- **KO** : `<Replacement oldValue="일 천" newValue="천" onScale="1" onValue="1" />`
+  ajouté dans `KO.xml` (le texte de groupe onScale inclut le `separator=" "` configuré).
+  1 000 → "천" (au lieu de "일 천").
 
-`ValidateVariantReferences` vérifie que les clés de contrainte (`gender`, `case`…) correspondent
-à des dimensions déclarées, mais pas que les *valeurs* utilisées (`strī`, `partitiivi`…) figurent
-dans les valeurs déclarées de la dimension.
-Un typo de valeur (ex. `variant="stri"` au lieu de `"strī"`) passe silencieusement ;
-la règle ne s'applique jamais sans erreur visible.
-Même emplacement dans `ValidateVariantReferences`, même principe que la validation des clés.
-
-### 27. `VariantRules` pré-triées à la construction
-
-`ApplyVariantRules` et `ApplyVariantRulesForScale` appellent chacune `.OrderBy(r => r.Specificity)`
-à chaque appel de `Convert()`. L'ordre est stable et connu à la construction : trier une seule fois
-dans le constructeur et stocker le résultat dans un `ImmutableArray` déjà ordonné.
-Évite une allocation + tri à chaque appel pour les langues avec de nombreuses règles (AR, PL, DE…).
-
-### 28. Config FI et KO : suppression du multiplicateur "1" devant l'unité de mille
-
-- **FI** : 1 000 s'écrit "tuhat" en finnois, pas "yksi tuhat". Ajouter
-  `<Replacement oldValue="yksi tuhat" newValue="tuhat" onScale="1" onValue="1" />` dans `FI.xml`.
-- **KO** : 1 000 s'écrit "천", pas "일 천". Même type de remplacement à ajouter dans `KO.xml`.
-
-Ces deux configs sont les seuls endroits du projet où le multiplicateur 1 n'est pas absorbé
-alors que la langue l'exige.
+Les tests existants qui attendaient l'ancien comportement (`NumberToStringConverterFITests.cs`,
+`NumberToStringConverterKOTests.cs`, et un cas dans `NumberToStringConverterImprovementsTests.cs`)
+ont été mis à jour en conséquence.

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterCoverageGapsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterCoverageGapsTests.cs
@@ -1,0 +1,122 @@
+using System.Numerics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.NumberToString;
+
+namespace UtilsTest.Mathematics.Numbers;
+
+/// <summary>
+/// Tests for items 35-38 of TODO.md: closing cross-language coverage gaps for features
+/// previously tested almost exclusively on EN/FR (double/float, DecimalFormatOptions,
+/// TimeSpan/DateOnly/DateTime, BigInteger significant digits, ConvertYear negative + variants).
+/// </summary>
+[TestClass]
+public class NumberToStringConverterCoverageGapsTests
+{
+    // ─── Item 35 — Convert(double/float) + DecimalFormatOptions on DE/ES/IT ─
+
+    [TestMethod]
+    public void Convert_Double_DE_WithGenderVariant()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+        Assert.AreEqual("eine komma fünf", de.Convert(1.5, "gender=feminin"));
+    }
+
+    [TestMethod]
+    public void Convert_Double_ES_Basic()
+    {
+        var es = NumberToStringConverter.GetConverter("ES");
+        Assert.AreEqual("uno coma cinco", es.Convert(1.5));
+    }
+
+    [TestMethod]
+    public void Convert_Double_IT_Basic()
+    {
+        var it = NumberToStringConverter.GetConverter("IT");
+        Assert.AreEqual("uno virgola cinque", it.Convert(1.5));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_DE_SeparatorAndSuffix_Pluralized()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+        var opts = new DecimalFormatOptions { DecimalSeparator = "Euro(s)", DecimalSuffix = "Cent(s)" };
+        Assert.AreEqual("einundzwanzig Euros fünfzig Cents", de.Convert(21.50m, 2, opts));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_ES_SeparatorAndSuffix_Pluralized()
+    {
+        var es = NumberToStringConverter.GetConverter("ES");
+        var opts = new DecimalFormatOptions { DecimalSeparator = "euro(s)", DecimalSuffix = "centimo(s)" };
+        Assert.AreEqual("veintiuno euros cincuenta centimos", es.Convert(21.50m, 2, opts));
+    }
+
+    [TestMethod]
+    public void DecimalFormatOptions_IT_SeparatorAndSuffix_Pluralized()
+    {
+        var it = NumberToStringConverter.GetConverter("IT");
+        var opts = new DecimalFormatOptions { DecimalSeparator = "euro(s)", DecimalSuffix = "centesimo(s)" };
+        Assert.AreEqual("venti uno euros cinquanta centesimos", it.Convert(21.50m, 2, opts));
+    }
+
+    // ─── Item 36 — Convert(TimeSpan/DateOnly/DateTime) not tested for DE ────
+
+    [TestMethod]
+    public void Convert_DateTime_DE_ContainsDateAndTimeParts()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+        var dt = new System.DateTime(2026, 7, 2, 14, 30, 5);
+        string result = de.Convert(dt);
+        Assert.IsTrue(result.Contains("Juli"), $"Actual: {result}");
+        Assert.IsTrue(result.Contains("Stunden"), $"Actual: {result}");
+    }
+
+    [TestMethod]
+    public void Convert_DateOnly_DE_FirstDay_OrdinalDay()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+        // firstDay="ersten" also applies to {ordinal-day} when day == 1 (not just {cardinal-day})
+        string result = de.Convert(new System.DateOnly(2026, 7, 1));
+        Assert.IsTrue(result.Contains("ersten"), $"Actual: {result}");
+    }
+
+    // ─── Item 37 — Convert(BigInteger, significantDigits) per language ──────
+
+    [TestMethod]
+    public void Convert_BigInteger_SignificantDigits_DE()
+    {
+        var de = NumberToStringConverter.GetConverter("DE");
+        Assert.AreEqual("einhundert Millionen", de.Convert((BigInteger)123456789, 1));
+    }
+
+    [TestMethod]
+    public void Convert_BigInteger_SignificantDigits_ES_WithGenderVariant()
+    {
+        var es = NumberToStringConverter.GetConverter("ES");
+        // Rounding combined with a gender variant on a large number
+        Assert.AreEqual("doscientas millones", es.Convert((BigInteger)223456789, 1, "gender=femenino"));
+    }
+
+    // ─── Item 38 — ConvertYear negative (beforeChristSuffix) combined with variants ─
+    //
+    // No shipped language XML declares beforeChristSuffix (it exists only as an engine/options
+    // feature, exercised in NumberToStringConverterBatchTests via a hand-built converter).
+    // These tests combine it with a gender variant, which was never exercised together before.
+
+    [TestMethod]
+    public void ConvertYear_Negative_WithGenderVariant_BeforeChristSuffix()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        var options = new NumberToStringConverterOptions(fr)
+        {
+            YearFormat = new YearFormatOptions(null, null, null, BeforeChristSuffix: "av. J.-C.")
+        };
+        var converter = new NumberToStringConverter(options);
+
+        // Year 1 BC: the numeral itself ("un"/"une") is gender-sensitive.
+        Assert.AreEqual("un av. J.-C.",  converter.ConvertYear(-1));
+        Assert.AreEqual("une av. J.-C.", converter.ConvertYear(-1, "gender=feminin"));
+        // Positive years are unaffected by the suffix.
+        Assert.AreEqual("un", converter.ConvertYear(1));
+    }
+}

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterESTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterESTests.cs
@@ -89,8 +89,21 @@ namespace UtilsTest.Mathematics.Numbers
             };
 
             Assert.AreEqual("una peseta",  c.ConvertCurrency(1m, peseta, "gender=femenino"));
-            // 21 is fused ("veintiuno"/"veintiuna") — LastWord replacement does apply here
+            // 31 uses the space-separated buildString ("treinta y *") — LastWord applies directly
             Assert.AreEqual("treinta y una pesetas", c.ConvertCurrency(31m, peseta, "gender=femenino"));
+        }
+
+        [TestMethod]
+        public void Convert_ES_21_29_Gender_Femenino()
+        {
+            var c = NumberToStringConverter.GetConverter("ES");
+
+            // item 41: 21 is a fused word ("veintiuno") — whole-word replacement now covers it.
+            Assert.AreEqual("veintiuna",  c.Convert(21, "gender=femenino"));
+            Assert.AreEqual("veintiuno",  c.Convert(21));
+            // 22-29 do not vary in gender (only the "uno" unit does).
+            Assert.AreEqual("veintidos",  c.Convert(22, "gender=femenino"));
+            Assert.AreEqual("veintinueve", c.Convert(29, "gender=femenino"));
         }
     }
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterEngineFixesTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterEngineFixesTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Numerics;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.NumberToString;
+
+namespace UtilsTest.Mathematics.Numbers;
+
+/// <summary>
+/// Tests for items 29, 30, 31, 45, 46 of TODO.md (engine robustness and API symmetry fixes).
+/// </summary>
+[TestClass]
+public class NumberToStringConverterEngineFixesTests
+{
+    // ─── Item 29 — GetMonthName catch scoped to expected exceptions ─────────
+
+    [TestMethod]
+    public void GetMonthName_OutOfRangeMonth_FallsBackToNumber()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        var method = en.GetType().GetMethod("GetMonthName", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(method);
+        // Month 0 → index -1 is out of range for MonthNames[month - 1] → must fall back, not throw.
+        string result = (string)method!.Invoke(en, [0])!;
+        Assert.AreEqual("0", result);
+    }
+
+    // ─── Item 30 — BuildFractionText with negative numerator ────────────────
+
+    [TestMethod]
+    public void ConvertFraction_EN_NegativeNumerator_UsesNamedSuffix()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        // Denominator 10 is a power of ten → named suffix branch ("tenth(s)").
+        // -1/10 should reuse the named suffix like 1/10 does, prefixed by the sign.
+        string positive = en.ConvertFraction(1, 10);
+        string negative = en.ConvertFraction(-1, 10);
+        Assert.AreEqual("one tenth", positive);
+        Assert.IsTrue(negative.EndsWith("one tenth"), $"Actual: {negative}");
+        Assert.AreNotEqual(positive, negative);
+    }
+
+    [TestMethod]
+    public void ConvertFraction_FR_NegativeNumerator_UsesNamedSuffix()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        string positive = fr.ConvertFraction(3, 10);
+        string negative = fr.ConvertFraction(-3, 10);
+        Assert.AreEqual("trois dixièmes", positive);
+        Assert.IsTrue(negative.EndsWith("trois dixièmes"), $"Actual: {negative}");
+    }
+
+    // ─── Item 31 — ApplyVariantRules / ApplyVariantRulesForScale factored ───
+
+    [TestMethod]
+    public void ApplyVariantRules_StillAppliesAfterRefactor_FR()
+    {
+        var fr = NumberToStringConverter.GetConverter("FR");
+        // Regression check on gender variant application post-refactor.
+        Assert.AreEqual("une", fr.Convert(1, "gender=feminin"));
+        Assert.AreEqual("un", fr.Convert(1));
+    }
+
+    [TestMethod]
+    public void ApplyVariantRulesForScale_StillAppliesAfterRefactor_RO()
+    {
+        var ro = NumberToStringConverter.GetConverter("RO");
+        // Scale-scoped variant rules (unu → o mie at scale 1) must still apply post-refactor.
+        Assert.AreEqual("o mie", ro.Convert(1000));
+        Assert.AreEqual("un milion", ro.Convert(1_000_000));
+    }
+
+    // ─── Item 45 — Convert(double)/Convert(float) overload + NaN/Infinity ───
+
+    [TestMethod]
+    public void Convert_Double_WithoutVariants_Works()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.AreEqual(en.Convert(3.5, System.Array.Empty<string>()), en.Convert(3.5));
+    }
+
+    [TestMethod]
+    public void Convert_Float_WithoutVariants_Works()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.AreEqual(en.Convert(3.5f, System.Array.Empty<string>()), en.Convert(3.5f));
+    }
+
+    [TestMethod]
+    public void Convert_Double_NaN_ThrowsArgumentException()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.ThrowsException<ArgumentException>(() => en.Convert(double.NaN));
+    }
+
+    [TestMethod]
+    public void Convert_Double_Infinity_ThrowsArgumentException()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.ThrowsException<ArgumentException>(() => en.Convert(double.PositiveInfinity));
+        Assert.ThrowsException<ArgumentException>(() => en.Convert(double.NegativeInfinity));
+    }
+
+    [TestMethod]
+    public void Convert_Float_NaN_ThrowsArgumentException()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.ThrowsException<ArgumentException>(() => en.Convert(float.NaN));
+    }
+
+    // ─── Item 46 — ConvertFraction(int/long) overloads ───────────────────────
+
+    [TestMethod]
+    public void ConvertFraction_Int_MatchesBigInteger()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.AreEqual(en.ConvertFraction((BigInteger)1, (BigInteger)3), en.ConvertFraction(1, 3));
+    }
+
+    [TestMethod]
+    public void ConvertFraction_Long_MatchesBigInteger()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        Assert.AreEqual(en.ConvertFraction((BigInteger)3L, (BigInteger)4L), en.ConvertFraction(3L, 4L));
+    }
+}

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterFITests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterFITests.cs
@@ -35,8 +35,8 @@ namespace UtilsTest.Mathematics.Numbers
         public void Cardinals_Thousands()
         {
             var c = NumberToStringConverter.GetConverter("FI");
-            // Finnish: no replacement rule for 1×tuhat; engine outputs "yksi tuhat"
-            Assert.AreEqual("yksi tuhat",   c.Convert(1_000));
+            // Finnish elides the multiplier "yksi" before "tuhat": 1 000 = "tuhat", not "yksi tuhat"
+            Assert.AreEqual("tuhat",        c.Convert(1_000));
             Assert.AreEqual("kaksi tuhat",  c.Convert(2_000));
         }
 
@@ -55,8 +55,8 @@ namespace UtilsTest.Mathematics.Numbers
             Assert.AreEqual("kahdestoista",   c.ConvertOrdinal(12));
             Assert.AreEqual("kahdeskymmenes", c.ConvertOrdinal(20));
             Assert.AreEqual("sadas",          c.ConvertOrdinal(100));
-            // 1000 = "yksi tuhat" → last word "tuhat" → "tuhannes"
-            Assert.AreEqual("yksi tuhannes",  c.ConvertOrdinal(1_000));
+            // 1000 = "tuhat" (multiplier elided) → last word "tuhat" → "tuhannes"
+            Assert.AreEqual("tuhannes",  c.ConvertOrdinal(1_000));
         }
 
         [TestMethod]
@@ -69,8 +69,8 @@ namespace UtilsTest.Mathematics.Numbers
             Assert.AreEqual("kolmea",    c.Convert(3,     "case=partitiivi"));
             Assert.AreEqual("kymmentä",  c.Convert(10,    "case=partitiivi"));
             Assert.AreEqual("sataa",         c.Convert(100,   "case=partitiivi"));
-            // 1000 = "yksi tuhat" → LastWord "tuhat" → "tuhatta" → "yksi tuhatta"
-            Assert.AreEqual("yksi tuhatta", c.Convert(1_000, "case=partitiivi"));
+            // 1000 = "tuhat" (multiplier elided) → LastWord "tuhat" → "tuhatta"
+            Assert.AreEqual("tuhatta", c.Convert(1_000, "case=partitiivi"));
         }
 
         [TestMethod]
@@ -80,8 +80,8 @@ namespace UtilsTest.Mathematics.Numbers
             Assert.AreEqual("yhden",    c.Convert(1,     "case=genetiivi"));
             Assert.AreEqual("kahden",   c.Convert(2,     "case=genetiivi"));
             Assert.AreEqual("sadan",     c.Convert(100,   "case=genetiivi"));
-            // "tuhat" in "yksi tuhat" uses scope="Standalone" in config → not replaced when not alone
-            Assert.AreEqual("yksi tuhat", c.Convert(1_000, "case=genetiivi"));
+            // 1000 = "tuhat" (multiplier elided) → Standalone genetiivi rule applies → "tuhannen"
+            Assert.AreEqual("tuhannen", c.Convert(1_000, "case=genetiivi"));
         }
 
         [TestMethod]

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterFRTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterFRTests.cs
@@ -28,8 +28,12 @@ namespace UtilsTest.Mathematics.Numbers
                 (60, "soixante"),
                 (61, "soixante et un"),
                 (62, "soixante deux"),
+                // item 34: "et" appears only before the unit "un" (71/81/91), not before 72-79/82-89/92-99
+                (71, "septante et un"),
                 (72, "septante deux"),
+                (81, "huitante et un"),
                 (82, "huitante deux"),
+                (91, "nonante et un"),
                 (92, "nonante deux"),
                 (111, "cent onze"),
                 (121, "cent vingt et un"),

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterGLTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterGLTests.cs
@@ -29,5 +29,18 @@ namespace UtilsTest.Mathematics.Numbers
             var converter = NumberToStringConverter.GetConverter("gl-ES");
             Assert.AreEqual("un coma cinco", converter.Convert(1.5m));
         }
+
+        [TestMethod]
+        public void Cardinals_Gender_Feminino()
+        {
+            var c = NumberToStringConverter.GetConverter("GL");
+
+            Assert.AreEqual("unha",       c.Convert(1,   "gender=feminino"), "1f");
+            Assert.AreEqual("dúas",       c.Convert(2,   "gender=feminino"), "2f");
+            // item 33: 200 is the only hundred that varies in Galician (douscentos/douscentas);
+            // other hundreds (e.g. trescentos) are invariable — see NumberConvertionConfiguration.GL.xml.
+            Assert.AreEqual("douscentas", c.Convert(200, "gender=feminino"), "200f");
+            Assert.AreEqual("trescentos", c.Convert(300, "gender=feminino"), "300f (invariable)");
+        }
     }
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterHRTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterHRTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.NumberToString;
+
+namespace UtilsTest.Mathematics.Numbers
+{
+    [TestClass]
+    public class NumberToStringConverterHRTests
+    {
+        [TestMethod]
+        public void Cardinals_Basic()
+        {
+            var c = NumberToStringConverter.GetConverter("HR");
+            (long n, string expected)[] cases =
+            [
+                (0,   "nula"),
+                (1,   "jedan"),
+                (2,   "dva"),
+                (9,   "devet"),
+                (10,  "deset"),
+                (11,  "jedanaest"),
+                (12,  "dvanaest"),
+                (19,  "devetnaest"),
+                (20,  "dvadeset"),
+                (21,  "dvadeset jedan"),
+                (100, "sto"),
+                (101, "sto jedan"),
+                (200, "dvjesto"),
+            ];
+            foreach (var (n, expected) in cases)
+                Assert.AreEqual(expected, c.Convert(n), $"HR {n}");
+        }
+
+        [TestMethod]
+        public void Cardinals_Thousands()
+        {
+            var c = NumberToStringConverter.GetConverter("HR");
+            // "jedan tisuća" is elided to "tisuća" (Replacement onScale=1 onValue=1)
+            Assert.AreEqual("tisuća",       c.Convert(1_000));
+            Assert.AreEqual("dva tisuća",   c.Convert(2_000));
+            Assert.AreEqual("deset tisuća", c.Convert(10_000));
+        }
+
+        [TestMethod]
+        public void Cardinals_LongScale()
+        {
+            var c = NumberToStringConverter.GetConverter("HR");
+            // Long scale generated via Suffixes "jun"/"jarda" and groupSeparator "li"
+            Assert.AreEqual("jedan milijun",   c.Convert(1_000_000));
+            Assert.AreEqual("jedan milijarda", c.Convert(1_000_000_000));
+            Assert.AreEqual("jedan bilijun",   c.Convert(1_000_000_000_000L));
+        }
+
+        [TestMethod]
+        public void Ordinals_Exceptions()
+        {
+            var c = NumberToStringConverter.GetConverter("HR");
+            Assert.IsTrue(c.SupportsOrdinals);
+            Assert.AreEqual("prvi",  c.ConvertOrdinal(1));
+            Assert.AreEqual("drugi", c.ConvertOrdinal(2));
+            Assert.AreEqual("treći", c.ConvertOrdinal(3));
+        }
+
+        [TestMethod]
+        public void HR_RegisteredUnderHRAndHRHR()
+        {
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("HR"));
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("HR-HR"));
+        }
+    }
+}

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterHUTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterHUTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.NumberToString;
+
+namespace UtilsTest.Mathematics.Numbers
+{
+    [TestClass]
+    public class NumberToStringConverterHUTests
+    {
+        [TestMethod]
+        public void Cardinals_Basic()
+        {
+            var c = NumberToStringConverter.GetConverter("HU");
+            (long n, string expected)[] cases =
+            [
+                (0,  "nulla"),
+                (1,  "egy"),
+                (2,  "kettő"),   // standalone exception; "két" is the combining form
+                (3,  "három"),
+                (9,  "kilenc"),
+                (10, "tíz"),
+                (11, "tizenegy"),
+                (12, "tizenkét"),
+                (20, "húsz"),
+                (21, "huszonegy"),
+                (30, "harminc"),
+                (31, "harmincegy"),
+            ];
+            foreach (var (n, expected) in cases)
+                Assert.AreEqual(expected, c.Convert(n), $"HU {n}");
+        }
+
+        [TestMethod]
+        public void Cardinals_Hundreds()
+        {
+            var c = NumberToStringConverter.GetConverter("HU");
+            // "egyszáz" is elided to "száz"
+            Assert.AreEqual("száz",             c.Convert(100));
+            Assert.AreEqual("százegy",          c.Convert(101));
+            Assert.AreEqual("kétszáz",          c.Convert(200));
+            Assert.AreEqual("kétszázhuszonegy", c.Convert(221));
+        }
+
+        [TestMethod]
+        public void Cardinals_Thousands()
+        {
+            var c = NumberToStringConverter.GetConverter("HU");
+            Assert.AreEqual("ezer",      c.Convert(1_000));      // "egyezer" → "ezer"
+            Assert.AreEqual("kétezer",   c.Convert(2_000));      // "kettő" → "két" before scale name
+            Assert.AreEqual("tízezer",   c.Convert(10_000));
+        }
+
+        [TestMethod]
+        public void Cardinals_LongScale()
+        {
+            var c = NumberToStringConverter.GetConverter("HU");
+            Assert.AreEqual("millió",    c.Convert(1_000_000));      // "egymillió" → "millió"
+            Assert.AreEqual("kétmillió", c.Convert(2_000_000));
+            Assert.AreEqual("milliárd",  c.Convert(1_000_000_000L));
+            // startIndex="2": scale 4 → billió
+            Assert.AreEqual("billió",    c.Convert(1_000_000_000_000L));
+        }
+
+        [TestMethod]
+        public void Ordinals_Exceptions()
+        {
+            var c = NumberToStringConverter.GetConverter("HU");
+            Assert.IsTrue(c.SupportsOrdinals);
+            Assert.AreEqual("első",     c.ConvertOrdinal(1));
+            Assert.AreEqual("második",  c.ConvertOrdinal(2));
+            Assert.AreEqual("harmadik", c.ConvertOrdinal(3));
+            Assert.AreEqual("tizedik",  c.ConvertOrdinal(10));
+            Assert.AreEqual("századik", c.ConvertOrdinal(100));
+            Assert.AreEqual("ezredik",  c.ConvertOrdinal(1000));
+        }
+
+        [TestMethod]
+        public void HU_RegisteredUnderHUAndHUHU()
+        {
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("HU"));
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("HU-HU"));
+        }
+    }
+}

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterImprovementsTests.cs
@@ -710,8 +710,8 @@ public class NumberToStringConverterImprovementsTests
         // Scale words alone
         Assert.AreEqual("kymmentä",      converter.Convert(10,  "sijamuoto=partitiivi"));
         Assert.AreEqual("sataa",         converter.Convert(100, "sijamuoto=partitiivi"));
-        // 1000: FI has no replacement "yksi tuhat"→"tuhat", so "yksi" stays
-        Assert.AreEqual("yksi tuhatta",  converter.Convert(1000, "sijamuoto=partitiivi"));
+        // 1000: FI elides the multiplier "yksi tuhat"→"tuhat" before the case is applied
+        Assert.AreEqual("tuhatta",  converter.Convert(1000, "sijamuoto=partitiivi"));
         // Compounds: tens + unit
         Assert.AreEqual("kaksikymmentä yhtä", converter.Convert(21, "sijamuoto=partitiivi"));
         Assert.AreEqual("kaksikymmentä kahta", converter.Convert(22, "sijamuoto=partitiivi"));

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterJATests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterJATests.cs
@@ -21,5 +21,22 @@ namespace UtilsTest.Mathematics.Numbers
                 Assert.AreEqual(test.Expected, converter.Convert(test.Number));
             }
         }
+
+        [TestMethod]
+        public void Cardinals_Thousands()
+        {
+            var c = NumberToStringConverter.GetConverter("JA");
+            // item 32: "1 000" is "千", not "一 千" (unlike Chinese, which keeps "一千")
+            Assert.AreEqual("千",    c.Convert(1_000));
+            Assert.AreEqual("二 千", c.Convert(2_000));
+        }
+
+        [TestMethod]
+        public void Cardinals_Hundred_NoLeadingOne()
+        {
+            var c = NumberToStringConverter.GetConverter("JA");
+            // Already correct before item 32: "百", not "一百"
+            Assert.AreEqual("百", c.Convert(100));
+        }
     }
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterKOTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterKOTests.cs
@@ -35,8 +35,8 @@ namespace UtilsTest.Mathematics.Numbers
         public void Cardinals_Thousands()
         {
             var c = NumberToStringConverter.GetConverter("KO");
-            // No replacement for 1000; engine produces "일 천"
-            Assert.AreEqual("일 천",    c.Convert(1_000));
+            // Korean elides the multiplier "일" before "천": 1 000 = "천", not "일 천"
+            Assert.AreEqual("천",       c.Convert(1_000));
             Assert.AreEqual("이 천",    c.Convert(2_000));
             Assert.AreEqual("십 천",    c.Convert(10_000));
         }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterKOTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterKOTests.cs
@@ -38,6 +38,7 @@ namespace UtilsTest.Mathematics.Numbers
             // Korean elides the multiplier "일" before "천": 1 000 = "천", not "일 천"
             Assert.AreEqual("천",       c.Convert(1_000));
             Assert.AreEqual("이 천",    c.Convert(2_000));
+            // 10 000 uses the "만" scale suffix path, unaffected by the onValue=1 replacement above
             Assert.AreEqual("십 천",    c.Convert(10_000));
         }
 

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterNOTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterNOTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.NumberToString;
+
+namespace UtilsTest.Mathematics.Numbers
+{
+    [TestClass]
+    public class NumberToStringConverterNOTests
+    {
+        [TestMethod]
+        public void Cardinals_Basic()
+        {
+            var c = NumberToStringConverter.GetConverter("NO");
+            (long n, string expected)[] cases =
+            [
+                (0,  "null"),
+                (1,  "en"),
+                (2,  "to"),
+                (9,  "ni"),
+                (10, "ti"),
+                (11, "elleve"),
+                (19, "nitten"),
+                (20, "tjue"),
+                (21, "tjue en"),
+                (100, "ett hundre"),
+            ];
+            foreach (var (n, expected) in cases)
+                Assert.AreEqual(expected, c.Convert(n), $"NO {n}");
+        }
+
+        [TestMethod]
+        public void Cardinals_Thousands()
+        {
+            var c = NumberToStringConverter.GetConverter("NO");
+            // "en tusen" is elided to "tusen"
+            Assert.AreEqual("tusen",     c.Convert(1_000));
+            Assert.AreEqual("to tusen",  c.Convert(2_000));
+        }
+
+        [TestMethod]
+        public void Cardinals_LongScale()
+        {
+            var c = NumberToStringConverter.GetConverter("NO");
+            Assert.AreEqual("en million",     c.Convert(1_000_000));
+            Assert.AreEqual("to millioner",   c.Convert(2_000_000));
+            Assert.AreEqual("en milliard",    c.Convert(1_000_000_000));
+            Assert.AreEqual("tre milliarder", c.Convert(3_000_000_000L));
+            Assert.AreEqual("en billion",     c.Convert(1_000_000_000_000L));
+            Assert.AreEqual("en billiard",    c.Convert(1_000_000_000_000_000L));
+        }
+
+        [TestMethod]
+        public void SupportsOrdinals_False()
+        {
+            var c = NumberToStringConverter.GetConverter("NO");
+            Assert.IsFalse(c.SupportsOrdinals);
+        }
+
+        [TestMethod]
+        public void NO_RegisteredUnderNOAndNBAndNBNO()
+        {
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("NO"));
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("NB"));
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("NB-NO"));
+        }
+    }
+}

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterSVTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterSVTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.NumberToString;
+
+namespace UtilsTest.Mathematics.Numbers
+{
+    [TestClass]
+    public class NumberToStringConverterSVTests
+    {
+        [TestMethod]
+        public void Cardinals_Basic()
+        {
+            var c = NumberToStringConverter.GetConverter("SV");
+            (long n, string expected)[] cases =
+            [
+                (0,  "noll"),
+                (1,  "ett"),
+                (2,  "två"),
+                (9,  "nio"),
+                (10, "tio"),
+                (11, "elva"),
+                (19, "nitton"),
+                (20, "tjugo"),
+                (21, "tjugoett"),   // 20s fuse without space
+                (31, "trettio ett"),
+                (100, "ett hundra"),
+            ];
+            foreach (var (n, expected) in cases)
+                Assert.AreEqual(expected, c.Convert(n), $"SV {n}");
+        }
+
+        [TestMethod]
+        public void Cardinals_Thousands()
+        {
+            var c = NumberToStringConverter.GetConverter("SV");
+            // "ett tusen" is elided to "tusen"
+            Assert.AreEqual("tusen",     c.Convert(1_000));
+            Assert.AreEqual("två tusen", c.Convert(2_000));
+        }
+
+        [TestMethod]
+        public void Cardinals_LongScale()
+        {
+            var c = NumberToStringConverter.GetConverter("SV");
+            Assert.AreEqual("ett miljon",     c.Convert(1_000_000));
+            Assert.AreEqual("två miljoner",   c.Convert(2_000_000));
+            Assert.AreEqual("ett miljard",    c.Convert(1_000_000_000));
+            Assert.AreEqual("tre miljarder",  c.Convert(3_000_000_000L));
+            Assert.AreEqual("ett biljon",     c.Convert(1_000_000_000_000L));
+            Assert.AreEqual("ett biljard",    c.Convert(1_000_000_000_000_000L));
+        }
+
+        [TestMethod]
+        public void SupportsOrdinals_False()
+        {
+            var c = NumberToStringConverter.GetConverter("SV");
+            Assert.IsFalse(c.SupportsOrdinals);
+        }
+
+        [TestMethod]
+        public void SV_RegisteredUnderSVAndSVSE()
+        {
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("SV"));
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("SV-SE"));
+        }
+    }
+}

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterUKTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterUKTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.NumberToString;
+
+namespace UtilsTest.Mathematics.Numbers
+{
+    [TestClass]
+    public class NumberToStringConverterUKTests
+    {
+        [TestMethod]
+        public void Cardinals_Basic()
+        {
+            var c = NumberToStringConverter.GetConverter("UK");
+            (long n, string expected)[] cases =
+            [
+                (0,   "нуль"),
+                (1,   "один"),
+                (2,   "два"),
+                (9,   "дев'ять"),
+                (10,  "десять"),
+                (11,  "одинадцять"),
+                (19,  "дев'ятнадцять"),
+                (20,  "двадцять"),
+                (21,  "двадцять один"),
+                (100, "сто"),
+            ];
+            foreach (var (n, expected) in cases)
+                Assert.AreEqual(expected, c.Convert(n), $"UK {n}");
+        }
+
+        [TestMethod]
+        public void Cardinals_Thousands()
+        {
+            var c = NumberToStringConverter.GetConverter("UK");
+            // "один тисяч" is elided to "тисяч"; thousands word is invariant (accepted limitation)
+            Assert.AreEqual("тисяч",      c.Convert(1_000));
+            Assert.AreEqual("два тисяч",  c.Convert(2_000));
+        }
+
+        [TestMethod]
+        public void Cardinals_LongScale()
+        {
+            var c = NumberToStringConverter.GetConverter("UK");
+            Assert.AreEqual("один мільйон",  c.Convert(1_000_000));
+            Assert.AreEqual("два мільйонів", c.Convert(2_000_000));
+            Assert.AreEqual("один мільярд",  c.Convert(1_000_000_000));
+            Assert.AreEqual("один більйон",  c.Convert(1_000_000_000_000L));
+            Assert.AreEqual("один трильйон", c.Convert(1_000_000_000_000_000_000L));
+        }
+
+        [TestMethod]
+        public void SupportsOrdinals_False()
+        {
+            var c = NumberToStringConverter.GetConverter("UK");
+            Assert.IsFalse(c.SupportsOrdinals);
+        }
+
+        [TestMethod]
+        public void UK_RegisteredUnderUKAndUKUA()
+        {
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("UK"));
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("UK-UA"));
+        }
+    }
+}

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterVNTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterVNTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.NumberToString;
+
+namespace UtilsTest.Mathematics.Numbers
+{
+    [TestClass]
+    public class NumberToStringConverterVNTests
+    {
+        [TestMethod]
+        public void Cardinals_Basic()
+        {
+            var c = NumberToStringConverter.GetConverter("VN");
+            (long n, string expected)[] cases =
+            [
+                (0,  "không"),
+                (1,  "một"),
+                (2,  "hai"),
+                (9,  "chín"),
+                (10, "mười"),
+                (11, "mười một"),
+                (15, "mười lăm"),   // "mười năm" → "mười lăm" allomorph
+                (19, "mười chín"),
+                (20, "hai mươi"),
+                (21, "hai mươi mốt"),  // "mươi một" → "mươi mốt" allomorph
+                (25, "hai mươi lăm"),  // "mươi năm" → "mươi lăm" allomorph
+                (100, "một trăm"),
+            ];
+            foreach (var (n, expected) in cases)
+                Assert.AreEqual(expected, c.Convert(n), $"VN {n}");
+        }
+
+        [TestMethod]
+        public void Cardinals_Thousands()
+        {
+            var c = NumberToStringConverter.GetConverter("VN");
+            // "một nghìn" is elided to "nghìn"
+            Assert.AreEqual("nghìn",     c.Convert(1_000));
+            Assert.AreEqual("hai nghìn", c.Convert(2_000));
+        }
+
+        [TestMethod]
+        public void Cardinals_MillionsAndBillions()
+        {
+            var c = NumberToStringConverter.GetConverter("VN");
+            // "một triệu"/"một tỷ" are correct Vietnamese; no elision at these scales
+            Assert.AreEqual("một triệu", c.Convert(1_000_000));
+            Assert.AreEqual("một tỷ",    c.Convert(1_000_000_000));
+        }
+
+        [TestMethod]
+        public void Ordinals_PrefixAndException()
+        {
+            var c = NumberToStringConverter.GetConverter("VN");
+            Assert.IsTrue(c.SupportsOrdinals);
+            Assert.AreEqual("thứ nhất", c.ConvertOrdinal(1));  // exception, not "thứ một"
+            Assert.AreEqual("thứ hai",  c.ConvertOrdinal(2));
+        }
+
+        [TestMethod]
+        public void VN_RegisteredUnderVNAndVIAndVIVN()
+        {
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("VN"));
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("VI"));
+            Assert.IsNotNull(NumberToStringConverter.GetConverter("VI-VN"));
+        }
+    }
+}

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterZHTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterZHTests.cs
@@ -32,6 +32,8 @@ namespace UtilsTest.Mathematics.Numbers
                 (10,  "十"),
                 (20,  "二十"),
                 (100, "一百"),
+                // item 32 evaluated "一千" for a possible elision fix (as done for FI/KO/JA) but
+                // standard Mandarin requires "一" before both 百 and 千 — left unchanged.
                 (1_000, "一 千"),
             ];
             foreach (var (n, expected) in cases)


### PR DESCRIPTION
## Summary

### Items 24-28
- Add dedicated test files for HR, HU, NO, SV, UK, VN (31 tests) - item 24
- ValidateVariantReferences now also validates constraint *values* against declared dimension values, not just the keys - item 26
- VariantRules are sorted once at construction (_sortedVariantRules) instead of re-sorting on every Convert() call - item 27
- FI/KO: elide the multiplier "1" before the thousands scale name (FI: yksi tuhat -> tuhat, KO: il cheon -> cheon) - item 28
- Item 25 (HI feminine ordinals) was already covered by PR #419 - documented, no code change needed
- Fixed two stale TODO.md notes: the RO scaleConnector and VN intraGroupConnector limitations were already resolved in earlier PRs but the doc still described them as missing

### Items 29-46
- Engine: scope the `GetMonthName` catch, fix negative-numerator named fractions, merge `ApplyVariantRules`/`ApplyVariantRulesForScale` into one method, add `Convert(double)`/`Convert(float)` no-variant overloads with NaN/Infinity guards, add `ConvertFraction(int/long)` overloads, add `<exception>` XML docs across the public interface
- JA: elide the multiplier "1" before "thousand" like FI/KO (`一 千` -> `千`); ZH intentionally left unchanged since "一千" is standard Mandarin, verified against an existing passing test rather than assumed
- ES 21-29 ("veintiuno") now takes the feminine variant via a whole-word replacement
- PT/GL and FR-be-ch "et" connector items turned out to already be correct; added regression tests instead of code changes
- EL (centaines feminine/masculine forms) was attempted then reverted after a test caught a regression: the shared "gender" `VariantDimension` only supports one default value (`Values[0]`), needed as neuter for cardinals and masculine for ordinal `forms=` at once - documented as an architecture limitation in TODO.md item 39
- Closed test-coverage gaps for double/float + `DecimalFormatOptions`, `TimeSpan`/`DateOnly`/`DateTime`, `BigInteger` significant digits, and `ConvertYear` negative-year + variant combinations across DE/ES/IT/FR
- README: documented the 14 languages missing from the supported-cultures table, plus `groupConnector`/`intraGroupConnector`/`scaleConnector` and `beforeChristSuffix` attributes
- Item 40 (Slavic noun-agreement declension) remains reported: it needs agreement on the externally counted noun, which the engine does not model

## Test plan
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` - 3279 passed, 3 ignored, 0 failed
- [x] `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj` - 265 passed, 4 ignored, 0 failed
- [x] Updated existing FI/KO assertions that encoded the old (incorrect) behavior

Generated with Claude Code
