### PR TITLE
docs(Utils.Fonts): add quality audit TODO with proposed fixes

### DIFF
--- a/Utils.Fonts/TODO.md
+++ b/Utils.Fonts/TODO.md
@@ -1,0 +1,186 @@
+# Utils.Fonts — Audit qualité (2026-07-10)
+
+Audit complet du package : conformité AGENTS.md, bugs, dette technique, couverture de tests.
+Package : parsing/écriture de polices PostScript (`Utils.Fonts/PostScript/`) et TrueType/OpenType
+(`Utils.Fonts/TTF/`). Propositions ci-dessous, aucune n'est encore corrigée.
+
+## Bugs fonctionnels (priorité haute)
+
+### 1. `CmapTable.ReadData` — décalage d'indice dans le calcul des longueurs de sous-table
+`Utils.Fonts/TTF/Tables/CmapTable.cs:171-181`
+Le calcul `subTables[i] = (platformID, platformSpecificID, offset, offset - lastOffset)`, avec
+`lastOffset` mis à jour *après* l'assignation, attribue à la sous-table `i` la longueur
+`offset[i] - offset[i-1]` — c'est-à-dire la taille de la sous-table `i-1`, pas celle de `i`. Pour
+toute police avec plus d'une sous-table cmap (cas très courant : Windows-Unicode + Mac-Roman, ou
+symbol + BMP), les slices passées à `CMapFormatBase.GetMap` ont la mauvaise longueur, ce qui peut
+tronquer la dernière sous-table ou décaler la lecture des autres.
+**Fix proposé** : calculer `length[i] = offset[i+1] - offset[i]` (ou `dataLength_de_la_table - offset[i]`
+pour la dernière sous-table), avec un offset "suivant" plutôt que "précédent".
+
+### 2. `CMapFormat4.WriteData` — troncature des indices de glyphe sur 1 octet au lieu de 2
+`Utils.Fonts/TTF/Tables/Cmap/CMapFormat4.cs:376-379`
+Dans la boucle qui écrit le tableau de correspondance d'un `TableMap`, `data.Write<Byte>((byte)index)`
+écrit un seul octet alors que le format cmap 4 stocke des `uint16` par entrée (et `TableMap.Length`
+déclare bien `Map.Count * sizeof(short)`). Toute police avec plus de 255 glyphes et une sous-table à
+correspondance explicite produira un flux cmap corrompu en écriture (glyphIdArray tronqué +
+désalignement de tout ce qui suit).
+**Fix proposé** : `data.Write<Int16>(index)`.
+
+### 3. `CMapFormat4.WriteData` — calcul de `glyphArrayOffset` incohérent avec l'écriture réelle
+`Utils.Fonts/TTF/Tables/Cmap/CMapFormat4.cs:367-382`
+`glyphArrayOffset += tableMap.Map.Count * 2` suppose 2 octets par entrée alors que la boucle
+d'écriture correspondante (item 2) n'en écrit qu'un actuellement. À corriger conjointement avec
+l'item 2, puis revalider avec un test d'aller-retour (plusieurs `TableMap` consécutifs).
+
+### 4. `GlyphSimple.WriteData` — tailles d'octets inversées par rapport à `ReadData`/`GetFlags`
+`Utils.Fonts/TTF/Tables/Glyf/GlyphSimple.cs:237-259`
+La fonction locale `Write` fait : si `isByte` est posé, écrit un `Int16` (2 octets) quand `isSame`
+est aussi posé, et rien sinon ; si `isByte` n'est pas posé, écrit un seul octet. C'est l'inverse de
+la logique de `ReadData`/`GetFlags`, où `XIsByte`/`YIsByte` signifie "1 octet" et son absence
+signifie "2 octets (`Int16`)". Toute écriture de glyphe simple produit donc un flux `glyf` binaire
+cassé (tailles ne correspondant pas aux flags écrits), rendant `WriteFont()` invalide pour toute
+police TrueType contenant des contours. Aucun test ne couvre `GlyphSimple.WriteData`/round-trip,
+d'où le passage inaperçu.
+**Fix proposé** : inverser la logique — `isByte` posé ⇒ écrire un octet (signe selon `isSame`),
+sinon ⇒ écrire `Int16`.
+
+### 5. `PostMapFormat0.stdNames[63]` — nom de glyphe erroné
+`Utils.Fonts/TTF/Tables/PostTable.cs:73` : `"ackslash"` au lieu de `"backslash"`.
+Casse la correspondance nom↔index standard Macintosh pour l'index 63 (`getGlyphNameIndex("backslash")`
+retourne 0/`.notdef` au lieu de 63). **Fix proposé** : corriger la faute de frappe.
+
+### 6. `PostMapFormat2.WriteData` — `Seek(0)` parasite en fin d'écriture
+`Utils.Fonts/TTF/Tables/PostTable.cs:203-215`
+Après avoir écrit `glyphNameIndex` et les noms de glyphes, la méthode fait
+`data.Seek(0, SeekOrigin.Begin)`, repositionnant le flux au tout début. Si `PostTable.WriteData`
+(ou l'appelant `TrueTypeFont.WriteFont`) écrit autre chose après cet appel dans le même flux, les
+données précédentes seront écrasées. Ressemble à un artefact de debug oublié.
+**Fix proposé** : supprimer cette ligne.
+
+### 7. `TtfEncoderFactory.GetEncoding` — confusion entre `TtfLanguageID` et code page Windows
+`Utils.Fonts/TTF/TtfEncoderFactory.cs:23-47`
+Pour les plateformes Macintosh et Microsoft, le code appelle `Encoding.GetEncoding((int)languageID)`
+en traitant l'identifiant de langue TrueType (ex. `MS_English_United_States = 1033`, un LCID
+Windows) comme un *code page* .NET. Ce comportement erroné est déjà documenté par le test
+`TtfEncoderFactoryTests.Microsoft_InvalidCodePage_FallsBackToAscii` ("1033 is a Windows LCID, not a
+valid code page"), qui se contente de vérifier le repli sur ASCII plutôt que de corriger la
+logique. En pratique, quasiment tous les enregistrements `name`/`post` avec un LanguageID Microsoft
+réaliste tombent en ASCII, corrompant silencieusement les métadonnées non-ASCII (accents, CJK, etc.)
+lues via `NameTable.ReadData`/`WriteData`.
+**Fix proposé** : construire une vraie table de correspondance LanguageID→Encoding (ou a minima
+PlatformID/PlatformSpecificID→Encoding, le triplet réellement pertinent selon la spec OpenType — le
+languageID seul ne détermine pas l'encodage).
+
+### 8. `TtfHinting.MovePoint`/`ScalePoints` — troncature des coordonnées de points en `short`
+`Utils.Fonts/TTF/TtfHinting.cs:61-83`
+`TTFPoint` stocke `X`/`Y` en `float`, mais `MovePoint` et `ScalePoints` reconstruisent le point avec
+`(short)(pt.Y + delta)` / `(short)(pt.X * scale)`. Toute fraction de pixel introduite par le hinting
+est perdue immédiatement, à l'encontre de l'objet même du hinting (ajustements sous-pixel). Portée
+limitée : `TtfHinting` semble être une infrastructure expérimentale sans appelant de production
+identifié.
+**Fix proposé** : conserver le résultat en `float`, sans cast intermédiaire vers `short`.
+
+## Dette technique / non-conformité AGENTS.md
+
+### 9. `using static System.Net.Mime.MediaTypeNames;` inutilisé et trompeur
+`Utils.Fonts/TTF/TrueTypeFont.cs:11`
+Directive non utilisée dans le fichier (probablement un artefact d'auto-complétion IDE important
+`Text`/`Application` depuis un espace de noms sans rapport). **Fix proposé** : supprimer.
+
+### 10. Code mort — implémentation ACNT parallèle et non branchée
+`Utils.Fonts/TTF/Tables/Acnt/AcntFormatBase.cs`, `AcntFormat0.cs`, `AcntFormat1.cs`
+Ces trois classes forment une implémentation alternative, simplifiée et non testée du format ACNT,
+distincte de `AcntTable` (hiérarchie `AccentDescription.Single`/`Multiple`, testée par
+`AcntTableTests.cs`). Aucune n'est référencée en dehors du dossier `Acnt/` — ni `[TTFTable]`, ni
+appelée par `TrueTypeFont`.
+**Fix proposé** : supprimer le dossier `TTF/Tables/Acnt/` (3 fichiers), ou documenter explicitement
+pourquoi il est conservé.
+
+### 11. `NameTable.WriteData` — positionnement du flux non garanti en fin d'écriture
+`Utils.Fonts/TTF/Tables/NameTable.cs:200-225`
+Chaque enregistrement de nom est écrit via `Push()`/`Seek(6+12*Count+offset)`/écriture/`Pop()`, mais
+après la boucle, la position du flux reste juste après le dernier enregistrement d'en-tête (pas à la
+fin des données de chaîne). Ça fonctionne actuellement par accident de l'implémentation de
+`MemoryStream` (qui s'étend correctement via `Seek`+écritures), mais c'est fragile et non documenté.
+**Fix proposé** : documenter l'invariant, ou repositionner explicitement `data.Position` à la fin du
+bloc de chaînes avant de retourner.
+
+### 12. Style — tableau non-bracket dans `PostMapFormat0.stdNames`
+`Utils.Fonts/TTF/Tables/PostTable.cs:65` : `protected internal string[] stdNames = { ... }` utilise
+l'initialiseur `{ }` au lieu de la syntaxe crochets `[ ]` requise par AGENTS.md.
+**Fix proposé** : `= [ ... ]`.
+
+### 13. `params (float x, float y)[] points` / `params TableTypes.Tags[] dependsOn` non conformes
+`Utils.Fonts/IFont.cs:90`, `Utils.Fonts/TTF/TTFTableAttribute.cs:19`
+Ces deux paramètres sont lus séquentiellement sans accès indexé nécessaire ; AGENTS.md demande de
+préférer `params IEnumerable<T>` dans ce cas. Impact réel très faible (API publique déjà stable),
+signalé pour cohérence avec les changements déjà appliqués ailleurs dans `Utils/`
+(`EnumerableEx`/`Bytes`).
+
+### 14. Duplication de constantes de recherche binaire AAT (`searchRange`/`entrySelector`/`rangeShift`)
+Répétée quasi identiquement dans `KernTable.WriteData`, `BslnTable.WriteLookupTableFormat6`,
+`LcarTable.WriteData`, `OpbdTable.WriteData`, `PropTable.WriteLookupTableFormat6` (5 occurrences du
+même calcul `BitOperations.Log2`/`searchRange`/`entrySelector`/`rangeShift`).
+**Fix proposé** : factoriser dans une méthode statique partagée (ex.
+`AatBinarySearchHeader.Compute(int unitCount, int unitSize)`), pour éviter qu'un futur correctif ne
+soit appliqué qu'à un sous-ensemble des tables.
+
+### 15. Documentation XML manquante sur certains membres internes de collections
+Ex. `LocaTable` : les champs privés `headTable`/`maxpTable`/`offsets` n'ont pas de doc XML,
+contrairement à d'autres tables du même fichier (`HmtxTable.advanceWidths`/`leftSideBearings`,
+`VmtxTable.advanceHeights`/`topSideBearings`, qui en ont). Application inconsistante plutôt
+qu'absente partout — suggère un passage de conformité partiel déjà fait.
+
+## Manque de test (pas un bug, mais racine de plusieurs bugs ci-dessus)
+
+### 16. Aucun test de round-trip sur les tables TTF "cœur" — priorité haute
+Tables concernées : `Cmap`, `Glyf`, `Hmtx`, `Kern`, `Name`, `Loca`, `Maxp`, `Hhea`, `Vmtx`, `Post`.
+Seul `TrueTypeFontTests.LoadFontGlyphTest` exerce indirectement `CmapTable`/`GlyfTable`/`HmtxTable`
+en lecture (via `TrueTypeFont.GetGlyph('a')` sur une police Arial embarquée), sans jamais vérifier
+`WriteData`/round-trip, ni les cas à plusieurs sous-tables cmap, ni `KernTable.GetSpacingCorrection`,
+ni `NameTable`/`PostTable`. C'est précisément la zone où se cachaient les bugs 1 à 6 : un test de
+round-trip (`ParseFont` → `WriteFont` → `ParseFont`, comparer les valeurs) sur une police réelle
+multi-glyphes aurait très probablement détecté les bugs 2 et 4.
+**Fix proposé** : ajouter des tests dédiés par table dans `UtilsTest.Functional/Fonts/`, en
+particulier un test d'aller-retour bit-exact sur `TrueTypeFont.WriteFont()`.
+
+### 17. Aucun test pour `Type3Font`, `Type42Font`, `CidKeyedFont`
+`Utils.Fonts/PostScript/Type3Font.cs`, `Type42Font.cs`, `CidKeyedFont.cs`
+Seul `PostScriptFont` est couvert (`UtilsTest.Functional/Fonts/PostScriptFontTests.cs`). Les trois
+autres classes du même répertoire — dont deux (`Type3Font`, `CidKeyedFont`) contiennent une logique
+de parsing regex+charstring non triviale largement dupliquée depuis `PostScriptFont` — n'ont aucune
+couverture.
+
+### 18. Aucun test pour les tables AAT restantes
+Tables concernées : `Feat`, `Fdsc`, `Fmtx`, `Lcar`, `Opbd`, `Prop`, `Trak`, `Hdmx`. Toutes bien
+conçues et cohérentes à la lecture, mais sans fichier de test dédié, contrairement à leurs pairs déjà
+testés (`AcntTableTests`, `AvarTableTests`, `BslnTableTests`, `CvarTableTests`, `FvarTableTests`,
+`GaspTableTests`, `LtshTableTests`, `Os2TableTests`, `PcltTableTests`, `VheaTableTests`,
+`DsigTableTests`). Vu la cohérence de style avec les tables déjà testées, probablement un oubli
+plutôt qu'un choix — bonne opportunité de compléter la suite existante par symétrie.
+
+### 19. `CvtTable`/`FpgmTable`/`PrepTable` sans test
+Ces trois tables (bytecode brut) sont fonctionnellement triviales et sans bug détecté, mais sans
+aucun test dédié ni indirect. Risque faible vu la simplicité du code.
+
+### 20. `TtfHinting.cs` (`TtfHintingContext`/`TtfHintingProcessor`) sans aucun test
+Aucune référence dans les dossiers de test. Combiné à l'item 8 (troncature `short`), cette
+infrastructure semble non exercée en pratique.
+
+## Résumé priorisé
+
+| # | Sévérité | Fichier |
+|---|---|---|
+| 4 | Bug fonctionnel majeur | `GlyphSimple.cs` (WriteData round-trip cassé) |
+| 1 | Bug fonctionnel | `CmapTable.cs` (longueurs de sous-table décalées) |
+| 2, 3 | Bug fonctionnel | `CMapFormat4.cs` (troncature glyph index en écriture) |
+| 7 | Bug fonctionnel connu/documenté | `TtfEncoderFactory.cs` (LCID confondu avec code page) |
+| 6 | Bug fonctionnel potentiel | `PostTable.cs` (`Seek(0)` parasite) |
+| 5 | Bug fonctionnel mineur | `PostTable.cs` (typo "ackslash") |
+| 8 | Bug fonctionnel (portée limitée) | `TtfHinting.cs` (troncature `short`) |
+| 16 | Manque de test (racine des bugs 1-6) | Cmap/Glyf/Hmtx/Kern/Name/Loca/Maxp/Hhea/Vmtx/Post |
+| 17 | Manque de test | Type3Font/Type42Font/CidKeyedFont |
+| 10 | Dette technique | `Acnt/` (code mort) |
+| 9, 12, 13 | Cosmétique | using inutile, initialiseur de tableau, params |
+| 11, 14, 15 | Dette technique mineure | position flux NameTable, duplication AAT header, docs incomplètes |
+| 18, 19, 20 | Manque de test | tables AAT restantes, Cvt/Fpgm/Prep, TtfHinting |


### PR DESCRIPTION
## Summary
- Adds `Utils.Fonts/TODO.md`, a quality audit of the package: AGENTS.md conformance plus manual bug hunting on the binary TrueType/PostScript parsing code.
- Documents proposals only — nothing is fixed yet in this PR.
- Highlights of what the audit found (see file for full detail, file/line references, and proposed fixes):
  - Several real functional bugs: `CmapTable` sub-table length off-by-one, `CMapFormat4.WriteData` truncating glyph indices to 1 byte instead of 2, `GlyphSimple.WriteData` byte/Int16 flags inverted (breaks `WriteFont()` round-trip for any glyph with contours), a `PostTable` typo (`"ackslash"`) and a stray `Seek(0)` that could clobber later stream writes, `TtfEncoderFactory` confusing a TrueType LanguageID (LCID) with a .NET code page, and `TtfHinting` truncating hint deltas to `short`.
  - Dead code (`TTF/Tables/Acnt/AcntFormat0.cs`/`AcntFormat1.cs`/`AcntFormatBase.cs`, unreferenced elsewhere) and minor AGENTS.md style gaps.
  - Test coverage gaps that are the likely root cause the functional bugs went unnoticed: no round-trip test on the core TTF tables (Cmap/Glyf/Hmtx/Kern/Name/Loca/Maxp/Hhea/Vmtx/Post), and no tests at all for `Type3Font`/`Type42Font`/`CidKeyedFont`.

## Test plan
- Documentation-only change (new TODO.md); no code behavior changed, so no new tests apply here.
- Follow-up PRs will implement individual items from the TODO list, each with its own tests, following the same pattern as the `Utils.Geography`/`Utils.Reflection` audits.

Generated with Claude Code
