### PR TITLE
fix(Utils.Fonts): WriteFont round-trip bugs + remaining second-audit items

### DIFF
--- a/Utils.Fonts/PostScript/CidKeyedFont.cs
+++ b/Utils.Fonts/PostScript/CidKeyedFont.cs
@@ -36,7 +36,12 @@ public class CidKeyedFont : IFont
     }
 
     /// <inheritdoc />
-    /// <remarks>Glyphs are looked up by their character code treated as CID.</remarks>
+    /// <remarks>
+    /// Glyphs are looked up by their character code treated as CID. Glyphs are stored internally by
+    /// CID (<see cref="int"/>, which may exceed <see cref="ushort.MaxValue"/>), but this method takes
+    /// a <see cref="char"/> -- a limitation of the <see cref="IFont"/> interface, not of this class --
+    /// so CIDs above 0xFFFF can never be reached through this API.
+    /// </remarks>
     public IGlyph GetGlyph(char c) => _glyphs.TryGetValue(c, out var g) ? g : null;
 
     /// <inheritdoc />

--- a/Utils.Fonts/TODO.md
+++ b/Utils.Fonts/TODO.md
@@ -424,12 +424,16 @@ comparaison future à `UNICODE_DEFAULT` sans vérifier `platformID` en premier s
 **Fix proposé** : scinder en deux enums distincts par plateforme (`MacintoshEncodingID`,
 `MicrosoftEncodingID`), ou documenter le piège par un commentaire XML sur chaque valeur partagée.
 **Sévérité** : dette technique / cosmétique (latent, pas encore exploité par un bug réel).
+**Corrigé** (option documentation, pour rester non-breaking en attendant le batch de version 2.0.0) :
+`<remarks>` ajouté sur l'enum expliquant le piège et renvoyant vers `TtfEncoderFactory.GetEncoding`
+comme pattern correct.
 
 ### 6. `GaspTable` — commentaire XML dupliqué sur le constructeur
 `Utils.Fonts/TTF/Tables/GaspTable.cs:46-50` : deux blocs `<summary>Initializes a new instance...`
 consécutifs précèdent le même constructeur — artefact de copier-coller.
 **Fix proposé** : supprimer le premier bloc dupliqué.
 **Sévérité** : cosmétique.
+**Corrigé.**
 
 ### 7. `DsigTable` — doc XML de classe incohérente avec le code ("12-byte" vs 8 octets réels)
 `Utils.Fonts/TTF/Tables/DsigTable.cs:14-21`. Le résumé de la classe affirme un en-tête de 12 octets
@@ -438,6 +442,7 @@ alors que `ReadData`/`WriteData`/`Length` (`8 + SignatureData.Length`) utilisent
 DSIG réelle. Le code est correct ; c'est la documentation qui ment.
 **Fix proposé** : corriger "12-byte" en "8-byte" dans le commentaire XML.
 **Sévérité** : cosmétique (doc trompeuse, AGENTS.md exige une doc XML exacte).
+**Corrigé.**
 
 ### 8. `PropTable` format 2 — incohérence mineure de convention de sentinel avec `BslnTable`
 `Utils.Fonts/TTF/Tables/PropTable.cs:133` teste `if (firstGlyph == 0xFFFF) break;` alors que
@@ -448,6 +453,8 @@ partiellement adapté — augmente le risque qu'une future modification n'en cor
 **Fix proposé** : uniformiser sur un seul champ de test, éventuellement en factorisant le lecteur de
 format 2 commun aux tables AAT (même esprit que `AatBinarySearchHeader`).
 **Sévérité** : cosmétique / dette technique mineure (aucun bug actif).
