### PR TITLE
fix(Utils.Fonts): kerning glyph-index resolution + compound glyph transform/write bugs

### DIFF
--- a/Utils.Fonts/TODO.md
+++ b/Utils.Fonts/TODO.md
@@ -356,6 +356,10 @@ choisit des paires où le code caractère ASCII coïncide par construction avec 
 via `cmap` avant d'appeler `kernTable.GetSpacingCorrection` ; `KernTable.GetSpacingCorrection`
 devrait accepter des `ushort` (glyph index) plutôt que des `char`.
 **Sévérité** : bug fonctionnel (kerning silencieusement incorrect sur toute police réelle non triviale).
+**Corrigé.** `TrueTypeFont` factorise la résolution char→glyph index (`ResolveGlyphIndex`, partagée
+avec `GetGlyph`) et `GetSpacingCorrection` l'utilise avant d'interroger `KernTable`, dont la
+signature accepte désormais des `ushort` (glyph index) plutôt que des `char`. Test :
+`TrueTypeFontTests.GetSpacingCorrection_ResolvesCharactersToGlyphIndicesViaCmap`.
 
 ### 2. `GlyphCompound.ComputeTransform` — mauvaise paire de coefficients pour `AdjustY`
 `Utils.Fonts/TTF/Tables/Glyf/GlyphCompound.cs:84-97`.
@@ -371,6 +375,9 @@ doublement de `AdjustY` (33/65535) se déclenche sur la mauvaise condition.
 **Sévérité** : bug fonctionnel (portée limitée aux glyphes composites avec cisaillement asymétrique
 — rare mais réel). *À revalider contre la spec primaire avant application, la formule exacte des
 indices matriciels est subtile.*
+**Corrigé** : `Math.Abs(Math.Abs(M21) - Math.Abs(M22)) < limit` pour la branche `AdjustY`, avec un
+`<remarks>` documentant la correspondance a/b/c/d (spec) ↔ M11/M21/M12/M22 (code). Test :
+`GlyphCompoundTests.Transform_ScaledOffset_AdjustYUsesCorrectCoefficientPair`.
 
 ### 3. `GlyphCompound.Transform` — mise à l'échelle inconditionnelle de l'offset de translation
 `Utils.Fonts/TTF/Tables/Glyf/GlyphCompound.cs:113-118`.
@@ -388,12 +395,22 @@ n'appliquer `AdjustX`/`AdjustY` à la translation que si `ScaledComponentOffset`
 posé (ne pas les appliquer par défaut, pour matcher le comportement de facto standard).
 **Sévérité** : bug fonctionnel (positionnement incorrect des glyphes composites accentués/composés
 dès qu'une échelle est présente — cas courant pour les caractères accentués Latin).
+**Corrigé** : `Transform` ne multiplie plus l'offset par `AdjustX`/`AdjustY` que si
+`ScaledComponentOffset` est posé (les flags viennent d'être ajoutés, item 4). Test :
+`GlyphCompoundTests.Transform_NeitherScaledNorUnscaledFlagSet_OffsetIsNotScaled`.
+
+En corrigeant les items 2/3, découverte d'un bug plus sévère dans la même classe, absent des deux
+audits : **`GlyphCompound` n'avait aucun `WriteData`/`Length`**, héritant silencieusement de
+l'implémentation `GlyphBase` (en-tête 10 octets seul) — écrire un glyphe composite (caractères
+accentués, ligatures...) produisait des données tronquées/corrompues. Ajouté. Test :
+`GlyphCompoundTests.ReadThenWrite_SingleComponent_ProducesIdenticalBytes`.
 
 ### 4. `CompoundGlyfFlags` — flags `SCALED_COMPONENT_OFFSET`/`UNSCALED_COMPONENT_OFFSET` manquants
 `Utils.Fonts/Enums.cs:216-267`. Conséquence directe de l'item 3 : l'énumération ne déclare que 10
 des 12 flags du spec glyf composite (il manque les bits 0x0800 et 0x1000).
 **Fix proposé** : ajouter `ScaledComponentOffset = 0x0800` et `UnscaledComponentOffset = 0x1000`.
 **Sévérité** : dette technique (prérequis du fix de l'item 3).
+**Corrigé.**
 
 ## Dette technique / non-conformité AGENTS.md
 
@@ -452,6 +469,8 @@ rendue vérifiée) les aurait détectés.
 l'item 2, (c) test du flag `SCALED_COMPONENT_OFFSET`/`UNSCALED_COMPONENT_OFFSET` une fois l'item 3
 corrigé.
 **Sévérité** : manque de test (racine des bugs 2 et 3).
+**Corrigé.** `GlyphCompoundTests.cs` ajouté (round-trip byte-exact, offset non scellé, cisaillement
+asymétrique via le flag `ScaledComponentOffset`).
 
 ### 11. Aucun test ne couvre `KernTable.GetSpacingCorrection` avec un glyph index ≠ code caractère
 `UtilsTest.Functional/Fonts/KernTableTests.cs` — le test existant choisit des valeurs où code
@@ -460,6 +479,8 @@ caractère == glyph index par construction, masquant le bug de l'item 1 plutôt 
 caractère, pour vérifier que `TrueTypeFont.GetSpacingCorrection` résout bien l'index avant
 d'interroger `KernTable`.
 **Sévérité** : manque de test (aurait révélé le bug 1 immédiatement).
+**Corrigé.** Test ajouté :
+`TrueTypeFontTests.GetSpacingCorrection_ResolvesCharactersToGlyphIndicesViaCmap`.
 
 ### 12. Aucun test de round-trip bit-exact sur `TrueTypeFont.WriteFont()` complet
 Toujours pas traité malgré la mention explicite dans la section précédente (item 16, "reste : round-

--- a/Utils.Fonts/TTF/Enums.cs
+++ b/Utils.Fonts/TTF/Enums.cs
@@ -263,7 +263,21 @@ public enum CompoundGlyfFlags : short
     /// <summary>
     /// Components overlap.
     /// </summary>
-    OverlapCompound = 0x0400
+    OverlapCompound = 0x0400,
+
+    /// <summary>
+    /// The component's translation offset should be scaled by the same factor as its
+    /// transformation matrix before being applied. Mutually exclusive with
+    /// <see cref="UnscaledComponentOffset"/>; if neither is set, the offset is used unscaled
+    /// (the de facto convention followed by most font tools and rasterizers).
+    /// </summary>
+    ScaledComponentOffset = 0x0800,
+
+    /// <summary>
+    /// The component's translation offset should be used as-is, without scaling. Mutually
+    /// exclusive with <see cref="ScaledComponentOffset"/>.
+    /// </summary>
+    UnscaledComponentOffset = 0x1000
 }
 
 /// <summary>

--- a/Utils.Fonts/TTF/Tables/Glyf/GlyphCompound.cs
+++ b/Utils.Fonts/TTF/Tables/Glyf/GlyphCompound.cs
@@ -235,6 +235,14 @@ public class GlyphCompound : GlyphBase
     }
 
     /// <summary>
