### PR TITLE
Utils: fix TODO.md functional bugs and inconsistencies

### DIFF
--- a/Utils/Collections/ForwardFusion.cs
+++ b/Utils/Collections/ForwardFusion.cs
@@ -101,27 +101,53 @@ public class ForwardFusion<T1, T2> : IEnumerable<(T1 Left, T2 Right)>, IDisposab
         {
             if (hasLeft && hasRight)
             {
-                // Compare the current elements from both lists
-                switch (compare(leftEnum.Current, rightEnum.Current))
+                // Compare the current elements from both lists. Only the sign of the result is
+                // significant (as with any IComparable/IComparer contract), not its magnitude.
+                int comparison = compare(leftEnum.Current, rightEnum.Current);
+                if (comparison == 0)
                 {
-                    case 0:
-                        yield return (leftEnum.Current, rightEnum.Current); // Emit matched pair
-                        hasRight = rightEnum.MoveNext();
-                        break;
-                    case -1:
-                        if (joinType.HasFlag(JoinType.LeftJoin))
-                        {
-                            yield return (leftEnum.Current, default); // Emit left element with no match
-                        }
+                    // Buffer every consecutive left and right element that share this key so that
+                    // duplicate keys on both sides produce the full cartesian product of matches,
+                    // as a correct sort-merge join requires (not just the 1-to-N case).
+                    var leftGroup = new List<T1> { leftEnum.Current };
+                    hasLeft = leftEnum.MoveNext();
+                    while (hasLeft && compare(leftEnum.Current, rightEnum.Current) == 0)
+                    {
+                        leftGroup.Add(leftEnum.Current);
                         hasLeft = leftEnum.MoveNext();
-                        break;
-                    case 1:
-                        if (joinType.HasFlag(JoinType.RightJoin))
-                        {
-                            yield return (default, rightEnum.Current); // Emit right element with no match
-                        }
+                    }
+
+                    var rightGroup = new List<T2> { rightEnum.Current };
+                    hasRight = rightEnum.MoveNext();
+                    while (hasRight && compare(leftGroup[0], rightEnum.Current) == 0)
+                    {
+                        rightGroup.Add(rightEnum.Current);
                         hasRight = rightEnum.MoveNext();
-                        break;
+                    }
+
+                    foreach (T1 left in leftGroup)
+                    {
+                        foreach (T2 right in rightGroup)
+                        {
+                            yield return (left, right);
+                        }
+                    }
+                }
+                else if (comparison < 0)
+                {
+                    if (joinType.HasFlag(JoinType.LeftJoin))
+                    {
+                        yield return (leftEnum.Current, default); // Emit left element with no match
+                    }
+                    hasLeft = leftEnum.MoveNext();
+                }
+                else
+                {
+                    if (joinType.HasFlag(JoinType.RightJoin))
+                    {
+                        yield return (default, rightEnum.Current); // Emit right element with no match
+                    }
+                    hasRight = rightEnum.MoveNext();
                 }
             }
             else if (hasLeft)

--- a/Utils/Collections/LRUCache.cs
+++ b/Utils/Collections/LRUCache.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace Utils.Collections;
 
@@ -9,6 +8,12 @@ namespace Utils.Collections;
 /// </summary>
 /// <typeparam name="K">The type of keys in the cache.</typeparam>
 /// <typeparam name="V">The type of values in the cache.</typeparam>
+/// <remarks>
+/// This type is <b>not thread-safe</b>. Concurrent reads and writes from multiple threads (including
+/// enumeration via <see cref="GetEnumerator"/>, <see cref="Keys"/>, or <see cref="Values"/> while the
+/// cache is mutated) must be synchronized externally by the caller, for example with a single
+/// <see langword="lock"/> shared by all callers of a given instance.
+/// </remarks>
 public class LRUCache<K, V> : IDictionary<K, V>
     where K : notnull
 {
@@ -58,13 +63,11 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// <returns>The value associated with the specified key.</returns>
     public V this[K key]
     {
-        [MethodImpl(MethodImplOptions.Synchronized)]
         get
         {
             TryGetValue(key, out V value);
             return value;
         }
-        [MethodImpl(MethodImplOptions.Synchronized)]
         set
         {
             Remove(key);
@@ -97,7 +100,6 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// </summary>
     /// <param name="key">The key of the element to add.</param>
     /// <param name="value">The value of the element to add.</param>
-    [MethodImpl(MethodImplOptions.Synchronized)]
     public void Add(K key, V value)
     {
         if (cacheMap.Count >= capacity)
@@ -161,11 +163,8 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// </summary>
     public void Clear()
     {
-        lock (lruList)
-        {
-            lruList.Clear();
-            cacheMap.Clear();
-        }
+        lruList.Clear();
+        cacheMap.Clear();
     }
 
     /// <summary>

--- a/Utils/Collections/LRUCache.cs
+++ b/Utils/Collections/LRUCache.cs
@@ -10,13 +10,15 @@ namespace Utils.Collections;
 /// <typeparam name="V">The type of values in the cache.</typeparam>
 /// <remarks>
 /// This type is thread-safe: every member, including enumeration and the <see cref="Keys"/>/
-/// <see cref="Values"/> views, is synchronized through a single internal lock. Enumerating the cache
-/// (directly, or through <see cref="Keys"/> or <see cref="Values"/>) takes a point-in-time snapshot
-/// under that lock rather than returning a live cursor, so it never throws because of a concurrent
-/// modification and never observes a torn state — it just won't reflect mutations made after the
-/// snapshot was taken. As with most thread-safe collections, individual members are atomic but
-/// compound operations spanning more than one call (e.g. "add if not already present") are not;
-/// callers needing that must synchronize externally.
+/// <see cref="Values"/> views, is synchronized through a single internal lock (a private object, not
+/// this instance — locking on the cache instance itself from calling code has no effect on it). Enumerating
+/// the cache (directly, or through <see cref="Keys"/> or <see cref="Values"/>) takes a point-in-time
+/// snapshot under that lock rather than returning a live cursor, so it never throws because of a
+/// concurrent modification and never observes a torn state — it just won't reflect mutations made
+/// after the snapshot was taken. As with most thread-safe collections, individual members are atomic
+/// but compound operations spanning more than one call (e.g. "add if not already present", or
+/// "read-modify-write") are <b>not</b> currently supported atomically by this type; there is no public
+/// way to make such a sequence atomic from outside the class.
 /// </remarks>
 public class LRUCache<K, V> : IDictionary<K, V>
     where K : notnull

--- a/Utils/Collections/LRUCache.cs
+++ b/Utils/Collections/LRUCache.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Utils.Collections;
@@ -9,14 +9,19 @@ namespace Utils.Collections;
 /// <typeparam name="K">The type of keys in the cache.</typeparam>
 /// <typeparam name="V">The type of values in the cache.</typeparam>
 /// <remarks>
-/// This type is <b>not thread-safe</b>. Concurrent reads and writes from multiple threads (including
-/// enumeration via <see cref="GetEnumerator"/>, <see cref="Keys"/>, or <see cref="Values"/> while the
-/// cache is mutated) must be synchronized externally by the caller, for example with a single
-/// <see langword="lock"/> shared by all callers of a given instance.
+/// This type is thread-safe: every member, including enumeration and the <see cref="Keys"/>/
+/// <see cref="Values"/> views, is synchronized through a single internal lock. Enumerating the cache
+/// (directly, or through <see cref="Keys"/> or <see cref="Values"/>) takes a point-in-time snapshot
+/// under that lock rather than returning a live cursor, so it never throws because of a concurrent
+/// modification and never observes a torn state — it just won't reflect mutations made after the
+/// snapshot was taken. As with most thread-safe collections, individual members are atomic but
+/// compound operations spanning more than one call (e.g. "add if not already present") are not;
+/// callers needing that must synchronize externally.
 /// </remarks>
 public class LRUCache<K, V> : IDictionary<K, V>
     where K : notnull
 {
+    private readonly object syncRoot = new();
     private readonly int capacity;
     private readonly Dictionary<K, LinkedListNode<KeyValuePair<K, V>>> cacheMap;
     private readonly LinkedList<KeyValuePair<K, V>> lruList;
@@ -32,8 +37,8 @@ public class LRUCache<K, V> : IDictionary<K, V>
         this.capacity = capacity;
         this.cacheMap = new Dictionary<K, LinkedListNode<KeyValuePair<K, V>>>(capacity);
         this.lruList = new LinkedList<KeyValuePair<K, V>>();
-        this._keysView = new KeyCollection(lruList);
-        this._valuesView = new ValueCollection(lruList);
+        this._keysView = new KeyCollection(this);
+        this._valuesView = new ValueCollection(this);
     }
 
     /// <summary>
@@ -49,7 +54,16 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// <summary>
     /// Gets the number of elements contained in the cache.
     /// </summary>
-    public int Count => lruList.Count;
+    public int Count
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return lruList.Count;
+            }
+        }
+    }
 
     /// <summary>
     /// Gets a value indicating whether the cache is read-only.
@@ -65,18 +79,25 @@ public class LRUCache<K, V> : IDictionary<K, V>
     {
         get
         {
-            TryGetValue(key, out V value);
-            return value;
+            lock (syncRoot)
+            {
+                TryGetValueCore(key, out V value);
+                return value;
+            }
         }
         set
         {
-            Remove(key);
-            Add(key, value);
+            lock (syncRoot)
+            {
+                RemoveCore(key);
+                AddCore(key, value);
+            }
         }
     }
 
     /// <summary>
     /// Removes the first element from the LRU list and the cache when the capacity is exceeded.
+    /// Must be called while holding <see cref="syncRoot"/>.
     /// </summary>
     private void RemoveFirst()
     {
@@ -93,7 +114,13 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// </summary>
     /// <param name="key">The key to locate in the cache.</param>
     /// <returns><see langword="true"/> if the cache contains an element with the specified key; otherwise, <see langword="false"/>.</returns>
-    public bool ContainsKey(K key) => cacheMap.ContainsKey(key);
+    public bool ContainsKey(K key)
+    {
+        lock (syncRoot)
+        {
+            return cacheMap.ContainsKey(key);
+        }
+    }
 
     /// <summary>
     /// Adds the specified key and value to the cache. If the cache exceeds its capacity, it removes the least recently used item.
@@ -101,6 +128,17 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// <param name="key">The key of the element to add.</param>
     /// <param name="value">The value of the element to add.</param>
     public void Add(K key, V value)
+    {
+        lock (syncRoot)
+        {
+            AddCore(key, value);
+        }
+    }
+
+    /// <summary>
+    /// Adds the specified key and value to the cache. Must be called while holding <see cref="syncRoot"/>.
+    /// </summary>
+    private void AddCore(K key, V value)
     {
         if (cacheMap.Count >= capacity)
         {
@@ -120,6 +158,17 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// <returns><see langword="true"/> if the element is successfully removed; otherwise, <see langword="false"/>.</returns>
     public bool Remove(K key)
     {
+        lock (syncRoot)
+        {
+            return RemoveCore(key);
+        }
+    }
+
+    /// <summary>
+    /// Removes the element with the specified key from the cache. Must be called while holding <see cref="syncRoot"/>.
+    /// </summary>
+    private bool RemoveCore(K key)
+    {
         if (cacheMap.TryGetValue(key, out var node))
         {
             lruList.Remove(node);
@@ -136,6 +185,17 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// <param name="value">When this method returns, the value associated with the specified key, if the key is found; otherwise, the default value for the type of the value parameter.</param>
     /// <returns><see langword="true"/> if the cache contains an element with the specified key; otherwise, <see langword="false"/>.</returns>
     public bool TryGetValue(K key, out V value)
+    {
+        lock (syncRoot)
+        {
+            return TryGetValueCore(key, out value);
+        }
+    }
+
+    /// <summary>
+    /// Gets the value associated with the specified key. Must be called while holding <see cref="syncRoot"/>.
+    /// </summary>
+    private bool TryGetValueCore(K key, out V value)
     {
         if (cacheMap.TryGetValue(key, out var node))
         {
@@ -163,8 +223,11 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// </summary>
     public void Clear()
     {
-        lruList.Clear();
-        cacheMap.Clear();
+        lock (syncRoot)
+        {
+            lruList.Clear();
+            cacheMap.Clear();
+        }
     }
 
     /// <summary>
@@ -172,7 +235,13 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// </summary>
     /// <param name="item">The key-value pair to locate in the cache.</param>
     /// <returns><see langword="true"/> if the cache contains the specified key-value pair; otherwise, <see langword="false"/>.</returns>
-    public bool Contains(KeyValuePair<K, V> item) => lruList.Contains(item);
+    public bool Contains(KeyValuePair<K, V> item)
+    {
+        lock (syncRoot)
+        {
+            return lruList.Contains(item);
+        }
+    }
 
     /// <summary>
     /// Copies the elements of the cache to an array, starting at a particular array index.
@@ -181,9 +250,12 @@ public class LRUCache<K, V> : IDictionary<K, V>
     /// <param name="arrayIndex">The zero-based index in the array at which copying begins.</param>
     public void CopyTo(KeyValuePair<K, V>[] array, int arrayIndex)
     {
-        foreach (var item in lruList)
+        lock (syncRoot)
         {
-            array[arrayIndex++] = new KeyValuePair<K, V>(item.Key, item.Value);
+            foreach (var item in lruList)
+            {
+                array[arrayIndex++] = new KeyValuePair<K, V>(item.Key, item.Value);
+            }
         }
     }
 
@@ -195,22 +267,64 @@ public class LRUCache<K, V> : IDictionary<K, V>
     public bool Remove(KeyValuePair<K, V> item) => Remove(item.Key);
 
     /// <summary>
-    /// Returns an enumerator that iterates through the cache.
+    /// Returns an enumerator over a point-in-time snapshot of the cache, taken under the internal lock.
     /// </summary>
     /// <returns>An enumerator for the cache.</returns>
-    public IEnumerator<KeyValuePair<K, V>> GetEnumerator() => lruList.GetEnumerator();
+    public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+    {
+        List<KeyValuePair<K, V>> snapshot;
+        lock (syncRoot)
+        {
+            snapshot = new List<KeyValuePair<K, V>>(lruList);
+        }
+        return snapshot.GetEnumerator();
+    }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     private sealed class KeyCollection : ICollection<K>
     {
-        private readonly LinkedList<KeyValuePair<K, V>> _list;
-        internal KeyCollection(LinkedList<KeyValuePair<K, V>> list) => _list = list;
-        public int Count => _list.Count;
+        private readonly LRUCache<K, V> _owner;
+        internal KeyCollection(LRUCache<K, V> owner) => _owner = owner;
+
+        public int Count
+        {
+            get { lock (_owner.syncRoot) { return _owner.lruList.Count; } }
+        }
+
         public bool IsReadOnly => true;
-        public bool Contains(K item) { foreach (var kvp in _list) if (EqualityComparer<K>.Default.Equals(kvp.Key, item)) return true; return false; }
-        public void CopyTo(K[] array, int arrayIndex) { foreach (var kvp in _list) array[arrayIndex++] = kvp.Key; }
-        public IEnumerator<K> GetEnumerator() { foreach (var kvp in _list) yield return kvp.Key; }
+
+        public bool Contains(K item)
+        {
+            lock (_owner.syncRoot)
+            {
+                foreach (var kvp in _owner.lruList)
+                    if (EqualityComparer<K>.Default.Equals(kvp.Key, item)) return true;
+                return false;
+            }
+        }
+
+        public void CopyTo(K[] array, int arrayIndex)
+        {
+            lock (_owner.syncRoot)
+            {
+                foreach (var kvp in _owner.lruList)
+                    array[arrayIndex++] = kvp.Key;
+            }
+        }
+
+        public IEnumerator<K> GetEnumerator()
+        {
+            List<K> snapshot;
+            lock (_owner.syncRoot)
+            {
+                snapshot = new List<K>(_owner.lruList.Count);
+                foreach (var kvp in _owner.lruList)
+                    snapshot.Add(kvp.Key);
+            }
+            return snapshot.GetEnumerator();
+        }
+
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         public void Add(K item) => throw new NotSupportedException();
         public void Clear() => throw new NotSupportedException();
@@ -219,13 +333,47 @@ public class LRUCache<K, V> : IDictionary<K, V>
 
     private sealed class ValueCollection : ICollection<V>
     {
-        private readonly LinkedList<KeyValuePair<K, V>> _list;
-        internal ValueCollection(LinkedList<KeyValuePair<K, V>> list) => _list = list;
-        public int Count => _list.Count;
+        private readonly LRUCache<K, V> _owner;
+        internal ValueCollection(LRUCache<K, V> owner) => _owner = owner;
+
+        public int Count
+        {
+            get { lock (_owner.syncRoot) { return _owner.lruList.Count; } }
+        }
+
         public bool IsReadOnly => true;
-        public bool Contains(V item) { foreach (var kvp in _list) if (EqualityComparer<V>.Default.Equals(kvp.Value, item)) return true; return false; }
-        public void CopyTo(V[] array, int arrayIndex) { foreach (var kvp in _list) array[arrayIndex++] = kvp.Value; }
-        public IEnumerator<V> GetEnumerator() { foreach (var kvp in _list) yield return kvp.Value; }
+
+        public bool Contains(V item)
+        {
+            lock (_owner.syncRoot)
+            {
+                foreach (var kvp in _owner.lruList)
+                    if (EqualityComparer<V>.Default.Equals(kvp.Value, item)) return true;
+                return false;
+            }
+        }
+
+        public void CopyTo(V[] array, int arrayIndex)
+        {
+            lock (_owner.syncRoot)
+            {
+                foreach (var kvp in _owner.lruList)
+                    array[arrayIndex++] = kvp.Value;
+            }
+        }
+
+        public IEnumerator<V> GetEnumerator()
+        {
+            List<V> snapshot;
+            lock (_owner.syncRoot)
+            {
+                snapshot = new List<V>(_owner.lruList.Count);
+                foreach (var kvp in _owner.lruList)
+                    snapshot.Add(kvp.Value);
+            }
+            return snapshot.GetEnumerator();
+        }
+
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         public void Add(V item) => throw new NotSupportedException();
         public void Clear() => throw new NotSupportedException();

--- a/Utils/Numerics/Number.cs
+++ b/Utils/Numerics/Number.cs
@@ -22,6 +22,13 @@ public readonly struct Number :
     private readonly BigInteger _denominator;
 
     /// <summary>
+    /// Gets the denominator used for all computations, treating the zero-initialized
+    /// default value of this struct (whose fields bypass the constructor) as an
+    /// effective denominator of one, equivalent to <see cref="Zero"/>.
+    /// </summary>
+    private BigInteger EffectiveDenominator => _denominator.IsZero ? BigInteger.One : _denominator;
+
+    /// <summary>
     /// Gets the value zero.
     /// </summary>
     public static Number Zero => new(BigInteger.Zero);
@@ -178,7 +185,7 @@ public readonly struct Number :
     /// </summary>
     /// <returns>The decimal value.</returns>
     /// <exception cref="OverflowException">Thrown when the value does not fit in a <see cref="decimal"/>.</exception>
-    public decimal ToDecimal() => (decimal)_numerator / (decimal)_denominator;
+    public decimal ToDecimal() => (decimal)_numerator / (decimal)EffectiveDenominator;
 
     /// <inheritdoc/>
     public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
@@ -216,7 +223,7 @@ public readonly struct Number :
 
         if (formatRequiresFraction || !decimalAvailable)
         {
-            fractionText = string.Format(CultureInfo.InvariantCulture, "{0}/{1}", _numerator, _denominator);
+            fractionText = string.Format(CultureInfo.InvariantCulture, "{0}/{1}", _numerator, EffectiveDenominator);
         }
 
         if (formatRequiresFraction)
@@ -252,7 +259,7 @@ public readonly struct Number :
     /// <summary>
     /// Gets the denominator of this number.
     /// </summary>
-    public BigInteger Denominator => _denominator;
+    public BigInteger Denominator => EffectiveDenominator;
 
     /// <summary>
     /// Returns the absolute value of the specified number.
@@ -269,7 +276,7 @@ public readonly struct Number :
     static bool INumberBase<Number>.IsComplexNumber(Number value) => false;
 
     /// <inheritdoc/>
-    static bool INumberBase<Number>.IsEvenInteger(Number value) => value._denominator.IsOne && value._numerator.IsEven;
+    static bool INumberBase<Number>.IsEvenInteger(Number value) => value.EffectiveDenominator.IsOne && value._numerator.IsEven;
 
     /// <inheritdoc/>
     static bool INumberBase<Number>.IsFinite(Number value) => true;
@@ -281,7 +288,7 @@ public readonly struct Number :
     static bool INumberBase<Number>.IsInfinity(Number value) => false;
 
     /// <inheritdoc/>
-    static bool INumberBase<Number>.IsInteger(Number value) => value._denominator.IsOne;
+    static bool INumberBase<Number>.IsInteger(Number value) => value.EffectiveDenominator.IsOne;
 
     /// <inheritdoc/>
     static bool INumberBase<Number>.IsNaN(Number value) => false;
@@ -296,7 +303,7 @@ public readonly struct Number :
     static bool INumberBase<Number>.IsNormal(Number value) => true;
 
     /// <inheritdoc/>
-    static bool INumberBase<Number>.IsOddInteger(Number value) => value._denominator.IsOne && !value._numerator.IsEven;
+    static bool INumberBase<Number>.IsOddInteger(Number value) => value.EffectiveDenominator.IsOne && !value._numerator.IsEven;
 
     /// <inheritdoc/>
     static bool INumberBase<Number>.IsPositive(Number value) => value._numerator.Sign > 0;
@@ -349,17 +356,17 @@ public readonly struct Number :
     public static Number Pow(Number x, Number y)
     {
         // Handle simple integer exponents for exact results
-        if (y._denominator.IsOne && y._numerator >= 0 && y._numerator <= int.MaxValue)
+        if (y.EffectiveDenominator.IsOne && y._numerator >= 0 && y._numerator <= int.MaxValue)
         {
             int exp = (int)y._numerator;
             BigInteger numerator = BigInteger.Pow(x._numerator, exp);
-            BigInteger denominator = BigInteger.Pow(x._denominator, exp);
+            BigInteger denominator = BigInteger.Pow(x.EffectiveDenominator, exp);
             return new Number(numerator, denominator);
         }
-        if (y._denominator.IsOne && y._numerator < 0 && y._numerator >= int.MinValue)
+        if (y.EffectiveDenominator.IsOne && y._numerator < 0 && y._numerator >= int.MinValue)
         {
             int exp = (int)BigInteger.Abs(y._numerator);
-            BigInteger numerator = BigInteger.Pow(x._denominator, exp);
+            BigInteger numerator = BigInteger.Pow(x.EffectiveDenominator, exp);
             BigInteger denominator = BigInteger.Pow(x._numerator, exp);
             return new Number(numerator, denominator);
         }
@@ -375,7 +382,7 @@ public readonly struct Number :
     static Number IPowerFunctions<Number>.Pow(Number x, Number y) => Pow(x, y);
 
     private static double ToDouble(Number value)
-        => (double)value._numerator / (double)value._denominator;
+        => (double)value._numerator / (double)value.EffectiveDenominator;
 
     private static Number FromDouble(double value)
         => Parse(value.ToString("R", CultureInfo.InvariantCulture));
@@ -389,7 +396,7 @@ public readonly struct Number :
     /// <returns>The formatted numeric string or <c>null</c> when no representation could be produced.</returns>
     private string? FormatAsDecimal(string? format, IFormatProvider provider, out bool success)
     {
-        if (_denominator.IsOne)
+        if (EffectiveDenominator.IsOne)
         {
             success = true;
             return _numerator.ToString(format, provider);
@@ -588,8 +595,8 @@ public readonly struct Number :
     /// </summary>
     public static Number operator +(Number left, Number right)
     {
-        BigInteger numerator = left._numerator * right._denominator + right._numerator * left._denominator;
-        BigInteger denominator = left._denominator * right._denominator;
+        BigInteger numerator = left._numerator * right.EffectiveDenominator + right._numerator * left.EffectiveDenominator;
+        BigInteger denominator = left.EffectiveDenominator * right.EffectiveDenominator;
         return new Number(numerator, denominator);
     }
 
@@ -598,8 +605,8 @@ public readonly struct Number :
     /// </summary>
     public static Number operator -(Number left, Number right)
     {
-        BigInteger numerator = left._numerator * right._denominator - right._numerator * left._denominator;
-        BigInteger denominator = left._denominator * right._denominator;
+        BigInteger numerator = left._numerator * right.EffectiveDenominator - right._numerator * left.EffectiveDenominator;
+        BigInteger denominator = left.EffectiveDenominator * right.EffectiveDenominator;
         return new Number(numerator, denominator);
     }
 
@@ -608,7 +615,7 @@ public readonly struct Number :
     /// </summary>
     public static Number operator *(Number left, Number right)
     {
-        return new Number(left._numerator * right._numerator, left._denominator * right._denominator);
+        return new Number(left._numerator * right._numerator, left.EffectiveDenominator * right.EffectiveDenominator);
     }
 
     /// <summary>
@@ -616,7 +623,7 @@ public readonly struct Number :
     /// </summary>
     public static Number operator /(Number left, Number right)
     {
-        return new Number(left._numerator * right._denominator, left._denominator * right._numerator);
+        return new Number(left._numerator * right.EffectiveDenominator, left.EffectiveDenominator * right._numerator);
     }
 
     /// <summary>
@@ -624,10 +631,10 @@ public readonly struct Number :
     /// </summary>
     public static Number operator %(Number left, Number right)
     {
-        BigInteger leftScaled = left._numerator * right._denominator;
-        BigInteger rightScaled = left._denominator * right._numerator;
+        BigInteger leftScaled = left._numerator * right.EffectiveDenominator;
+        BigInteger rightScaled = left.EffectiveDenominator * right._numerator;
         BigInteger remainder = BigInteger.Remainder(leftScaled, rightScaled);
-        return new Number(remainder, left._denominator * right._denominator);
+        return new Number(remainder, left.EffectiveDenominator * right.EffectiveDenominator);
     }
 
     /// <summary>
@@ -638,7 +645,7 @@ public readonly struct Number :
     /// <summary>
     /// Negates the specified number.
     /// </summary>
-    public static Number operator -(Number value) => new Number(BigInteger.Negate(value._numerator), value._denominator);
+    public static Number operator -(Number value) => new Number(BigInteger.Negate(value._numerator), value.EffectiveDenominator);
 
     /// <summary>
     /// Increments the specified value by one.
@@ -671,21 +678,21 @@ public readonly struct Number :
     public static bool operator <=(Number left, Number right) => left.CompareTo(right) <= 0;
 
     /// <inheritdoc/>
-    public bool Equals(Number other) => _numerator.Equals(other._numerator) && _denominator.Equals(other._denominator);
+    public bool Equals(Number other) => _numerator.Equals(other._numerator) && EffectiveDenominator.Equals(other.EffectiveDenominator);
 
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is Number other && Equals(other);
 
     /// <inheritdoc/>
-    public override int GetHashCode() => HashCode.Combine(_numerator, _denominator);
+    public override int GetHashCode() => HashCode.Combine(_numerator, EffectiveDenominator);
 
     /// <summary>
     /// Compares two numbers.
     /// </summary>
     public int CompareTo(Number other)
     {
-        BigInteger left = _numerator * other._denominator;
-        BigInteger right = other._numerator * _denominator;
+        BigInteger left = _numerator * other.EffectiveDenominator;
+        BigInteger right = other._numerator * EffectiveDenominator;
         return left.CompareTo(right);
     }
 

--- a/Utils/Numerics/Number.cs
+++ b/Utils/Numerics/Number.cs
@@ -113,14 +113,30 @@ public readonly struct Number :
             return new Number(value);
         }
 
-        if (text.Contains(info.NumberDecimalSeparator))
+        string separator = info.NumberDecimalSeparator;
+        int separatorIndex = text.IndexOf(separator, StringComparison.Ordinal);
+        if (separatorIndex >= 0)
         {
-            string[] parts = text.Split(info.NumberDecimalSeparator);
-            BigInteger integerPart = BigInteger.Parse(parts[0], provider);
-            string fractionText = parts[1];
-            BigInteger fractionPart = BigInteger.Parse(fractionText, provider);
+            if (text.IndexOf(separator, separatorIndex + separator.Length, StringComparison.Ordinal) >= 0)
+                throw new FormatException($"The input string '{text}' contains more than one decimal separator.");
+
+            string integerText = text[..separatorIndex];
+            string fractionText = text[(separatorIndex + separator.Length)..];
+
+            bool isNegative = integerText.StartsWith(info.NegativeSign, StringComparison.Ordinal);
+            string integerDigits = isNegative ? integerText[info.NegativeSign.Length..] : integerText;
+
+            // Leading/trailing decimal separator forms (".5", "-.5", "5.") are supported by
+            // treating the missing integer or fractional part as zero.
+            if (integerDigits.Length == 0 && fractionText.Length == 0)
+                throw new FormatException($"The input string '{text}' is not a valid number.");
+
+            BigInteger integerMagnitude = integerDigits.Length == 0 ? BigInteger.Zero : BigInteger.Parse(integerDigits, provider);
+            BigInteger fractionPart = fractionText.Length == 0 ? BigInteger.Zero : BigInteger.Parse(fractionText, provider);
             BigInteger denominator = BigInteger.Pow(10, fractionText.Length);
-            BigInteger numerator = integerPart * denominator + (integerPart.Sign >= 0 ? fractionPart : -fractionPart);
+            BigInteger numerator = integerMagnitude * denominator + fractionPart;
+            if (isNegative)
+                numerator = -numerator;
             return new Number(numerator, denominator);
         }
 

--- a/Utils/Objects/ObjectUtils.cs
+++ b/Utils/Objects/ObjectUtils.cs
@@ -97,7 +97,7 @@ public static class ObjectUtils
         {
             if (rank == array.Rank)
             {
-                hash = hash * HashMultiplier +array.GetValue(indices).GetHashCode();
+                hash = hash * HashMultiplier + (array.GetValue(indices)?.GetHashCode() ?? 0);
             }
             else
             {

--- a/Utils/Objects/ObjectUtils.cs
+++ b/Utils/Objects/ObjectUtils.cs
@@ -51,31 +51,83 @@ public static class ObjectUtils
     }
 
     /// <summary>
-    /// Asynchronously executes the specified function if the object is not null; otherwise, executes the fallback function.
+    /// Executes the specified synchronous function on the thread pool if the object is not null; otherwise, executes the synchronous fallback function.
     /// </summary>
     /// <typeparam name="T">The type of the object.</typeparam>
     /// <typeparam name="Result">The type of the result.</typeparam>
     /// <param name="value">The object to check.</param>
-    /// <param name="ifNotNull">The function to execute if the object is not null.</param>
-    /// <param name="ifNull">The function to execute if the object is null.</param>
+    /// <param name="ifNotNull">The synchronous function to execute if the object is not null.</param>
+    /// <param name="ifNull">The synchronous function to execute if the object is null.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// <paramref name="ifNotNull"/> and <paramref name="ifNull"/> are synchronous delegates offloaded
+    /// to the thread pool via <see cref="Task.Run(Func{Result})"/>; this consumes a thread-pool thread
+    /// for the duration of the call. For delegates that are already asynchronous, use the
+    /// <see cref="DoAsync{T, Result}(T, Func{T, Task{Result}}, Func{Task{Result}})"/> overload instead,
+    /// which composes the returned tasks directly without occupying an extra thread.
+    /// </remarks>
     public static async Task<Result> DoAsync<T, Result>(this T value, Func<T, Result> ifNotNull, Func<Result> ifNull)
     {
         return await Task.Run(() => value != null ? ifNotNull(value) : ifNull()).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Asynchronously executes the specified function if the object is not null; otherwise, returns a fallback value.
+    /// Executes the specified synchronous function on the thread pool if the object is not null; otherwise, returns a fallback value.
     /// </summary>
     /// <typeparam name="T">The type of the object.</typeparam>
     /// <typeparam name="Result">The type of the result.</typeparam>
     /// <param name="value">The object to check.</param>
-    /// <param name="ifNotNull">The function to execute if the object is not null.</param>
+    /// <param name="ifNotNull">The synchronous function to execute if the object is not null.</param>
     /// <param name="ifNull">The value to return if the object is null.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// <paramref name="ifNotNull"/> is a synchronous delegate offloaded to the thread pool via
+    /// <see cref="Task.Run(Func{Result})"/>; this consumes a thread-pool thread for the duration of the
+    /// call. For a delegate that is already asynchronous, use the
+    /// <see cref="DoAsync{T, Result}(T, Func{T, Task{Result}}, Result)"/> overload instead, which
+    /// composes the returned task directly without occupying an extra thread.
+    /// </remarks>
     public static async Task<Result> DoAsync<T, Result>(this T value, Func<T, Result> ifNotNull, Result ifNull)
     {
         return await Task.Run(() => value != null ? ifNotNull(value) : ifNull).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes the specified async function if the object is not null; otherwise, executes the async fallback function.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="Result">The type of the result.</typeparam>
+    /// <param name="value">The object to check.</param>
+    /// <param name="ifNotNull">The asynchronous function to execute if the object is not null.</param>
+    /// <param name="ifNull">The asynchronous function to execute if the object is null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Unlike the synchronous-delegate overloads, this composes the tasks returned by
+    /// <paramref name="ifNotNull"/> and <paramref name="ifNull"/> directly, without offloading to the
+    /// thread pool via <see cref="Task.Run(Func{Result})"/>.
+    /// </remarks>
+    public static async Task<Result> DoAsync<T, Result>(this T value, Func<T, Task<Result>> ifNotNull, Func<Task<Result>> ifNull)
+    {
+        return value != null ? await ifNotNull(value).ConfigureAwait(false) : await ifNull().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes the specified async function if the object is not null; otherwise, returns a fallback value.
+    /// </summary>
+    /// <typeparam name="T">The type of the object.</typeparam>
+    /// <typeparam name="Result">The type of the result.</typeparam>
+    /// <param name="value">The object to check.</param>
+    /// <param name="ifNotNull">The asynchronous function to execute if the object is not null.</param>
+    /// <param name="ifNull">The value to return if the object is null.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// Unlike the synchronous-delegate overload, this composes the task returned by
+    /// <paramref name="ifNotNull"/> directly, without offloading to the thread pool via
+    /// <see cref="Task.Run(Func{Result})"/>.
+    /// </remarks>
+    public static async Task<Result> DoAsync<T, Result>(this T value, Func<T, Task<Result>> ifNotNull, Result ifNull)
+    {
+        return value != null ? await ifNotNull(value).ConfigureAwait(false) : ifNull;
     }
 
     /// <summary>

--- a/Utils/Randomization/DistributedRandom.cs
+++ b/Utils/Randomization/DistributedRandom.cs
@@ -68,7 +68,7 @@ public class DistributedRandom
         min.ArgMustBeLesserThan(max);
 
         double distributedValue = NextDouble();
-        return double.Floor(distributedValue * (max - min)) + min;
+        return distributedValue * (max - min) + min;
     }
 
 

--- a/Utils/Randomization/DistributedRandom.cs
+++ b/Utils/Randomization/DistributedRandom.cs
@@ -62,7 +62,7 @@ public class DistributedRandom
     /// </summary>
     /// <param name="min">The inclusive lower bound of the random number.</param>
     /// <param name="max">The exclusive upper bound of the random number.</param>
-    /// <returns>An integer value that follows the specified distribution within the specified range.</returns>
+    /// <returns>A double value that follows the specified distribution within the specified range.</returns>
     public double NextDouble(double min, double max)
     {
         min.ArgMustBeLesserThan(max);

--- a/Utils/Randomization/RandomExtensions.cs
+++ b/Utils/Randomization/RandomExtensions.cs
@@ -232,10 +232,18 @@ namespace Utils.Randomization
         }
 
         /// <summary>
-        /// Generates a random <see cref="float"/> value from random bytes.
+        /// Generates a random <see cref="float"/> value by reinterpreting raw random bytes, consistent
+        /// with <see cref="RandomByte"/>/<see cref="RandomShort"/>/<see cref="RandomInt"/>/<see cref="RandomLong"/>,
+        /// which likewise fill the full bit pattern of their return type rather than a normalized range.
         /// </summary>
         /// <param name="r">The random generator.</param>
-        /// <returns>A random single-precision floating-point value.</returns>
+        /// <returns>
+        /// A random single-precision floating-point value spanning the full <see cref="float"/> bit
+        /// pattern space. Unlike <see cref="Random.NextSingle"/>, this can return <see cref="float.NaN"/>,
+        /// <see cref="float.PositiveInfinity"/>, <see cref="float.NegativeInfinity"/>, subnormal values,
+        /// and values outside <c>[0, 1)</c>. Useful for binary fuzzing/round-trip testing; use
+        /// <see cref="Random.NextSingle"/> when a finite value in <c>[0, 1)</c> is required instead.
+        /// </returns>
         public static float RandomFloat(this Random r)
         {
             byte[] result = new byte[sizeof(float)];
@@ -244,10 +252,18 @@ namespace Utils.Randomization
         }
 
         /// <summary>
-        /// Generates a random <see cref="double"/> value from random bytes.
+        /// Generates a random <see cref="double"/> value by reinterpreting raw random bytes, consistent
+        /// with <see cref="RandomByte"/>/<see cref="RandomShort"/>/<see cref="RandomInt"/>/<see cref="RandomLong"/>,
+        /// which likewise fill the full bit pattern of their return type rather than a normalized range.
         /// </summary>
         /// <param name="r">The random generator.</param>
-        /// <returns>A random double-precision floating-point value.</returns>
+        /// <returns>
+        /// A random double-precision floating-point value spanning the full <see cref="double"/> bit
+        /// pattern space. Unlike <see cref="Random.NextDouble"/>, this can return <see cref="double.NaN"/>,
+        /// <see cref="double.PositiveInfinity"/>, <see cref="double.NegativeInfinity"/>, subnormal values,
+        /// and values outside <c>[0, 1)</c>. Useful for binary fuzzing/round-trip testing; use
+        /// <see cref="Random.NextDouble"/> when a finite value in <c>[0, 1)</c> is required instead.
+        /// </returns>
         public static double RandomDouble(this Random r)
         {
             byte[] result = new byte[sizeof(double)];

--- a/Utils/Range/IntRange.cs
+++ b/Utils/Range/IntRange.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Numerics;
 using Utils.Mathematics;
-using System.Formats.Tar; // If needed for IAdditionOperators, etc.
 
 namespace Utils.Range
 {

--- a/Utils/Range/IntRange.cs
+++ b/Utils/Range/IntRange.cs
@@ -99,8 +99,9 @@ namespace Utils.Range
             public int CompareTo(object? obj)
                 => obj switch
                 {
+                    null => 1, // Non-null > null by .NET convention
                     SimpleRange r => CompareTo(r),
-                    _ => throw new NotImplementedException()
+                    _ => throw new ArgumentException($"Object must be of type {nameof(SimpleRange)}.", nameof(obj))
                 };
 
 

--- a/Utils/Range/Ranges.Specifics.cs
+++ b/Utils/Range/Ranges.Specifics.cs
@@ -266,7 +266,8 @@ public class DateTimeRanges : Ranges<DateTime>
             + PatternToRegEx(formatInfo.ShortTimePattern)
             + "))?";
 
-        var separators = new string[] { "-", ".." }.Where(s => !dateSearch.Contains(s)).ToArray();
+        string[] candidateSeparators = ["-", ".."];
+        var separators = candidateSeparators.Where(s => !dateSearch.Contains(s)).ToArray();
 
         // Parse the string into ranges using the constructed pattern.
         return InnerParse(range, dateSearch, separators, s => DateTime.Parse(s, formatInfo));

--- a/Utils/Range/Ranges.cs
+++ b/Utils/Range/Ranges.cs
@@ -108,12 +108,16 @@ public class Ranges<T> : IFormattable, IEquatable<Ranges<T>>,
     /// <param name="itemSearchPattern">The regex pattern to match the elements in the range.</param>
     /// <param name="separators">The separator strings used to delimit the start and end values.</param>
     /// <param name="valueParser">A function to parse the string into type T1.</param>
-    /// <returns>An enumerable collection of parsed Range objects.</returns>
+    /// <returns>
+    /// An enumerable collection of parsed Range objects. An empty or whitespace-only
+    /// <paramref name="range"/> is a legitimate representation of an empty set and yields no ranges
+    /// without throwing.
+    /// </returns>
     /// <exception cref="FormatException">
-    /// Thrown when <paramref name="range"/> contains content that is not part of a recognized range
-    /// expression (only whitespace is allowed between, before, or after matched ranges). This is a
-    /// strict parser: it requires the entire input to be consumed, unlike an extraction API that would
-    /// intentionally skip over surrounding text.
+    /// Thrown when <paramref name="range"/> contains non-whitespace content that is not part of a
+    /// recognized range expression (only whitespace is allowed between, before, or after matched
+    /// ranges). This is a strict parser: it requires the entire input to be consumed, unlike an
+    /// extraction API that would intentionally skip over surrounding text.
     /// </exception>
     protected static IEnumerable<IRange<T1>> InnerParse<T1>(string range, string itemSearchPattern, IEnumerable<string> separators, Func<string, T1> valueParser)
         where T1 : IComparable<T1>

--- a/Utils/Range/Ranges.cs
+++ b/Utils/Range/Ranges.cs
@@ -109,14 +109,26 @@ public class Ranges<T> : IFormattable, IEquatable<Ranges<T>>,
     /// <param name="separators">The separator strings used to delimit the start and end values.</param>
     /// <param name="valueParser">A function to parse the string into type T1.</param>
     /// <returns>An enumerable collection of parsed Range objects.</returns>
+    /// <exception cref="FormatException">
+    /// Thrown when <paramref name="range"/> contains content that is not part of a recognized range
+    /// expression (only whitespace is allowed between, before, or after matched ranges). This is a
+    /// strict parser: it requires the entire input to be consumed, unlike an extraction API that would
+    /// intentionally skip over surrounding text.
+    /// </exception>
     protected static IEnumerable<IRange<T1>> InnerParse<T1>(string range, string itemSearchPattern, IEnumerable<string> separators, Func<string, T1> valueParser)
         where T1 : IComparable<T1>
     {
         var parse = new Regex(@"(?<includesStart>(\[|\]))\s*(?<start>" + itemSearchPattern + @")\s*(" + string.Join('|', separators) + @")\s*(?<end>" + itemSearchPattern + @")\s*(?<includesEnd>(\[|\]))");
         var results = parse.Matches(range);
 
+        int consumed = 0;
         foreach (Match result in results)
         {
+            string skipped = range[consumed..result.Index];
+            if (!string.IsNullOrWhiteSpace(skipped))
+                throw new FormatException($"Unrecognized content '{skipped.Trim()}' in range expression '{range}'.");
+            consumed = result.Index + result.Length;
+
             yield return new Range<T1>(
                 valueParser(result.Groups["start"].Value),
                 valueParser(result.Groups["end"].Value),
@@ -124,6 +136,10 @@ public class Ranges<T> : IFormattable, IEquatable<Ranges<T>>,
                 result.Groups["includesEnd"].Value == "]"
             );
         }
+
+        string trailing = range[consumed..];
+        if (!string.IsNullOrWhiteSpace(trailing))
+            throw new FormatException($"Unrecognized content '{trailing.Trim()}' in range expression '{range}'.");
     }
 
 

--- a/Utils/String/StringUtils.cs
+++ b/Utils/String/StringUtils.cs
@@ -110,7 +110,7 @@ public static class StringUtils
                         {
                             case ' ':
                                 {
-                                    result.Add(line.Substring(lastindex, i - lastindex).TrimBrackets('\"'));
+                                    result.Add(TrimQuotes(line.Substring(lastindex, i - lastindex)));
                                     lastindex = i + 1;
                                 }
                                 break;

--- a/Utils/TODO.md
+++ b/Utils/TODO.md
@@ -6,8 +6,12 @@ Security, Transactions, Files — 136 fichiers). Suit la même méthodologie que
 sur Utils.Geography, Utils.Reflection et Utils.Fonts : chaque proposition ci-dessous a été vérifiée
 manuellement (lecture du code, traçage à la main d'un scénario concret, ou absence de test qui
 l'aurait révélée) avant d'être retenue — plusieurs pistes soulevées lors du balayage initial se sont
-révélées être des faux positifs après vérification (voir section finale). Aucune proposition
-ci-dessous n'est encore corrigée.
+révélées être des faux positifs après vérification (voir section finale).
+
+**État (2026-07-11) :** les 13 propositions ci-dessous sont toutes corrigées, chacune avec un commit
+dédié et un test de régression, en commençant par les bugs fonctionnels (items 1, 2, 3, 6, 7, 8) puis
+les incohérences d'écriture par ordre de priorité (items 4, 9, 11, 12, 10, 5, 13). Branche
+`claude/utils-todo-fixes`.
 
 ## Bugs fonctionnels
 
@@ -26,6 +30,9 @@ assumée d'un "merge join" simplifié), soit implémenter le vrai algorithme de 
 bufferise le run de doublons du côté qui en a besoin pour produire le produit cartésien correct.
 **Sévérité** : bug fonctionnel (résultats de jointure incomplets/faux pour toute clé dupliquée des
 deux côtés — silencieux, aucune exception).
+**Corrigé.** `Enumerate` bufferise désormais les runs de clés dupliquées des deux côtés et émet leur
+produit cartésien complet ; la comparaison à `-1`/`1` littéraux a aussi été remplacée par un test de
+signe. Tests : `ForwardFusionTests.cs` (5 nouveaux cas).
 
 ### 2. `DistributedRandom.NextDouble(double min, double max)` — `Floor()` transforme la sortie en entier
 `Utils/Randomization/DistributedRandom.cs:66-72`. La méthode est documentée "Generates a random
@@ -41,6 +48,8 @@ triviaux sont documentés dans le xml compilé, aucun fichier de test trouvé).
 - min) + min` tel quel) ; `NextInt` peut appliquer son propre floor/cast sur le résultat continu.
 **Sévérité** : bug fonctionnel (API publique inutilisable pour son usage documenté ; non couvert par
 un test).
+**Corrigé.** `Floor()` retiré de `NextDouble(min, max)` ; `NextInt` tronque toujours via son propre
+cast. Tests : `DistributedRandomTests.cs` (nouveau fichier).
 
 ### 3. `StringUtils.ParseCommandLine` — dernier argument dé-échappé différemment des autres
 `Utils/String/StringUtils.cs:113` vs `139`. Pour un argument entre guillemets suivi d'un espace, le
@@ -56,6 +65,8 @@ convention d'échappement.
 façon uniforme à tous les arguments, y compris ceux suivis d'un espace.
 **Sévérité** : bug fonctionnel (incohérence de désérialisation selon la position de l'argument dans
 la ligne — pas de test existant pour `StringUtils` du tout).
+**Corrigé.** `TrimQuotes` appliqué uniformément à tous les arguments. Tests :
+`UtilsTest/String/StringUtilsTests.cs` (nouveau fichier).
 
 ### 6. `Number` — `default(Number)` represents an invalid `0/0` fraction
 `Utils/Numerics/Number.cs`. `Number` is a `readonly struct` whose constructor rejects a zero
@@ -74,6 +85,9 @@ change. Add a regression test asserting that `default(Number)` behaves exactly l
 
 **Severity**: critical functional invariant violation. A public value type should have a valid and
 well-defined default value.
+**Fixed.** Introduced an `EffectiveDenominator` used throughout instead of the raw field, so
+`default(Number)` is fully equivalent to `Number.Zero` (equality, hash code, arithmetic, formatting).
+Tests: `UtilsTest/Math/NumberTests.cs`.
 
 ### 7. `Number.Parse` silently accepts malformed decimal inputs
 `Utils/Numerics/Number.cs:101-123`. Decimal parsing uses
@@ -90,6 +104,9 @@ supported. Add tests for multiple separators, `.5`, `-.5`, `5.`, culture-specifi
 thousands separators.
 
 **Severity**: high. Malformed input can be accepted with a value different from the supplied text.
+**Fixed.** The separator is now located explicitly, a second occurrence throws `FormatException`, and
+a missing integer/fractional part is treated as zero (supporting `.5`, `-.5`, `5.`). Tests:
+`UtilsTest/Math/NumberTests.cs`.
 
 ### 8. `ObjectUtils.ComputeHash(Array)` throws on `null` elements
 `Utils/Objects/ObjectUtils.cs:88-113`. The non-generic multidimensional-array overload computes each
@@ -104,6 +121,8 @@ code `0` using `value?.GetHashCode() ?? 0`.
 custom hash delegate.
 
 **Severity**: medium functional bug for reference-type arrays containing null values.
+**Fixed.** Applies the same `value?.GetHashCode() ?? 0` pattern already used by the
+`IEnumerable<object>` overload. Tests: `UtilsTest/Objects/ObjectUtilsTests.cs` (new file).
 
 ## Incohérences d'écriture
 
@@ -122,6 +141,10 @@ clairement que la classe n'est **pas** thread-safe et retirer les attributs `Syn
 sur l'indexeur/`Add`.
 **Sévérité** : incohérence de conception (thread-safety partielle et trompeuse, pas un bug isolé mais
 un risque de course si un appelant se fie à la présence de `[Synchronized]` sur certains membres).
+**Corrigé.** Choix retenu : documenter le type comme non thread-safe et retirer les attributs
+`[Synchronized]` trompeurs (dont `Clear()`, qui verrouillait en réalité un moniteur différent de
+celui de l'indexeur/`Add`, donc sans exclusion mutuelle réelle entre eux). Tests :
+`LRUCacheTests.cs` (`Clear`, garde par réflexion contre la réapparition de `[Synchronized]`).
 
 ### 5. `Ranges.Specifics.cs` — tableau non-bracket
 `Utils/Range/Ranges.Specifics.cs:269` : `new string[] { "-", ".." }` devrait utiliser la syntaxe
@@ -129,6 +152,7 @@ crochets (`["-", ".."]`), conformément à la règle du projet (AGENTS.md : "Arr
 syntax").
 **Fix proposé** : remplacer par `["-", ".."]`.
 **Sévérité** : cosmétique.
+**Corrigé.**
 
 ### 9. `ObjectUtils.DoAsync` is asynchronous in name only
 `Utils/Objects/ObjectUtils.cs:64-80`. Both `DoAsync` overloads accept synchronous delegates and wrap
@@ -142,6 +166,9 @@ If the current thread-pool semantics are intentionally retained, rename the meth
 behavior explicit.
 
 **Severity**: medium design and scalability issue rather than an isolated correctness bug.
+**Fixed.** Documented the thread-pool offloading on the existing overloads and added
+`Func<T, Task<Result>>`/`Func<Task<Result>>` overloads that compose the returned tasks directly
+without `Task.Run`. Tests: `UtilsTest/Objects/ObjectUtilsTests.cs`.
 
 ### 10. `IntRange<T>.SimpleRange.CompareTo(object)` violates the `IComparable` contract
 `Utils/Range/IntRange.cs:101-106`. The non-generic `CompareTo(object?)` implementation throws
@@ -155,6 +182,8 @@ The conventional .NET contract is to return a positive value for `null` and thro
 
 **Severity**: low contract inconsistency. The nested type is private, but the behavior can still be
 observed through non-generic sorting and collection APIs.
+**Fixed.** Now returns `1` for `null` and throws `ArgumentException` for an incompatible type. Tests:
+`IntRangeTests.cs` (reflection-based, since `SimpleRange` is private).
 
 ### 11. `RandomExtensions.RandomFloat` and `RandomDouble` expose ambiguous semantics
 `Utils/Randomization/RandomExtensions.cs:241-258`. These methods fill the raw bytes of a `float` or
@@ -171,6 +200,13 @@ special IEEE-754 values.
 
 **Severity**: medium API-design inconsistency; it becomes a functional bug when callers assume a
 finite normalized value.
+**Resolved by documentation, not renaming.** `RandomFloat`/`RandomDouble` follow the same
+full-bit-pattern convention as `RandomByte`/`RandomShort`/`RandomInt`/`RandomLong` in the same file,
+and an existing serialization round-trip test in `UtilsTest.Functional` already depends on the
+raw-bit behavior to exercise edge-case values. Renaming would have broken both. Documented the
+behavior prominently (NaN/Infinity/subnormal/out-of-range possible) and pointed to
+`Random.NextSingle()`/`NextDouble()` for finite `[0, 1)` semantics. Tests:
+`RandomExtensionsTests.cs`.
 
 ### 12. `Ranges<T>.InnerParse` accepts valid fragments inside otherwise invalid input
 `Utils/Range/Ranges.cs:114-129`. The parser uses `Regex.Matches` with an unanchored pattern and yields
@@ -182,6 +218,10 @@ entire input be consumed, while a separately named API such as `ExtractRanges` m
 search for valid ranges inside larger text.
 
 **Severity**: medium parsing-contract ambiguity and possible silent data acceptance.
+**Fixed.** `InnerParse` now requires every character of the input to belong to a matched range or be
+whitespace, throwing `FormatException` otherwise (leading, trailing, in-between garbage, and
+zero-match input are all rejected); the existing concatenated-range syntax keeps working unchanged.
+Tests: `UtilsTest/Objects/RangesTests.cs`.
 
 ### 13. `IntRange.cs` contains an unrelated `System.Formats.Tar` import
 `Utils/Range/IntRange.cs:11` contains `using System.Formats.Tar; // If needed for IAdditionOperators,
@@ -191,6 +231,7 @@ from generated or unfinished code.
 **Proposed fix**: remove the unused import and its misleading comment.
 
 **Severity**: cosmetic, but indicative of incomplete cleanup.
+**Fixed.**
 
 ## Missing regression coverage
 

--- a/Utils/TODO.md
+++ b/Utils/TODO.md
@@ -224,9 +224,13 @@ search for valid ranges inside larger text.
 
 **Severity**: medium parsing-contract ambiguity and possible silent data acceptance.
 **Fixed.** `InnerParse` now requires every character of the input to belong to a matched range or be
-whitespace, throwing `FormatException` otherwise (leading, trailing, in-between garbage, and
-zero-match input are all rejected); the existing concatenated-range syntax keeps working unchanged.
-Tests: `UtilsTest/Objects/RangesTests.cs`.
+whitespace, throwing `FormatException` otherwise (leading, trailing, and in-between garbage are all
+rejected, as is any *non-whitespace* input that matches no range at all — e.g. `"not a range at
+all"`); the existing concatenated-range syntax keeps working unchanged. An empty or whitespace-only
+string is treated as a legitimate representation of an empty set and does **not** throw (matching
+`new Ranges<T>()`'s own empty default). Tests: `UtilsTest/Objects/RangesTests.cs`
+(`DoubleRangesParseEmptyStringProducesEmptySetTest`,
+`DoubleRangesParseWhitespaceOnlyStringProducesEmptySetTest`).
 
 ### 13. `IntRange.cs` contains an unrelated `System.Formats.Tar` import
 `Utils/Range/IntRange.cs:11` contains `using System.Formats.Tar; // If needed for IAdditionOperators,

--- a/Utils/TODO.md
+++ b/Utils/TODO.md
@@ -141,10 +141,15 @@ clairement que la classe n'est **pas** thread-safe et retirer les attributs `Syn
 sur l'indexeur/`Add`.
 **Sévérité** : incohérence de conception (thread-safety partielle et trompeuse, pas un bug isolé mais
 un risque de course si un appelant se fie à la présence de `[Synchronized]` sur certains membres).
-**Corrigé.** Choix retenu : documenter le type comme non thread-safe et retirer les attributs
-`[Synchronized]` trompeurs (dont `Clear()`, qui verrouillait en réalité un moniteur différent de
-celui de l'indexeur/`Add`, donc sans exclusion mutuelle réelle entre eux). Tests :
-`LRUCacheTests.cs` (`Clear`, garde par réflexion contre la réapparition de `[Synchronized]`).
+**Corrigé (en deux temps).** D'abord documenté comme non thread-safe et les attributs
+`[Synchronized]` trompeurs retirés (dont `Clear()`, qui verrouillait en réalité un moniteur différent
+de celui de l'indexeur/`Add`, donc sans exclusion mutuelle réelle entre eux). Puis, à la demande de
+l'utilisateur (c'est le contexte d'usage le plus probable), rendu réellement thread-safe : un verrou
+interne unique (`syncRoot`) protège désormais tous les membres, y compris `Keys`/`Values` (vues
+« vivantes » mais dont chaque appel prend un instantané sous verrou) et `GetEnumerator` (idem, plutôt
+qu'un curseur vivant sur la `LinkedList` interne, qui aurait levé `InvalidOperationException` en cas
+de mutation concurrente). Tests : `LRUCacheTests.cs` (`ConcurrentAddsWithDistinctKeys_...`,
+`ConcurrentReadWriteEnumerateStress_...`).
 
 ### 5. `Ranges.Specifics.cs` — tableau non-bracket
 `Utils/Range/Ranges.Specifics.cs:269` : `new string[] { "-", ".." }` devrait utiliser la syntaxe

--- a/UtilsTest/Collections/LRUCacheTests.cs
+++ b/UtilsTest/Collections/LRUCacheTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Utils.Collections;
 
 namespace UtilsTest.Collections;
@@ -66,5 +67,33 @@ public class LRUCacheTests
         cache.Add("x", 42);
         Assert.IsTrue(cache.Keys.Contains("x"));
         Assert.IsFalse(cache.Keys.Contains("y"));
+    }
+
+    [TestMethod]
+    public void Clear_RemovesAllEntries()
+    {
+        var cache = new LRUCache<int, string>(5);
+        cache.Add(1, "one");
+        cache.Add(2, "two");
+
+        cache.Clear();
+
+        Assert.AreEqual(0, cache.Count);
+        Assert.IsFalse(cache.ContainsKey(1));
+        Assert.IsFalse(cache.ContainsKey(2));
+    }
+
+    [TestMethod]
+    public void PublicMembers_AreNotMarkedSynchronized()
+    {
+        // LRUCache<K,V> is documented as not thread-safe. MethodImplOptions.Synchronized locks on
+        // `this`, which is misleading (and a race risk) when only some members carry it; guard
+        // against it silently creeping back onto a subset of members.
+        var type = typeof(LRUCache<int, string>);
+        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+        {
+            bool isSynchronized = (method.MethodImplementationFlags & MethodImplAttributes.Synchronized) != 0;
+            Assert.IsFalse(isSynchronized, $"{method.Name} should not be marked MethodImplOptions.Synchronized.");
+        }
     }
 }

--- a/UtilsTest/Collections/LRUCacheTests.cs
+++ b/UtilsTest/Collections/LRUCacheTests.cs
@@ -1,7 +1,10 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Utils.Collections;
 
 namespace UtilsTest.Collections;
@@ -86,14 +89,92 @@ public class LRUCacheTests
     [TestMethod]
     public void PublicMembers_AreNotMarkedSynchronized()
     {
-        // LRUCache<K,V> is documented as not thread-safe. MethodImplOptions.Synchronized locks on
-        // `this`, which is misleading (and a race risk) when only some members carry it; guard
-        // against it silently creeping back onto a subset of members.
+        // LRUCache<K,V> synchronizes through an explicit internal lock object, not
+        // MethodImplOptions.Synchronized (which locks on `this` — a public reference other code
+        // could also lock on, risking contention or deadlocks). Guard against it creeping back in.
         var type = typeof(LRUCache<int, string>);
         foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
         {
             bool isSynchronized = (method.MethodImplementationFlags & MethodImplAttributes.Synchronized) != 0;
             Assert.IsFalse(isSynchronized, $"{method.Name} should not be marked MethodImplOptions.Synchronized.");
         }
+    }
+
+    [TestMethod]
+    public void ConcurrentAddsWithDistinctKeys_AllSucceedAndAreRetrievable()
+    {
+        const int threadCount = 8;
+        const int keysPerThread = 200;
+        var cache = new LRUCache<int, int>(threadCount * keysPerThread);
+
+        Parallel.For(0, threadCount, t =>
+        {
+            for (int i = 0; i < keysPerThread; i++)
+            {
+                int key = t * keysPerThread + i;
+                cache.Add(key, key * 2);
+            }
+        });
+
+        Assert.AreEqual(threadCount * keysPerThread, cache.Count);
+        for (int t = 0; t < threadCount; t++)
+        {
+            for (int i = 0; i < keysPerThread; i++)
+            {
+                int key = t * keysPerThread + i;
+                Assert.IsTrue(cache.TryGetValue(key, out int value), $"key {key} should be retrievable");
+                Assert.AreEqual(key * 2, value);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ConcurrentReadWriteEnumerateStress_DoesNotThrow()
+    {
+        var cache = new LRUCache<int, int>(50);
+        const int threadCount = 8;
+        const int opsPerThread = 2000;
+        var exceptions = new ConcurrentBag<Exception>();
+
+        Parallel.For(0, threadCount, t =>
+        {
+            try
+            {
+                var rnd = new Random(t);
+                for (int i = 0; i < opsPerThread; i++)
+                {
+                    int key = rnd.Next(0, 100);
+                    switch (rnd.Next(6))
+                    {
+                        case 0:
+                            cache[key] = key; // upsert: safe to call concurrently with the same key
+                            break;
+                        case 1:
+                            cache.TryGetValue(key, out _);
+                            break;
+                        case 2:
+                            cache.Remove(key);
+                            break;
+                        case 3:
+                            _ = cache.Keys.Count;
+                            foreach (var _ in cache.Keys) { }
+                            break;
+                        case 4:
+                            foreach (var _ in cache.Values) { }
+                            break;
+                        case 5:
+                            foreach (var _ in cache) { }
+                            break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                exceptions.Add(ex);
+            }
+        });
+
+        Assert.IsTrue(exceptions.IsEmpty, string.Join(Environment.NewLine, exceptions));
+        Assert.IsTrue(cache.Count <= 50);
     }
 }

--- a/UtilsTest/Math/NumberTests.cs
+++ b/UtilsTest/Math/NumberTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Numerics;
 using System;
 using System.Globalization;
+using System.Numerics;
 
 namespace UtilsTest.Numerics;
 
@@ -127,5 +128,40 @@ public class NumberTests
         Number result = Number.Cos(angle);
         string expected = Number.Parse(Math.Cos(0.5).ToString("R", CultureInfo.InvariantCulture)).ToString();
         Assert.AreEqual(expected, result.ToString());
+    }
+
+    [TestMethod]
+    public void DefaultValueEqualsZeroTest()
+    {
+        Number defaultValue = default;
+        Assert.AreEqual(Number.Zero, defaultValue);
+        Assert.IsTrue(defaultValue == Number.Zero);
+        Assert.AreEqual(Number.Zero.GetHashCode(), defaultValue.GetHashCode());
+        Assert.AreEqual(BigInteger.One, defaultValue.Denominator);
+        Assert.AreEqual(BigInteger.Zero, defaultValue.Numerator);
+        Assert.AreEqual(Number.Zero.ToString(null, CultureInfo.InvariantCulture), defaultValue.ToString(null, CultureInfo.InvariantCulture));
+        Assert.AreEqual(0m, defaultValue.ToDecimal());
+    }
+
+    [TestMethod]
+    public void DefaultValueArithmeticDoesNotThrowTest()
+    {
+        Number defaultValue = default;
+        Number one = Number.One;
+
+        Assert.AreEqual(one, defaultValue + one);
+        Assert.AreEqual(-one, defaultValue - one);
+        Assert.AreEqual(Number.Zero, defaultValue * one);
+        Assert.AreEqual(Number.Zero, defaultValue / one);
+        Assert.AreEqual(Number.Zero, -defaultValue);
+        Assert.AreEqual(0, defaultValue.CompareTo(Number.Zero));
+    }
+
+    [TestMethod]
+    public void TryParseFailureResultEqualsZeroTest()
+    {
+        bool ok = Number.TryParse("not_a_number", null, out Number result);
+        Assert.IsFalse(ok);
+        Assert.AreEqual(Number.Zero, result);
     }
 }

--- a/UtilsTest/Math/NumberTests.cs
+++ b/UtilsTest/Math/NumberTests.cs
@@ -164,4 +164,46 @@ public class NumberTests
         Assert.IsFalse(ok);
         Assert.AreEqual(Number.Zero, result);
     }
+
+    [TestMethod]
+    public void ParseRejectsMultipleDecimalSeparatorsTest()
+    {
+        Assert.ThrowsExactly<FormatException>(() => Number.Parse("1.2.3", CultureInfo.InvariantCulture));
+    }
+
+    [TestMethod]
+    public void ParseLeadingDecimalSeparatorTest()
+    {
+        Assert.AreEqual(Number.Parse("0.5", CultureInfo.InvariantCulture), Number.Parse(".5", CultureInfo.InvariantCulture));
+    }
+
+    [TestMethod]
+    public void ParseNegativeLeadingDecimalSeparatorTest()
+    {
+        Assert.AreEqual(Number.Parse("-0.5", CultureInfo.InvariantCulture), Number.Parse("-.5", CultureInfo.InvariantCulture));
+    }
+
+    [TestMethod]
+    public void ParseTrailingDecimalSeparatorTest()
+    {
+        Assert.AreEqual(Number.Parse("5", CultureInfo.InvariantCulture), Number.Parse("5.", CultureInfo.InvariantCulture));
+    }
+
+    [TestMethod]
+    public void ParseLoneDecimalSeparatorThrowsTest()
+    {
+        Assert.ThrowsExactly<FormatException>(() => Number.Parse(".", CultureInfo.InvariantCulture));
+    }
+
+    [TestMethod]
+    public void ParseRespectsCultureSpecificDecimalSeparatorTest()
+    {
+        Assert.AreEqual(Number.Parse("10.5", CultureInfo.InvariantCulture), Number.Parse("10,5", CultureInfo.GetCultureInfo("fr-FR")));
+    }
+
+    [TestMethod]
+    public void ParseRejectsThousandsSeparatorTest()
+    {
+        Assert.ThrowsExactly<FormatException>(() => Number.Parse("1,234.5", CultureInfo.InvariantCulture));
+    }
 }

--- a/UtilsTest/Objects/ForwardFusionTests.cs
+++ b/UtilsTest/Objects/ForwardFusionTests.cs
@@ -167,5 +167,105 @@ namespace UtilsTest.Objects
 
         }
 
+        [TestMethod]
+        public void FusionManyToManyDuplicateKeysOnBothSidesTest()
+        {
+            int[] list1 = { 1, 1 };
+            int[] list2 = { 1 };
+
+            (int Left, int Right)[] expected = {
+                (1, 1),
+                (1, 1)
+            };
+
+            var fusion = new ForwardFusion<int, int>(list1, list2);
+            var result = fusion.ToArray();
+
+            var comparer = new EnumerableEqualityComparer<(int Left, int Right)>((i1, i2) => i1.Left == i2.Left && i1.Right == i2.Right);
+
+            Assert.AreEqual(expected, result, comparer);
+        }
+
+        [TestMethod]
+        public void FusionManyToManyCartesianProductTest()
+        {
+            int[] list1 = { 1, 1, 1, 2 };
+            int[] list2 = { 1, 1, 2, 2 };
+
+            (int Left, int Right)[] expected = {
+                (1, 1), (1, 1),
+                (1, 1), (1, 1),
+                (1, 1), (1, 1),
+                (2, 2), (2, 2)
+            };
+
+            var fusion = new ForwardFusion<int, int>(list1, list2);
+            var result = fusion.ToArray();
+
+            var comparer = new EnumerableEqualityComparer<(int Left, int Right)>((i1, i2) => i1.Left == i2.Left && i1.Right == i2.Right);
+
+            Assert.AreEqual(expected, result, comparer);
+        }
+
+        [TestMethod]
+        public void FusionManyToManyWithSurroundingKeysTest()
+        {
+            int[] list1 = { 0, 1, 1, 2 };
+            int[] list2 = { 1, 1, 3 };
+
+            (int Left, int Right)[] expected = {
+                (1, 1), (1, 1),
+                (1, 1), (1, 1)
+            };
+
+            var fusion = new ForwardFusion<int, int>(list1, list2);
+            var result = fusion.ToArray();
+
+            var comparer = new EnumerableEqualityComparer<(int Left, int Right)>((i1, i2) => i1.Left == i2.Left && i1.Right == i2.Right);
+
+            Assert.AreEqual(expected, result, comparer);
+        }
+
+        [TestMethod]
+        public void FusionManyToManyFullOuterJoinTest()
+        {
+            int[] list1 = { 1, 1, 2 };
+            int[] list2 = { 1, 1, 3 };
+
+            (int Left, int Right)[] expected = {
+                (1, 1), (1, 1),
+                (1, 1), (1, 1),
+                (2, 0),
+                (0, 3)
+            };
+
+            var fusion = new ForwardFusion<int, int>(list1, list2, JoinType.FullOuterJoin);
+            var result = fusion.ToArray();
+
+            var comparer = new EnumerableEqualityComparer<(int Left, int Right)>((i1, i2) => i1.Left == i2.Left && i1.Right == i2.Right);
+
+            Assert.AreEqual(expected, result, comparer);
+        }
+
+        [TestMethod]
+        public void FusionComparerWithNonUnitMagnitudeTest()
+        {
+            // The comparison delegate follows the standard IComparable contract: only the sign
+            // matters, not the magnitude. This must not rely on the result being exactly -1/0/1.
+            int[] list1 = { 1, 1, 5 };
+            int[] list2 = { 1, 5, 5 };
+
+            (int Left, int Right)[] expected = {
+                (1, 1), (1, 1),
+                (5, 5), (5, 5)
+            };
+
+            var fusion = new ForwardFusion<int, int>(list1, list2, (l, r) => l - r);
+            var result = fusion.ToArray();
+
+            var comparer = new EnumerableEqualityComparer<(int Left, int Right)>((i1, i2) => i1.Left == i2.Left && i1.Right == i2.Right);
+
+            Assert.AreEqual(expected, result, comparer);
+        }
     }
 }

--- a/UtilsTest/Objects/IntRangeTests.cs
+++ b/UtilsTest/Objects/IntRangeTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using Utils.Collections;
 using Utils.Range;
 
@@ -209,6 +211,31 @@ namespace UtilsTest.Objects
                 var result = range.ToArray();
                 Assert.IsTrue(comparer.Equals(test.result, result), $"{{{string.Join(",", result)}}} est différent de {{{string.Join(",", test.result)}}}");
             }
+        }
+
+        [TestMethod]
+        public void SimpleRangeCompareToObjectFollowsIComparableContractTest()
+        {
+            // SimpleRange is a private nested type; reach it via reflection to verify its
+            // non-generic IComparable.CompareTo(object) follows the standard .NET contract
+            // (positive for null, ArgumentException for an incompatible type) instead of
+            // throwing NotImplementedException.
+            var nestedOpen = typeof(IntRange<>).GetNestedType("SimpleRange", BindingFlags.NonPublic);
+            var simpleRangeType = nestedOpen.MakeGenericType(typeof(int));
+            var ctor = simpleRangeType.GetConstructor(new[] { typeof(int?), typeof(int?) });
+            var compareTo = simpleRangeType.GetMethod("CompareTo", new[] { typeof(object) });
+
+            object range = ctor.Invoke(new object[] { 1, 5 });
+
+            int nullResult = (int)compareTo.Invoke(range, new object[] { null });
+            Assert.IsTrue(nullResult > 0, "Comparing to null should return a positive value.");
+
+            var thrown = Assert.ThrowsExactly<TargetInvocationException>(() => compareTo.Invoke(range, new object[] { "not a range" }));
+            Assert.IsInstanceOfType(thrown.InnerException, typeof(ArgumentException));
+
+            object smaller = ctor.Invoke(new object[] { 0, 5 });
+            int sameTypeResult = (int)compareTo.Invoke(range, new object[] { smaller });
+            Assert.IsTrue(sameTypeResult > 0, "Comparing to a smaller SimpleRange should return a positive value.");
         }
     }
 }

--- a/UtilsTest/Objects/ObjectUtilsTests.cs
+++ b/UtilsTest/Objects/ObjectUtilsTests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Objects;
+
+namespace UtilsTest.Objects;
+
+[TestClass]
+public class ObjectUtilsTests
+{
+    [TestMethod]
+    public void ComputeHashArrayWithNullElementDoesNotThrowTest()
+    {
+        System.Array array = new object[] { "a", null, "b" };
+        int hash = array.ComputeHash();
+        int enumerableHash = ((IEnumerable<object>)array).ComputeHash();
+        Assert.AreEqual(enumerableHash, hash);
+    }
+
+    [TestMethod]
+    public void ComputeHashArrayWithNullElementIsConsistentTest()
+    {
+        System.Array withNull = new object[] { "a", null, "b" };
+        System.Array sameShape = new object[] { "a", null, "b" };
+        Assert.AreEqual(withNull.ComputeHash(), sameShape.ComputeHash());
+    }
+
+    [TestMethod]
+    public void ComputeHashMultidimensionalArrayWithNullElementDoesNotThrowTest()
+    {
+        var array = new object[2, 2];
+        array[0, 0] = "a";
+        array[0, 1] = null;
+        array[1, 0] = "b";
+        array[1, 1] = "c";
+
+        int hash = ((System.Array)array).ComputeHash();
+        Assert.AreNotEqual(0, hash);
+    }
+}

--- a/UtilsTest/Objects/ObjectUtilsTests.cs
+++ b/UtilsTest/Objects/ObjectUtilsTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Objects;
 
@@ -35,5 +37,60 @@ public class ObjectUtilsTests
 
         int hash = ((System.Array)array).ComputeHash();
         Assert.AreNotEqual(0, hash);
+    }
+
+    [TestMethod]
+    public async Task DoAsyncWithSyncDelegatesReturnsIfNotNullResultTest()
+    {
+        string value = "hello";
+        string result = await value.DoAsync(v => v.ToUpperInvariant(), () => "fallback");
+        Assert.AreEqual("HELLO", result);
+    }
+
+    [TestMethod]
+    public async Task DoAsyncWithSyncDelegatesReturnsIfNullResultTest()
+    {
+        string value = null;
+        string result = await value.DoAsync(v => v.ToUpperInvariant(), () => "fallback");
+        Assert.AreEqual("fallback", result);
+    }
+
+    [TestMethod]
+    public async Task DoAsyncWithAsyncDelegatesComposesTasksWithoutThreadPoolOffloadTest()
+    {
+        int callingThreadId = Environment.CurrentManagedThreadId;
+        int? observedThreadId = null;
+
+        string value = "hello";
+        string result = await value.DoAsync(
+            async v =>
+            {
+                observedThreadId = Environment.CurrentManagedThreadId;
+                await Task.Yield();
+                return v.ToUpperInvariant();
+            },
+            async () =>
+            {
+                await Task.Yield();
+                return "fallback";
+            });
+
+        Assert.AreEqual("HELLO", result);
+        // Unlike the sync-delegate overload (which offloads via Task.Run), the async-delegate
+        // overload invokes the delegate synchronously up to its first await, on the caller's thread.
+        Assert.AreEqual(callingThreadId, observedThreadId);
+    }
+
+    [TestMethod]
+    public async Task DoAsyncWithAsyncDelegateAndFallbackValueReturnsFallbackWhenNullTest()
+    {
+        string value = null;
+        string result = await value.DoAsync(async v =>
+        {
+            await Task.Yield();
+            return v.ToUpperInvariant();
+        }, "fallback");
+
+        Assert.AreEqual("fallback", result);
     }
 }

--- a/UtilsTest/Objects/RangesTests.cs
+++ b/UtilsTest/Objects/RangesTests.cs
@@ -258,5 +258,22 @@ namespace UtilsTest.Objects
             var range = DoubleRanges.Parse(" [1-5]  [7-9] ", CultureInfo.InvariantCulture);
             Assert.AreEqual("[ 1 - 5 ] ∪ [ 7 - 9 ]", range.ToString(CultureInfo.InvariantCulture));
         }
+
+        [TestMethod]
+        public void DoubleRangesParseEmptyStringProducesEmptySetTest()
+        {
+            // An empty string is a legitimate representation of an empty set, not malformed input:
+            // it must not throw, unlike non-whitespace content that matches no range (see
+            // DoubleRangesParseRejectsContentWithoutAnyMatchTest).
+            var range = DoubleRanges.Parse("", CultureInfo.InvariantCulture);
+            Assert.AreEqual(0, range.Count);
+        }
+
+        [TestMethod]
+        public void DoubleRangesParseWhitespaceOnlyStringProducesEmptySetTest()
+        {
+            var range = DoubleRanges.Parse("   \t  ", CultureInfo.InvariantCulture);
+            Assert.AreEqual(0, range.Count);
+        }
     }
 }

--- a/UtilsTest/Objects/RangesTests.cs
+++ b/UtilsTest/Objects/RangesTests.cs
@@ -227,5 +227,36 @@ namespace UtilsTest.Objects
                 Assert.AreEqual(test.result, range.ToString("d", CultureInfo.GetCultureInfo("fr-FR")), $"{test} => {range} != {test.result}");
             }
         }
+
+        [TestMethod]
+        public void DoubleRangesParseRejectsTrailingGarbageTest()
+        {
+            Assert.ThrowsExactly<FormatException>(() => DoubleRanges.Parse("[1-5] trailing garbage", CultureInfo.InvariantCulture));
+        }
+
+        [TestMethod]
+        public void DoubleRangesParseRejectsLeadingGarbageTest()
+        {
+            Assert.ThrowsExactly<FormatException>(() => DoubleRanges.Parse("invalid [1-5]", CultureInfo.InvariantCulture));
+        }
+
+        [TestMethod]
+        public void DoubleRangesParseRejectsGarbageBetweenRangesTest()
+        {
+            Assert.ThrowsExactly<FormatException>(() => DoubleRanges.Parse("[1-5] and [7-9]", CultureInfo.InvariantCulture));
+        }
+
+        [TestMethod]
+        public void DoubleRangesParseRejectsContentWithoutAnyMatchTest()
+        {
+            Assert.ThrowsExactly<FormatException>(() => DoubleRanges.Parse("not a range at all", CultureInfo.InvariantCulture));
+        }
+
+        [TestMethod]
+        public void DoubleRangesParseAllowsWhitespaceBetweenRangesTest()
+        {
+            var range = DoubleRanges.Parse(" [1-5]  [7-9] ", CultureInfo.InvariantCulture);
+            Assert.AreEqual("[ 1 - 5 ] ∪ [ 7 - 9 ]", range.ToString(CultureInfo.InvariantCulture));
+        }
     }
 }

--- a/UtilsTest/Randomization/DistributedRandomTests.cs
+++ b/UtilsTest/Randomization/DistributedRandomTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Utils.Randomization;
+
+namespace UtilsTest.Randomization;
+
+[TestClass]
+public class DistributedRandomTests
+{
+    [TestMethod]
+    public void NextDoubleWithRangeReturnsContinuousValuesTest()
+    {
+        var random = new DistributedRandom(x => x, seed: 12345);
+        bool foundFractional = false;
+        for (int i = 0; i < 20; i++)
+        {
+            double value = random.NextDouble(0.0, 100.0);
+            Assert.IsTrue(value >= 0.0 && value < 100.0);
+            if (value != Math.Floor(value))
+            {
+                foundFractional = true;
+            }
+        }
+        Assert.IsTrue(foundFractional, "NextDouble(min, max) must be able to return non-integer values.");
+    }
+
+    [TestMethod]
+    public void NextDoubleWithIdentityDistributionMatchesUnderlyingUniformRandomTest()
+    {
+        double expectedUniform = new Random(42).NextDouble();
+        double expected = expectedUniform * (10.0 - 5.0) + 5.0;
+
+        var distributed = new DistributedRandom(x => x, seed: 42);
+        double actual = distributed.NextDouble(5.0, 10.0);
+
+        Assert.AreEqual(expected, actual, 1e-12);
+    }
+
+    [TestMethod]
+    public void NextIntStaysWithinRangeAndTruncatesTest()
+    {
+        var distributed = new DistributedRandom(x => x, seed: 7);
+        for (int i = 0; i < 20; i++)
+        {
+            int value = distributed.NextInt(0, 100);
+            Assert.IsTrue(value >= 0 && value < 100);
+        }
+    }
+}

--- a/UtilsTest/Randomization/RandomExtensionsTests.cs
+++ b/UtilsTest/Randomization/RandomExtensionsTests.cs
@@ -46,4 +46,62 @@ public class RandomExtensionsTests
         string result = rng.RandomString(7);
         Assert.AreEqual(7, result.Length);
     }
+
+    [TestMethod]
+    public void RandomFloat_CanProduceValuesOutsideZeroOneRange()
+    {
+        // RandomFloat fills the full IEEE-754 bit pattern, unlike Random.NextSingle()'s [0, 1) range.
+        var rng = new Random(12345);
+        bool foundOutsideRange = false;
+        for (int i = 0; i < 1000 && !foundOutsideRange; i++)
+        {
+            float value = rng.RandomFloat();
+            if (float.IsNaN(value) || value < 0f || value >= 1f)
+                foundOutsideRange = true;
+        }
+        Assert.IsTrue(foundOutsideRange, "RandomFloat should be able to produce values outside [0, 1) (including NaN/Infinity).");
+    }
+
+    [TestMethod]
+    public void RandomDouble_CanProduceValuesOutsideZeroOneRange()
+    {
+        // RandomDouble fills the full IEEE-754 bit pattern, unlike Random.NextDouble()'s [0, 1) range.
+        var rng = new Random(12345);
+        bool foundOutsideRange = false;
+        for (int i = 0; i < 1000 && !foundOutsideRange; i++)
+        {
+            double value = rng.RandomDouble();
+            if (double.IsNaN(value) || value < 0d || value >= 1d)
+                foundOutsideRange = true;
+        }
+        Assert.IsTrue(foundOutsideRange, "RandomDouble should be able to produce values outside [0, 1) (including NaN/Infinity).");
+    }
+
+    [TestMethod]
+    public void RandomFloat_CanProduceNaNOrInfinity()
+    {
+        var rng = new Random(12345);
+        bool foundNonFinite = false;
+        for (int i = 0; i < 100_000 && !foundNonFinite; i++)
+        {
+            float value = rng.RandomFloat();
+            if (!float.IsFinite(value))
+                foundNonFinite = true;
+        }
+        Assert.IsTrue(foundNonFinite, "RandomFloat should be able to produce NaN or Infinity values.");
+    }
+
+    [TestMethod]
+    public void RandomDouble_CanProduceNaNOrInfinity()
+    {
+        var rng = new Random(12345);
+        bool foundNonFinite = false;
+        for (int i = 0; i < 100_000 && !foundNonFinite; i++)
+        {
+            double value = rng.RandomDouble();
+            if (!double.IsFinite(value))
+                foundNonFinite = true;
+        }
+        Assert.IsTrue(foundNonFinite, "RandomDouble should be able to produce NaN or Infinity values.");
+    }
 }

--- a/UtilsTest/String/StringUtilsTests.cs
+++ b/UtilsTest/String/StringUtilsTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.String;
+
+namespace UtilsTest.String;
+
+[TestClass]
+public class StringUtilsTests
+{
+    [TestMethod]
+    public void ParseCommandLineSplitsUnquotedArgumentsTest()
+    {
+        CollectionAssert.AreEqual(new[] { "a", "b", "c" }, StringUtils.ParseCommandLine("a b c"));
+    }
+
+    [TestMethod]
+    public void ParseCommandLineKeepsSpacesInsideQuotesTest()
+    {
+        CollectionAssert.AreEqual(new[] { "a b", "c" }, StringUtils.ParseCommandLine("\"a b\" c"));
+    }
+
+    [TestMethod]
+    public void ParseCommandLineUnescapesDoubledQuotesConsistentlyTest()
+    {
+        // Both arguments contain an escaped internal quote ("" -> "). Previously the
+        // non-last argument kept the doubled quote while only the last one was unescaped.
+        string[] result = StringUtils.ParseCommandLine("\"a\"\"b\" \"c\"\"d\"");
+        CollectionAssert.AreEqual(new[] { "a\"b", "c\"d" }, result);
+    }
+
+    [TestMethod]
+    public void ParseCommandLineUnescapesDoubledQuotesInLastArgumentTest()
+    {
+        string[] result = StringUtils.ParseCommandLine("\"c\"\"d\"");
+        CollectionAssert.AreEqual(new[] { "c\"d" }, result);
+    }
+}


### PR DESCRIPTION
## Summary
Addresses the findings from `Utils/TODO.md` (2026-07-10 quality audit), one item per commit, starting with the functional bugs (P0/P1) then the write-up inconsistencies (P2-P4).

- [x] #6 `default(Number)` produces an invalid 0/0 fraction (P0)
- [x] #7 `Number.Parse` silently accepts malformed decimal input (P1)
- [x] #1 `ForwardFusion` many-to-many join incomplete (P1)
- [x] #2 `DistributedRandom.NextDouble` truncates to integers (P1)
- [x] #3 `ParseCommandLine` inconsistent unescaping (P1)
- [x] #8 `ComputeHash(Array)` throws on null elements (P2)
- [x] #4 `LRUCache` partial/misleading synchronization (P2) — later made **actually thread-safe** (see below)
- [x] #9 `DoAsync` wraps sync work in Task.Run (P2)
- [x] #11 `RandomFloat`/`RandomDouble` ambiguous semantics (P2)
- [x] #12 `Ranges<T>.InnerParse` accepts partial invalid input (P2)
- [x] #10 `CompareTo(object)` violates IComparable contract (P3)
- [x] #5 bracket-array style violation (P4)
- [x] #13 unrelated `System.Formats.Tar` using directive (P4)

`Utils/TODO.md` updated to record what changed and where the regression tests live for each item.

## Follow-up: LRUCache made thread-safe
LRU caches are most often reached for in concurrent contexts, so "document as not thread-safe" was reconsidered. `LRUCache<K,V>` now synchronizes every member through a single internal lock; `GetEnumerator`/`Keys`/`Values` take a point-in-time snapshot under that lock instead of exposing a live cursor over the internal `LinkedList` (which used to throw `InvalidOperationException` under concurrent mutation). Covered by two new stress tests.

## Follow-up: two documentation fixes from review
1. `Ranges<T>.InnerParse`: `Utils/TODO.md` overclaimed that "zero-match input" is always rejected. An empty/whitespace-only string was, and remains, intentionally accepted as a legitimate empty set (only non-whitespace unmatched content throws). Clarified the doc and TODO.md wording, added regression tests for `""` and `"   "`.
2. `LRUCache<K,V>`'s remarks claimed compound operations "must synchronize externally" — misleading, since the lock is a private object and `lock (cache)` from calling code has no effect on it. Reworded to state plainly that compound operations are not currently supported atomically.

## Test plan
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` passes after each item
- [x] Full suite green (3552 passed, 3 ignored, 0 failed)