+**Corrigé** : les deux formats (2 et 4) de `PropTable` testent désormais `lastGlyph == 0xFFFF`,
+alignés sur `BslnTable`.
 
 ### 9. `CidKeyedFont.GetGlyph(char c)` — limite CID > 0xFFFF non documentée
 `Utils.Fonts/PostScript/CidKeyedFont.cs:18-44`. Le glyph est stocké par CID (`int`, pouvant dépasser
@@ -456,6 +463,7 @@ l'interface `IFont`, pas de cette classe spécifiquement, mais non documentée s
 **Fix proposé** : étoffer le commentaire `<remarks>` pour documenter explicitement la limite de
 plage (CID > 0xFFFF inatteignables via cette API).
 **Sévérité** : cosmétique / documentation.
+**Corrigé.**
 
 ## Manque de test
 
@@ -493,6 +501,27 @@ checksum global) qu'aucun test par-table ne peut voir.
 existante, appelle `WriteFont()`, reparse, et compare au minimum les métriques de plusieurs glyphes
 (avance, contours, points) avant/après.
 **Sévérité** : manque de test (déjà signalé au premier passage, toujours pas comblé).
+**Corrigé.** Test ajouté : `TrueTypeFontTests.WriteFont_RoundTrip_PreservesGlyphMetricsAndOutlines`.
+Comme prévu, ce test a immédiatement révélé des bugs réels qu'aucun test par-table ne pouvait voir,
+tous corrigés dans des commits séparés sur la même branche :
+- `TrueTypeFont.WriteFont()` écrivait l'en-tête sfnt et le répertoire des tables en little-endian
+  (writer par défaut) au lieu de big-endian.
+- `TrueTypeFont.WriteFont()` écrivait le padding d'alignement (0-3 octets) après avoir restauré le
+  curseur d'écriture dans la zone du répertoire des tables (`Pop()` appelé trop tôt), corrompant le
+  répertoire de toute police avec plus d'une table dont la taille n'est pas multiple de 4.
+- `GlyfTable.Length` plantait (`NullReferenceException`) sur tout glyphe vide (ex. l'espace, entrée
+  `loca` de taille 0 → entrée `null` dans le tableau de glyphes), alors que `WriteData` gérait déjà ce
+  cas via `?.`.
+- `GlyphCompound` ignorait totalement le flag `ARGS_ARE_WORDS` : les arguments de composant étaient
+  toujours lus/écrits comme des mots (2 octets), alors que de nombreuses polices réelles (dont Arial)
+  les stockent en un octet signé quand la valeur le permet — désynchronisant le flux binaire pour
+  tout ce qui suit dans le glyphe composite concerné.
+- `GlyphSimple.Length` sous-comptait les octets réellement écrits par `WriteData` pour toute run de
+  flags répétés de plus d'un point (`WriteData` écrit une paire de 2 octets par run, `Length` ne
+  comptait qu'un octet par run distincte).
+- `LocaTable.WriteData` réécrivait les offsets figés à la lecture au lieu de les recalculer à partir
+  des longueurs réelles des glyphes au moment de l'écriture — désormais recalculés à la demande via
+  `GlyfTable` (voir `RefreshOffsetsFromGlyf`).
 
 ## Résumé priorisé
 

--- a/Utils.Fonts/TTF/Enums.cs
+++ b/Utils.Fonts/TTF/Enums.cs
@@ -295,6 +295,15 @@ public enum TtfPlatFormId : short
 /// <summary>
 /// Identifies the platform-specific encodings associated with a <see cref="TtfPlatFormId"/>.
 /// </summary>