+    /// Gets a value indicating whether any component declared <see cref="CompoundGlyfFlags.HasInstructions"/>,
+    /// meaning a trailing instruction-length word (and instruction bytes) follow the components --
+    /// even when there happen to be zero instruction bytes. Mirrors the condition <see cref="ReadData"/>
+    /// uses to decide whether to read that trailing data.
+    /// </summary>
+    private bool HasInstructionsFlag => Components.Any(c => c.Flags.HasFlag(CompoundGlyfFlags.HasInstructions));
+
+    /// <summary>
     /// Gets the length (in bytes) of the compound-glyph-specific data (components plus any
     /// trailing instructions), on top of the 10-byte header written by <see cref="GlyphBase"/>.
     /// </summary>
@@ -259,7 +267,7 @@ public class GlyphCompound : GlyphBase
                     _ => 0,
                 };
             }
-            if (Instructions.Length > 0)
+            if (HasInstructionsFlag)
             {
                 size += 2 + Instructions.Length;
             }
@@ -310,7 +318,7 @@ public class GlyphCompound : GlyphBase
                 data.Write<Int16>((short)Math.Round(component.M22 * 16384f));
             }
         }
-        if (Instructions.Length > 0)
+        if (HasInstructionsFlag)
         {
             data.Write<UInt16>((ushort)Instructions.Length);
             foreach (byte b in Instructions)

--- a/Utils.Fonts/TTF/Tables/Glyf/GlyphCompound.cs
+++ b/Utils.Fonts/TTF/Tables/Glyf/GlyphCompound.cs
@@ -81,6 +81,15 @@ public class GlyphCompound : GlyphBase
         /// <summary>
         /// Computes the transformation adjustment factors based on the current matrix values.
         /// </summary>
+        /// <remarks>
+        /// Follows the F2Dot14 compensation algorithm from the TrueType/OpenType glyf composite
+        /// glyph spec. In the spec's own naming, the transform matrix is <c>[a c; b d]</c> with
+        /// <c>a</c>=<see cref="M11"/>, <c>b</c>=<see cref="M21"/>, <c>c</c>=<see cref="M12"/>,
+        /// <c>d</c>=<see cref="M22"/> (matching the read order for a full 2x2 matrix and the point
+        /// transform formula in <see cref="Transform(float, float, bool)"/>): <c>m0 = max(|a|,|b|)</c>,
+        /// doubled when <c>||a|-|c|| &lt;= limit</c>; <c>n0 = max(|c|,|d|)</c>, doubled when
+        /// <c>||b|-|d|| &lt;= limit</c>.
+        /// </remarks>
         public virtual void ComputeTransform()
         {
             const float limit = (33f / 65535f);
@@ -90,7 +99,7 @@ public class GlyphCompound : GlyphBase
                 AdjustX *= 2f;
             }
             AdjustY = Math.Max(Math.Abs(M12), Math.Abs(M22));
-            if (Math.Abs(Math.Abs(M12) - Math.Abs(M22)) < limit)
+            if (Math.Abs(Math.Abs(M21) - Math.Abs(M22)) < limit)
             {
                 AdjustY *= 2f;
             }
@@ -110,12 +119,26 @@ public class GlyphCompound : GlyphBase
         /// <param name="y">The y-coordinate to transform.</param>
         /// <param name="onCurve">Indicates whether the point is on the curve.</param>
         /// <returns>A new <see cref="TTFPoint"/> representing the transformed point.</returns>
+        /// <remarks>
+        /// The translation offset (<see cref="TranslateX"/>/<see cref="TranslateY"/>) is only scaled
+        /// by <see cref="AdjustX"/>/<see cref="AdjustY"/> when the component explicitly declares
+        /// <see cref="CompoundGlyfFlags.ScaledComponentOffset"/>. When neither that flag nor
+        /// <see cref="CompoundGlyfFlags.UnscaledComponentOffset"/> is present -- the common case for
+        /// fonts built with Microsoft-oriented tooling -- the offset is used unscaled, matching the
+        /// de facto convention (also followed by FreeType) rather than the historical Apple default
+        /// of always scaling it.
+        /// </remarks>
         public TTFPoint Transform(float x, float y, bool onCurve)
-            => new TTFPoint(
-                M11 * x + M12 * y + AdjustX * TranslateX,
-                M21 * x + M22 * y + AdjustY * TranslateY,
+        {
+            bool scaleOffset = Flags.HasFlag(CompoundGlyfFlags.ScaledComponentOffset);
+            float offsetScaleX = scaleOffset ? AdjustX : 1f;
+            float offsetScaleY = scaleOffset ? AdjustY : 1f;
+            return new TTFPoint(
+                M11 * x + M12 * y + offsetScaleX * TranslateX,
+                M21 * x + M22 * y + offsetScaleY * TranslateY,
                 onCurve
             );
+        }
     }
 
     /// <inheritdoc/>
@@ -209,6 +232,92 @@ public class GlyphCompound : GlyphBase
             instructions = []; // Using target-typed empty array syntax
         }
         Instructions = instructions;
