### PR TITLE
feat+fix(Utils.Geography): GeoPoint/GeoVector as structs with composition

### DIFF
--- a/Utils.Geography/Geography/Model/GeoPoint.cs
+++ b/Utils.Geography/Geography/Model/GeoPoint.cs
@@ -28,34 +28,34 @@ namespace Utils.Geography.Model
 
     /// <summary>
     /// Represents an immutable geographic point with latitude and longitude.
-    /// This class supports parsing, formatting, and mathematical operations between geographic points.
+    /// This type supports parsing, formatting, and mathematical operations between geographic points.
     /// </summary>
     /// <typeparam name="T">
     /// Numeric type implementing IFloatingPointIeee754 (e.g., float, double, decimal).
     /// </typeparam>
-    public class GeoPoint<T> : IEquatable<GeoPoint<T>>, IFormattable, IEqualityOperators<GeoPoint<T>, GeoPoint<T>, bool>
+    public readonly struct GeoPoint<T> : IEquatable<GeoPoint<T>>, IFormattable, IEqualityOperators<GeoPoint<T>, GeoPoint<T>, bool>
         where T : struct, IFloatingPointIeee754<T>, IDivisionOperators<T, T, T>
     {
         // Constants for degrees, minutes, and seconds conversions
         /// <summary>
         /// Number of minutes in a degree.
         /// </summary>
-        protected static readonly T MinutesInDegree = T.CreateChecked(60);
+        private static readonly T MinutesInDegree = T.CreateChecked(60);
 
         /// <summary>
         /// Number of seconds in a degree.
         /// </summary>
-        protected static readonly T SecondsInDegree = T.CreateChecked(3600);
+        private static readonly T SecondsInDegree = T.CreateChecked(3600);
 
         /// <summary>
         /// Number of seconds in a minute.
         /// </summary>
-        protected static readonly T SecondsInMinute = T.CreateChecked(60);
+        private static readonly T SecondsInMinute = T.CreateChecked(60);
 
         /// <summary>
         /// Angle calculator configured to work in degrees.
         /// </summary>
-        protected static readonly IAngleCalculator<T> degree = Trigonometry<T>.Degree;
+        private static readonly IAngleCalculator<T> degree = Trigonometry<T>.Degree;
 
         /// <summary>
         /// Number of decimal places latitude/longitude (and bearing, for <see cref="GeoVector{T}"/>) are
@@ -65,7 +65,7 @@ namespace Utils.Geography.Model
         /// but land on opposite sides of a rounding boundary as unequal. See the remarks on
         /// <see cref="Equals(GeoPoint{T})"/> for the full rationale and a worked example.
         /// </summary>
-        protected const int EqualityPrecision = 5;
+        internal const int EqualityPrecision = 5;
 
         /// <summary>
         /// Floating-point comparer used for tolerance-based domain checks that are not part of the
@@ -73,7 +73,7 @@ namespace Utils.Geography.Model
         /// meridians in <see cref="GeoVector{T}.ComputeBearing"/>, or the default tolerance used by
         /// <see cref="IsApproximately(GeoPoint{T})"/>).
         /// </summary>
-        protected static readonly FloatingPointComparer<T> comparer = new(EqualityPrecision);
+        private static readonly FloatingPointComparer<T> comparer = new(EqualityPrecision);
 
         /// <summary>
         /// Maximum valid latitude in degrees.
@@ -88,22 +88,22 @@ namespace Utils.Geography.Model
         /// <summary>
         /// Modifiers that indicate a positive latitude value.
         /// </summary>
-        protected static readonly IReadOnlyList<string> PositiveLatitude = ["+", "N"];
+        internal static readonly IReadOnlyList<string> PositiveLatitude = ["+", "N"];
 
         /// <summary>
         /// Modifiers that indicate a negative latitude value.
         /// </summary>
-        protected static readonly IReadOnlyList<string> NegativeLatitude = ["-", "S"];
+        internal static readonly IReadOnlyList<string> NegativeLatitude = ["-", "S"];
 
         /// <summary>
         /// Modifiers that indicate a positive longitude value.
         /// </summary>
-        protected static readonly IReadOnlyList<string> PositiveLongitude = ["+", "E"];
+        internal static readonly IReadOnlyList<string> PositiveLongitude = ["+", "E"];
 
         /// <summary>
         /// Modifiers that indicate a negative longitude value.
         /// </summary>
-        protected static readonly IReadOnlyList<string> NegativeLongitude = ["-", "W"];
+        internal static readonly IReadOnlyList<string> NegativeLongitude = ["-", "W"];
 
         /// <summary>
         /// Latitude in degrees (immutable).
@@ -124,11 +124,6 @@ namespace Utils.Geography.Model
         /// Alias for Longitude.
         /// </summary>
         public T λ => Longitude;
-
-        /// <summary>
-        /// Protected default constructor used for inheritance scenarios or reflection.
-        /// </summary>
-        protected GeoPoint() { }
 
         /// <summary>
         /// Copy constructor for creating a new GeoPoint from an existing one.
@@ -217,7 +212,7 @@ namespace Utils.Geography.Model
         /// Attempts to parse the provided latitude and longitude strings using the specified culture and regex.
         /// If successful, lat/lon will be set and <see langword="true"/> will be returned.
         /// </summary>
-        protected bool ParseCoordinates(
+        private bool ParseCoordinates(
             string latitudeString,
             string longitudeString,
             CultureInfo cultureInfo,
@@ -254,7 +249,7 @@ namespace Utils.Geography.Model
         /// <summary>
         /// Parses a single string coordinate value based on its direction (Latitude/Longitude).
         /// </summary>
-        protected static T ParseCoordinate(
+        internal static T ParseCoordinate(
             CoordinateDirection direction,
             string coordinateValue,
             IReadOnlyList<string> positiveModifiers,
@@ -378,10 +373,8 @@ namespace Utils.Geography.Model
         /// handled separately above), so it only needs a plain rounded comparison.
         /// </para>
         /// </remarks>
-        public bool Equals(GeoPoint<T>? other)
+        public bool Equals(GeoPoint<T> other)
         {
-            if (other is null) return false;
-
             T roundedLatitude = T.Round(Latitude, EqualityPrecision);
             T otherRoundedLatitude = T.Round(other.Latitude, EqualityPrecision);
 
@@ -432,8 +425,6 @@ namespace Utils.Geography.Model
         /// </remarks>
         public bool IsApproximately(GeoPoint<T> other, T tolerance)
         {
-            other.Arg().MustNotBeNull();
-
             if (degree.AreEqual(Latitude, MaxLatitude, tolerance) && degree.AreEqual(other.Latitude, MaxLatitude, tolerance)) return true;
             if (degree.AreEqual(Latitude, MinLatitude, tolerance) && degree.AreEqual(other.Latitude, MinLatitude, tolerance)) return true;
 
@@ -465,7 +456,7 @@ namespace Utils.Geography.Model
         /// Returns this geographic point as a string in the specified format and culture.
         /// Supported formats: "0.#####", "d" and "D" (for degree-minute-second).
         /// </summary>
-        public virtual string ToString(string? format, IFormatProvider? formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
         {
             formatProvider ??= CultureInfo.InvariantCulture;
             format ??= "0.#####";
@@ -533,15 +524,15 @@ namespace Utils.Geography.Model
         /// current culture then the invariant culture.
         /// </summary>
         /// <param name="coordinates">The string to parse.</param>
-        /// <param name="result">The parsed point, or <see langword="null"/> on failure.</param>
+        /// <param name="result">The parsed point, or <c>default</c> on failure.</param>
         /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
-        public static bool TryParse(string coordinates, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out GeoPoint<T>? result)
+        public static bool TryParse(string coordinates, out GeoPoint<T> result)
             => TryParse(coordinates, [], out result);
 
         /// <summary>
         /// Attempts to parse a combined coordinate string using the specified cultures.
         /// </summary>
-        public static bool TryParse(string coordinates, CultureInfo[] cultureInfos, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out GeoPoint<T>? result)
+        public static bool TryParse(string coordinates, CultureInfo[] cultureInfos, out GeoPoint<T> result)
         {
             try
             {
@@ -550,7 +541,7 @@ namespace Utils.Geography.Model
             }
             catch
             {
-                result = null;
+                result = default;
                 return false;
             }
         }
@@ -561,15 +552,15 @@ namespace Utils.Geography.Model
         /// </summary>
         /// <param name="latitudeString">Latitude string (e.g. <c>"N48°51'"</c> or <c>"48.8566"</c>).</param>
         /// <param name="longitudeString">Longitude string (e.g. <c>"E2°21'"</c> or <c>"2.3522"</c>).</param>
-        /// <param name="result">The parsed point, or <see langword="null"/> on failure.</param>
+        /// <param name="result">The parsed point, or <c>default</c> on failure.</param>
         /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
-        public static bool TryParse(string latitudeString, string longitudeString, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out GeoPoint<T>? result)
+        public static bool TryParse(string latitudeString, string longitudeString, out GeoPoint<T> result)
             => TryParse(latitudeString, longitudeString, [], out result);
 
         /// <summary>
         /// Attempts to parse separate latitude and longitude strings using the specified cultures.
         /// </summary>
-        public static bool TryParse(string latitudeString, string longitudeString, CultureInfo[] cultureInfos, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out GeoPoint<T>? result)
+        public static bool TryParse(string latitudeString, string longitudeString, CultureInfo[] cultureInfos, out GeoPoint<T> result)
         {
             try
             {
@@ -578,7 +569,7 @@ namespace Utils.Geography.Model
             }
             catch
             {
-                result = null;
+                result = default;
                 return false;
             }
         }
@@ -590,12 +581,12 @@ namespace Utils.Geography.Model
         /// <summary>
         /// Determines whether two geographic points are equal.
         /// </summary>
-        public static bool operator ==(GeoPoint<T>? left, GeoPoint<T>? right) => left?.Equals(right) ?? right is null;
+        public static bool operator ==(GeoPoint<T> left, GeoPoint<T> right) => left.Equals(right);
 
         /// <summary>
         /// Determines whether two geographic points are not equal.
         /// </summary>
-        public static bool operator !=(GeoPoint<T>? left, GeoPoint<T>? right) => !(left == right);
+        public static bool operator !=(GeoPoint<T> left, GeoPoint<T> right) => !left.Equals(right);
 
         #endregion
 
@@ -607,7 +598,7 @@ namespace Utils.Geography.Model
         /// <summary>
         /// Builds or retrieves from cache the regex used to parse coordinate values from strings.
         /// </summary>
-        protected static Regex BuildRegexCoordinates(CultureInfo culture)
+        internal static Regex BuildRegexCoordinates(CultureInfo culture)
         {
             string nativeDigits = string.Join("", culture.NumberFormat.NativeDigits);
             string decimalSeparator = culture.NumberFormat.NumberDecimalSeparator;

--- a/Utils.Geography/Geography/Model/GeoVector.cs
+++ b/Utils.Geography/Geography/Model/GeoVector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Numerics;
 using Utils.Mathematics;
@@ -10,19 +10,60 @@ namespace Utils.Geography.Model;
 /// Represents a vector of displacement on a spherical geodesic with a bearing (heading direction).
 /// </summary>
 /// <typeparam name="T">The numeric type used for calculations, typically a floating point.</typeparam>
-// CA2260 expects IEqualityOperators<TSelf, TOther, TResult> to be implemented via CRTP (GeoPoint<TSelf>),
-// but GeoVector<T> classically inherits GeoPoint<T> (same T) instead of GeoPoint<GeoVector<T>>. The ==/!=
-// operators on both types are correct and tested; adopting the CRTP pattern here would require turning
-// GeoPoint<T> into GeoPoint<TSelf, T>, a breaking API change for every consumer of this package. Suppressed
-// as informational-only.
-#pragma warning disable CA2260
-public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnaryNegationOperators<GeoVector<T>, GeoVector<T>>, IEqualityOperators<GeoVector<T>, GeoVector<T>, bool>
+/// <remarks>
+/// Wraps a <see cref="GeoPoint{T}"/> (composition) rather than inheriting from it: a vector "has a"
+/// position, it isn't itself a point. Besides being the more accurate model, this also sidesteps a real
+/// bug the previous inheritance-based design had: <see cref="GeoPoint{T}.Equals(object?)"/> matches any
+/// <see cref="GeoPoint{T}"/>-derived instance via <c>obj is GeoPoint&lt;T&gt;</c>, so comparing a bare
+/// <see cref="GeoPoint{T}"/> against a <see cref="GeoVector{T}"/> at the same coordinates used to report
+/// them as equal (silently ignoring the bearing) while their hash codes (one over lat/lon, the other over
+/// lat/lon/bearing) could differ — breaking the <see cref="object.GetHashCode"/> contract for any
+/// <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>/<see cref="System.Collections.Generic.HashSet{T}"/>
+/// mixing both types. Composition makes that mismatch impossible: <see cref="GeoVector{T}"/> and
+/// <see cref="GeoPoint{T}"/> are unrelated types and can no longer compare equal to each other.
+/// </remarks>
+public readonly struct GeoVector<T> : IEquatable<GeoVector<T>>, IFormattable, IUnaryNegationOperators<GeoVector<T>, GeoVector<T>>, IEqualityOperators<GeoVector<T>, GeoVector<T>, bool>
     where T : struct, IFloatingPointIeee754<T>, IDivisionOperators<T, T, T>
 {
+    /// <summary>
+    /// Angle calculator configured to work in degrees.
+    /// </summary>
+    private static readonly IAngleCalculator<T> degree = Trigonometry<T>.Degree;
+
+    /// <summary>
+    /// Floating-point comparer used for the default tolerance in <see cref="IsApproximately(GeoVector{T})"/>.
+    /// </summary>
+    private static readonly FloatingPointComparer<T> comparer = new(GeoPoint<T>.EqualityPrecision);
+
+    /// <summary>
+    /// The geographic position this vector originates from. Immutable.
+    /// </summary>
+    public GeoPoint<T> Point { get; }
+
     /// <summary>
     /// Bearing in degrees relative to north, measured clockwise. Immutable.
     /// </summary>
     public T Bearing { get; }
+
+    /// <summary>
+    /// Latitude in degrees (immutable). Alias for <see cref="Point"/>'s latitude.
+    /// </summary>
+    public T Latitude => Point.Latitude;
+
+    /// <summary>
+    /// Longitude in degrees (immutable). Alias for <see cref="Point"/>'s longitude.
+    /// </summary>
+    public T Longitude => Point.Longitude;
+
+    /// <summary>
+    /// Alias for Latitude.
+    /// </summary>
+    public T φ => Point.Latitude;
+
+    /// <summary>
+    /// Alias for Longitude.
+    /// </summary>
+    public T λ => Point.Longitude;
 
     /// <summary>
     /// Bearing in degrees relative to north, measured clockwise.
@@ -49,8 +90,8 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// </summary>
     /// <param name="parsed">The parsed latitude, longitude, and bearing.</param>
     private GeoVector((T latitude, T longitude, T bearing) parsed)
-        : base(parsed.latitude, parsed.longitude)
     {
+        Point = new GeoPoint<T>(parsed.latitude, parsed.longitude);
         Bearing = parsed.bearing;
     }
 
@@ -69,8 +110,8 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <param name="geoPoint">Base geographic point (latitude/longitude).</param>
     /// <param name="bearing">Heading direction in degrees.</param>
     public GeoVector(GeoPoint<T> geoPoint, T bearing)
-        : base(geoPoint.Latitude, geoPoint.Longitude)
     {
+        Point = geoPoint;
         Bearing = degree.Normalize0To2Max(bearing);
     }
 
@@ -80,8 +121,8 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <param name="geoPoint">Start point.</param>
     /// <param name="destination">Destination point.</param>
     public GeoVector(GeoPoint<T> geoPoint, GeoPoint<T> destination)
-        : base(geoPoint.Latitude, geoPoint.Longitude)
     {
+        Point = geoPoint;
         Bearing = ComputeBearing(geoPoint, destination);
     }
 
@@ -92,8 +133,8 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <param name="longitude">Longitude in degrees.</param>
     /// <param name="bearing">Heading direction in degrees.</param>
     public GeoVector(T latitude, T longitude, T bearing)
-        : base(latitude, longitude)
     {
+        Point = new GeoPoint<T>(latitude, longitude);
         Bearing = degree.Normalize0To2Max(bearing);
     }
 
@@ -105,8 +146,8 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <param name="bearing">Bearing direction in degrees.</param>
     /// <param name="cultureInfos">Culture information used to parse the coordinates.</param>
     public GeoVector(string latitudeString, string longitudeString, T bearing, params CultureInfo[] cultureInfos)
-        : base(latitudeString, longitudeString, cultureInfos)
     {
+        Point = new GeoPoint<T>(latitudeString, longitudeString, cultureInfos);
         Bearing = degree.Normalize0To2Max(bearing);
     }
 
@@ -151,25 +192,25 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
             // Reuse GeoPoint's existing parse approach:
             // We can re-use the static or protected logic from base if it’s accessible,
             // or replicate it here. For simplicity, let's do a quick manual parse:
-            var regex = BuildRegexCoordinates(cultureInfo);
+            var regex = GeoPoint<T>.BuildRegexCoordinates(cultureInfo);
 
             // parse latitude
-            var lat = ParseCoordinate(
+            var lat = GeoPoint<T>.ParseCoordinate(
                 CoordinateDirection.Latitude,
                 parts[0],
-                PositiveLatitude,
-                NegativeLatitude,
+                GeoPoint<T>.PositiveLatitude,
+                GeoPoint<T>.NegativeLatitude,
                 cultureInfo,
                 regex
             );
             if (T.IsNaN(lat)) continue; // failed parse
 
             // parse longitude
-            var lon = ParseCoordinate(
+            var lon = GeoPoint<T>.ParseCoordinate(
                 CoordinateDirection.Longitude,
                 parts[1],
-                PositiveLongitude,
-                NegativeLongitude,
+                GeoPoint<T>.PositiveLongitude,
+                GeoPoint<T>.NegativeLongitude,
                 cultureInfo,
                 regex
             );
@@ -194,8 +235,8 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <param name="bearing">Bearing, in degrees.</param>
     public void Deconstruct(out T latitude, out T longitude, out T bearing)
     {
-        latitude = Latitude;
-        longitude = Longitude;
+        latitude = Point.Latitude;
+        longitude = Point.Longitude;
         bearing = Bearing;
     }
 
@@ -240,7 +281,6 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <returns>A new <see cref="GeoVector{T}"/> representing the position and bearing after traveling.</returns>
     public GeoVector<T> Travel(T angle)
     {
-        // (Unchanged logic from your snippet—just referencing the new base's immutability.)
         bool negative = T.Sign(angle) == -1;
 
         // Force angle into [0, 360)
@@ -309,7 +349,7 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
         λ2 = T.Round(λ2, 5);
 
         var arrival = new GeoPoint<T>(φ2, λ2);
-        T newBearing = MathEx.Mod(bearingCorrection + ComputeBearing(arrival, this), degree.Perigon);
+        T newBearing = MathEx.Mod(bearingCorrection + ComputeBearing(arrival, this.Point), degree.Perigon);
 
         return new GeoVector<T>(arrival, newBearing);
     }
@@ -324,28 +364,26 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// - The new latitude = spherical distance (central angle) from "this" to "other".
     /// - The new longitude = difference in initial bearings, so that "this.Bearing" becomes 0°.
     /// - The new bearing = difference in heading from "this.Bearing".
-    /// 
+    ///
     /// Change the reference so that the current vector is effectively the new origin with heading=0.
     /// </summary>
     /// <returns>The point recentered with the current vector as new reference</returns>
     public GeoVector<T> Recenter(GeoVector<T> other)
     {
-        other.Arg().MustNotBeNull();
-
-        // If "other" IS the same instance as "this," map to (0,0,0).
+        // If "other" IS the same vector as "this," map to (0,0,0).
         if (this == other)
         {
             return new GeoVector<T>(T.Zero, T.Zero, T.Zero);
         }
 
         // 1) New latitude = central angle between "reference" and "other".
-        //    (This uses the sphere-based "AngleWith" method you already have.)
-        T newLat = this.AngleWith(other);
+        //    (This uses the sphere-based "AngleWith" method on GeoPoint.)
+        T newLat = this.Point.AngleWith(other.Point);
 
         // 2) We define "new longitude" by the difference in initial bearings
         //    so that reference.Bearing becomes 0 in the new system.
-        T bearingRefToOther = ComputeBearing(this, other); // from your static "ComputeBearing" method
-                                                           // We want to shift so that reference.Bearing => 0.
+        T bearingRefToOther = ComputeBearing(this.Point, other.Point);
+        // We want to shift so that reference.Bearing => 0.
         T newLon = MathEx.Mod(bearingRefToOther - this.Bearing, degree.Perigon);
 
         // 3) We define the new bearing as the difference from reference.Bearing.
@@ -369,11 +407,9 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <returns>An array of 2 intersection points, or an empty array if the circles are identical.</returns>
     public GeoPoint<T>[] Intersections(GeoVector<T> other)
     {
-        // Same logic from your snippet, with minimal changes.
-
         var temp = (
-            a: Travel(this.AngleWith(other)),
-            b: (-this).Travel(this.AngleWith(other))
+            a: Travel(this.Point.AngleWith(other.Point)),
+            b: (-this).Travel(this.Point.AngleWith(other.Point))
         );
 
         if (other.In(temp.a, -temp.a, temp.b, -temp.b))
@@ -481,12 +517,7 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     #region Equality & Overrides
 
     /// <inheritdoc />
-    public override bool Equals(object? obj)
-    {
-        if (ReferenceEquals(this, obj)) return true;
-        if (obj is GeoVector<T> vector) return Equals(vector);
-        return base.Equals(obj);
-    }
+    public override bool Equals(object? obj) => obj is GeoVector<T> vector && Equals(vector);
 
     /// <summary>
     /// Determines whether the specified <see cref="GeoVector{T}"/> has the same position and bearing as
@@ -510,22 +541,20 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// are treated as unequal. See <c>GeoVectorTests.VectorsOnOppositeSidesOfARoundingBoundaryAreNotEqual</c>
     /// for a regression test pinning down this behavior.
     /// </remarks>
-    public bool Equals(GeoVector<T>? other)
-        => other is not null
-           && degree.AreEqualRounded(Bearing, other.Bearing, EqualityPrecision)
-           && base.Equals(other);
+    public bool Equals(GeoVector<T> other)
+        => degree.AreEqualRounded(Bearing, other.Bearing, GeoPoint<T>.EqualityPrecision)
+           && Point.Equals(other.Point);
 
     /// <summary>
-    /// Returns a hash code consistent with <see cref="Equals(GeoVector{T})"/>: latitude is rounded, and
-    /// longitude/bearing are normalized (to handle antimeridian/0-360° wraparound) and rounded, to
-    /// <see cref="GeoPoint{T}.EqualityPrecision"/> decimal places before hashing — the exact same values
-    /// that <see cref="Equals(GeoVector{T})"/> compares on.
+    /// Returns a hash code consistent with <see cref="Equals(GeoVector{T})"/>: it combines <see cref="Point"/>'s
+    /// own hash code (already rounded/normalized, see <see cref="GeoPoint{T}.GetHashCode"/>) with the bearing,
+    /// normalized (to handle 0°/360° wraparound) and rounded to <see cref="GeoPoint{T}.EqualityPrecision"/>
+    /// decimal places — the exact same values that <see cref="Equals(GeoVector{T})"/> compares on.
     /// </summary>
     public override int GetHashCode()
         => ObjectUtils.ComputeHash(
-            T.Round(Latitude, EqualityPrecision),
-            degree.NormalizeRounded(Longitude, EqualityPrecision),
-            degree.NormalizeRounded(Bearing, EqualityPrecision));
+            Point.GetHashCode(),
+            degree.NormalizeRounded(Bearing, GeoPoint<T>.EqualityPrecision));
 
     /// <summary>
     /// Determines whether this vector is within <paramref name="tolerance"/> of <paramref name="other"/>,
@@ -540,15 +569,11 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// of each other; otherwise <see langword="false"/>.
     /// </returns>
     public bool IsApproximately(GeoVector<T> other, T tolerance)
-    {
-        other.Arg().MustNotBeNull();
-        return degree.AreEqual(Bearing, other.Bearing, tolerance) && base.IsApproximately(other, tolerance);
-    }
+        => degree.AreEqual(Bearing, other.Bearing, tolerance) && Point.IsApproximately(other.Point, tolerance);
 
     /// <summary>
-    /// Determines whether this vector is within the default tolerance (see <see cref="GeoPoint{T}.comparer"/>)
-    /// of <paramref name="other"/>. See <see cref="IsApproximately(GeoVector{T}, T)"/> for the full rationale
-    /// and usage guidance.
+    /// Determines whether this vector is within the default tolerance of <paramref name="other"/>.
+    /// See <see cref="IsApproximately(GeoVector{T}, T)"/> for the full rationale and usage guidance.
     /// </summary>
     /// <param name="other">The vector to compare with this instance.</param>
     /// <returns><see langword="true"/> if both vectors are within the default tolerance; otherwise <see langword="false"/>.</returns>
@@ -573,14 +598,23 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <summary>
     /// Determines whether two geographic vectors are equal.
     /// </summary>
-    public static bool operator ==(GeoVector<T>? left, GeoVector<T>? right)
-            => left?.Equals(right) ?? right is null;
+    public static bool operator ==(GeoVector<T> left, GeoVector<T> right) => left.Equals(right);
 
     /// <summary>
     /// Determines whether two geographic vectors are not equal.
     /// </summary>
-    public static bool operator !=(GeoVector<T>? left, GeoVector<T>? right)
-            => !(left?.Equals(right) ?? right is null);
+    public static bool operator !=(GeoVector<T> left, GeoVector<T> right) => !left.Equals(right);
+
+    /// <summary>
+    /// Returns this geographic vector as a string in the format "Latitude, Longitude, Bearing"
+    /// with five decimal places by default.
+    /// </summary>
+    public override string ToString() => ToString("0.#####", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Returns this geographic vector as a string in the specified format and the invariant culture.
+    /// </summary>
+    public string ToString(string format) => ToString(format, null);
 
     /// <summary>
     /// Returns a string representation of the vector using the specified format and provider.
@@ -588,15 +622,14 @@ public sealed class GeoVector<T> : GeoPoint<T>, IEquatable<GeoVector<T>>, IUnary
     /// <param name="format">Format string applied to latitude, longitude, and bearing.</param>
     /// <param name="formatProvider">Culture-specific format provider.</param>
     /// <returns>A formatted string representing the vector.</returns>
-    public override string ToString(string? format, IFormatProvider? formatProvider)
+    public string ToString(string? format, IFormatProvider? formatProvider)
     {
         formatProvider ??= CultureInfo.InvariantCulture;
         var textInfo = formatProvider.GetFormat(typeof(TextInfo)) as TextInfo;
 
         // Example: "Latitude, Longitude, Bearing"
-        return $"{base.ToString(format, formatProvider)}{textInfo?.ListSeparator ?? ","} {Bearing:##0.##}";
+        return $"{Point.ToString(format, formatProvider)}{textInfo?.ListSeparator ?? ","} {Bearing:##0.##}";
     }
 
     #endregion
 }
-#pragma warning restore CA2260

--- a/Utils.Geography/Geography/Model/MapPosition.cs
+++ b/Utils.Geography/Geography/Model/MapPosition.cs
@@ -33,11 +33,9 @@ public sealed class MapPosition<T> : IEquatable<MapPosition<T>>, IEqualityOperat
     /// </summary>
     /// <param name="geoPoint">The geographical coordinates of the map center.</param>
     /// <param name="zoomLevel">The zoom level of the map.</param>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="geoPoint"/> is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="zoomLevel"/> is less than or equal to 0.</exception>
     public MapPosition(GeoPoint<T> geoPoint, byte zoomLevel)
     {
-        geoPoint.Arg().MustNotBeNull();
         zoomLevel.ArgMustBeGreaterThan((byte)0);
 
         this.GeoPoint = geoPoint;
@@ -58,13 +56,12 @@ public sealed class MapPosition<T> : IEquatable<MapPosition<T>>, IEqualityOperat
     public bool Equals(MapPosition<T>? other)
     {
         if (other is null) return false;
-        if (this.GeoPoint is null) return other.GeoPoint is null;
 
         return this.GeoPoint.Equals(other.GeoPoint) && this.ZoomLevel == other.ZoomLevel;
     }
 
     /// <inheritdoc />
-    public override int GetHashCode() => ObjectUtils.ComputeHash(this.GeoPoint?.GetHashCode() ?? 0, this.ZoomLevel);
+    public override int GetHashCode() => ObjectUtils.ComputeHash(this.GeoPoint.GetHashCode(), this.ZoomLevel);
 
     /// <summary>
     /// Equality operator for comparing two <see cref="MapPosition{T}"/> instances.

--- a/Utils.Geography/README.md
+++ b/Utils.Geography/README.md
@@ -102,7 +102,10 @@ double lonSpan = bbox.LongitudeSpan;         // 0.3
 
 ## GeoVector examples
 
-`GeoVector<T>` extends `GeoPoint<T>` with a bearing, representing a point and direction.
+`GeoVector<T>` wraps a `GeoPoint<T>` (its `Point` property) plus a bearing, representing a point and
+direction. It composes a `GeoPoint<T>` rather than inheriting from it — a vector "has a" position, it
+isn't itself a point — so `Latitude`/`Longitude`/`φ`/`λ` remain available as convenience aliases forwarding
+to `Point`.
 
 ### Construction
 

--- a/Utils.Geography/TODO.md
+++ b/Utils.Geography/TODO.md
@@ -163,15 +163,23 @@ explicite en ce sens.
   type `int` était trop étroit pour un usage réaliste) ; `MapPoint` calcule aussi sa taille de carte en
   `long` directement. Testé : `GetMapSizeDoesNotOverflowAtHighZoomLevels`.
 
-### Avertissement analyseur CA2260 sur `GeoVector<T>` (supprimé via pragma)
+### Avertissement analyseur CA2260 sur `GeoVector<T>` (résolu, 2026-07-10 : composition + struct)
 `GeoVector<T> : GeoPoint<T>, IEqualityOperators<GeoVector<T>, GeoVector<T>, bool>` — l'analyseur
-signale que `GeoPoint<T>` (qui implémente lui-même `IEqualityOperators<GeoPoint<T>, GeoPoint<T>,
-bool>`) attend que `T` soit rempli par le type dérivé (CRTP), ce qui n'est pas le cas ici puisque
-`GeoVector<T>` hérite classiquement de `GeoPoint<T>` plutôt que de `GeoPoint<GeoVector<T>>`. Corriger
-proprement demanderait de transformer `GeoPoint<T>` en `GeoPoint<TSelf, T>` (CRTP) — un changement
-d'API cassant pour tous les consommateurs, jugé disproportionné pour un warning informatif sans impact
-fonctionnel connu. **Décision** : `#pragma warning disable/restore CA2260` autour de la classe, avec un
-commentaire expliquant pourquoi.
+signalait que `GeoPoint<T>` (qui implémente lui-même `IEqualityOperators<GeoPoint<T>, GeoPoint<T>,
+bool>`) attendait que `T` soit rempli par le type dérivé (CRTP), ce qui n'était pas le cas ici puisque
+`GeoVector<T>` héritait classiquement de `GeoPoint<T>` plutôt que de `GeoPoint<GeoVector<T>>`.
+**Résolu** : `GeoVector<T>` et `GeoPoint<T>` ont été transformés en `readonly struct` indépendants ;
+`GeoVector<T>` compose désormais un `GeoPoint<T>` (propriété `Point`) plutôt que d'en hériter — une
+struct ne peut de toute façon pas hériter, donc CA2260 ne se pose plus. Le pragma a été supprimé.
+Cette refonte corrige aussi un bug réel que l'héritage masquait : `GeoPoint<T>.Equals(object?)`
+matche `obj is GeoPoint<T>`, donc comparer un `GeoPoint<T>` brut à un `GeoVector<T>` aux mêmes
+coordonnées les déclarait égaux en ignorant silencieusement le bearing, alors que leurs
+`GetHashCode()` respectifs (lat/lon vs lat/lon/bearing) différaient — un contrat Equals/GetHashCode
+cassé pour tout `Dictionary`/`HashSet` mélangeant les deux types. Composition + struct rend ce
+mélange impossible : les deux types sont désormais sans relation. Voir aussi les tests mis à jour
+dans `GeoPointTests.cs`/`GeoVectorTests.cs` (pattern `TryParse(out T result)` non-nullable idiomatique
+des structs, suppression des tests `null` désormais impossibles à écrire pour des paramètres struct
+non-nullables).
 
 ## Documentation mise à jour
 - `LambertAzimuthalEqualArea<T>` : la XML doc ne précisait pas que cette implémentation est l'aspect

--- a/UtilsTest/Geography/GeoPointTests.cs
+++ b/UtilsTest/Geography/GeoPointTests.cs
@@ -62,9 +62,8 @@ namespace UtilsTest.Geography
         {
             foreach (var point in points)
             {
-                bool ok = GeoPoint<double>.TryParse(point.coordinates, out GeoPoint<double>? result);
+                bool ok = GeoPoint<double>.TryParse(point.coordinates, out GeoPoint<double> result);
                 Assert.IsTrue(ok);
-                Assert.IsNotNull(result);
                 Assert.AreEqual(point.latitude, result.Latitude, 1e-9);
                 Assert.AreEqual(point.longitude, result.Longitude, 1e-9);
             }
@@ -73,9 +72,9 @@ namespace UtilsTest.Geography
         [TestMethod]
         public void TryParse_InvalidCoordinates_ReturnsFalse()
         {
-            bool ok = GeoPoint<double>.TryParse("not a coordinate", out GeoPoint<double>? result);
+            bool ok = GeoPoint<double>.TryParse("not a coordinate", out GeoPoint<double> result);
             Assert.IsFalse(ok);
-            Assert.IsNull(result);
+            Assert.AreEqual(default, result);
         }
 
         [TestMethod]

--- a/UtilsTest/Geography/GeoVectorTests.cs
+++ b/UtilsTest/Geography/GeoVectorTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -184,13 +183,6 @@ namespace UtilsTest.Geography
         }
 
         [TestMethod]
-        public void RecenterOnNullThrows()
-        {
-            var vector = new GeoVector<double>(45, 30, 90);
-            Assert.ThrowsException<ArgumentNullException>(() => vector.Recenter(null!));
-        }
-
-        [TestMethod]
         public void RecenterMapsOtherPointToNewLatitudeEqualToAngularDistance()
         {
             var reference = new GeoVector<double>(0, 0, 90);
@@ -198,7 +190,7 @@ namespace UtilsTest.Geography
 
             var recentered = reference.Recenter(other);
 
-            Assert.AreEqual(reference.AngleWith(other), recentered.Latitude, 1e-9);
+            Assert.AreEqual(reference.Point.AngleWith(other.Point), recentered.Latitude, 1e-9);
         }
 
         [TestMethod]

--- a/UtilsTest/Geography/MapPositionTests.cs
+++ b/UtilsTest/Geography/MapPositionTests.cs
@@ -8,12 +8,6 @@ namespace UtilsTest.Geography;
 public class MapPositionTests
 {
     [TestMethod]
-    public void ConstructorRejectsNullGeoPoint()
-    {
-        Assert.ThrowsException<ArgumentNullException>(() => new MapPosition<double>(null!, 5));
-    }
-
-    [TestMethod]
     public void ConstructorRejectsZeroZoomLevel()
     {
         var point = new GeoPoint<double>(0, 0);

--- a/UtilsTest/Geography/PlanetTests.cs
+++ b/UtilsTest/Geography/PlanetTests.cs
@@ -88,11 +88,11 @@ public class PlanetTests
 
         var vector1 = new GeoVector<double>(paris, newyork);
         Assert.AreEqual(291.7, vector1.Bearing, 0.1);
-        Assert.AreEqual(newyork, new GeoPoint<double>(earth.Travel(vector1, earth.Distance(paris, newyork))));
+        Assert.AreEqual(newyork, earth.Travel(vector1, earth.Distance(paris, newyork)).Point);
 
         var vector2 = new GeoVector<double>(baghdad, osaka);
         Assert.AreEqual(60.1, vector2.Bearing, 0.1);
-        Assert.AreEqual(osaka, new GeoPoint<double>(earth.Travel(vector2, earth.Distance(baghdad, osaka))));
+        Assert.AreEqual(osaka, earth.Travel(vector2, earth.Distance(baghdad, osaka)).Point);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- `GeoVector<T>` now composes a `GeoPoint<T>` (new `Point` property) instead of inheriting from it, and both types are converted from classes to `readonly struct`.
- Fixes a real bug the inheritance hid: `GeoPoint<T>.Equals(object?)` matched any `GeoPoint<T>`-derived instance, so comparing a bare `GeoPoint<T>` to a `GeoVector<T>` at the same coordinates reported them equal while silently ignoring the bearing — and their `GetHashCode()` values (lat/lon vs lat/lon/bearing) could differ, breaking the `Equals`/`GetHashCode` contract for any `Dictionary`/`HashSet` mixing both types.
- Removes the `#pragma warning disable CA2260` on `GeoVector<T>`: the CRTP conflict the analyzer flagged no longer exists once `GeoVector` stops extending `GeoPoint`.
- `GeoPoint<T>.TryParse` switches from a nullable `out GeoPoint<T>? result` to the idiomatic struct pattern `out GeoPoint<T> result` (default value on failure), matching BCL conventions like `double.TryParse`.
- `protected` members on `GeoPoint<T>` became `internal`/`private` (structs can't have `protected` members, having no inheritance); `MapPosition<T>`'s now-meaningless null checks on its `GeoPoint<T>` field were removed.

## Test plan
- [x] `dotnet build Utils.Geography/Utils.Geography.csproj` — 0 errors
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter "FullyQualifiedName~Geography"` — 100/100 passing
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` (full suite) — 3476 passing, 3 ignored (pre-existing), 0 failing
- [x] Two tests exercising "throws on null" for now-non-nullable struct parameters (`GeoVectorTests.RecenterOnNullThrows`, `MapPositionTests.ConstructorRejectsNullGeoPoint`) were removed, since passing `null!` to them is now a compile-time error (CS0037), not a runtime behavior to test.

Generated with Claude Code