+/// <remarks>
+/// This single enum is shared across platforms, but its meaning depends on the accompanying
+/// <see cref="TtfPlatFormId"/>: <see cref="MAC_ROMAN"/> (Macintosh) and <see cref="UNICODE_DEFAULT"/>
+/// (Microsoft/Unicode) both have numeric value 0. Always guard a comparison against one of these two
+/// members with a check on <see cref="TtfPlatFormId"/> first (see
+/// <see cref="Utils.Fonts.TTF.TtfEncoderFactory.GetEncoding"/> for the correct pattern) -- comparing a
+/// platform-specific ID to <see cref="UNICODE_DEFAULT"/> without checking the platform first would
+/// also match a Macintosh Roman-script record.
+/// </remarks>
 public enum TtfPlatformSpecificID : short
 {
 #pragma warning disable CS1591

--- a/Utils.Fonts/TTF/Tables/DsigTable.cs
+++ b/Utils.Fonts/TTF/Tables/DsigTable.cs
@@ -9,10 +9,10 @@ namespace Utils.Fonts.TTF.Tables;
 /// The 'DSIG' (Digital Signature) table contains one or more cryptographic signatures that
 /// attest to the authenticity and integrity of a font. Most tools treat this table as an opaque
 /// blob: they preserve it on read and discard or regenerate it on write. This implementation
-/// stores the entire table as raw bytes after the 12-byte outer header.
+/// stores the entire table as raw bytes after the 8-byte outer header.
 /// </summary>
 /// <remarks>
-/// <para>Header structure (12 bytes):</para>
+/// <para>Header structure (8 bytes):</para>
 /// <list type="table">
 ///   <item><term>UInt32 version</term><description>Always 1.</description></item>
 ///   <item><term>UInt16 numSigs</term><description>Number of signature blocks.</description></item>

--- a/Utils.Fonts/TTF/Tables/GaspTable.cs
+++ b/Utils.Fonts/TTF/Tables/GaspTable.cs
@@ -46,7 +46,6 @@ public class GaspTable : TrueTypeTable
     /// <summary>
     /// Initializes a new instance of the <see cref="GaspTable"/> class.
     /// </summary>
-    /// <summary>Initializes a new instance of the <see cref="GaspTable"/> class.</summary>
     public GaspTable() : base(TableTypes.GASP) { }
 
     /// <summary>Gets or sets the table version. 0 = original; 1 = ClearType symmetric flags supported.</summary>

--- a/Utils.Fonts/TTF/Tables/Glyf/GlyphCompound.cs
+++ b/Utils.Fonts/TTF/Tables/Glyf/GlyphCompound.cs
@@ -185,15 +185,18 @@ public class GlyphCompound : GlyphBase
             current = new GlyfComponent();
             current.Flags = (CompoundGlyfFlags)data.Read<Int16>();
             current.GlyphIndex = data.Read<Int16>();
+            bool argsAreWords = current.Flags.HasFlag(CompoundGlyfFlags.ArgsAreWords);
             if (current.Flags.HasFlag(CompoundGlyfFlags.ArgsAreXY))
             {
-                current.TranslateX = data.Read<Int16>();
-                current.TranslateY = data.Read<Int16>();
+                // Offsets are signed: int16 when ARGS_ARE_WORDS, otherwise int8.
+                current.TranslateX = argsAreWords ? data.Read<Int16>() : data.Read<SByte>();
+                current.TranslateY = argsAreWords ? data.Read<Int16>() : data.Read<SByte>();
             }
             else
             {
-                current.CompoundPoint = data.Read<Int16>();
-                current.ComponentPoint = data.Read<Int16>();
+                // Point-matching indices are unsigned: uint16 when ARGS_ARE_WORDS, otherwise uint8.
+                current.CompoundPoint = argsAreWords ? data.Read<UInt16>() : data.Read<Byte>();
+                current.ComponentPoint = argsAreWords ? data.Read<UInt16>() : data.Read<Byte>();
             }
 
             if (current.Flags.HasFlag(CompoundGlyfFlags.HasScale))
@@ -258,7 +261,7 @@ public class GlyphCompound : GlyphBase
             foreach (var component in Components)
             {
                 size += 4; // flags (Int16) + glyphIndex (Int16)
-                size += 4; // translate/point-matching args, always word-sized (2 x Int16)
+                size += component.Flags.HasFlag(CompoundGlyfFlags.ArgsAreWords) ? 4 : 2; // translate/point-matching args
                 size += component.Flags switch
                 {
                     var f when f.HasFlag(CompoundGlyfFlags.HasTwoByTwo) => 8,
@@ -277,11 +280,9 @@ public class GlyphCompound : GlyphBase
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Mirrors the wire format read by <see cref="ReadData"/> exactly, including its limitations:
-    /// point-matching arguments (<see cref="GlyfComponent.CompoundPoint"/>/
-    /// <see cref="GlyfComponent.ComponentPoint"/>) and translation offsets are always written as
-    /// 16-bit words (the <c>ARGS_ARE_WORDS</c> flag is not checked, matching <see cref="ReadData"/>
-    /// not checking it either).
+    /// Mirrors the wire format read by <see cref="ReadData"/> exactly: point-matching arguments
+    /// (<see cref="GlyfComponent.CompoundPoint"/>/<see cref="GlyfComponent.ComponentPoint"/>) and
+    /// translation offsets are written as bytes or words depending on <c>ARGS_ARE_WORDS</c>.
     /// </remarks>
     public override void WriteData(Writer data)
     {
@@ -290,15 +291,32 @@ public class GlyphCompound : GlyphBase
         {
             data.Write<Int16>((short)component.Flags);
             data.Write<Int16>(component.GlyphIndex);
+            bool argsAreWords = component.Flags.HasFlag(CompoundGlyfFlags.ArgsAreWords);
             if (component.Flags.HasFlag(CompoundGlyfFlags.ArgsAreXY))
             {
-                data.Write<Int16>((short)component.TranslateX);
-                data.Write<Int16>((short)component.TranslateY);
+                if (argsAreWords)
+                {
+                    data.Write<Int16>((short)component.TranslateX);
+                    data.Write<Int16>((short)component.TranslateY);
+                }
+                else
+                {
+                    data.Write<SByte>((sbyte)component.TranslateX);
+                    data.Write<SByte>((sbyte)component.TranslateY);
+                }
             }
             else
             {
-                data.Write<Int16>((short)component.CompoundPoint);
-                data.Write<Int16>((short)component.ComponentPoint);
+                if (argsAreWords)
+                {
+                    data.Write<UInt16>((ushort)component.CompoundPoint);
+                    data.Write<UInt16>((ushort)component.ComponentPoint);
+                }
+                else
+                {
+                    data.Write<Byte>((byte)component.CompoundPoint);
+                    data.Write<Byte>((byte)component.ComponentPoint);
+                }
             }
 
             if (component.Flags.HasFlag(CompoundGlyfFlags.HasScale))

--- a/Utils.Fonts/TTF/Tables/Glyf/GlyphSimple.cs
+++ b/Utils.Fonts/TTF/Tables/Glyf/GlyphSimple.cs
@@ -279,7 +279,20 @@ public class GlyphSimple : GlyphBase
             int length = base.Length;
             length += NumContours * 2;               // Contour endpoint values
             length += 2 + InstructionsCount;         // Instruction length field and instructions
-            length += compactFlags.Count();          // Packed flags
+
+            // Packed flags: mirrors WriteData's repeat-splitting exactly -- a run of 1 point is a
+            // single byte, but a run of N > 1 identical flags is written as (flag|Repeat, count)
+            // pairs, one pair per 255 points (WriteData's `repetition -= 255` loop), not one byte
+            // per distinct run as this used to assume.
+            foreach (var flag in compactFlags)
+            {
+                int repetition = flag.Repetition;
+                while (repetition > 0)
+                {
+                    length += repetition > 1 ? 2 : 1;
+                    repetition -= 255;
+                }
+            }
             for (int i = 0; i < PointsCount; i++)
             {
                 OutlineFlags flag = flags[i];

--- a/Utils.Fonts/TTF/Tables/GlyfTable.cs
+++ b/Utils.Fonts/TTF/Tables/GlyfTable.cs
@@ -53,7 +53,13 @@ public class GlyfTable : TrueTypeTable
     /// <summary>
     /// Gets the total length (in bytes) of the glyf table, calculated as the sum of the lengths of all glyph data.
     /// </summary>
-    public override int Length => glyphs.Sum(g => g.Length);
+    /// <remarks>
+    /// A glyph index with a zero-length 'loca' entry (e.g. the space character, which has no
+    /// contours) has a null entry in <see cref="glyphs"/> rather than an empty <see cref="GlyphBase"/>
+    /// instance -- see <see cref="ReadData"/> -- so this must be null-safe, matching
+    /// <see cref="WriteData"/>'s use of <c>glyf?.WriteData(data)</c>.
+    /// </remarks>
+    public override int Length => glyphs.Sum(g => g?.Length ?? 0);
 
     /// <summary>
     /// Retrieves the glyph data for the glyph at the specified index.

--- a/Utils.Fonts/TTF/Tables/LocaTable.cs
+++ b/Utils.Fonts/TTF/Tables/LocaTable.cs
@@ -87,6 +87,7 @@ public class LocaTable : TrueTypeTable, IEnumerable<LocaRecord>
     {
         get
         {
+            RefreshOffsetsFromGlyf();
             // In short format each offset is stored as a 16-bit value; in long format as a 32-bit value.
             return IsLongFormat ? offsets.Length << 2 : offsets.Length << 1;
         }
@@ -98,6 +99,7 @@ public class LocaTable : TrueTypeTable, IEnumerable<LocaRecord>
     /// <param name="data">The writer to which the table data is written.</param>
     public override void WriteData(Writer data)
     {
+        RefreshOffsetsFromGlyf();
         if (IsLongFormat)
         {
             for (int i = 0; i < offsets.Length; i++)
@@ -112,6 +114,36 @@ public class LocaTable : TrueTypeTable, IEnumerable<LocaRecord>
                 data.Write<Int16>((short)(offsets[i] >> 1));
             }
         }
+    }
+
+    /// <summary>
+    /// Recomputes <see cref="offsets"/> from the actual, current lengths of the glyphs in the 'glyf'
+    /// table, rather than the possibly-stale offsets captured at <see cref="ReadData"/> time.
+    /// </summary>
+    /// <remarks>
+    /// Without this, writing a font whose glyph encoding changed size since it was read (e.g. a
+    /// component argument now encoded as a byte instead of a word) would serialize a 'glyf' table
+    /// whose actual layout no longer matches the offsets declared here, corrupting every glyph after
+    /// the first one whose size changed. Not declared as a dependency in this class's
+    /// <see cref="TTFTableAttribute"/> because 'glyf' itself depends on 'loca' to be read -- looking
+    /// the table up on demand here (only needed for writing, long after both tables exist) avoids the
+    /// circular read-time dependency that declaring it would create.
+    /// </remarks>
+    private void RefreshOffsetsFromGlyf()
+    {
+        if (!TrueTypeFont.TryGetTable<GlyfTable>(TableTypes.GLYF, out var glyfTable))
+        {
+            return;
+        }
+        var refreshed = new int[GlyphCount + 1];
+        int offset = 0;
+        for (int i = 0; i < GlyphCount; i++)
+        {
+            refreshed[i] = offset;
+            offset += glyfTable.GetGlyph(i)?.Length ?? 0;
+        }
+        refreshed[GlyphCount] = offset;
+        offsets = refreshed;
     }
 
     /// <summary>

--- a/Utils.Fonts/TTF/Tables/PropTable.cs
+++ b/Utils.Fonts/TTF/Tables/PropTable.cs
@@ -130,7 +130,7 @@ public class PropTable : TrueTypeTable
                     ushort lastGlyph  = data.Read<UInt16>();
                     ushort firstGlyph = data.Read<UInt16>();
                     ushort value      = data.Read<UInt16>();
-                    if (firstGlyph == 0xFFFF) break;
+                    if (lastGlyph == 0xFFFF) break; // sentinel segment, matches BslnTable's convention
                     for (ushort g = firstGlyph; g <= lastGlyph; g++)
                         result[g] = value;
                 }
@@ -147,7 +147,7 @@ public class PropTable : TrueTypeTable
                     ushort lastGlyph  = data.Read<UInt16>();
                     ushort firstGlyph = data.Read<UInt16>();
                     ushort offset     = data.Read<UInt16>();
-                    if (firstGlyph == 0xFFFF) break;
+                    if (lastGlyph == 0xFFFF) break; // sentinel segment, matches BslnTable's convention
                     data.Push((int)(tableStart + offset), SeekOrigin.Begin);
                     for (ushort g = firstGlyph; g <= lastGlyph; g++)
                         result[g] = data.Read<UInt16>();

--- a/Utils.Fonts/TTF/TrueTypeFont.cs
+++ b/Utils.Fonts/TTF/TrueTypeFont.cs
@@ -174,13 +174,13 @@ public class TrueTypeFont : IFont
             data.Push();
             data.Seek(currentoffset, SeekOrigin.Begin);
             data.Write<byte[]>(datas);
-            data.Pop();
             currentoffset += dataLength;
             while (currentoffset % TtfAlignment > 0)
             {
-                currentoffset++;
                 data.WriteByte(0);
+                currentoffset++;
             }
+            data.Pop();
         }
         data.Position = 0;
         UpdateChecksumAdj(new ReaderWriter(ms));

--- a/Utils.Fonts/TTF/TrueTypeFont.cs
+++ b/Utils.Fonts/TTF/TrueTypeFont.cs
@@ -149,7 +149,7 @@ public class TrueTypeFont : IFont
     public virtual byte[] WriteFont()
     {
         using var ms = new MemoryStream(Length);
-        var data = new Writer(ms);
+        var data = new Writer(ms, rawWriter.WriterDelegates);
 
         data.Write<Int32>(Type);
         data.Write<Int16>(TablesCount);

--- a/UtilsTest.Functional/Fonts/GlyphCompoundTests.cs
+++ b/UtilsTest.Functional/Fonts/GlyphCompoundTests.cs
@@ -49,7 +49,7 @@ public class GlyphCompoundTests
         w.Write<short>(-1); // numberOfContours == -1 => compound glyph
         w.Write<short>(0); w.Write<short>(0); w.Write<short>(0); w.Write<short>(0); // bbox
 
-        var flags = CompoundGlyfFlags.ArgsAreXY | CompoundGlyfFlags.HasTwoByTwo | extraFlags;
+        var flags = CompoundGlyfFlags.ArgsAreWords | CompoundGlyfFlags.ArgsAreXY | CompoundGlyfFlags.HasTwoByTwo | extraFlags;
         w.Write<short>((short)flags);
         w.Write<short>(0); // glyphIndex: references glyph 0
         w.Write<short>(translateX);
@@ -201,5 +201,40 @@ public class GlyphCompoundTests
 
         Assert.AreEqual(glyph.Length, ms.ToArray().Length);
         CollectionAssert.AreEqual(original, ms.ToArray());
+    }
+
+    // Regression test: ReadData/WriteData/Length always assumed component arguments (translation
+    // offset or point-matching indices) were word-sized (2 bytes each), never checking the
+    // ARGS_ARE_WORDS flag (0x0001). Real fonts commonly clear this flag to save space when the
+    // offsets fit in a signed byte -- reading such a component as if it were word-sized desyncs the
+    // byte stream for everything that follows it, corrupting the rest of the glyph (and, in a full
+    // font, every glyph after it once loca offsets are involved). Found while diagnosing a full
+    // WriteFont() round-trip test against a real font (see TrueTypeFontTests), where several real
+    // compound glyphs decoded with a garbage multi-kilobyte instruction blob as a direct symptom.
+    [TestMethod]
+    public void ReadThenWrite_ArgsAreBytes_RoundTripsCorrectly()
+    {
+        using var ms = new MemoryStream();
+        var w = new Writer(ms, BigEndianWriter.WriterDelegates);
+        w.Write<short>(-1); // numberOfContours == -1 => compound glyph
+        w.Write<short>(0); w.Write<short>(0); w.Write<short>(0); w.Write<short>(0); // bbox
+
+        // ArgsAreWords deliberately NOT set: translate offsets are signed bytes, not words.
+        var flags = CompoundGlyfFlags.ArgsAreXY | CompoundGlyfFlags.HasScale;
+        w.Write<short>((short)flags);
+        w.Write<short>(0); // glyphIndex: references glyph 0
+        w.WriteByte(unchecked((byte)(sbyte)-5));  // translateX = -5
+        w.WriteByte(unchecked((byte)(sbyte)10));  // translateY = 10
+        w.Write<short>((short)System.Math.Round(1f * 16384f)); // uniform scale
+
+        byte[] original = ms.ToArray();
+        var glyph = (GlyphCompound)GlyphBase.CreateGlyf(MakeReader(original), null);
+
+        using var outMs = new MemoryStream();
+        var writer = new Writer(outMs, BigEndianWriter.WriterDelegates);
+        glyph.WriteData(writer);
+
+        Assert.AreEqual(glyph.Length, outMs.ToArray().Length);
+        CollectionAssert.AreEqual(original, outMs.ToArray());
     }
 }

--- a/UtilsTest.Functional/Fonts/TrueTypeFontTests.cs
+++ b/UtilsTest.Functional/Fonts/TrueTypeFontTests.cs
@@ -2,7 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Numerics;
 using System.Text;
+using Utils.Fonts;
 using Utils.Fonts.TTF;
 using Utils.Fonts.TTF.Tables;
 using Utils.Fonts.TTF.Tables.CMap;
@@ -18,6 +21,21 @@ namespace UtilsTest.Fonts
 
         private static Reader MakeReader(byte[] data)
             => new Reader(new MemoryStream(data), BigEndianReader.ReaderDelegates);
+
+        // Records every call made to it as a string, so two glyph outlines can be compared for
+        // equality without depending on a mocking framework's strict call-order verification.
+        private sealed class RecordingGraphicConverter : IGraphicConverter
+        {
+            public List<string> Commands { get; } = [];
+            public void StartAt(float x, float y) => Commands.Add($"StartAt({x:F2},{y:F2})");
+            public void LineTo(float x, float y) => Commands.Add($"LineTo({x:F2},{y:F2})");
+            public void BezierTo(params (float x, float y)[] points)
+                => Commands.Add($"BezierTo({string.Join(";", points.Select(p => $"{p.x:F2},{p.y:F2}"))})");
+            public void ClosePath() => Commands.Add("ClosePath");
+            public void BeginDrawGlyph(float x, float y, Matrix3x2 transform)
+                => Commands.Add($"BeginDrawGlyph({x:F2},{y:F2},{transform})");
+            public void EndDrawGlyph() => Commands.Add("EndDrawGlyph");
+        }
 
         [TestMethod]
         public void LoadFontTest()
@@ -68,6 +86,41 @@ namespace UtilsTest.Fonts
             font.AddTable(TableTypes.KERN, kern);
 
             Assert.AreEqual(-40f, font.GetSpacingCorrection('A', 'B'));
+        }
+
+        // Regression coverage for a gap noted in TODO.md: every existing test validates a single
+        // table in isolation, but nothing exercised a full WriteFont() round trip, which is the only
+        // way to catch interactions between tables (loca/glyf offset drift, checksum, table
+        // directory). Loads the embedded Arial font, writes it back out, reparses the result, and
+        // compares metrics and outlines for a sample of glyphs -- including 'g', a compound glyph on
+        // most fonts (e.g. built from a dotless component) -- between the original and the round
+        // tripped font.
+        [TestMethod]
+        public void WriteFont_RoundTrip_PreservesGlyphMetricsAndOutlines()
+        {
+            var original = TrueTypeFont.ParseFont((byte[])Fonts.ResourceManager.GetObject("Arial"));
+            byte[] rewritten = original.WriteFont();
+            var reparsed = TrueTypeFont.ParseFont(rewritten);
+
+            Assert.AreEqual(original.TablesCount, reparsed.TablesCount);
+
+            foreach (char c in "AaGg1.")
+            {
+                var originalGlyph = original.GetGlyph(c);
+                var reparsedGlyph = reparsed.GetGlyph(c);
+                Assert.IsNotNull(originalGlyph, $"Original font has no glyph for '{c}'");
+                Assert.IsNotNull(reparsedGlyph, $"Round-tripped font has no glyph for '{c}'");
+
+                Assert.AreEqual(originalGlyph.Width, reparsedGlyph.Width, 1e-3f, $"Width mismatch for '{c}'");
+                Assert.AreEqual(originalGlyph.Height, reparsedGlyph.Height, 1e-3f, $"Height mismatch for '{c}'");
+                Assert.AreEqual(originalGlyph.BaseLine, reparsedGlyph.BaseLine, 1e-3f, $"BaseLine mismatch for '{c}'");
+
+                var originalCommands = new RecordingGraphicConverter();
+                originalGlyph.ToGraphic(originalCommands);
+                var reparsedCommands = new RecordingGraphicConverter();
+                reparsedGlyph.ToGraphic(reparsedCommands);
+                CollectionAssert.AreEqual(originalCommands.Commands, reparsedCommands.Commands, $"Outline mismatch for '{c}'");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Implements the remaining items (5-9, 12) from the second Utils.Fonts audit in `Utils.Fonts/TODO.md`, following up on PR #436 (items 1-4, 10-11).

- **Items 5-9**: cosmetic/documentation fixes -- `TtfPlatformSpecificID`'s shared zero value documented, a duplicated XML doc block removed from `GaspTable`, `DsigTable`'s header size doc corrected (8 bytes, not 12), `PropTable`'s sentinel check unified with `BslnTable`'s convention, `CidKeyedFont.GetGlyph`'s CID range limit documented.
- **Item 12**: added a full `TrueTypeFont.WriteFont()` round-trip test (load a real font, write it back out, reparse, compare glyph metrics/outlines) -- the one kind of test no per-table test can substitute for.

Writing that round-trip test immediately surfaced **five previously undetected, real bugs** in `WriteFont()`'s write path, each fixed in its own commit:
- The sfnt header and table directory were written little-endian instead of big-endian.
- Alignment padding bytes were written into the table directory instead of the table's data area (a `Pop()` called before writing the padding), corrupting the directory of any font with more than one non-4-byte-aligned table.
- `GlyfTable.Length` threw a `NullReferenceException` on any empty glyph (e.g. space).
- `GlyphCompound` ignored the `ARGS_ARE_WORDS` flag entirely, always treating component arguments as word-sized -- real fonts (including the test font) commonly use byte-sized arguments, and reading them as words desyncs the rest of the glyph.
- `GlyphSimple.Length` undercounted the bytes `WriteData` actually writes for repeated flag runs.
- `LocaTable.WriteData` wrote back stale offsets captured at read time instead of recomputing them from the glyphs' actual current lengths, so any of the above size-affecting fixes would silently desync `loca` from `glyf` again without this last fix.

All five are pre-existing bugs, unrelated to either audit's original findings -- they were unreachable by any previous test because nothing exercised a full, real-font `WriteFont()` round trip before.

## Test plan
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` -- 3507 passed, 3 ignored, 0 failed
- [x] `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj` -- 328 passed, 4 ignored, 0 failed (131 in the Fonts filter)