+    }
+
+    /// <summary>
+    /// Gets the length (in bytes) of the compound-glyph-specific data (components plus any
+    /// trailing instructions), on top of the 10-byte header written by <see cref="GlyphBase"/>.
+    /// </summary>
+    /// <exception cref="NullReferenceException">
+    /// Thrown if this glyph has no components (e.g. constructed without calling
+    /// <see cref="ReadData"/>).
+    /// </exception>
+    public override short Length
+    {
+        get
+        {
+            int size = base.Length;
+            foreach (var component in Components)
+            {
+                size += 4; // flags (Int16) + glyphIndex (Int16)
+                size += 4; // translate/point-matching args, always word-sized (2 x Int16)
+                size += component.Flags switch
+                {
+                    var f when f.HasFlag(CompoundGlyfFlags.HasTwoByTwo) => 8,
+                    var f when f.HasFlag(CompoundGlyfFlags.HasXYScale) => 4,
+                    var f when f.HasFlag(CompoundGlyfFlags.HasScale) => 2,
+                    _ => 0,
+                };
+            }
+            if (Instructions.Length > 0)
+            {
+                size += 2 + Instructions.Length;
+            }
+            return (short)size;
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Mirrors the wire format read by <see cref="ReadData"/> exactly, including its limitations:
+    /// point-matching arguments (<see cref="GlyfComponent.CompoundPoint"/>/
+    /// <see cref="GlyfComponent.ComponentPoint"/>) and translation offsets are always written as
+    /// 16-bit words (the <c>ARGS_ARE_WORDS</c> flag is not checked, matching <see cref="ReadData"/>
+    /// not checking it either).
+    /// </remarks>
+    public override void WriteData(Writer data)
+    {
+        base.WriteData(data);
+        foreach (var component in Components)
+        {
+            data.Write<Int16>((short)component.Flags);
+            data.Write<Int16>(component.GlyphIndex);
+            if (component.Flags.HasFlag(CompoundGlyfFlags.ArgsAreXY))
+            {
+                data.Write<Int16>((short)component.TranslateX);
+                data.Write<Int16>((short)component.TranslateY);
+            }
+            else
+            {
+                data.Write<Int16>((short)component.CompoundPoint);
+                data.Write<Int16>((short)component.ComponentPoint);
+            }
+
+            if (component.Flags.HasFlag(CompoundGlyfFlags.HasScale))
+            {
+                data.Write<Int16>((short)Math.Round(component.M11 * 16384f));
+            }
+            else if (component.Flags.HasFlag(CompoundGlyfFlags.HasXYScale))
+            {
+                data.Write<Int16>((short)Math.Round(component.M11 * 16384f));
+                data.Write<Int16>((short)Math.Round(component.M22 * 16384f));
+            }
+            else if (component.Flags.HasFlag(CompoundGlyfFlags.HasTwoByTwo))
+            {
+                data.Write<Int16>((short)Math.Round(component.M11 * 16384f));
+                data.Write<Int16>((short)Math.Round(component.M21 * 16384f));
+                data.Write<Int16>((short)Math.Round(component.M12 * 16384f));
+                data.Write<Int16>((short)Math.Round(component.M22 * 16384f));
+            }
+        }
+        if (Instructions.Length > 0)
+        {
+            data.Write<UInt16>((ushort)Instructions.Length);
+            foreach (byte b in Instructions)
+            {
+                data.WriteByte(b);
+            }
+        }
     }
 
     /// <inheritdoc/>

--- a/Utils.Fonts/TTF/Tables/KernTable.cs
+++ b/Utils.Fonts/TTF/Tables/KernTable.cs
@@ -29,16 +29,18 @@ namespace Utils.Fonts.TTF.Tables
 
         /// <summary>
         /// Retrieves the spacing correction (kerning value) between two glyphs.
-        /// In this simplified implementation, the input characters are treated as glyph indices.
         /// </summary>
-        /// <param name="before">The glyph index of the preceding character.</param>
-        /// <param name="after">The glyph index of the following character.</param>
+        /// <param name="before">The glyph index of the preceding glyph.</param>
+        /// <param name="after">The glyph index of the following glyph.</param>
         /// <returns>The kerning adjustment in font units, or 0 if no kerning pair is found.</returns>
-        public float GetSpacingCorrection(char before, char after)
+        /// <remarks>
+        /// The 'kern' table stores pairs by glyph index, never by character code: callers must
+        /// resolve character codes to glyph indices (e.g. via a 'cmap' subtable) before calling this
+        /// method. <see cref="TrueTypeFont.GetSpacingCorrection(char, char)"/> does this resolution.
+        /// </remarks>
+        public float GetSpacingCorrection(ushort before, ushort after)
         {
-            ushort left = (ushort)before;
-            ushort right = (ushort)after;
-            if (kerningPairs.TryGetValue((left, right), out short value))
+            if (kerningPairs.TryGetValue((before, after), out short value))
             {
                 return value;
             }

--- a/Utils.Fonts/TTF/TrueTypeFont.cs
+++ b/Utils.Fonts/TTF/TrueTypeFont.cs
@@ -426,6 +426,25 @@ public class TrueTypeFont : IFont
     }
 
     /// <summary>
+    /// Resolves a character to its glyph index using the font's 'cmap' table.
+    /// </summary>
+    /// <param name="cmap">The font's cmap table.</param>
+    /// <param name="c">The character to resolve.</param>
+    /// <returns>The glyph index for <paramref name="c"/>, or 0 (<c>.notdef</c>) if no subtable maps it.</returns>
+    private static int ResolveGlyphIndex(CmapTable cmap, char c)
+    {
+        foreach (var map in cmap.CMaps)
+        {
+            int index = map.Map(c);
+            if (index > 0)
+            {
+                return index;
+            }
+        }
+        return 0;
+    }
+
+    /// <summary>
     /// Retrieves the glyph corresponding to the specified character.
     /// </summary>
     /// <param name="c">The character for which to retrieve the glyph.</param>
@@ -435,15 +454,12 @@ public class TrueTypeFont : IFont
         var cmap = GetTable<CmapTable>(TableTypes.CMAP);
         var glyf = GetTable<GlyfTable>(TableTypes.GLYF);
         var hmtx = GetTable<HmtxTable>(TableTypes.HMTX);
-        foreach (var map in cmap.CMaps)
+        int index = ResolveGlyphIndex(cmap, c);
+        if (index > 0)
         {
-            int index = map.Map(c);
-            if (index > 0)
-            {
-                var glyphBase = glyf.GetGlyph(index);
-                if (glyphBase != null)
-                    return new TrueTypeGlyph(glyphBase, hmtx.GetAdvance(index));
-            }
+            var glyphBase = glyf.GetGlyph(index);
+            if (glyphBase != null)
+                return new TrueTypeGlyph(glyphBase, hmtx.GetAdvance(index));
         }
         return null;
     }
@@ -455,14 +471,21 @@ public class TrueTypeFont : IFont
     /// <param name="before">The preceding character.</param>
     /// <param name="after">The following character.</param>
     /// <returns>The spacing correction in font units.</returns>
+    /// <remarks>
+    /// The 'kern' table stores kerning pairs by glyph index, never by character code, so
+    /// <paramref name="before"/> and <paramref name="after"/> are resolved through 'cmap' first
+    /// (the same resolution <see cref="GetGlyph"/> performs) before consulting the kern table.
+    /// </remarks>
     public float GetSpacingCorrection(char before, char after)
     {
         // If the font contains a kern table, retrieve it and use it to compute spacing correction.
         if (ContainsTable(TableTypes.KERN))
         {
-            // Assuming a KernTable type with a GetSpacingCorrection method exists.
+            var cmap = GetTable<CmapTable>(TableTypes.CMAP);
+            ushort beforeGlyph = (ushort)ResolveGlyphIndex(cmap, before);
+            ushort afterGlyph = (ushort)ResolveGlyphIndex(cmap, after);
             var kernTable = GetTable<KernTable>(TableTypes.KERN);
-            return kernTable.GetSpacingCorrection(before, after);
+            return kernTable.GetSpacingCorrection(beforeGlyph, afterGlyph);
         }
         return 0f;
     }

--- a/UtilsTest.Functional/Fonts/GlyphCompoundTests.cs
+++ b/UtilsTest.Functional/Fonts/GlyphCompoundTests.cs
@@ -1,0 +1,170 @@
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Fonts;
+using Utils.Fonts.TTF;
+using Utils.Fonts.TTF.Tables;
+using Utils.Fonts.TTF.Tables.Glyf;
+using Utils.IO.Serialization;
+
+namespace UtilsTest.Fonts;
+
+[TestClass]
+public class GlyphCompoundTests
+{
+    private static readonly RawReader BigEndianReader = new RawReader() { BigEndian = true };
+    private static readonly RawWriter BigEndianWriter = new RawWriter() { BigEndian = true };
+
+    private static Reader MakeReader(byte[] data)
+        => new Reader(new MemoryStream(data), BigEndianReader.ReaderDelegates);
+
+    // Raw bytes for glyph 0: a simple glyph with a single on-curve point at the origin (0,0). Used
+    // as the referenced component in the compound glyphs below, so that a transformed contour point
+    // reduces to exactly (offsetScaleX * TranslateX, offsetScaleY * TranslateY): the M11..M22 terms
+    // vanish because x=y=0, isolating the translation-offset behavior under test.
+    private static byte[] BuildOriginPointGlyphBytes()
+    {
+        using var ms = new MemoryStream();
+        var w = new Writer(ms, BigEndianWriter.WriterDelegates);
+        w.Write<short>(1);  // numberOfContours
+        w.Write<short>(0); w.Write<short>(0); w.Write<short>(0); w.Write<short>(0); // bbox
+        w.Write<short>(0);  // endPtsOfContours[0] -> 1 point
+        w.Write<short>(0);  // instructionLength
+        w.WriteByte((byte)(OutlineFlags.XIsSame | OutlineFlags.YIsSame | OutlineFlags.OnCurve));
+        return ms.ToArray();
+    }
+
+    // Builds a compound glyph with a single component (HasTwoByTwo, ArgsAreXY) referencing glyph
+    // index 0, with the given matrix/translation/extra flags.
+    private static byte[] BuildCompoundGlyphBytes(
+        short translateX, short translateY,
+        float m11, float m21, float m12, float m22,
+        CompoundGlyfFlags extraFlags)
+    {
+        using var ms = new MemoryStream();
+        var w = new Writer(ms, BigEndianWriter.WriterDelegates);
+        w.Write<short>(-1); // numberOfContours == -1 => compound glyph
+        w.Write<short>(0); w.Write<short>(0); w.Write<short>(0); w.Write<short>(0); // bbox
+
+        var flags = CompoundGlyfFlags.ArgsAreXY | CompoundGlyfFlags.HasTwoByTwo | extraFlags;
+        w.Write<short>((short)flags);
+        w.Write<short>(0); // glyphIndex: references glyph 0
+        w.Write<short>(translateX);
+        w.Write<short>(translateY);
+        w.Write<short>((short)System.Math.Round(m11 * 16384f));
+        w.Write<short>((short)System.Math.Round(m21 * 16384f));
+        w.Write<short>((short)System.Math.Round(m12 * 16384f));
+        w.Write<short>((short)System.Math.Round(m22 * 16384f));
+
+        return ms.ToArray();
+    }
+
+    // Wires up a minimal TrueTypeFont (maxp/head/loca/glyf) containing the origin-point glyph at
+    // index 0 followed by the given compound glyphs, and returns the GlyfTable to query.
+    private static GlyfTable BuildFontWithCompoundGlyphs(params byte[][] compoundGlyphBytes)
+    {
+        byte[] originGlyph = BuildOriginPointGlyphBytes();
+        byte[][] allGlyphs = new byte[compoundGlyphBytes.Length + 1][];
+        allGlyphs[0] = originGlyph;
+        for (int i = 0; i < compoundGlyphBytes.Length; i++)
+        {
+            allGlyphs[i + 1] = compoundGlyphBytes[i];
+        }
+
+        var font = new TrueTypeFont(0);
+
+        var maxp = (MaxpTable)font.CreateTable(TableTypes.MAXP);
+        maxp.NumGlyphs = (short)allGlyphs.Length;
+        font.AddTable(TableTypes.MAXP, maxp);
+
+        var head = (HeadTable)font.CreateTable(TableTypes.HEAD);
+        head.IndexToLocFormat = 1; // long format, simpler offset arithmetic
+        font.AddTable(TableTypes.HEAD, head);
+
+        var loca = (LocaTable)font.CreateTable(TableTypes.LOCA);
+        font.AddTable(TableTypes.LOCA, loca); // wires headTable/maxpTable before ReadData needs them
+        using (var locaMs = new MemoryStream())
+        {
+            var locaWriter = new Writer(locaMs, BigEndianWriter.WriterDelegates);
+            int offset = 0;
+            foreach (var g in allGlyphs)
+            {
+                locaWriter.Write<int>(offset);
+                offset += g.Length;
+            }
+            locaWriter.Write<int>(offset); // trailing offset (GlyphCount + 1 entries)
+            loca.ReadData(MakeReader(locaMs.ToArray()));
+        }
+
+        var glyf = (GlyfTable)font.CreateTable(TableTypes.GLYF);
+        font.AddTable(TableTypes.GLYF, glyf); // wires loca/maxp before ReadData needs them
+        using (var glyfMs = new MemoryStream())
+        {
+            foreach (var g in allGlyphs)
+            {
+                glyfMs.Write(g, 0, g.Length);
+            }
+            glyf.ReadData(MakeReader(glyfMs.ToArray()));
+        }
+
+        return glyf;
+    }
+
+    [TestMethod]
+    public void ReadThenWrite_SingleComponent_ProducesIdenticalBytes()
+    {
+        byte[] original = BuildCompoundGlyphBytes(50, 100, 2f, 0f, 0f, 2f, default);
+        var glyph = (GlyphCompound)GlyphBase.CreateGlyf(MakeReader(original), null);
+
+        using var ms = new MemoryStream();
+        var writer = new Writer(ms, BigEndianWriter.WriterDelegates);
+        glyph.WriteData(writer);
+
+        Assert.AreEqual(glyph.Length, ms.ToArray().Length);
+        CollectionAssert.AreEqual(original, ms.ToArray());
+    }
+
+    // Regression test: Transform used to always scale the translation offset by AdjustX/AdjustY,
+    // matching the historical Apple-only behavior. Per the OpenType spec, that scaling should only
+    // happen when the component explicitly sets SCALED_COMPONENT_OFFSET; with neither that flag nor
+    // UNSCALED_COMPONENT_OFFSET present (the common case for fonts built with Microsoft-oriented
+    // tooling), the offset must be used as-is.
+    [TestMethod]
+    public void Transform_NeitherScaledNorUnscaledFlagSet_OffsetIsNotScaled()
+    {
+        // Uniform 2x scale (HasTwoByTwo with M11=M22=2, M12=M21=0): AdjustX would be 2 under the old
+        // always-scale behavior, so a wrongly-scaled offset would double translateX/Y below.
+        byte[] compound = BuildCompoundGlyphBytes(50, 100, 2f, 0f, 0f, 2f, default);
+        var glyf = BuildFontWithCompoundGlyphs(compound);
+
+        var compoundGlyph = (GlyphCompound)glyf.GetGlyph(1);
+        var point = compoundGlyph.Contours.Single().Single();
+
+        Assert.AreEqual(50f, point.X, 1e-4f);
+        Assert.AreEqual(100f, point.Y, 1e-4f);
+    }
+
+    // Regression test: ComputeTransform used to derive AdjustY's doubling condition from the wrong
+    // matrix coefficient pair (|M12|-|M22]| instead of |M21|-|M22|), which only coincided with the
+    // correct result for shear-free (M12 == M21) matrices. With M21 == M22 (triggering the correct
+    // doubling condition) but M12 far from M22 (which would NOT trigger the old, wrong condition),
+    // and SCALED_COMPONENT_OFFSET set so AdjustY actually affects the output, the two implementations
+    // diverge: AdjustY = 2 (correct) vs 1 (old bug), so TranslateY ends up doubled only when correct.
+    [TestMethod]
+    public void Transform_ScaledOffset_AdjustYUsesCorrectCoefficientPair()
+    {
+        byte[] compound = BuildCompoundGlyphBytes(
+            50, 100,
+            m11: 1f, m21: 1f, m12: 0.3f, m22: 1f,
+            extraFlags: CompoundGlyfFlags.ScaledComponentOffset);
+        var glyf = BuildFontWithCompoundGlyphs(compound);
+
+        var compoundGlyph = (GlyphCompound)glyf.GetGlyph(1);
+        var point = compoundGlyph.Contours.Single().Single();
+
+        // AdjustX is unaffected by this fix (still 1): X offset is scaled by 1 either way.
+        Assert.AreEqual(50f, point.X, 1e-3f);
+        // AdjustY must be 2 (doubled because |M21|-|M22| ~ 0), not 1 (the old, wrongly-paired check).
+        Assert.AreEqual(200f, point.Y, 1e-3f);
+    }
+}

--- a/UtilsTest.Functional/Fonts/GlyphCompoundTests.cs
+++ b/UtilsTest.Functional/Fonts/GlyphCompoundTests.cs
@@ -35,11 +35,14 @@ public class GlyphCompoundTests
     }
 
     // Builds a compound glyph with a single component (HasTwoByTwo, ArgsAreXY) referencing glyph
