### PR TITLE
feat(Geography): normalize projections; suppress CA2260 via pragma

### DIFF
--- a/Utils.Geography/Geography/Display/MapPoint.cs
+++ b/Utils.Geography/Geography/Display/MapPoint.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Utils.Geography.Model;
 using Utils.Geography.Projections;
+using Utils.Mathematics;
 
 namespace Utils.Geography.Display
 {
@@ -67,9 +68,13 @@ namespace Utils.Geography.Display
         /// <remarks>
         /// Uses <see cref="IProjectionTransformation{T}.Normalize"/> (via <see cref="ProjectedPoint{T}.Projection"/>)
         /// to convert the projected point into <c>[0,1]</c> map-fraction coordinates before scaling by the
-        /// total map size in pixels (<c>tileSize &lt;&lt; zoomLevel</c>), matching
+        /// total map size in pixels (<c>tileSize &lt;&lt; zoomLevel</c>, computed in <see langword="long"/>
+        /// to avoid overflowing <see langword="int"/> at high zoom levels), matching
         /// <see cref="RepresentationConverter{T}.GetMapSize"/> and <see cref="RepresentationConverter{T}.MappointToTile"/>
-        /// exactly, so both paths agree on which tile a given point falls into.
+        /// exactly, so both paths agree on which tile a given point falls into. The resulting pixel
+        /// coordinates are clamped to <c>[0, mapSize - 1]</c>: a normalized value of exactly <c>1</c>
+        /// (e.g. Equirectangular's latitude <c>90°</c>, or Mercator's own <see cref="MercatorProjection{T}.MaxLatitude"/>)
+        /// would otherwise floor to <c>mapSize</c>, one pixel past the last valid one.
         /// </remarks>
         public MapPoint(ProjectedPoint<T> projectedPoint, byte zoomLevel, int tileSize)
         {
@@ -77,9 +82,12 @@ namespace Utils.Geography.Display
             TileSize = tileSize;
 
             var (nx, ny) = projectedPoint.Projection.Normalize(projectedPoint);
-            T mapSize = T.CreateChecked(tileSize << zoomLevel);
-            X = long.CreateChecked(T.Floor(nx * mapSize));
-            Y = long.CreateChecked(T.Floor(ny * mapSize));
+            long mapSize = (long)tileSize << zoomLevel;
+            T mapSizeT = T.CreateChecked(mapSize);
+            T maxPixel = T.CreateChecked(mapSize - 1);
+
+            X = long.CreateChecked(MathEx.Clamp(T.Floor(nx * mapSizeT), T.Zero, maxPixel));
+            Y = long.CreateChecked(MathEx.Clamp(T.Floor(ny * mapSizeT), T.Zero, maxPixel));
         }
 
         /// <summary>

--- a/Utils.Geography/Geography/Display/MapPoint.cs
+++ b/Utils.Geography/Geography/Display/MapPoint.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using Utils.Geography.Model;
+using Utils.Geography.Projections;
 
 namespace Utils.Geography.Display
 {
@@ -63,13 +64,22 @@ namespace Utils.Geography.Display
         /// <param name="projectedPoint">Projected map coordinates.</param>
         /// <param name="zoomLevel">Target zoom level.</param>
         /// <param name="tileSize">Tile size in pixels.</param>
+        /// <remarks>
+        /// Uses <see cref="IProjectionTransformation{T}.Normalize"/> (via <see cref="ProjectedPoint{T}.Projection"/>)
+        /// to convert the projected point into <c>[0,1]</c> map-fraction coordinates before scaling by the
+        /// total map size in pixels (<c>tileSize &lt;&lt; zoomLevel</c>), matching
+        /// <see cref="RepresentationConverter{T}.GetMapSize"/> and <see cref="RepresentationConverter{T}.MappointToTile"/>
+        /// exactly, so both paths agree on which tile a given point falls into.
+        /// </remarks>
         public MapPoint(ProjectedPoint<T> projectedPoint, byte zoomLevel, int tileSize)
         {
-            T zoomFactor = (T)Convert.ChangeType(1 << zoomLevel, typeof(T));
             ZoomLevel = zoomLevel;
-            X = (long)Convert.ChangeType(T.Floor(projectedPoint.X * zoomFactor), typeof(long));
-            Y = (long)Convert.ChangeType(T.Floor(projectedPoint.Y * zoomFactor), typeof(long));
             TileSize = tileSize;
+
+            var (nx, ny) = projectedPoint.Projection.Normalize(projectedPoint);
+            T mapSize = T.CreateChecked(tileSize << zoomLevel);
+            X = long.CreateChecked(T.Floor(nx * mapSize));
+            Y = long.CreateChecked(T.Floor(ny * mapSize));
         }
 
         /// <summary>

--- a/Utils.Geography/Geography/Display/RepresentationConverter.cs
+++ b/Utils.Geography/Geography/Display/RepresentationConverter.cs
@@ -86,12 +86,24 @@ namespace Utils.Geography.Display
         /// <param name="projectedPoint">Projected map point.</param>
         /// <param name="zoomLevel">Zoom level of the tile grid.</param>
         /// <returns>The tile containing the projected point.</returns>
+        /// <remarks>
+        /// Uses <see cref="IProjectionTransformation{T}.Normalize"/> to convert the projected point into
+        /// <c>[0,1]</c> map-fraction coordinates before scaling by <see cref="GetMapSize"/>, matching
+        /// <see cref="MapPoint{T}"/>'s own pixel calculation exactly, so both agree on which tile a given
+        /// point falls into.
+        /// </remarks>
         public Tile<T> MappointToTile(ProjectedPoint<T> projectedPoint, byte zoomLevel)
         {
-            long zoom = 1 << zoomLevel;
+            long zoom = 1L << zoomLevel;
+
+            var (nx, ny) = projectedPoint.Projection.Normalize(projectedPoint);
+            T mapSize = T.CreateChecked(GetMapSize(zoomLevel));
+            long pixelX = long.CreateChecked(T.Floor(nx * mapSize));
+            long pixelY = long.CreateChecked(T.Floor(ny * mapSize));
+
             return new Tile<T>(
-                MathEx.Clamp((long)Convert.ChangeType(projectedPoint.X, typeof(long)) / TileSize, 0, zoom - 1),
-                MathEx.Clamp((long)Convert.ChangeType(projectedPoint.Y, typeof(long)) / TileSize, 0, zoom - 1),
+                MathEx.Clamp(pixelX / TileSize, 0, zoom - 1),
+                MathEx.Clamp(pixelY / TileSize, 0, zoom - 1),
                 zoomLevel,
                 TileSize);
         }

--- a/Utils.Geography/Geography/Display/RepresentationConverter.cs
+++ b/Utils.Geography/Geography/Display/RepresentationConverter.cs
@@ -90,16 +90,23 @@ namespace Utils.Geography.Display
         /// Uses <see cref="IProjectionTransformation{T}.Normalize"/> to convert the projected point into
         /// <c>[0,1]</c> map-fraction coordinates before scaling by <see cref="GetMapSize"/>, matching
         /// <see cref="MapPoint{T}"/>'s own pixel calculation exactly, so both agree on which tile a given
-        /// point falls into.
+        /// point falls into. The resulting pixel coordinates are clamped to <c>[0, mapSize - 1]</c> before
+        /// dividing by <see cref="TileSize"/>: a normalized value of exactly <c>1</c> (e.g. Equirectangular's
+        /// latitude <c>90°</c>, or Mercator's own <see cref="MercatorProjection{T}.MaxLatitude"/>) would
+        /// otherwise floor to <c>mapSize</c>, one tile past the last valid one — the same edge case
+        /// <see cref="MapPoint{T}"/> guards against.
         /// </remarks>
         public Tile<T> MappointToTile(ProjectedPoint<T> projectedPoint, byte zoomLevel)
         {
             long zoom = 1L << zoomLevel;
 
             var (nx, ny) = projectedPoint.Projection.Normalize(projectedPoint);
-            T mapSize = T.CreateChecked(GetMapSize(zoomLevel));
-            long pixelX = long.CreateChecked(T.Floor(nx * mapSize));
-            long pixelY = long.CreateChecked(T.Floor(ny * mapSize));
+            long mapSize = GetMapSize(zoomLevel);
+            T mapSizeT = T.CreateChecked(mapSize);
+            T maxPixel = T.CreateChecked(mapSize - 1);
+
+            long pixelX = long.CreateChecked(MathEx.Clamp(T.Floor(nx * mapSizeT), T.Zero, maxPixel));
+            long pixelY = long.CreateChecked(MathEx.Clamp(T.Floor(ny * mapSizeT), T.Zero, maxPixel));
 
             return new Tile<T>(
                 MathEx.Clamp(pixelX / TileSize, 0, zoom - 1),
@@ -113,9 +120,14 @@ namespace Utils.Geography.Display
         /// </summary>
         /// <param name="zoomLevel">Zoom level of the tile grid.</param>
         /// <returns>Total map size in pixels.</returns>
-        public int GetMapSize(byte zoomLevel)
+        /// <remarks>
+        /// Returns <see langword="long"/> (rather than <see langword="int"/>) because <c>TileSize &lt;&lt; zoomLevel</c>
+        /// overflows a 32-bit <see langword="int"/> at realistic zoom levels — e.g. with the default 256px
+        /// tile size, zoom 24 already overflows.
+        /// </remarks>
+        public long GetMapSize(byte zoomLevel)
         {
-            return TileSize << zoomLevel;
+            return (long)TileSize << zoomLevel;
         }
 
         /// <summary>
@@ -126,7 +138,7 @@ namespace Utils.Geography.Display
         /// <returns>Ground resolution (meters per pixel) at the specified latitude.</returns>
         public T ComputeGroundResolution(T latitude, byte zoomLevel)
         {
-            var mapSize = (T)Convert.ChangeType(GetMapSize(zoomLevel), typeof(T));
+            var mapSize = T.CreateChecked(GetMapSize(zoomLevel));
             return degree.Cos(latitude) * Planet.EquatorialCircumference / mapSize;
         }
     }

--- a/Utils.Geography/Geography/Model/GeoVector.cs
+++ b/Utils.Geography/Geography/Model/GeoVector.cs
@@ -10,6 +10,12 @@ namespace Utils.Geography.Model;
 /// Represents a vector of displacement on a spherical geodesic with a bearing (heading direction).
 /// </summary>
 /// <typeparam name="T">The numeric type used for calculations, typically a floating point.</typeparam>
+// CA2260 expects IEqualityOperators<TSelf, TOther, TResult> to be implemented via CRTP (GeoPoint<TSelf>),
+// but GeoVector<T> classically inherits GeoPoint<T> (same T) instead of GeoPoint<GeoVector<T>>. The ==/!=
+// operators on both types are correct and tested; adopting the CRTP pattern here would require turning
+// GeoPoint<T> into GeoPoint<TSelf, T>, a breaking API change for every consumer of this package. Suppressed
+// as informational-only.
+#pragma warning disable CA2260
 public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnaryNegationOperators<GeoVector<T>, GeoVector<T>>, IEqualityOperators<GeoVector<T>, GeoVector<T>, bool>
     where T : struct, IFloatingPointIeee754<T>, IDivisionOperators<T, T, T>
 {
@@ -593,3 +599,4 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
 
     #endregion
 }
+#pragma warning restore CA2260

--- a/Utils.Geography/Geography/Projections/EquirectangularProjection.cs
+++ b/Utils.Geography/Geography/Projections/EquirectangularProjection.cs
@@ -34,6 +34,14 @@ public class EquirectangularProjection<T> : IProjectionTransformation<T>
     /// </summary>
     private static T ClampLatitude(T latitude) => MathEx.Clamp(latitude, -MaxLatitude, MaxLatitude);
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Both axes are finite over the whole sphere for this projection (X=longitude ∈ [-180°,180°],
+    /// Y=latitude ∈ [-90°,90°]), so no practical cutoff is needed here (unlike, e.g., Mercator).
+    /// </remarks>
+    public (T MinX, T MaxX, T MinY, T MaxY) Bounds
+        => (-degree.StraightAngle, degree.StraightAngle, -MaxLatitude, MaxLatitude);
+
     /// <summary>
     /// Projects a geographic point (lat, lon in degrees) to a 2D plane:
     ///   X = longitude, Y = latitude.

--- a/Utils.Geography/Geography/Projections/GallsPetersProjection.cs
+++ b/Utils.Geography/Geography/Projections/GallsPetersProjection.cs
@@ -32,6 +32,15 @@ namespace Utils.Geography.Projections
         private static readonly T cos45 = degree.Cos(T.CreateChecked(45));
         private static readonly T invCos45 = T.One / cos45;
 
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Both axes are finite over the whole sphere for this projection (Y=sin(lat)/cos(45°) reaches
+        /// its extreme, finite value exactly at the poles), so no practical cutoff is needed here (unlike,
+        /// e.g., Mercator).
+        /// </remarks>
+        public (T MinX, T MaxX, T MinY, T MaxY) Bounds
+            => (-cos45 * degree.StraightAngle, cos45 * degree.StraightAngle, -invCos45, invCos45);
+
         /// <summary>
         /// Projects a geographical point (in degrees) to the Gall–Peters projection (also in degrees).
         /// (0°,0°) maps to (0,0), with standard parallels at ±45° for equal-area property.

--- a/Utils.Geography/Geography/Projections/IProjectionTransformation.cs
+++ b/Utils.Geography/Geography/Projections/IProjectionTransformation.cs
@@ -36,12 +36,27 @@ public interface IProjectionTransformation<T>
     /// map-fraction coordinates before scaling to a pixel/tile grid.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// For a projection whose output is genuinely unbounded at some point of the sphere (e.g. Mercator at
     /// the poles), <see cref="Bounds"/> must report a practical, finite envelope rather than the true
     /// (infinite) mathematical range — see each projection's own documentation for how that envelope is
     /// chosen and what it excludes.
+    /// </para>
+    /// <para>
+    /// This member has a default implementation (throwing <see cref="NotSupportedException"/>) rather
+    /// than being required, so that adding it to this public interface does not break existing
+    /// third-party <see cref="IProjectionTransformation{T}"/> implementations: they keep compiling and
+    /// working exactly as before, and only fail — with a clear message — if they (or code that consumes
+    /// them, like <see cref="Normalize"/>, <see cref="Utils.Geography.Display.MapPoint{T}"/>'s
+    /// <see cref="ProjectedPoint{T}"/> constructor, or <see cref="Utils.Geography.Display.RepresentationConverter{T}.MappointToTile"/>)
+    /// actually try to use it without overriding it. All 7 projections built into this package override it.
+    /// </para>
     /// </remarks>
-    (T MinX, T MaxX, T MinY, T MaxY) Bounds { get; }
+    (T MinX, T MaxX, T MinY, T MaxY) Bounds
+        => throw new NotSupportedException(
+            $"{GetType().Name} does not override {nameof(IProjectionTransformation<T>)}.{nameof(Bounds)}, " +
+            $"so it cannot be used with {nameof(Normalize)} or with the APIs that depend on it " +
+            $"(MapPoint<T>'s ProjectedPoint constructor, RepresentationConverter<T>.MappointToTile).");
 
     /// <summary>
     /// Normalizes <paramref name="projectedPoint"/> into map-fraction coordinates using <see cref="Bounds"/>:
@@ -92,8 +107,11 @@ public abstract class ProjectionTransformation<T> :
     /// <inheritdoc/>
     public abstract GeoPoint<T> MapPointToGeoPoint(ProjectedPoint<T> mapPoint);
 
-    /// <inheritdoc/>
-    public abstract (T MinX, T MaxX, T MinY, T MaxY) Bounds { get; }
+    // Bounds is intentionally not redeclared here: leaving it out means every existing subclass of
+    // this base class automatically falls back to IProjectionTransformation<T>.Bounds' default
+    // (throwing) implementation, exactly like a class that doesn't implement the interface member
+    // directly — no breaking change for anyone who already derived from ProjectionTransformation<T>.
+    // Subclasses that want Normalize/Bounds support can still override Bounds directly.
 
     /// <inheritdoc/>
     public override bool Equals(object? obj)

--- a/Utils.Geography/Geography/Projections/IProjectionTransformation.cs
+++ b/Utils.Geography/Geography/Projections/IProjectionTransformation.cs
@@ -27,6 +27,49 @@ public interface IProjectionTransformation<T>
     /// <param name="mapPoint">A projected point on a 2D map.</param>
     /// <returns>The corresponding geographic point.</returns>
     GeoPoint<T> MapPointToGeoPoint(ProjectedPoint<T> mapPoint);
+
+    /// <summary>
+    /// Gets the rectangular bounds, expressed in this projection's own native output units, that
+    /// <see cref="GeoPointToMapPoint"/> stays within for every valid <see cref="GeoPoint{T}"/>. Used by
+    /// <see cref="Normalize"/> (and, in turn, by <see cref="Utils.Geography.Display.MapPoint{T}"/> and
+    /// <see cref="Utils.Geography.Display.RepresentationConverter{T}"/>) to convert a projected point into
+    /// map-fraction coordinates before scaling to a pixel/tile grid.
+    /// </summary>
+    /// <remarks>
+    /// For a projection whose output is genuinely unbounded at some point of the sphere (e.g. Mercator at
+    /// the poles), <see cref="Bounds"/> must report a practical, finite envelope rather than the true
+    /// (infinite) mathematical range — see each projection's own documentation for how that envelope is
+    /// chosen and what it excludes.
+    /// </remarks>
+    (T MinX, T MaxX, T MinY, T MaxY) Bounds { get; }
+
+    /// <summary>
+    /// Normalizes <paramref name="projectedPoint"/> into map-fraction coordinates using <see cref="Bounds"/>:
+    /// <c>(MinX, MinY)</c> maps to <c>(0, 0)</c> and <c>(MaxX, MaxY)</c> maps to <c>(1, 1)</c>, independently
+    /// on each axis.
+    /// </summary>
+    /// <param name="projectedPoint">A point produced by <see cref="GeoPointToMapPoint"/> using this projection.</param>
+    /// <returns>
+    /// The normalized <c>(X, Y)</c> coordinates. For points within <see cref="Bounds"/> these are in
+    /// <c>[0, 1]</c>; a point outside <see cref="Bounds"/> (e.g. near an excluded singularity, see its
+    /// remarks) normalizes outside that range rather than being clamped.
+    /// </returns>
+    /// <remarks>
+    /// This is a plain independent linear rescale of each axis: it does not assume that either axis
+    /// corresponds to a cardinal direction (that assumption only holds for cylindrical/pseudo-cylindrical
+    /// projections such as <see cref="MercatorProjection{T}"/>/<see cref="EquirectangularProjection{T}"/>,
+    /// not for azimuthal ones such as <see cref="LambertAzimuthalEqualArea{T}"/>/<see cref="StereographicProjection{T}"/>
+    /// where a single axis does not track latitude alone). Callers that need a specific tile-numbering
+    /// orientation (e.g. row 0 = north, matching common slippy-map conventions) must apply that convention
+    /// themselves on top of this normalized value.
+    /// </remarks>
+    (T X, T Y) Normalize(ProjectedPoint<T> projectedPoint)
+    {
+        var (minX, maxX, minY, maxY) = Bounds;
+        T x = (projectedPoint.X - minX) / (maxX - minX);
+        T y = (projectedPoint.Y - minY) / (maxY - minY);
+        return (x, y);
+    }
 }
 
 /// <summary>
@@ -48,6 +91,9 @@ public abstract class ProjectionTransformation<T> :
 
     /// <inheritdoc/>
     public abstract GeoPoint<T> MapPointToGeoPoint(ProjectedPoint<T> mapPoint);
+
+    /// <inheritdoc/>
+    public abstract (T MinX, T MaxX, T MinY, T MaxY) Bounds { get; }
 
     /// <inheritdoc/>
     public override bool Equals(object? obj)

--- a/Utils.Geography/Geography/Projections/LambertProjection.cs
+++ b/Utils.Geography/Geography/Projections/LambertProjection.cs
@@ -23,6 +23,23 @@ public class LambertAzimuthalEqualArea<T> : IProjectionTransformation<T>
     /// </summary>
     private static T Sqrt2 { get; } = T.Sqrt(T.CreateChecked(2));
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Both axes are finite over the whole sphere for this projection: ρ (and therefore both x and y)
+    /// reaches its maximum, finite value of exactly 2 at the south pole (lat=-90°, the point diametrically
+    /// opposite this projection's center), so no practical cutoff is needed here (unlike, e.g., Mercator).
+    /// Because this is a polar azimuthal projection, x and y do not independently track longitude/latitude
+    /// the way they do for cylindrical projections — see <see cref="IProjectionTransformation{T}.Normalize"/>.
+    /// </remarks>
+    public (T MinX, T MaxX, T MinY, T MaxY) Bounds
+    {
+        get
+        {
+            T two = T.CreateChecked(2);
+            return (-two, two, -two, two);
+        }
+    }
+
     /// <summary>
     /// Projects geographic coordinates onto the Lambert azimuthal equal-area plane.
     /// </summary>

--- a/Utils.Geography/Geography/Projections/MercatorProjection.cs
+++ b/Utils.Geography/Geography/Projections/MercatorProjection.cs
@@ -24,6 +24,32 @@ public class MercatorProjection<T> : IProjectionTransformation<T>
     private static readonly IAngleCalculator<T> degree = Trigonometry<T>.Degree;
 
     /// <summary>
+    /// Gets the maximum (and, by symmetry, minimum negated) latitude this projection treats as
+    /// representable: ~85.05112878°, the standard "Web Mercator" cutoff used by essentially every
+    /// slippy-map implementation (OpenStreetMap, Google Maps, Bing Maps, Leaflet, ...). It is the
+    /// solution of <c>2·atan(e^π) - π/2</c>, i.e. the latitude at which this projection's Y value
+    /// (converted to radians) equals π.
+    /// </summary>
+    /// <remarks>
+    /// Unlike latitude itself, Y = ln(tan(45° + lat/2)) grows without bound as latitude approaches ±90°
+    /// (the poles are a genuine mathematical singularity for Mercator: <c>tan(90°)</c> is undefined).
+    /// <see cref="Bounds"/> therefore cannot use lat=±90° directly and instead evaluates Y at
+    /// <see cref="MaxLatitude"/>, giving a finite, standard, and widely-recognized envelope.
+    /// </remarks>
+    public static T MaxLatitude { get; } = degree.FromRadian(
+        T.CreateChecked(2) * T.Atan(T.Exp(T.Pi)) - T.Pi / T.CreateChecked(2));
+
+    /// <inheritdoc/>
+    public (T MinX, T MaxX, T MinY, T MaxY) Bounds
+    {
+        get
+        {
+            T maxY = GeoPointToMapPoint(new GeoPoint<T>(MaxLatitude, T.Zero)).Y;
+            return (-degree.StraightAngle, degree.StraightAngle, -maxY, maxY);
+        }
+    }
+
+    /// <summary>
     /// Projects a geographic point (latitude/longitude in degrees) into a 2D "Mercator in degrees"
     /// space so that (0°,0°) → (0,0).
     /// </summary>

--- a/Utils.Geography/Geography/Projections/MillerProjection.cs
+++ b/Utils.Geography/Geography/Projections/MillerProjection.cs
@@ -16,6 +16,21 @@ public class MillerProjection<T> : IProjectionTransformation<T>
     /// </summary>
     private static readonly IAngleCalculator<T> degree = Trigonometry<T>.Degree;
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Unlike Mercator, Miller's Y is finite even at the poles: the "inside" tangent argument is scaled
+    /// down to <c>45° + (2/5)·lat</c>, which only reaches <c>81°</c> at lat=±90° (well short of the 90°
+    /// singularity), so no practical cutoff is needed here.
+    /// </remarks>
+    public (T MinX, T MaxX, T MinY, T MaxY) Bounds
+    {
+        get
+        {
+            T maxY = GeoPointToMapPoint(new GeoPoint<T>(degree.RightAngle, T.Zero)).Y;
+            return (-degree.StraightAngle, degree.StraightAngle, -maxY, maxY);
+        }
+    }
+
     /// <summary>
     /// Projects geographic coordinates to Miller cylindrical coordinates.
     /// </summary>

--- a/Utils.Geography/Geography/Projections/MollweideProjection.cs
+++ b/Utils.Geography/Geography/Projections/MollweideProjection.cs
@@ -31,6 +31,22 @@ public class MollweideProjection<T> : IProjectionTransformation<T>
     private static readonly T Eps = T.CreateChecked(1.0e-7);
     private const int MaxIter = 10;
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Both axes are finite over the whole sphere for this projection (the bounding ellipse fits
+    /// exactly within x ∈ [-2√2, 2√2], y ∈ [-√2, √2], reached at lon=±180°/lat=0° and lat=±90°
+    /// respectively), so no practical cutoff is needed here (unlike, e.g., Mercator).
+    /// </remarks>
+    public (T MinX, T MaxX, T MinY, T MaxY) Bounds
+    {
+        get
+        {
+            T two = T.CreateChecked(2);
+            T maxX = two * Sqrt2;
+            return (-maxX, maxX, -Sqrt2, Sqrt2);
+        }
+    }
+
     /// <summary>
     /// Projects (latitude, longitude) in degrees => Mollweide (x, y).
     ///

--- a/Utils.Geography/Geography/Projections/StereographicProjection.cs
+++ b/Utils.Geography/Geography/Projections/StereographicProjection.cs
@@ -29,6 +29,19 @@ public class StereographicProjection<T> : IProjectionTransformation<T>
     /// </summary>
     private static readonly IAngleCalculator<T> degree = Trigonometry<T>.Degree;
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Unlike Mercator, this projection's singularity is not at the poles (both poles are finite:
+    /// ρ=1) but at the antipodal point (lat=0°, lon=±180°) — see the class remarks. Because that
+    /// singularity is a single point rather than a well-defined latitude cutoff, there is no clean
+    /// finite envelope that fully contains every representable point the way there is for the other
+    /// projections in this package. <see cref="Bounds"/> reports the finite extent reached at the
+    /// poles (x,y ∈ [-1,1]); points near the antipodal meridian can legitimately fall well outside it,
+    /// and <see cref="IProjectionTransformation{T}.Normalize"/> will report a value outside <c>[0,1]</c>
+    /// for them rather than clamping.
+    /// </remarks>
+    public (T MinX, T MaxX, T MinY, T MaxY) Bounds => (-T.One, T.One, -T.One, T.One);
+
     /// <summary>
     /// Projects geographic coordinates onto the stereographic projection plane.
     /// </summary>

--- a/Utils.Geography/README.md
+++ b/Utils.Geography/README.md
@@ -294,7 +294,7 @@ Tile<double> tile = converter.MappointToTile(projected, zoomLevel: 10);
 Console.WriteLine($"tile x={tile.TileX}, y={tile.TileY}, zoom={tile.ZoomFactor}");
 
 // Total map size at zoom 8 (256 * 2^8 = 65536 px)
-int mapSize = converter.GetMapSize(zoomLevel: 8);
+long mapSize = converter.GetMapSize(zoomLevel: 8);
 
 // Ground resolution (meters/pixel) at Paris latitude, zoom 14
 double resolution = converter.ComputeGroundResolution(paris.Latitude, zoomLevel: 14);

--- a/Utils.Geography/README.md
+++ b/Utils.Geography/README.md
@@ -254,6 +254,27 @@ Console.WriteLine(back.Latitude);  // ≈ 48.8566
 IProjectionTransformation<double> p = Projections<double>.GetProjection("lambert");
 ```
 
+### Bounds and normalization
+
+Every projection reports the rectangular bounds (in its own native output units) that
+`GeoPointToMapPoint` stays within, and can normalize a projected point into `[0,1] x [0,1]`
+map-fraction coordinates — this is what `MapPoint<T>`/`RepresentationConverter<T>` use internally to
+convert to pixel/tile coordinates.
+
+```csharp
+var mercator = Projections<double>.Mercator;
+
+// Mercator's Y is unbounded at the poles (tan(90°) is undefined), so its bounds use a documented
+// maximum latitude instead — the standard "Web Mercator" cutoff (~85.05°) used by every major
+// slippy-map implementation.
+Console.WriteLine(MercatorProjection<double>.MaxLatitude); // ~85.05112878
+
+var (minX, maxX, minY, maxY) = mercator.Bounds;
+
+var projected = mercator.GeoPointToMapPoint(paris);
+var (x, y) = mercator.Normalize(projected); // both in [0,1] for any point within Bounds
+```
+
 ## RepresentationConverter examples
 
 `RepresentationConverter<T>` bridges geo coordinates, projected points, and tile grid coordinates.

--- a/Utils.Geography/TODO.md
+++ b/Utils.Geography/TODO.md
@@ -139,6 +139,30 @@ Si un usage réel de rendu de tuiles façon slippy-map est prévu, il faudra inv
 part (dans `MapPoint`/`RepresentationConverter`, ou par un flag) — non fait ici faute de demande
 explicite en ce sens.
 
+**Corrections suite à la revue Codex sur la PR #425** :
+- **Compatibilité ascendante de `Bounds`** — ajouter `Bounds` comme membre requis de l'interface
+  publique `IProjectionTransformation<T>` aurait cassé toute implémentation tierce existante
+  (source et binaire). **Fix** : `Bounds` a désormais une implémentation par défaut sur l'interface
+  (C# 8+) qui lève `NotSupportedException` avec un message explicite, plutôt que d'être abstraite.
+  Les implémentations existantes qui ne la redéfinissent pas continuent de compiler et de fonctionner
+  pour `GeoPointToMapPoint`/`MapPointToGeoPoint` sans aucun changement ; elles ne lèvent que si du code
+  appelle réellement `Bounds`/`Normalize` dessus. La classe abstraite `ProjectionTransformation<T>` ne
+  redéclare plus `Bounds` en `abstract` pour la même raison (hérite du même filet de sécurité). Testé :
+  `CustomProjectionsThatDoNotOverrideBoundsStillCompileAndWorkForCoreConversions` et
+  `...ThrowOnlyWhenNormalizeIsActuallyUsed`.
+- **Bord exact `normalized=1` non clampé** — `Floor(1 × mapSize)` vaut `mapSize`, un pixel après le
+  dernier valide (ex. latitude exactement `90°` en Equirectangular, ou exactement
+  `MercatorProjection<T>.MaxLatitude`). `MapPoint` ne clampait pas ce cas alors que `MappointToTile`
+  clampait déjà l'index de tuile — donc les deux chemins auraient pu à nouveau diverger sur cette
+  frontière précise. **Fix** : les deux méthodes clampent désormais le pixel lui-même à
+  `[0, mapSize - 1]` avant tout calcul de tuile. Testé : `PixelCoordinatesAreClampedExactlyAtTheBoundaryEdge`.
+- **Overflow `int` de la taille de carte aux hauts niveaux de zoom** — `tileSize << zoomLevel` en `int`
+  déborde dès le zoom 24 avec une tuile de 256px (`256 << 24` dépasse `int.MaxValue`), produisant une
+  taille de carte négative ou nulle et des tuiles fausses. **Fix** :
+  `RepresentationConverter.GetMapSize` retourne désormais `long` (changement de signature — l'ancien
+  type `int` était trop étroit pour un usage réaliste) ; `MapPoint` calcule aussi sa taille de carte en
+  `long` directement. Testé : `GetMapSizeDoesNotOverflowAtHighZoomLevels`.
+
 ### Avertissement analyseur CA2260 sur `GeoVector<T>` (supprimé via pragma)
 `GeoVector<T> : GeoPoint<T>, IEqualityOperators<GeoVector<T>, GeoVector<T>, bool>` — l'analyseur
 signale que `GeoPoint<T>` (qui implémente lui-même `IEqualityOperators<GeoPoint<T>, GeoPoint<T>,

--- a/Utils.Geography/TODO.md
+++ b/Utils.Geography/TODO.md
@@ -89,23 +89,6 @@ comportement « égal à epsilon près » a disparu de `Equals`. **Fix** : ajout
 `comparer.Interval`) et des équivalents sur `GeoVector<T>`, explicitement documentés comme *non*
 utilisables pour le hachage/les clés de dictionnaire (fenêtre de tolérance non transitive).
 
-## Documentation mise à jour
-- `LambertAzimuthalEqualArea<T>` : la XML doc ne précisait pas que cette implémentation est l'aspect
-  **polaire** (centré sur le pôle nord, `(lat=90°,lon=0°) → (0,0)`), pas l'aspect équatorial. Un test
-  naïf supposant que `(0,0) → (0,0)` pour toutes les projections a révélé la confusion. Documenté.
-- `StereographicProjection<T>` : documentation de la singularité au point antipodal (lat=0°, lon=±180°)
-  — le dénominateur nul est remplacé par `T.Epsilon` (valeur finie mais énorme) plutôt que de lever une
-  exception ; documenté explicitement plutôt que changé, pour ne pas risquer un changement de
-  comportement non validé.
-- `Planet<T>.Area` : documentation des limites connues de la formule (polygones englobant un pôle,
-  auto-intersectants, ou couvrant une très large fraction de la surface).
-- Renommage du fichier `MollweidProjection.cs` → `MollweideProjection.cs` (la classe s'appelait déjà
-  `MollweideProjection`, seul le nom de fichier avait une coquille).
-- `README.md` : `Planets<double>.Moon` n'existe pas (les satellites sont préfixés par leur planète —
-  `EarthMoon`, `JupiterEurope`, ... — c'est voulu) → corrigé en `Planets<double>.EarthMoon`. Le bearing
-  Paris→Londres annoncé (`~296°`, à deux endroits) était faux ; vérifié par exécution réelle du
-  snippet : la valeur correcte est `~330°`. Corrigé aux deux occurrences.
-
 ### `MapPosition<T>` mutable alors qu'il surcharge `Equals`/`GetHashCode`
 `GeoPoint`/`ZoomLevel` avaient des setters publics alors que `GetHashCode` en dépend : muter l'instance
 après l'avoir stockée dans un `Dictionary`/`HashSet` aurait pu casser silencieusement les lookups, et la
@@ -123,6 +106,66 @@ vérifiés). **Changement d'API potentiellement cassant** pour du code externe q
 absents de `IList<T>` (`Sort`, `ForEach`, `AsReadOnly`, etc.) — aucun appelant de ce type trouvé dans le
 dépôt ; à mentionner dans le changelog si une nouvelle version est publiée.
 
+### `MapPoint<T>`/`Tile<T>`/`RepresentationConverter<T>` : mise à l'échelle incohérente
+Trois façons différentes de passer d'un `ProjectedPoint<T>` à un index de tuile coexistaient sans être
+cohérentes entre elles (`MapPoint` ignorait `tileSize` dans sa mise à l'échelle, `MappointToTile`
+utilisait la coordonnée projetée **brute**, sans mise à l'échelle du tout). Démontré concrètement :
+pour le même `ProjectedPoint` (Paris, Mercator, zoom 10), `MapPoint(...).Tile` donnait `(9, 3)` alors
+que `RepresentationConverter.MappointToTile(...)` donnait `(0, 0)`.
+
+**Fix** — ajout de `IProjectionTransformation<T>.Bounds` (bornes rectangulaires en unités natives de
+la projection) et `Normalize(ProjectedPoint<T>)` (implémentation par défaut sur l'interface, en
+C# 8+ : mise à l'échelle linéaire indépendante par axe vers `[0,1]`) :
+- Chaque projection déclare ses propres bornes. La plupart sont finies et exactes aux pôles
+  (Equirectangular, Gall-Peters, Miller, Mollweide, Lambert) ; **Mercator** est le cas particulier
+  demandé : `Y` diverge à `lat=±90°` (singularité mathématique du logarithme de tangente), donc sa
+  borne est dérivée d'une nouvelle propriété publique `MercatorProjection<T>.MaxLatitude`
+  (`≈85.05112878°`, le seuil standard « Web Mercator » utilisé par OpenStreetMap/Google
+  Maps/Bing/Leaflet, calculé comme `2·atan(e^π) − π/2`) plutôt que d'évaluer à `lat=90°`.
+  **Stereographic** reste un cas limite documenté : sa singularité est au point antipodal
+  (lat=0°,lon=±180°), pas aux pôles, donc ses bornes ne couvrent que l'étendue atteinte aux pôles
+  (`[-1,1]`) — les points proches du méridien antipodal se normalisent légitimement hors `[0,1]`.
+- `MapPoint(ProjectedPoint<T>, zoomLevel, tileSize)` et `RepresentationConverter.MappointToTile`
+  utilisent désormais tous les deux `Normalize` puis la même formule de taille de carte
+  (`tileSize << zoomLevel`, identique à `GetMapSize`) — les deux chemins sont maintenant garantis
+  cohérents entre eux (testé : `MappointToTileAgreesWithMapPointForTheSameProjectedPoint`).
+
+**Limite assumée, à noter si un usage « slippy-map » réel (OSM-like) est prévu** : `Normalize` ne fait
+aucune hypothèse d'orientation cardinale (nécessaire car les projections azimutales comme Lambert/
+Stereographic n'ont pas un axe Y qui suit seul la latitude). Conséquence pour les projections
+cylindriques (Mercator, Equirectangular, ...) : la ligne de tuile augmente **vers le nord**, alors que
+la convention standard OSM/Google/Bing veut que la ligne `0` soit au nord et augmente **vers le sud**.
+Si un usage réel de rendu de tuiles façon slippy-map est prévu, il faudra inverser cet axe Y quelque
+part (dans `MapPoint`/`RepresentationConverter`, ou par un flag) — non fait ici faute de demande
+explicite en ce sens.
+
+### Avertissement analyseur CA2260 sur `GeoVector<T>` (supprimé via pragma)
+`GeoVector<T> : GeoPoint<T>, IEqualityOperators<GeoVector<T>, GeoVector<T>, bool>` — l'analyseur
+signale que `GeoPoint<T>` (qui implémente lui-même `IEqualityOperators<GeoPoint<T>, GeoPoint<T>,
+bool>`) attend que `T` soit rempli par le type dérivé (CRTP), ce qui n'est pas le cas ici puisque
+`GeoVector<T>` hérite classiquement de `GeoPoint<T>` plutôt que de `GeoPoint<GeoVector<T>>`. Corriger
+proprement demanderait de transformer `GeoPoint<T>` en `GeoPoint<TSelf, T>` (CRTP) — un changement
+d'API cassant pour tous les consommateurs, jugé disproportionné pour un warning informatif sans impact
+fonctionnel connu. **Décision** : `#pragma warning disable/restore CA2260` autour de la classe, avec un
+commentaire expliquant pourquoi.
+
+## Documentation mise à jour
+- `LambertAzimuthalEqualArea<T>` : la XML doc ne précisait pas que cette implémentation est l'aspect
+  **polaire** (centré sur le pôle nord, `(lat=90°,lon=0°) → (0,0)`), pas l'aspect équatorial. Un test
+  naïf supposant que `(0,0) → (0,0)` pour toutes les projections a révélé la confusion. Documenté.
+- `StereographicProjection<T>` : documentation de la singularité au point antipodal (lat=0°, lon=±180°)
+  — le dénominateur nul est remplacé par `T.Epsilon` (valeur finie mais énorme) plutôt que de lever une
+  exception ; documenté explicitement plutôt que changé, pour ne pas risquer un changement de
+  comportement non validé.
+- `Planet<T>.Area` : documentation des limites connues de la formule (polygones englobant un pôle,
+  auto-intersectants, ou couvrant une très large fraction de la surface).
+- Renommage du fichier `MollweidProjection.cs` → `MollweideProjection.cs` (la classe s'appelait déjà
+  `MollweideProjection`, seul le nom de fichier avait une coquille).
+- `README.md` : `Planets<double>.Moon` n'existe pas (les satellites sont préfixés par leur planète —
+  `EarthMoon`, `JupiterEurope`, ... — c'est voulu) → corrigé en `Planets<double>.EarthMoon`. Le bearing
+  Paris→Londres annoncé (`~296°`, à deux endroits) était faux ; vérifié par exécution réelle du
+  snippet : la valeur correcte est `~330°`. Corrigé aux deux occurrences.
+
 ## Couverture de tests ajoutée
 Avant cet audit, ces classes n'avaient **aucun** test : `BoundingBox<T>`, `GeoPointList<T>`,
 `GeoPointList2<T>`, `MapPosition<T>`, `ProjectedPoint<T>`, `Tile<T>`, `MapPoint<T>`,
@@ -134,41 +177,11 @@ Fichiers ajoutés dans `UtilsTest/Geography/` :
 - `BoundingBoxTests.cs`, `GeoPointListTests.cs`, `MapPositionTests.cs`, `ProjectedPointTests.cs`,
   `MapPointTileTests.cs`, `CoordinatesUtilTests.cs`, `RepresentationConverterTests.cs`,
   `ProjectionsRoundTripTests.cs` (round-trip géographique pour les 7 projections + vérification du
-  centre de projection).
+  centre de projection), `ProjectionBoundsTests.cs` (`Bounds`/`Normalize` par projection,
+  `MercatorProjection<T>.MaxLatitude`, et la cohérence `MapPoint`/`RepresentationConverter`).
 - Extension de `GeoPointTests.cs`/`GeoVectorTests.cs` : cohérence hash/égalité, non-double-parsing du
   constructeur string, comportement de `Recenter`.
+- Extension de `RepresentationConverterTests.cs` : régression prouvant l'accord entre `MapPoint.Tile`
+  et `RepresentationConverter.MappointToTile` pour un même `ProjectedPoint`.
 
 Tous les nouveaux tests vont dans **UtilsTest.Unit** (aucune dépendance externe).
-
-## Items connus, non corrigés (nécessitent une décision de conception)
-
-### 1. `MapPoint<T>`/`Tile<T>`/`RepresentationConverter<T>` : mise à l'échelle incohérente — priorité haute si ce sous-système doit être utilisé
-Trois façons différentes de passer d'un `ProjectedPoint<T>` à un index de tuile coexistent et ne sont
-pas cohérentes entre elles :
-- `MapPoint(ProjectedPoint<T>, zoomLevel, tileSize)` multiplie `projectedPoint.X` par
-  `1 << zoomLevel` (pas de facteur `tileSize`).
-- `RepresentationConverter.GetMapSize(zoomLevel)` retourne `tileSize << zoomLevel` (donc suppose que
-  la taille totale de la carte en pixels inclut `tileSize`).
-- `RepresentationConverter.MappointToTile` utilise `projectedPoint.X` **brut** (aucune mise à
-  l'échelle par zoom) divisé par `tileSize`.
-
-Par ailleurs, **aucune** des 7 projections fournies ne produit de coordonnées normalisées `[0,1]`
-(Equirectangular sort des degrés, Mercator un logarithme, etc.), ce qui est le préalable habituel
-pour un système de tuiles à la Web-Mercator/Slippy-map. Sans étape de normalisation explicite entre
-`IProjectionTransformation<T>` et `MapPoint<T>`/`Tile<T>`, ce sous-système d'affichage n'est
-probablement pas utilisable tel quel.
-Aucun test, aucun appelant dans le reste du dépôt ne définit le comportement attendu — impossible de
-« corriger » sans deviner une nouvelle sémantique. **Recommandation** : décider explicitement du
-contrat (ex. ajouter une méthode de normalisation sur `IProjectionTransformation<T>`, ou documenter
-que `MapPoint`/`Tile`/`RepresentationConverter` attendent un `ProjectedPoint` déjà normalisé en
-`[0,1]`), puis aligner les trois formules.
-
-### 2. Avertissement analyseur CA2260 sur `GeoVector<T>`
-`GeoVector<T> : GeoPoint<T>, IEqualityOperators<GeoVector<T>, GeoVector<T>, bool>` — l'analyseur
-signale que `GeoPoint<T>` (qui implémente lui-même `IEqualityOperators<GeoPoint<T>, GeoPoint<T>,
-bool>`) attend que `T` soit rempli par le type dérivé (CRTP), ce qui n'est pas le cas ici puisque
-`GeoVector<T>` hérite classiquement de `GeoPoint<T>` plutôt que de `GeoPoint<GeoVector<T>>`. Corriger
-proprement demanderait de transformer `GeoPoint<T>` en `GeoPoint<TSelf, T>` (CRTP) — un changement
-d'API cassant pour tous les consommateurs. Laissé tel quel ; warning informatif, sans impact
-fonctionnel connu.
-

--- a/UtilsTest/Geography/ProjectionBoundsTests.cs
+++ b/UtilsTest/Geography/ProjectionBoundsTests.cs
@@ -1,0 +1,144 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Geography.Model;
+using Utils.Geography.Projections;
+
+namespace UtilsTest.Geography;
+
+/// <summary>
+/// Tests for <see cref="IProjectionTransformation{T}.Bounds"/> and
+/// <see cref="IProjectionTransformation{T}.Normalize"/>, added when <c>MapPoint&lt;T&gt;</c> and
+/// <c>RepresentationConverter&lt;T&gt;.MappointToTile</c> were rewired to use them (see
+/// <see cref="RepresentationConverterTests.MappointToTileAgreesWithMapPointForTheSameProjectedPoint"/>
+/// for the regression test proving the two now agree).
+/// </summary>
+[TestClass]
+public class ProjectionBoundsTests
+{
+    private const double Delta = 1e-6;
+
+    [TestMethod]
+    public void MercatorMaxLatitudeIsTheStandardWebMercatorCutoff()
+    {
+        // The well-known ~85.05112878 deg cutoff used by every major slippy-map implementation.
+        Assert.AreEqual(85.05112877980659, MercatorProjection<double>.MaxLatitude, 1e-9);
+    }
+
+    [TestMethod]
+    public void MercatorBoundsYIsPiAtTheMaxLatitudeCutoff()
+    {
+        // By construction, MaxLatitude is exactly the latitude at which Mercator's Y equals pi.
+        var bounds = Projections<double>.Mercator.Bounds;
+
+        Assert.AreEqual(-180, bounds.MinX, Delta);
+        Assert.AreEqual(180, bounds.MaxX, Delta);
+        Assert.AreEqual(-System.Math.PI, bounds.MinY, Delta);
+        Assert.AreEqual(System.Math.PI, bounds.MaxY, Delta);
+    }
+
+    [TestMethod]
+    public void EquirectangularBoundsMatchLatLonRange()
+    {
+        var bounds = Projections<double>.Equirectangular.Bounds;
+
+        Assert.AreEqual(-180, bounds.MinX, Delta);
+        Assert.AreEqual(180, bounds.MaxX, Delta);
+        Assert.AreEqual(-90, bounds.MinY, Delta);
+        Assert.AreEqual(90, bounds.MaxY, Delta);
+    }
+
+    [TestMethod]
+    public void GallsPetersBoundsReachedAtThePoles()
+    {
+        var bounds = Projections<double>.GallsPeters.Bounds;
+        double sqrt2 = System.Math.Sqrt(2);
+
+        Assert.AreEqual(-sqrt2, bounds.MinY, Delta);
+        Assert.AreEqual(sqrt2, bounds.MaxY, Delta);
+    }
+
+    [TestMethod]
+    public void MollweideBoundsMatchTheDocumentedBoundingEllipseRectangle()
+    {
+        var bounds = Projections<double>.Mollweide.Bounds;
+        double sqrt2 = System.Math.Sqrt(2);
+
+        Assert.AreEqual(-2 * sqrt2, bounds.MinX, Delta);
+        Assert.AreEqual(2 * sqrt2, bounds.MaxX, Delta);
+        Assert.AreEqual(-sqrt2, bounds.MinY, Delta);
+        Assert.AreEqual(sqrt2, bounds.MaxY, Delta);
+    }
+
+    [TestMethod]
+    public void LambertBoundsReachedAtTheSouthPole()
+    {
+        // This Lambert implementation is polar (north-pole-centered); the south pole (its antipode)
+        // is where rho reaches its maximum, finite value of exactly 2.
+        var bounds = Projections<double>.Lambert.Bounds;
+
+        Assert.AreEqual(-2, bounds.MinX, Delta);
+        Assert.AreEqual(2, bounds.MaxX, Delta);
+        Assert.AreEqual(-2, bounds.MinY, Delta);
+        Assert.AreEqual(2, bounds.MaxY, Delta);
+    }
+
+    [TestMethod]
+    public void StereographicBoundsAreReachedAtThePoles()
+    {
+        var bounds = Projections<double>.Stereographic.Bounds;
+
+        Assert.AreEqual(-1, bounds.MinX, Delta);
+        Assert.AreEqual(1, bounds.MaxX, Delta);
+        Assert.AreEqual(-1, bounds.MinY, Delta);
+        Assert.AreEqual(1, bounds.MaxY, Delta);
+    }
+
+    [TestMethod]
+    public void EachProjectionsOwnCenterNormalizesToOneHalf()
+    {
+        // Every projection here maps some specific GeoPoint to its own (0,0) origin (Lambert's is the
+        // north pole rather than the geographic (0,0), since it is polar-centered - see
+        // ProjectionsRoundTripTests.LambertNorthPoleMapsToOrigin). Normalizing that origin against the
+        // projection's own Bounds must land exactly at the center, (0.5, 0.5).
+        (IProjectionTransformation<double> projection, GeoPoint<double> center)[] cases =
+        [
+            (Projections<double>.Equirectangular, new GeoPoint<double>(0, 0)),
+            (Projections<double>.Mercator, new GeoPoint<double>(0, 0)),
+            (Projections<double>.GallsPeters, new GeoPoint<double>(0, 0)),
+            (Projections<double>.Miller, new GeoPoint<double>(0, 0)),
+            (Projections<double>.Mollweide, new GeoPoint<double>(0, 0)),
+            (Projections<double>.Lambert, new GeoPoint<double>(90, 0)),
+            (Projections<double>.Stereographic, new GeoPoint<double>(0, 0)),
+        ];
+
+        foreach (var (projection, center) in cases)
+        {
+            var projected = projection.GeoPointToMapPoint(center);
+            var (x, y) = projection.Normalize(projected);
+
+            Assert.AreEqual(0.5, x, Delta, projection.GetType().Name);
+            Assert.AreEqual(0.5, y, Delta, projection.GetType().Name);
+        }
+    }
+
+    [TestMethod]
+    public void NormalizeIsWithinUnitRangeForPointsWellWithinBounds()
+    {
+        var paris = new GeoPoint<double>(48.8566, 2.3522);
+
+        foreach (var projection in new[]
+                 {
+                     Projections<double>.Equirectangular,
+                     Projections<double>.Mercator,
+                     Projections<double>.GallsPeters,
+                     Projections<double>.Miller,
+                     Projections<double>.Mollweide,
+                 })
+        {
+            var projected = projection.GeoPointToMapPoint(paris);
+            var (x, y) = projection.Normalize(projected);
+
+            Assert.IsTrue(x is >= 0 and <= 1, $"{projection.GetType().Name}: x={x}");
+            Assert.IsTrue(y is >= 0 and <= 1, $"{projection.GetType().Name}: y={y}");
+        }
+    }
+}

--- a/UtilsTest/Geography/ProjectionBoundsTests.cs
+++ b/UtilsTest/Geography/ProjectionBoundsTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using Utils.Geography.Model;
 using Utils.Geography.Projections;
 
@@ -140,5 +141,44 @@ public class ProjectionBoundsTests
             Assert.IsTrue(x is >= 0 and <= 1, $"{projection.GetType().Name}: x={x}");
             Assert.IsTrue(y is >= 0 and <= 1, $"{projection.GetType().Name}: y={y}");
         }
+    }
+
+    /// <summary>
+    /// A minimal <see cref="IProjectionTransformation{T}"/> implementation that predates
+    /// <c>Bounds</c>/<c>Normalize</c> and does not override either — standing in for a third-party
+    /// projection compiled against an earlier version of this package.
+    /// </summary>
+    private sealed class LegacyProjectionWithoutBounds : IProjectionTransformation<double>
+    {
+        public ProjectedPoint<double> GeoPointToMapPoint(GeoPoint<double> geoPoint)
+            => new(geoPoint.Longitude, geoPoint.Latitude, this);
+
+        public GeoPoint<double> MapPointToGeoPoint(ProjectedPoint<double> mapPoint)
+            => new(mapPoint.Y, mapPoint.X);
+    }
+
+    [TestMethod]
+    public void CustomProjectionsThatDoNotOverrideBoundsStillCompileAndWorkForCoreConversions()
+    {
+        // Regression test for backwards compatibility: adding Bounds to the public interface must not
+        // break third-party IProjectionTransformation<T> implementations compiled before it existed.
+        IProjectionTransformation<double> legacy = new LegacyProjectionWithoutBounds();
+        var geoPoint = new GeoPoint<double>(10, 20);
+
+        var projected = legacy.GeoPointToMapPoint(geoPoint);
+        var roundTripped = legacy.MapPointToGeoPoint(projected);
+
+        Assert.AreEqual(geoPoint.Latitude, roundTripped.Latitude);
+        Assert.AreEqual(geoPoint.Longitude, roundTripped.Longitude);
+    }
+
+    [TestMethod]
+    public void CustomProjectionsThatDoNotOverrideBoundsThrowOnlyWhenNormalizeIsActuallyUsed()
+    {
+        IProjectionTransformation<double> legacy = new LegacyProjectionWithoutBounds();
+        var projected = legacy.GeoPointToMapPoint(new GeoPoint<double>(10, 20));
+
+        Assert.ThrowsException<NotSupportedException>(() => _ = legacy.Bounds);
+        Assert.ThrowsException<NotSupportedException>(() => legacy.Normalize(projected));
     }
 }

--- a/UtilsTest/Geography/RepresentationConverterTests.cs
+++ b/UtilsTest/Geography/RepresentationConverterTests.cs
@@ -13,9 +13,22 @@ public class RepresentationConverterTests
     {
         var converter = new RepresentationConverter<double>(Projections<double>.Equirectangular, tileSize: 256);
 
-        Assert.AreEqual(256, converter.GetMapSize(0));
-        Assert.AreEqual(512, converter.GetMapSize(1));
-        Assert.AreEqual(1024, converter.GetMapSize(2));
+        Assert.AreEqual(256L, converter.GetMapSize(0));
+        Assert.AreEqual(512L, converter.GetMapSize(1));
+        Assert.AreEqual(1024L, converter.GetMapSize(2));
+    }
+
+    [TestMethod]
+    public void GetMapSizeDoesNotOverflowAtHighZoomLevels()
+    {
+        // Regression test: TileSize << zoomLevel used to be computed as `int`, which overflows for
+        // realistic zoom levels (e.g. 256 << 24 already overflows a 32-bit int).
+        var converter = new RepresentationConverter<double>(Projections<double>.Equirectangular, tileSize: 256);
+
+        long mapSize = converter.GetMapSize(24);
+
+        Assert.AreEqual(256L << 24, mapSize);
+        Assert.IsTrue(mapSize > 0);
     }
 
     [TestMethod]
@@ -100,6 +113,29 @@ public class RepresentationConverterTests
 
         Assert.AreEqual(tileViaMapPoint.TileX, tileViaConverter.TileX);
         Assert.AreEqual(tileViaMapPoint.TileY, tileViaConverter.TileY);
+    }
+
+    [TestMethod]
+    public void PixelCoordinatesAreClampedExactlyAtTheBoundaryEdge()
+    {
+        // Regression test: a normalized value of exactly 1 (e.g. Equirectangular's max latitude, 90 deg)
+        // used to floor to `mapSize`, one pixel/tile past the last valid one, disagreeing with the
+        // tile-level clamp applied elsewhere. MapPoint and MappointToTile now both clamp the pixel
+        // coordinate itself, so the last valid tile (index zoom-1) is returned consistently by both.
+        var projection = Projections<double>.Equirectangular;
+        var northPole = new GeoPoint<double>(90, 0);
+        var projected = projection.GeoPointToMapPoint(northPole);
+        var converter = new RepresentationConverter<double>(projection, tileSize: 256);
+
+        var mapPoint = new MapPoint<double>(projected, zoomLevel: 2, tileSize: 256);
+        var tileViaConverter = converter.MappointToTile(projected, zoomLevel: 2);
+
+        long lastValidPixel = converter.GetMapSize(2) - 1;
+        int lastValidTileIndex = (1 << 2) - 1; // 3
+
+        Assert.AreEqual(lastValidPixel, mapPoint.Y);
+        Assert.AreEqual(lastValidTileIndex, mapPoint.Tile.TileY);
+        Assert.AreEqual(lastValidTileIndex, tileViaConverter.TileY);
     }
 
     [TestMethod]

--- a/UtilsTest/Geography/RepresentationConverterTests.cs
+++ b/UtilsTest/Geography/RepresentationConverterTests.cs
@@ -81,4 +81,39 @@ public class RepresentationConverterTests
         Assert.IsTrue(tile.TileX is >= 0 and <= 3);
         Assert.IsTrue(tile.TileY is >= 0 and <= 3);
     }