-    // index 0, with the given matrix/translation/extra flags.
+    // index 0, with the given matrix/translation/extra flags. When extraFlags includes
+    // HasInstructions, a trailing instruction-length word (and that many bytes) is appended, exactly
+    // as ReadData expects.
     private static byte[] BuildCompoundGlyphBytes(
         short translateX, short translateY,
         float m11, float m21, float m12, float m22,
-        CompoundGlyfFlags extraFlags)
+        CompoundGlyfFlags extraFlags,
+        byte[] instructions = null)
     {
         using var ms = new MemoryStream();
         var w = new Writer(ms, BigEndianWriter.WriterDelegates);
@@ -55,6 +58,16 @@ public class GlyphCompoundTests
         w.Write<short>((short)System.Math.Round(m21 * 16384f));
         w.Write<short>((short)System.Math.Round(m12 * 16384f));
         w.Write<short>((short)System.Math.Round(m22 * 16384f));
+
+        if (flags.HasFlag(CompoundGlyfFlags.HasInstructions))
+        {
+            instructions ??= [];
+            w.Write<ushort>((ushort)instructions.Length);
+            foreach (byte b in instructions)
+            {
+                w.WriteByte(b);
+            }
+        }
 
         return ms.ToArray();
     }
@@ -166,5 +179,27 @@ public class GlyphCompoundTests
         Assert.AreEqual(50f, point.X, 1e-3f);
         // AdjustY must be 2 (doubled because |M21|-|M22| ~ 0), not 1 (the old, wrongly-paired check).
         Assert.AreEqual(200f, point.Y, 1e-3f);
+    }
+
+    // Regression test: WriteData/Length used to gate the trailing instruction block on
+    // `Instructions.Length > 0` instead of on whether HasInstructions was actually declared. A
+    // component with HasInstructions set but zero instruction bytes (a valid, spec-compliant case)
+    // round-tripped through ReadData/WriteData would silently drop the 2-byte instruction-length
+    // word, truncating the glyph and under-reporting Length by 2 bytes.
+    [TestMethod]
+    public void ReadThenWrite_HasInstructionsFlagWithZeroLengthInstructions_PreservesLengthWord()
+    {
+        byte[] original = BuildCompoundGlyphBytes(
+            50, 100, 1f, 0f, 0f, 1f,
+            extraFlags: CompoundGlyfFlags.HasInstructions,
+            instructions: []);
+        var glyph = (GlyphCompound)GlyphBase.CreateGlyf(MakeReader(original), null);
+
+        using var ms = new MemoryStream();
+        var writer = new Writer(ms, BigEndianWriter.WriterDelegates);
+        glyph.WriteData(writer);
+
+        Assert.AreEqual(glyph.Length, ms.ToArray().Length);
+        CollectionAssert.AreEqual(original, ms.ToArray());
     }
 }

--- a/UtilsTest.Functional/Fonts/TrueTypeFontTests.cs
+++ b/UtilsTest.Functional/Fonts/TrueTypeFontTests.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Utils.Fonts.TTF;
+using Utils.Fonts.TTF.Tables;
+using Utils.Fonts.TTF.Tables.CMap;
 using Utils.IO.Serialization;
 
 namespace UtilsTest.Fonts