+
+    [TestMethod]
+    public void MappointToTileAgreesWithMapPointForTheSameProjectedPoint()
+    {
+        // Regression test: MapPoint(ProjectedPoint, zoom, tileSize).Tile and
+        // RepresentationConverter.MappointToTile used to disagree (three different, inconsistent
+        // scaling formulas) because MapPoint's pixel scale ignored tileSize, and MappointToTile used
+        // the raw (un-normalized) projected coordinate. Both now go through
+        // IProjectionTransformation<T>.Normalize + the same map-size formula, so they must agree.
+        var paris = new GeoPoint<double>(48.8566, 2.3522);
+        var projection = Projections<double>.Mercator;
+        var projected = projection.GeoPointToMapPoint(paris);
+        var converter = new RepresentationConverter<double>(projection, tileSize: 256);
+
+        var tileViaMapPoint = new MapPoint<double>(projected, zoomLevel: 10, tileSize: 256).Tile;
+        var tileViaConverter = converter.MappointToTile(projected, zoomLevel: 10);
+
+        Assert.AreEqual(tileViaMapPoint.TileX, tileViaConverter.TileX);
+        Assert.AreEqual(tileViaMapPoint.TileY, tileViaConverter.TileY);
+    }
+
+    [TestMethod]
+    public void MappointToTileMapsTheEquatorAndPrimeMeridianToTheCenterTile()
+    {
+        var projection = Projections<double>.Mercator;
+        var converter = new RepresentationConverter<double>(projection, tileSize: 256);
+        var origin = new GeoPoint<double>(0, 0);
+        var projectedOrigin = projection.GeoPointToMapPoint(origin);
+
+        var tile = converter.MappointToTile(projectedOrigin, zoomLevel: 10);
+
+        int centerTileIndex = (1 << 10) / 2;
+        Assert.AreEqual(centerTileIndex, tile.TileX);
+        Assert.AreEqual(centerTileIndex, tile.TileY);
+    }
 }