@@ -11,6 +13,12 @@ namespace UtilsTest.Fonts
     [TestClass]
     public class TrueTypeFontTests
     {
+        private static readonly RawReader BigEndianReader = new RawReader() { BigEndian = true };
+        private static readonly RawWriter BigEndianWriter = new RawWriter() { BigEndian = true };
+
+        private static Reader MakeReader(byte[] data)
+            => new Reader(new MemoryStream(data), BigEndianReader.ReaderDelegates);
+
         [TestMethod]
         public void LoadFontTest()
         {
@@ -25,5 +33,41 @@ namespace UtilsTest.Fonts
             Assert.IsNotNull(glyph);
         }
 
+        // Regression test: GetSpacingCorrection used to pass raw character codes straight to
+        // KernTable, which stores pairs by glyph index (never by character code) -- unlike
+        // GetGlyph, which correctly resolves through cmap first. Here 'A' and 'B' map to glyph
+        // indices 200/201 (deliberately different from their char codes 65/66), and the kern pair
+        // is stored for (200, 201): the bug would look up (65, 66), find nothing, and return 0.
+        [TestMethod]
+        public void GetSpacingCorrection_ResolvesCharactersToGlyphIndicesViaCmap()
+        {
+            var font = new TrueTypeFont(0);
+
+            var cmap = (CmapTable)font.CreateTable(TableTypes.CMAP);
+            var subtable = (CMapFormat0)CMapFormatBase.CreateCMap(0, 0);
+            subtable.SetMap((byte)'A', 200);
+            subtable.SetMap((byte)'B', 201);
+            cmap.AddCMap(3, 1, subtable);
+            font.AddTable(TableTypes.CMAP, cmap);
+
+            using var ms = new MemoryStream();
+            var w = new Writer(ms, BigEndianWriter.WriterDelegates);
+            w.Write<ushort>(0);  // version
+            w.Write<ushort>(1);  // nTables
+            w.Write<ushort>(0);  // subVersion
+            w.Write<ushort>(20); // subtable length (14 header + 6 for one pair)
+            w.Write<ushort>(0);  // coverage
+            w.Write<ushort>(1);  // nPairs
+            w.Write<ushort>(0); w.Write<ushort>(0); w.Write<ushort>(0); // searchRange/entrySelector/rangeShift
+            w.Write<ushort>(200); // left glyph
+            w.Write<ushort>(201); // right glyph
+            w.Write<short>(-40);  // kerning value
+
+            var kern = new KernTable();
+            kern.ReadData(MakeReader(ms.ToArray()));
+            font.AddTable(TableTypes.KERN, kern);
+
+            Assert.AreEqual(-40f, font.GetSpacingCorrection('A', 'B'));
+        }
     }
 }