### PR DESCRIPTION
## Summary
Resolves the last two open items from the `Utils.Geography` audit (see `TODO.md`):

- **CA2260** on `GeoVector<T>` (CRTP mismatch, informational-only) - suppressed with `#pragma warning disable/restore CA2260` and a comment, rather than a breaking `GeoPoint<TSelf,T>` redesign.
- **`MapPoint<T>`/`RepresentationConverter<T>.MappointToTile` scaling inconsistency** - the two paths used to disagree (demonstrated: same Mercator point at zoom 10, `MapPoint(...).Tile` gave `(9,3)` while `MappointToTile` gave `(0,0)`). Added `IProjectionTransformation<T>.Bounds` + a default-implemented `Normalize(ProjectedPoint<T>)` (linear rescale per axis into `[0,1]`), and wired both `MapPoint` and `MappointToTile` through it.

For Mercator specifically (per instruction): `Y` diverges at the poles, so its bound is derived from a new public `MercatorProjection<T>.MaxLatitude` (~85.05112878 deg, the standard "Web Mercator" cutoff used by OSM/Google/Bing/Leaflet - `2*atan(e^pi) - pi/2`) instead of evaluating at `lat=90`.

Stereographic remains a documented edge case: its singularity is the antipodal point (lat=0, lon=+-180), not the poles, so its bounds only cover the pole-to-pole extent (`[-1,1]`); points near the antipodal meridian legitimately normalize outside `[0,1]`.

**Known, documented limitation**: `Normalize` doesn't assume a cardinal orientation (azimuthal projections don't have a clean latitude-only axis), so for cylindrical projections the tile row increases northward rather than the OSM convention (row 0 = north, increasing south). Flipping this wasn't requested, so it wasn't added - flagged in `TODO.md` in case real slippy-map rendering is planned later.

## Test plan
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter FullyQualifiedName~Geography` - 98 tests pass, including a new regression test proving `MapPoint.Tile` and `RepresentationConverter.MappointToTile` now agree
- [x] Full `dotnet test UtilsTest/UtilsTest.Unit.csproj` - 3379 pass, 3 ignored, 0 failures
- [x] `dotnet build Utils.Geography/Utils.Geography.csproj` - zero warnings (CA2260 now suppressed)
- [x] Manually verified `MercatorProjection<double>.MaxLatitude`, `Bounds`, and `Normalize` output via a scratch console app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