### PR DESCRIPTION
## Summary
Second-audit bug fixes for Utils.Fonts (items 1-4, 10-11 of the "Second audit qualite" section in `Utils.Fonts/TODO.md`):

- **Item 1** - `TrueTypeFont.GetSpacingCorrection` passed raw character codes straight to `KernTable`, which stores pairs by glyph index (like `GetGlyph` already resolves via `cmap`). Kerning silently returned 0 on any real font where glyph index != character code. Fixed by resolving through `cmap` first; `KernTable.GetSpacingCorrection` now takes `ushort` glyph indices.
- **Items 2-4** - `GlyphCompound.ComputeTransform` derived `AdjustY`'s doubling condition from the wrong matrix coefficient pair (only coincidentally correct for shear-free matrices); `Transform` always scaled the translation offset instead of gating it on the (now added) `SCALED_COMPONENT_OFFSET` flag.
- **New finding (not from either audit)**: `GlyphCompound` had no `WriteData`/`Length` override at all, silently inheriting `GlyphBase`'s 10-byte header-only implementation, so writing any compound glyph (accented characters, etc.) produced corrupt/truncated data. Added the missing overrides.
- **Items 10-11** - added `GlyphCompoundTests.cs` (byte round-trip + both transform fixes) and a kerning test where glyph index deliberately differs from character code, so the fixed behavior is actually exercised.

`Utils.Fonts/TODO.md` updated to cross-reference each item with its fix/test.

Remaining second-audit items (5, 6, 7, 8, 9, 12) are cosmetic/doc/tech-debt or an additional missing-test proposal, left out of scope per the explicit "fix the bugs" request.

## Test plan
- [x] `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --filter "FullyQualifiedName~Fonts"` - 128 passed, 0 failed
