### PR TITLE
Utils.Mathematics: fix numerical-correctness and quality audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — `omy.Utils.Mathematics` (BREAKING)
+- **`Matrix<T>.DiagonalizeLU()` now returns a 3-tuple `(L, U, P)` instead of `(L, U)`.** The previous
+  two-factor result was mathematically unable to reconstruct the original matrix whenever partial
+  pivoting swapped rows (the documented `A = L·U` identity only held for inputs that happened not to
+  need a pivot swap; the fix also corrected `L` itself, which previously held the product of the
+  elimination operators rather than the actual multiplier matrix). The new contract is `P * A = L * U`.
+  Existing call sites using a two-element deconstruction (`var (l, u) = matrix.DiagonalizeLU();`) will
+  fail to compile and must be updated to `var (l, u, p) = matrix.DiagonalizeLU();`. No package version
+  bump yet — tracked for the coordinated `omy.Utils.*` 2.0.0 batch release rather than an individual
+  bump.
+- `Solve`/`Invert` singularity checks now use a scale-aware relative pivot tolerance (derived from the
+  scalar type's own machine epsilon) instead of comparing to exact zero; both gained an optional
+  `relativeSingularityTolerance` parameter to override the default. A previously-accepted matrix whose
+  elimination pivot is merely close to zero (relative to the matrix's magnitude) now throws
+  `InvalidOperationException` instead of returning a huge/NaN result.
+
 ### Changed — `omy.Utils.Reflection` (BREAKING, v1.2.1 → 2.0.0)
 - **`LibraryMapper.Emit<TInterface>` now runs in an isolated, sandboxed worker process by default**,
   instead of compiling and loading the generated mapping class directly in the calling process. Same

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
@@ -8,39 +8,6 @@ namespace Utils.Mathematics.LinearAlgebra;
 public partial class Matrix<T>
 {
     /// <summary>
-    /// Applies a linear transformation to the specified row of an array-based matrix.
-    /// </summary>
-    /// <param name="matrix">Matrix to transform.</param>
-    /// <param name="targetRow">Row index to replace.</param>
-    /// <param name="transformations">Coefficients describing the transformation.</param>
-    private static void ApplyLinearTransformation(T[,] matrix, int targetRow, T[] transformations)
-    {
-        if (transformations[targetRow] == T.Zero)
-        {
-            throw new ArgumentOutOfRangeException(nameof(targetRow), $"The transformation of row {targetRow} cannot nullify its own value.");
-        }
-
-        int rows = matrix.GetLength(0);
-        int cols = matrix.GetLength(1);
-        T[] newRow = new T[cols];
-
-        for (int col = 0; col < cols; col++)
-        {
-            T temp = T.Zero;
-            for (int row = 0; row < rows; row++)
-            {
-                temp += matrix[row, col] * transformations[row];
-            }
-            newRow[col] = temp;
-        }
-
-        for (int col = 0; col < cols; col++)
-        {
-            matrix[targetRow, col] = newRow[col];
-        }
-    }
-
-    /// <summary>
     /// Swaps two rows of an array-based matrix in place.
     /// </summary>
     /// <param name="matrix">Matrix whose rows should be permuted.</param>
@@ -62,16 +29,19 @@ public partial class Matrix<T>
     }
 
     /// <summary>
-    /// Performs LU decomposition of the current square matrix, resulting in a lower triangular matrix L
-    /// and an upper triangular matrix U such that the original matrix equals L multiplied by U.
+    /// Performs a pivoted LU decomposition of the current square matrix: a lower unitriangular
+    /// matrix L, an upper triangular matrix U, and a permutation matrix P such that P * A = L * U,
+    /// where A is the current matrix.
     /// </summary>
     /// <remarks>
-    /// The decomposition uses the same sequence of elementary row operations as the original mutable implementation
-    /// but operates entirely on local array copies to preserve immutability.
+    /// Uses partial pivoting (largest-magnitude pivot in each column) and stores the elimination
+    /// multipliers directly in L, as required for L to be the actual lower-triangular LU factor
+    /// rather than a by-product of applying the elimination row operations to an identity matrix.
+    /// Operates entirely on local array copies to preserve immutability.
     /// </remarks>
-    /// <returns>A tuple containing the lower and upper triangular matrices.</returns>
+    /// <returns>A tuple containing the lower-triangular, upper-triangular, and permutation matrices.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the matrix is not square or is singular.</exception>
-    public (Matrix<T> L, Matrix<T> U) DiagonalizeLU()
+    public (Matrix<T> L, Matrix<T> U, Matrix<T> P) DiagonalizeLU()
     {
         if (!IsSquare)
         {
@@ -81,10 +51,12 @@ public partial class Matrix<T>
         int n = Rows;
         T[,] u = ToArray();
         T[,] l = new T[n, n];
+        int[] permutation = new int[n];
 
         for (int i = 0; i < n; i++)
         {
             l[i, i] = T.One;
+            permutation[i] = i;
         }
 
         for (int k = 0; k < n; k++)
@@ -106,26 +78,33 @@ public partial class Matrix<T>
             if (pivotRow != k)
             {
                 PermuteRows(u, k, pivotRow);
+                // Only the already-computed multiplier columns (0..k-1) need to move with the row;
+                // column k onward is either not yet computed or the identity diagonal being formed.
                 PermuteRows(l, k, pivotRow, k);
+                (permutation[k], permutation[pivotRow]) = (permutation[pivotRow], permutation[k]);
             }
 
-            T[] transformations = new T[n];
             for (int row = k + 1; row < n; row++)
             {
-                transformations[row] = T.One;
-                transformations[k] = -u[row, k] / u[k, k];
-
-                ApplyLinearTransformation(u, row, transformations);
-                ApplyLinearTransformation(l, row, transformations);
-
-                transformations[row] = T.Zero;
-                transformations[k] = T.Zero;
+                T multiplier = u[row, k] / u[k, k];
+                l[row, k] = multiplier;
+                for (int col = k; col < n; col++)
+                {
+                    u[row, col] -= multiplier * u[k, col];
+                }
             }
         }
 
-        Matrix<T> L = new Matrix<T>(l, false, true, false, null);
+        T[,] p = new T[n, n];
+        for (int i = 0; i < n; i++)
+        {
+            p[i, permutation[i]] = T.One;
+        }
+
+        Matrix<T> L = new Matrix<T>(l, false, true, false, T.One);
         Matrix<T> U = new Matrix<T>(u, false, true, false, null);
-        return (L, U);
+        Matrix<T> P = new Matrix<T>(p, false, false, false, null);
+        return (L, U, P);
     }
 
     /// <summary>

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
@@ -126,7 +126,7 @@ public partial class Matrix<T>
     /// Inverts the matrix if it is invertible.
     /// </summary>
     /// <param name="relativeSingularityTolerance">
-    /// Overrides the default relative pivot tolerance (see <see cref="SingularityRelativeTolerance"/>)
+    /// Overrides the default relative pivot tolerance (see <see cref="DefaultSingularityRelativeTolerance"/>)
     /// used to reject a numerically near-singular matrix; the effective absolute threshold is this
     /// value multiplied by the matrix's largest entry. Must be finite and non-negative when supplied.
     /// </param>
@@ -150,7 +150,7 @@ public partial class Matrix<T>
         int n = Rows;
         T[,] working = ToArray();
         T[,] inverse = new T[n, n];
-        T pivotTolerance = MaxAbsoluteEntry(working) * (relativeSingularityTolerance ?? SingularityRelativeTolerance);
+        T pivotTolerance = MaxAbsoluteEntry(working) * (relativeSingularityTolerance ?? DefaultSingularityRelativeTolerance(n));
 
         for (int i = 0; i < n; i++)
         {

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
@@ -8,6 +8,21 @@ namespace Utils.Mathematics.LinearAlgebra;
 public partial class Matrix<T>
 {
     /// <summary>
+    /// Returns the largest absolute value among an array-based matrix's entries, used to derive a
+    /// scale-aware (rather than absolute) pivot tolerance for singularity checks.
+    /// </summary>
+    private static T MaxAbsoluteEntry(T[,] matrix)
+    {
+        T max = T.Zero;
+        int rows = matrix.GetLength(0);
+        int cols = matrix.GetLength(1);
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
+                max = T.Max(max, T.Abs(matrix[i, j]));
+        return max;
+    }
+
+    /// <summary>
     /// Swaps two rows of an array-based matrix in place.
     /// </summary>
     /// <param name="matrix">Matrix whose rows should be permuted.</param>
@@ -127,6 +142,7 @@ public partial class Matrix<T>
         int n = Rows;
         T[,] working = ToArray();
         T[,] inverse = new T[n, n];
+        T pivotTolerance = MaxAbsoluteEntry(working) * SingularityRelativeTolerance;
 
         for (int i = 0; i < n; i++)
         {
@@ -148,9 +164,9 @@ public partial class Matrix<T>
                 }
             }
 
-            if (working[pivotRow, pivotIndex].Equals(T.Zero))
+            if (pivotMagnitude <= pivotTolerance)
             {
-                throw new InvalidOperationException("The matrix is singular and cannot be inverted.");
+                throw new InvalidOperationException("The matrix is singular or numerically near-singular and cannot be reliably inverted.");
             }
 
             if (pivotRow != pivotIndex)

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
@@ -125,14 +125,22 @@ public partial class Matrix<T>
     /// <summary>
     /// Inverts the matrix if it is invertible.
     /// </summary>
+    /// <param name="relativeSingularityTolerance">
+    /// Overrides the default relative pivot tolerance (see <see cref="SingularityRelativeTolerance"/>)
+    /// used to reject a numerically near-singular matrix; the effective absolute threshold is this
+    /// value multiplied by the matrix's largest entry. Must be finite and non-negative when supplied.
+    /// </param>
     /// <returns>A new matrix representing the inverse of the current matrix.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the matrix is not square.</exception>
-    public Matrix<T> Invert()
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="relativeSingularityTolerance"/> is supplied but not finite or is negative.</exception>
+    public Matrix<T> Invert(T? relativeSingularityTolerance = null)
     {
         if (!IsSquare)
         {
             throw new InvalidOperationException("The matrix is not square.");
         }
+        if (relativeSingularityTolerance is { } explicitTolerance)
+            ValidateTolerance(explicitTolerance, nameof(relativeSingularityTolerance));
 
         if (IsIdentity)
         {
@@ -142,7 +150,7 @@ public partial class Matrix<T>
         int n = Rows;
         T[,] working = ToArray();
         T[,] inverse = new T[n, n];
-        T pivotTolerance = MaxAbsoluteEntry(working) * SingularityRelativeTolerance;
+        T pivotTolerance = MaxAbsoluteEntry(working) * (relativeSingularityTolerance ?? SingularityRelativeTolerance);
 
         for (int i = 0; i < n; i++)
         {

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
@@ -13,7 +13,7 @@ public sealed partial class Matrix<T>
     /// </summary>
     /// <param name="b">Right-hand-side vector. Its dimension must equal the number of rows.</param>
     /// <param name="relativeSingularityTolerance">
-    /// Overrides the default relative pivot tolerance (see <see cref="SingularityRelativeTolerance"/>)
+    /// Overrides the default relative pivot tolerance (see <see cref="DefaultSingularityRelativeTolerance"/>)
     /// used to reject a numerically near-singular matrix; the effective absolute threshold is this
     /// value multiplied by the matrix's largest entry. Pass a smaller value to accept more
     /// ill-conditioned systems, or a larger value to reject them more aggressively. Must be finite
@@ -37,7 +37,7 @@ public sealed partial class Matrix<T>
         T[] x = new T[n];
         for (int i = 0; i < n; i++) x[i] = b[i];
 
-        T pivotTolerance = MaxAbsoluteEntry(a) * (relativeSingularityTolerance ?? SingularityRelativeTolerance);
+        T pivotTolerance = MaxAbsoluteEntry(a) * (relativeSingularityTolerance ?? DefaultSingularityRelativeTolerance(n));
 
         // Forward elimination with partial pivoting
         for (int col = 0; col < n; col++)

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
@@ -27,6 +27,8 @@ public sealed partial class Matrix<T>
         T[] x = new T[n];
         for (int i = 0; i < n; i++) x[i] = b[i];
 
+        T pivotTolerance = MaxAbsoluteEntry(a) * SingularityRelativeTolerance;
+
         // Forward elimination with partial pivoting
         for (int col = 0; col < n; col++)
         {
@@ -35,8 +37,8 @@ public sealed partial class Matrix<T>
                 if (T.Abs(a[row, col]) > T.Abs(a[pivotRow, col]))
                     pivotRow = row;
 
-            if (a[pivotRow, col] == T.Zero)
-                throw new InvalidOperationException("Matrix is singular; the system has no unique solution.");
+            if (T.Abs(a[pivotRow, col]) <= pivotTolerance)
+                throw new InvalidOperationException("Matrix is singular or numerically near-singular; the system has no reliable unique solution.");
 
             if (pivotRow != col)
             {

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
@@ -12,22 +12,32 @@ public sealed partial class Matrix<T>
     /// Uses Gaussian elimination with partial pivoting.
     /// </summary>
     /// <param name="b">Right-hand-side vector. Its dimension must equal the number of rows.</param>
+    /// <param name="relativeSingularityTolerance">
+    /// Overrides the default relative pivot tolerance (see <see cref="SingularityRelativeTolerance"/>)
+    /// used to reject a numerically near-singular matrix; the effective absolute threshold is this
+    /// value multiplied by the matrix's largest entry. Pass a smaller value to accept more
+    /// ill-conditioned systems, or a larger value to reject them more aggressively. Must be finite
+    /// and non-negative when supplied.
+    /// </param>
     /// <returns>The solution vector <c>x</c>.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the matrix is not square or is singular.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="b"/> has the wrong dimension.</exception>
-    public Vector<T> Solve(Vector<T> b)
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="relativeSingularityTolerance"/> is supplied but not finite or is negative.</exception>
+    public Vector<T> Solve(Vector<T> b, T? relativeSingularityTolerance = null)
     {
         if (!IsSquare)
             throw new InvalidOperationException("Only square matrices can be solved with this method.");
         if (b.Dimension != Rows)
             throw new ArgumentException($"Vector dimension {b.Dimension} does not match matrix row count {Rows}.", nameof(b));
+        if (relativeSingularityTolerance is { } explicitTolerance)
+            ValidateTolerance(explicitTolerance, nameof(relativeSingularityTolerance));
 
         int n = Rows;
         T[,] a = ToArray();
         T[] x = new T[n];
         for (int i = 0; i < n; i++) x[i] = b[i];
 
-        T pivotTolerance = MaxAbsoluteEntry(a) * SingularityRelativeTolerance;
+        T pivotTolerance = MaxAbsoluteEntry(a) * (relativeSingularityTolerance ?? SingularityRelativeTolerance);
 
         // Forward elimination with partial pivoting
         for (int col = 0; col < n; col++)

--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -38,15 +38,24 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     }
 
     /// <summary>
-    /// Relative pivot tolerance used by <see cref="Solve"/> and <see cref="Invert"/> to reject a
-    /// numerically near-singular matrix (magnitude relative to the matrix's largest entry) instead
-    /// of dividing by a pivot that is merely close to zero, which would silently amplify rounding
-    /// error into a huge, infinite, or NaN result while still returning an apparently valid answer.
-    /// Derived from <see cref="MachineEpsilon"/> (scaled by a deliberately generous, not rigorously
-    /// derived, safety factor to absorb elimination round-off) so it stays meaningful - and non-zero -
-    /// across every supported scalar type instead of a single hard-coded absolute constant.
+    /// Computes the default relative pivot tolerance for an <paramref name="dimension"/>-by-
+    /// <paramref name="dimension"/> elimination used by <see cref="Solve"/>, <see cref="Invert"/>,
+    /// and <see cref="Determinant"/> to reject a numerically near-singular matrix (magnitude
+    /// relative to the matrix's largest entry) instead of dividing by a pivot that is merely close
+    /// to zero, which would silently amplify rounding error into a huge, infinite, or NaN result
+    /// while still returning an apparently valid answer.
     /// </summary>
-    private static readonly T SingularityRelativeTolerance = MachineEpsilon * T.CreateChecked(100);
+    /// <remarks>
+    /// Scaled by <paramref name="dimension"/> rather than a flat constant, following the common
+    /// numerical-linear-algebra convention that accumulated round-off across elimination grows
+    /// roughly with problem size (e.g. LAPACK-style rank/near-singularity heuristics use
+    /// <c>n * eps</c> rather than a size-independent multiplier). A flat multiplier large enough to
+    /// be meaningful for bigger systems (an earlier version of this method used a fixed 100x) is far
+    /// too loose for small matrices of a low-precision type: for a 2x2 <see cref="Half"/> matrix, a
+    /// flat 100x its machine epsilon is already about 10% of the matrix's magnitude, misclassifying
+    /// ordinary invertible matrices (e.g. a diagonal with a 20:1 ratio between entries) as singular.
+    /// </remarks>
+    private static T DefaultSingularityRelativeTolerance(int dimension) => MachineEpsilon * T.CreateChecked(dimension);
 
     /// <summary>
     /// Validates that a caller-supplied tolerance is usable as a comparison threshold: finite and
@@ -371,7 +380,7 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
         // Elimination divides by the pivot below, so a pivot that is merely close to zero (not
         // exactly zero) would otherwise amplify rounding error into a huge/infinite/NaN result
         // instead of the mathematically expected near-zero determinant of a near-singular matrix.
-        T pivotTolerance = MaxAbsoluteEntry(u) * SingularityRelativeTolerance;
+        T pivotTolerance = MaxAbsoluteEntry(u) * DefaultSingularityRelativeTolerance(n);
 
         for (int k = 0; k < n; k++)
         {

--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -20,12 +20,46 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     private int? hashCode;
 
     /// <summary>
+    /// The type's machine epsilon: the smallest positive value such that <c>1 + eps != 1</c> in
+    /// <typeparamref name="T"/>'s own arithmetic. Computed generically by successive halving rather
+    /// than a hard-coded literal such as <c>1e-10</c>, which is meaningless (and, for low-precision
+    /// types such as <see cref="Half"/>, would silently underflow to zero) across arbitrary
+    /// <see cref="IFloatingPoint{TSelf}"/> types with wildly different precision.
+    /// </summary>
+    private static readonly T MachineEpsilon = ComputeMachineEpsilon();
+
+    private static T ComputeMachineEpsilon()
+    {
+        T two = T.One + T.One;
+        T eps = T.One;
+        while (T.One + eps / two != T.One)
+            eps /= two;
+        return eps;
+    }
+
+    /// <summary>
     /// Relative pivot tolerance used by <see cref="Solve"/> and <see cref="Invert"/> to reject a
     /// numerically near-singular matrix (magnitude relative to the matrix's largest entry) instead
     /// of dividing by a pivot that is merely close to zero, which would silently amplify rounding
     /// error into a huge, infinite, or NaN result while still returning an apparently valid answer.
+    /// Derived from <see cref="MachineEpsilon"/> (scaled by a deliberately generous, not rigorously
+    /// derived, safety factor to absorb elimination round-off) so it stays meaningful - and non-zero -
+    /// across every supported scalar type instead of a single hard-coded absolute constant.
     /// </summary>
-    private static readonly T SingularityRelativeTolerance = T.CreateChecked(1e-10);
+    private static readonly T SingularityRelativeTolerance = MachineEpsilon * T.CreateChecked(100);
+
+    /// <summary>
+    /// Validates that a caller-supplied tolerance is usable as a comparison threshold: finite and
+    /// non-negative. A <see langword="NaN"/> tolerance would make every "is this within tolerance"
+    /// comparison false (vacuously accepting everything as "not equal" or, depending on the
+    /// comparison direction, silently accepting everything as "equal"), and a negative tolerance
+    /// would reject exact matches.
+    /// </summary>
+    private static void ValidateTolerance(T tolerance, string parameterName)
+    {
+        if (!T.IsFinite(tolerance) || tolerance < T.Zero)
+            throw new ArgumentOutOfRangeException(parameterName, tolerance, "Tolerance must be finite and non-negative.");
+    }
 
     /// <summary>
     /// Gets the number of rows in the matrix.
@@ -191,15 +225,25 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     /// noise left over from prior arithmetic or decomposition; it is a separate, explicitly opt-in
     /// predicate rather than a silently chosen global tolerance applied to <see cref="IsTriangular"/>.
     /// </summary>
-    /// <param name="tolerance">Maximum absolute value an off-diagonal entry may have and still be treated as zero.</param>
-    public bool IsTriangularWithin(T tolerance) => DetermineStructuralFlags(tolerance).Triangular;
+    /// <param name="tolerance">Maximum absolute value an off-diagonal entry may have and still be treated as zero. Must be finite and non-negative.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is not finite or is negative.</exception>
+    public bool IsTriangularWithin(T tolerance)
+    {
+        ValidateTolerance(tolerance, nameof(tolerance));
+        return DetermineStructuralFlags(tolerance).Triangular;
+    }
 
     /// <summary>
     /// Indicates whether the matrix is diagonal within <paramref name="tolerance"/>. See
     /// <see cref="IsTriangularWithin"/> for the tolerance-vs-exact rationale.
     /// </summary>
-    /// <param name="tolerance">Maximum absolute value an off-diagonal entry may have and still be treated as zero.</param>
-    public bool IsDiagonalWithin(T tolerance) => DetermineStructuralFlags(tolerance).Diagonal;
+    /// <param name="tolerance">Maximum absolute value an off-diagonal entry may have and still be treated as zero. Must be finite and non-negative.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is not finite or is negative.</exception>
+    public bool IsDiagonalWithin(T tolerance)
+    {
+        ValidateTolerance(tolerance, nameof(tolerance));
+        return DetermineStructuralFlags(tolerance).Diagonal;
+    }
 
     /// <summary>
     /// Indicates whether the matrix is the identity matrix within <paramref name="tolerance"/>,
@@ -207,16 +251,23 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     /// entries within <paramref name="tolerance"/> of zero, as matching. See
     /// <see cref="IsTriangularWithin"/> for the tolerance-vs-exact rationale.
     /// </summary>
-    /// <param name="tolerance">Maximum allowed absolute deviation from the expected exact value.</param>
-    public bool IsIdentityWithin(T tolerance) => DetermineStructuralFlags(tolerance).Identity;
+    /// <param name="tolerance">Maximum allowed absolute deviation from the expected exact value. Must be finite and non-negative.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is not finite or is negative.</exception>
+    public bool IsIdentityWithin(T tolerance)
+    {
+        ValidateTolerance(tolerance, nameof(tolerance));
+        return DetermineStructuralFlags(tolerance).Identity;
+    }
 
     /// <summary>
     /// Indicates whether the matrix represents a normal space within <paramref name="tolerance"/>.
     /// See <see cref="IsTriangularWithin"/> for the tolerance-vs-exact rationale.
     /// </summary>
-    /// <param name="tolerance">Maximum allowed absolute deviation from the expected exact value.</param>
+    /// <param name="tolerance">Maximum allowed absolute deviation from the expected exact value. Must be finite and non-negative.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is not finite or is negative.</exception>
     public bool IsNormalSpaceWithin(T tolerance)
     {
+        ValidateTolerance(tolerance, nameof(tolerance));
         if (!IsSquare) return false;
         int lastRow = Rows - 1;
         int lastCol = Columns - 1;

--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -95,6 +95,42 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     }
 
     /// <summary>
+    /// Computes the triangular/diagonal/identity structure treating any value within
+    /// <paramref name="tolerance"/> of the expected exact value (zero off-diagonal, one on the
+    /// diagonal) as matching. Never caches into <see cref="isTriangular"/>/<see cref="isDiagonal"/>/
+    /// <see cref="isIdentity"/>, which hold the exact-comparison result used by the parameterless
+    /// properties.
+    /// </summary>
+    private (bool Triangular, bool Diagonal, bool Identity) DetermineStructuralFlags(T tolerance)
+    {
+        if (!IsSquare) return (false, false, false);
+
+        int dimension = components.GetLength(0);
+        bool upperTriangular = true;
+        bool lowerTriangular = true;
+        bool identityCheck = true;
+
+        for (int row = 0; row < dimension; row++)
+        {
+            for (int col = 0; col < dimension; col++)
+            {
+                T value = components[row, col];
+                if (row == col && T.Abs(value - T.One) > tolerance)
+                    identityCheck = false;
+
+                if (T.Abs(value) > tolerance)
+                {
+                    if (row > col) upperTriangular = false;
+                    else if (row < col) lowerTriangular = false;
+                }
+            }
+        }
+
+        bool diagonal = upperTriangular && lowerTriangular;
+        return (upperTriangular || lowerTriangular, diagonal, diagonal && identityCheck);
+    }
+
+    /// <summary>
     /// Indicates whether the matrix is triangular (upper or lower).
     /// </summary>
     public bool IsTriangular
@@ -146,6 +182,49 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
             }
             return components[lastRow, lastCol] == T.One;
         }
+    }
+
+    /// <summary>
+    /// Indicates whether the matrix is triangular (upper or lower) within <paramref name="tolerance"/>,
+    /// treating any off-diagonal entry with absolute value at most <paramref name="tolerance"/> as
+    /// zero. Unlike <see cref="IsTriangular"/>, which requires exact zero, this tolerates rounding
+    /// noise left over from prior arithmetic or decomposition; it is a separate, explicitly opt-in
+    /// predicate rather than a silently chosen global tolerance applied to <see cref="IsTriangular"/>.
+    /// </summary>
+    /// <param name="tolerance">Maximum absolute value an off-diagonal entry may have and still be treated as zero.</param>
+    public bool IsTriangularWithin(T tolerance) => DetermineStructuralFlags(tolerance).Triangular;
+
+    /// <summary>
+    /// Indicates whether the matrix is diagonal within <paramref name="tolerance"/>. See
+    /// <see cref="IsTriangularWithin"/> for the tolerance-vs-exact rationale.
+    /// </summary>
+    /// <param name="tolerance">Maximum absolute value an off-diagonal entry may have and still be treated as zero.</param>
+    public bool IsDiagonalWithin(T tolerance) => DetermineStructuralFlags(tolerance).Diagonal;
+
+    /// <summary>
+    /// Indicates whether the matrix is the identity matrix within <paramref name="tolerance"/>,
+    /// treating diagonal entries within <paramref name="tolerance"/> of one, and off-diagonal
+    /// entries within <paramref name="tolerance"/> of zero, as matching. See
+    /// <see cref="IsTriangularWithin"/> for the tolerance-vs-exact rationale.
+    /// </summary>
+    /// <param name="tolerance">Maximum allowed absolute deviation from the expected exact value.</param>
+    public bool IsIdentityWithin(T tolerance) => DetermineStructuralFlags(tolerance).Identity;
+
+    /// <summary>
+    /// Indicates whether the matrix represents a normal space within <paramref name="tolerance"/>.
+    /// See <see cref="IsTriangularWithin"/> for the tolerance-vs-exact rationale.
+    /// </summary>
+    /// <param name="tolerance">Maximum allowed absolute deviation from the expected exact value.</param>
+    public bool IsNormalSpaceWithin(T tolerance)
+    {
+        if (!IsSquare) return false;
+        int lastRow = Rows - 1;
+        int lastCol = Columns - 1;
+        for (int col = 0; col < lastCol; col++)
+        {
+            if (T.Abs(components[lastRow, col]) > tolerance) return false;
+        }
+        return T.Abs(components[lastRow, lastCol] - T.One) <= tolerance;
     }
 
     /// <summary>

--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -20,6 +20,14 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     private int? hashCode;
 
     /// <summary>
+    /// Relative pivot tolerance used by <see cref="Solve"/> and <see cref="Invert"/> to reject a
+    /// numerically near-singular matrix (magnitude relative to the matrix's largest entry) instead
+    /// of dividing by a pivot that is merely close to zero, which would silently amplify rounding
+    /// error into a huge, infinite, or NaN result while still returning an apparently valid answer.
+    /// </summary>
+    private static readonly T SingularityRelativeTolerance = T.CreateChecked(1e-10);
+
+    /// <summary>
     /// Gets the number of rows in the matrix.
     /// </summary>
     public int Rows => components.GetLength(0);
@@ -230,6 +238,10 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
         int n = Rows;
         T[,] u = ToArray();
         int swaps = 0;
+        // Elimination divides by the pivot below, so a pivot that is merely close to zero (not
+        // exactly zero) would otherwise amplify rounding error into a huge/infinite/NaN result
+        // instead of the mathematically expected near-zero determinant of a near-singular matrix.
+        T pivotTolerance = MaxAbsoluteEntry(u) * SingularityRelativeTolerance;
 
         for (int k = 0; k < n; k++)
         {
@@ -240,7 +252,7 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
                     pivotRow = i;
             }
 
-            if (u[pivotRow, k].Equals(T.Zero))
+            if (T.Abs(u[pivotRow, k]) <= pivotTolerance)
                 return T.Zero;
 
             if (pivotRow != k)

--- a/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
+++ b/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
@@ -208,10 +208,10 @@ public static class MatrixTransformations
             }
         }
 
-        int lastRow = dimension - 1;
+        int lastColumn = dimension - 1;
         for (int i = 0; i < valuesArray.Length; i++)
         {
-            array[lastRow, i] = valuesArray[i];
+            array[i, lastColumn] = valuesArray[i];
         }
 
         return new Matrix<T>(array, false, false, false, null);

--- a/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
+++ b/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
@@ -100,11 +100,20 @@ public static class MatrixTransformations
     }
 
     /// <summary>
-    /// Generates a shear matrix using the provided angles.
+    /// Generates a shear (skew) matrix using the provided angles.
     /// </summary>
     /// <typeparam name="T">Numeric type of the matrix.</typeparam>
-    /// <param name="angles">Angles of the shear.</param>
-    /// <returns>New shear matrix.</returns>
+    /// <param name="angles">
+    /// One angle per off-diagonal coefficient of the base <c>d × d</c> shear block, in row-major
+    /// order skipping the diagonal (row 0's <c>d-1</c> off-diagonal columns, then row 1's, and so
+    /// on). The base dimension <c>d</c> is inferred from the count: <c>d * (d - 1)</c> angles are
+    /// required, since a full shear has one free coefficient per off-diagonal position.
+    /// </param>
+    /// <returns>
+    /// A new <c>(d+1) × (d+1)</c> homogeneous shear matrix: identity everywhere except the supplied
+    /// <c>tan(angle)</c> values at the base block's off-diagonal positions.
+    /// </returns>
+    /// <exception cref="ArgumentException">Thrown when the angle count does not match <c>d * (d - 1)</c> for any integer <c>d</c>.</exception>
     public static Matrix<T> Skew<T>(params IEnumerable<T> angles)
         where T : struct, IFloatingPoint<T>, ITrigonometricFunctions<T>, IRootFunctions<T>
     {
@@ -128,9 +137,9 @@ public static class MatrixTransformations
         int coefficientIndex = 0;
         for (int x = 0; x < baseDimension; x++)
         {
-            for (int y = 0; y < baseDimension; y++)
+            for (int y = 0; y < baseDimension - 1; y++)
             {
-                int column = y >= x ? y : y + 1;
+                int column = y < x ? y : y + 1;
                 array[x, column] = T.Tan(anglesArray[coefficientIndex]);
                 coefficientIndex++;
             }

--- a/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
@@ -216,7 +216,7 @@ public partial class Vector<T> :
     /// <param name="vector2">Second vector.</param>
     /// <returns>True if vectors are equal; otherwise, false.</returns>
     public static bool operator ==(Vector<T>? vector1, Vector<T>? vector2)
-        => (vector1 is not null && vector1.Equals(vector2)) || vector2 is null;
+        => ReferenceEquals(vector1, vector2) || (vector1 is not null && vector1.Equals(vector2));
 
     /// <summary>
     /// Checks if two vectors are not equal.

--- a/Utils.Mathematics/NumericalMethods.cs
+++ b/Utils.Mathematics/NumericalMethods.cs
@@ -23,12 +23,30 @@ public static class NumericalMethods
     /// Number of sub-intervals. Must be positive and even; an odd value is rounded up by one.
     /// Higher values increase accuracy at the cost of more function evaluations.
     /// </param>
-    /// <returns>The approximate value of ∫f(x)dx from a to b.</returns>
+    /// <returns>
+    /// The approximate value of ∫f(x)dx from a to b. If <paramref name="f"/> returns a non-finite
+    /// value anywhere in the interval, that non-finite value propagates into the result (visible to
+    /// the caller as NaN or an infinity) rather than being silently discarded.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="f"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="steps"/> is not positive, when <paramref name="steps"/> is the
+    /// odd value <see cref="int.MaxValue"/> (which cannot be rounded up to an even count without
+    /// overflowing), or when <paramref name="a"/>/<paramref name="b"/> is not finite.
+    /// </exception>
     public static T Integrate<T>(Func<T, T> f, T a, T b, int steps = 1000)
         where T : struct, IFloatingPoint<T>
     {
-        if (steps <= 0) throw new ArgumentOutOfRangeException(nameof(steps), "Steps must be positive.");
-        if (steps % 2 != 0) steps++;
+        ArgumentNullException.ThrowIfNull(f);
+        if (steps <= 0) throw new ArgumentOutOfRangeException(nameof(steps), steps, "Steps must be positive.");
+        if (!T.IsFinite(a)) throw new ArgumentOutOfRangeException(nameof(a), a, "Must be finite.");
+        if (!T.IsFinite(b)) throw new ArgumentOutOfRangeException(nameof(b), b, "Must be finite.");
+        if (steps % 2 != 0)
+        {
+            if (steps == int.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(steps), steps, "An odd step count of int.MaxValue cannot be rounded up to an even value without overflowing.");
+            steps++;
+        }
 
         T n = T.CreateChecked(steps);
         T h = (b - a) / n;

--- a/Utils.Mathematics/NumericalMethods.cs
+++ b/Utils.Mathematics/NumericalMethods.cs
@@ -75,16 +75,36 @@ public static class NumericalMethods
     /// Runge's phenomenon near the boundaries.
     /// </remarks>
     /// <typeparam name="T">Floating-point scalar type.</typeparam>
-    /// <param name="points">Sequence of (x, y) data points. All x values must be distinct.</param>
-    /// <param name="at">The point at which to evaluate the interpolating polynomial.</param>
+    /// <param name="points">Sequence of (x, y) data points. All x values must be distinct and every coordinate finite.</param>
+    /// <param name="at">The point at which to evaluate the interpolating polynomial. Must be finite.</param>
     /// <returns>The interpolated value at <paramref name="at"/>.</returns>
-    /// <exception cref="ArgumentException">Thrown when no points are provided or x values are not distinct.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when no points are provided, a coordinate is not finite, or x values are not distinct.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="at"/> is not finite.</exception>
     public static T Lagrange<T>(IEnumerable<(T x, T y)> points, T at)
         where T : struct, IFloatingPoint<T>
     {
         (T x, T y)[] pts = points.ToArray();
         if (pts.Length == 0)
             throw new ArgumentException("At least one data point is required.", nameof(points));
+        if (!T.IsFinite(at))
+            throw new ArgumentOutOfRangeException(nameof(at), at, "Must be finite.");
+
+        // Validate every point - including finiteness and pairwise distinctness of x - before
+        // evaluating anything. A NaN x value bypasses an equality-based distinctness check (NaN is
+        // never equal to anything, including another NaN), so finiteness must be checked
+        // separately rather than relying on the distinctness comparison alone.
+        for (int i = 0; i < pts.Length; i++)
+        {
+            if (!T.IsFinite(pts[i].x) || !T.IsFinite(pts[i].y))
+                throw new ArgumentException("All data point coordinates must be finite.", nameof(points));
+            for (int j = i + 1; j < pts.Length; j++)
+            {
+                if (pts[i].x == pts[j].x)
+                    throw new ArgumentException("All x values must be distinct.", nameof(points));
+            }
+        }
 
         T result = T.Zero;
         for (int i = 0; i < pts.Length; i++)
@@ -93,10 +113,7 @@ public static class NumericalMethods
             for (int j = 0; j < pts.Length; j++)
             {
                 if (j == i) continue;
-                T denom = pts[i].x - pts[j].x;
-                if (denom == T.Zero)
-                    throw new ArgumentException("All x values must be distinct.", nameof(points));
-                basis *= (at - pts[j].x) / denom;
+                basis *= (at - pts[j].x) / (pts[i].x - pts[j].x);
             }
             result += pts[i].y * basis;
         }

--- a/Utils.Mathematics/Polynomial.cs
+++ b/Utils.Mathematics/Polynomial.cs
@@ -24,22 +24,39 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
 
     /// <summary>
     /// Initializes a polynomial from its coefficients in ascending power order.
-    /// Leading zero coefficients are trimmed so the stored degree is minimal.
+    /// Trailing exact-zero coefficients are trimmed so the stored degree is minimal.
     /// </summary>
     /// <param name="coefficients">Coefficients [a₀, a₁, …, aₙ]. At least one value is required.</param>
     /// <exception cref="ArgumentException">Thrown when no coefficients are provided.</exception>
     public Polynomial(params IEnumerable<T> coefficients)
+        : this(Canonicalize(coefficients.ToArray()))
     {
-        T[] arr = coefficients.ToArray();
-        if (arr.Length == 0)
-            throw new ArgumentException("At least one coefficient is required.", nameof(coefficients));
-        // Trim trailing zeroes (leading in degree) to get canonical form
-        int last = arr.Length - 1;
-        while (last > 0 && T.Abs(arr[last]) <= Epsilon) last--;
-        _coefficients = arr[..(last + 1)];
     }
 
-    private Polynomial(T[] coefficients) => _coefficients = coefficients;
+    /// <summary>
+    /// Creates a polynomial directly from an already-canonical coefficient array (no trailing exact
+    /// zero unless the polynomial is the zero polynomial), without copying or re-trimming it. Every
+    /// call site owning a freshly built array must route it through <see cref="Canonicalize"/> first
+    /// so canonical form - and therefore <see cref="Equals(Polynomial{T})"/>/<see cref="GetHashCode"/>
+    /// consistency - holds regardless of which constructor or operator produced the instance.
+    /// </summary>
+    private Polynomial(T[] canonicalCoefficients) => _coefficients = canonicalCoefficients;
+
+    /// <summary>
+    /// Trims trailing exact-zero coefficients so the stored array has minimal length (degree zero
+    /// for the zero polynomial). Uses exact zero rather than a tolerance: an absolute epsilon has no
+    /// scale-independent meaning across arbitrary <typeparamref name="T"/> and coefficient
+    /// magnitudes, and would make canonical form - and therefore equality and hashing - depend on
+    /// where a caller's values happen to fall relative to a fixed constant.
+    /// </summary>
+    private static T[] Canonicalize(T[] coefficients)
+    {
+        if (coefficients.Length == 0)
+            throw new ArgumentException("At least one coefficient is required.", nameof(coefficients));
+        int last = coefficients.Length - 1;
+        while (last > 0 && coefficients[last] == T.Zero) last--;
+        return last == coefficients.Length - 1 ? coefficients : coefficients[..(last + 1)];
+    }
 
     // -------------------------------------------------------------------------
     // Evaluation
@@ -72,7 +89,7 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
         T[] d = new T[Degree];
         for (int i = 1; i <= Degree; i++)
             d[i - 1] = T.CreateChecked(i) * _coefficients[i];
-        return new Polynomial<T>(d);
+        return new Polynomial<T>(Canonicalize(d));
     }
 
     /// <summary>
@@ -86,7 +103,7 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
         result[0] = constant;
         for (int i = 0; i <= Degree; i++)
             result[i + 1] = _coefficients[i] / T.CreateChecked(i + 1);
-        return new Polynomial<T>(result);
+        return new Polynomial<T>(Canonicalize(result));
     }
 
     // -------------------------------------------------------------------------
@@ -133,7 +150,7 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
             T cb = i < b._coefficients.Length ? b._coefficients[i] : T.Zero;
             result[i] = ca + cb;
         }
-        return new Polynomial<T>(result);
+        return new Polynomial<T>(Canonicalize(result));
     }
 
     /// <summary>Returns the difference of two polynomials.</summary>
@@ -147,7 +164,7 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
             T cb = i < b._coefficients.Length ? b._coefficients[i] : T.Zero;
             result[i] = ca - cb;
         }
-        return new Polynomial<T>(result);
+        return new Polynomial<T>(Canonicalize(result));
     }
 
     /// <summary>Returns the product of two polynomials.</summary>
@@ -157,7 +174,7 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
         for (int i = 0; i < a._coefficients.Length; i++)
             for (int j = 0; j < b._coefficients.Length; j++)
                 result[i + j] += a._coefficients[i] * b._coefficients[j];
-        return new Polynomial<T>(result);
+        return new Polynomial<T>(Canonicalize(result));
     }
 
     /// <summary>Returns the polynomial scaled by a scalar.</summary>
@@ -165,7 +182,7 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
     {
         T[] result = new T[p._coefficients.Length];
         for (int i = 0; i < result.Length; i++) result[i] = scalar * p._coefficients[i];
-        return new Polynomial<T>(result);
+        return new Polynomial<T>(Canonicalize(result));
     }
 
     /// <summary>Returns the polynomial scaled by a scalar.</summary>
@@ -175,13 +192,39 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
     // Equality
     // -------------------------------------------------------------------------
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Determines whether this polynomial is exactly equal to <paramref name="other"/>: same degree
+    /// and identical coefficients. Consistent with <see cref="GetHashCode"/> by construction, unlike
+    /// a tolerance-based comparison would be. Use <see cref="ApproximatelyEquals"/> for a
+    /// tolerance-aware comparison; it must not be used to implement this member or
+    /// <see cref="GetHashCode"/>; doing so would let two polynomials compare equal while hashing
+    /// differently, breaking the contract required by <see cref="Dictionary{TKey, TValue}"/>,
+    /// <see cref="HashSet{T}"/>, and LINQ set operations.
+    /// </summary>
     public bool Equals(Polynomial<T>? other)
     {
         if (other is null) return false;
         if (Degree != other.Degree) return false;
         for (int i = 0; i <= Degree; i++)
-            if (T.Abs(_coefficients[i] - other._coefficients[i]) > Epsilon) return false;
+            if (_coefficients[i] != other._coefficients[i]) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether this polynomial is equal to <paramref name="other"/> within
+    /// <paramref name="tolerance"/> on every coefficient. This is a separate, explicitly opt-in
+    /// comparison: it is not used by <see cref="Equals(Polynomial{T})"/> or
+    /// <see cref="GetHashCode"/> and must not be relied upon for hashed-collection membership, since
+    /// approximate equality is not transitive in general and would violate the hash contract.
+    /// </summary>
+    /// <param name="other">The polynomial to compare with.</param>
+    /// <param name="tolerance">Maximum allowed absolute difference per coefficient.</param>
+    public bool ApproximatelyEquals(Polynomial<T>? other, T tolerance)
+    {
+        if (other is null) return false;
+        if (Degree != other.Degree) return false;
+        for (int i = 0; i <= Degree; i++)
+            if (T.Abs(_coefficients[i] - other._coefficients[i]) > tolerance) return false;
         return true;
     }
 
@@ -189,7 +232,14 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
     public override bool Equals(object? obj) => obj is Polynomial<T> p && Equals(p);
 
     /// <inheritdoc/>
-    public override int GetHashCode() => HashCode.Combine(Degree, _coefficients[0]);
+    public override int GetHashCode()
+    {
+        HashCode hash = new();
+        hash.Add(Degree);
+        foreach (T coefficient in _coefficients)
+            hash.Add(coefficient);
+        return hash.ToHashCode();
+    }
 
     /// <inheritdoc/>
     public override string ToString()

--- a/Utils.Mathematics/Polynomial.cs
+++ b/Utils.Mathematics/Polynomial.cs
@@ -85,7 +85,11 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
     /// <returns>A new polynomial representing the derivative.</returns>
     public Polynomial<T> Derive()
     {
-        if (Degree == 0) return new Polynomial<T>([T.Zero]);
+        // Route through Canonicalize like every other construction path, even though a single-
+        // element array is trivially already canonical: this keeps every array-producing call site
+        // consistent with the invariant documented on the private constructor, rather than relying
+        // on this specific case happening to need no trimming.
+        if (Degree == 0) return new Polynomial<T>(Canonicalize([T.Zero]));
         T[] d = new T[Degree];
         for (int i = 1; i <= Degree; i++)
             d[i - 1] = T.CreateChecked(i) * _coefficients[i];

--- a/Utils.Mathematics/Polynomial.cs
+++ b/Utils.Mathematics/Polynomial.cs
@@ -113,22 +113,38 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
     /// <summary>
     /// Attempts to find a real root near <paramref name="initialGuess"/> using Newton–Raphson iteration.
     /// </summary>
-    /// <param name="initialGuess">Starting point for the iteration.</param>
-    /// <param name="maxIterations">Maximum number of iterations.</param>
-    /// <param name="tolerance">Convergence tolerance; defaults to 1e-10.</param>
+    /// <param name="initialGuess">Starting point for the iteration. Must be finite.</param>
+    /// <param name="maxIterations">Maximum number of iterations. Must be greater than zero.</param>
+    /// <param name="tolerance">Convergence tolerance; defaults to 1e-10. Must be finite and positive.</param>
     /// <returns>The found root, or <see langword="null"/> if the method did not converge.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="maxIterations"/> is not positive, <paramref name="initialGuess"/>
+    /// is not finite, or <paramref name="tolerance"/> is not finite and positive.
+    /// </exception>
     public T? FindRoot(T initialGuess, int maxIterations = 100, T? tolerance = null)
     {
+        if (maxIterations <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxIterations), maxIterations, "Must be greater than zero.");
+        if (!T.IsFinite(initialGuess))
+            throw new ArgumentOutOfRangeException(nameof(initialGuess), initialGuess, "Must be a finite value.");
+
         T tol = tolerance ?? Epsilon;
+        if (!T.IsFinite(tol) || tol <= T.Zero)
+            throw new ArgumentOutOfRangeException(nameof(tolerance), tolerance, "Must be a finite, positive value.");
+
         var derivative = Derive();
         T x = initialGuess;
         for (int i = 0; i < maxIterations; i++)
         {
             T fx = Evaluate(x);
             if (T.Abs(fx) <= tol) return x;
+            // A derivative merely close to zero (not just exactly zero) already makes the Newton
+            // step numerically unstable; reuse the convergence tolerance as that threshold rather
+            // than comparing to exact zero.
             T fpx = derivative.Evaluate(x);
-            if (fpx == T.Zero) return null;
+            if (T.Abs(fpx) <= tol) return null;
             T next = x - fx / fpx;
+            if (!T.IsFinite(next)) return null;
             if (T.Abs(next - x) <= tol) return next;
             x = next;
         }

--- a/Utils.Mathematics/Polynomial.cs
+++ b/Utils.Mathematics/Polynomial.cs
@@ -234,9 +234,12 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
     /// approximate equality is not transitive in general and would violate the hash contract.
     /// </summary>
     /// <param name="other">The polynomial to compare with.</param>
-    /// <param name="tolerance">Maximum allowed absolute difference per coefficient.</param>
+    /// <param name="tolerance">Maximum allowed absolute difference per coefficient. Must be finite and non-negative.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is not finite or is negative.</exception>
     public bool ApproximatelyEquals(Polynomial<T>? other, T tolerance)
     {
+        if (!T.IsFinite(tolerance) || tolerance < T.Zero)
+            throw new ArgumentOutOfRangeException(nameof(tolerance), tolerance, "Tolerance must be finite and non-negative.");
         if (other is null) return false;
         if (Degree != other.Degree) return false;
         for (int i = 0; i <= Degree; i++)

--- a/Utils.Mathematics/README.md
+++ b/Utils.Mathematics/README.md
@@ -247,8 +247,8 @@ var m = new Matrix<double>(new double[,] {
 double det = m.Determinant;           // 1
 Matrix<double> inv = m.Invert();      // { {3,-1}, {-5,2} }
 
-var (L, U) = m.DiagonalizeLU();
-// L * U == m
+var (L, U, P) = m.DiagonalizeLU();
+// P * m == L * U
 ```
 
 ### Properties

--- a/Utils.Mathematics/Statistics.cs
+++ b/Utils.Mathematics/Statistics.cs
@@ -137,6 +137,6 @@ public static class Statistics
         if (sorted.Length == 0)
             throw new ArgumentException("Sequence must contain at least one element.", nameof(values));
         Array.Sort(sorted);
-        return sorted[sorted.Length / 2];
+        return sorted[(sorted.Length - 1) / 2];
     }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
 using Utils.Mathematics.LinearAlgebra;
 
 namespace UtilsTest.Mathematics.LinearAlgebra;
@@ -72,5 +73,57 @@ public class MatrixSolveTests
         // like a normal return value instead of a diagnosed failure.
         var a = new Matrix<double>(new double[,] { { 1, 2 }, { 2 + 2e-13, 4 + 4e-13 } });
         Assert.ThrowsException<InvalidOperationException>(() => a.Solve(V(1, 2)));
+    }
+
+    [TestMethod]
+    public void Solve_ExplicitToleranceOverride_AllowsSmallerThreshold()
+    {
+        // The perturbation (1e-14) sits below the default relative tolerance (rejected), but a
+        // caller can opt into a smaller explicit tolerance and accept the system anyway.
+        var a = new Matrix<double>(new double[,] { { 1, 2 }, { 2, 4 + 1e-14 } });
+        Assert.ThrowsException<InvalidOperationException>(() => a.Solve(V(1, 2)));
+
+        var x = a.Solve(V(1, 2), relativeSingularityTolerance: 0d);
+        Assert.IsNotNull(x);
+    }
+
+    [TestMethod]
+    public void Solve_InvalidExplicitTolerance_Throws()
+    {
+        var a = Matrix<double>.Diagonal(1.0, 1.0);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.Solve(V(1, 2), relativeSingularityTolerance: double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.Solve(V(1, 2), relativeSingularityTolerance: -1d));
+    }
+
+    [TestMethod]
+    public void SingularityRelativeTolerance_IsNonZeroForHalf()
+    {
+        // Regression: a hard-coded T.CreateChecked(1e-10) underflows to exactly zero for Half
+        // (whose smallest representable positive value is far larger than 1e-10), silently
+        // collapsing the scale-aware singularity check back into an exact-zero-only comparison -
+        // precisely the behavior the fix was meant to eliminate.
+        var field = typeof(Matrix<Half>).GetField("SingularityRelativeTolerance", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(field);
+        var tolerance = (Half)field!.GetValue(null)!;
+        Assert.AreNotEqual((Half)0, tolerance);
+    }
+
+    [TestMethod]
+    public void Solve_Half_WellConditionedSystem_Succeeds()
+    {
+        var a = Matrix<Half>.Diagonal((Half)2f, (Half)4f);
+        var x = a.Solve(new Vector<Half>((Half)6f, (Half)8f));
+        Assert.AreEqual((Half)3f, x[0]);
+        Assert.AreEqual((Half)2f, x[1]);
+    }
+
+    [TestMethod]
+    public void Solve_Half_RejectsNonZeroButNegligiblePivot()
+    {
+        // With the old literal-1e-10-derived tolerance (== 0 for Half), only an exactly-zero pivot
+        // was rejected. This pivot (0.001) is non-zero but negligible relative to the matrix's own
+        // scale under Half's own limited precision, and must still be rejected.
+        var a = new Matrix<Half>(new Half[,] { { (Half)1f, (Half)0f }, { (Half)0f, (Half)0.001f } });
+        Assert.ThrowsException<InvalidOperationException>(() => a.Solve(new Vector<Half>((Half)1f, (Half)1f)));
     }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs
@@ -62,4 +62,15 @@ public class MatrixSolveTests
         var a = new Matrix<double>(new double[,] { { 1, 2 }, { 2, 4 } });
         Assert.ThrowsException<InvalidOperationException>(() => a.Solve(V(1, 2)));
     }
+
+    [TestMethod]
+    public void Solve_NearSingularMatrix_ThrowsInsteadOfReturningGarbage()
+    {
+        // The second row is the first scaled by (1 + 1e-13): not exactly singular, but the pivot
+        // remaining after elimination is tiny relative to the matrix's own magnitude. Dividing by
+        // it would previously amplify rounding error into a huge/NaN "solution" that still looked
+        // like a normal return value instead of a diagnosed failure.
+        var a = new Matrix<double>(new double[,] { { 1, 2 }, { 2 + 2e-13, 4 + 4e-13 } });
+        Assert.ThrowsException<InvalidOperationException>(() => a.Solve(V(1, 2)));
+    }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs
@@ -76,15 +76,17 @@ public class MatrixSolveTests
     }
 
     [TestMethod]
-    public void Solve_ExplicitToleranceOverride_AllowsSmallerThreshold()
+    public void Solve_ExplicitToleranceOverride_CanRejectAWellConditionedMatrix()
     {
-        // The perturbation (1e-14) sits below the default relative tolerance (rejected), but a
-        // caller can opt into a smaller explicit tolerance and accept the system anyway.
-        var a = new Matrix<double>(new double[,] { { 1, 2 }, { 2, 4 + 1e-14 } });
-        Assert.ThrowsException<InvalidOperationException>(() => a.Solve(V(1, 2)));
-
-        var x = a.Solve(V(1, 2), relativeSingularityTolerance: 0d);
+        // A well-conditioned matrix solves fine under the default tolerance; passing a large
+        // explicit override demonstrates the parameter genuinely changes the accept/reject
+        // decision instead of being ignored.
+        var a = Matrix<double>.Diagonal(1.0, 0.5);
+        var x = a.Solve(V(1, 1));
         Assert.IsNotNull(x);
+
+        Assert.ThrowsException<InvalidOperationException>(
+            () => a.Solve(V(1, 1), relativeSingularityTolerance: 0.6));
     }
 
     [TestMethod]
@@ -96,16 +98,33 @@ public class MatrixSolveTests
     }
 
     [TestMethod]
-    public void SingularityRelativeTolerance_IsNonZeroForHalf()
+    public void MachineEpsilon_IsNonZeroForHalf()
     {
         // Regression: a hard-coded T.CreateChecked(1e-10) underflows to exactly zero for Half
         // (whose smallest representable positive value is far larger than 1e-10), silently
         // collapsing the scale-aware singularity check back into an exact-zero-only comparison -
         // precisely the behavior the fix was meant to eliminate.
-        var field = typeof(Matrix<Half>).GetField("SingularityRelativeTolerance", BindingFlags.NonPublic | BindingFlags.Static);
+        var field = typeof(Matrix<Half>).GetField("MachineEpsilon", BindingFlags.NonPublic | BindingFlags.Static);
         Assert.IsNotNull(field);
-        var tolerance = (Half)field!.GetValue(null)!;
-        Assert.AreNotEqual((Half)0, tolerance);
+        var epsilon = (Half)field!.GetValue(null)!;
+        Assert.AreNotEqual((Half)0, epsilon);
+    }
+
+    [TestMethod]
+    public void DefaultSingularityRelativeTolerance_ScalesWithDimensionNotFlatConstant()
+    {
+        // Regression: an earlier version used a flat 100x-machine-epsilon multiplier regardless of
+        // matrix size. For Half specifically that made the default relative tolerance for even a
+        // small 2x2 matrix close to 10% of its magnitude, misclassifying ordinary invertible
+        // matrices as singular. The default must scale with dimension instead of a fixed multiplier
+        // so a small matrix gets a correspondingly small (tight) default tolerance.
+        var method = typeof(Matrix<Half>).GetMethod("DefaultSingularityRelativeTolerance", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(method);
+        var tolerance2 = (Half)method!.Invoke(null, [2])!;
+        var tolerance10 = (Half)method!.Invoke(null, [10])!;
+
+        Assert.IsTrue(tolerance2 < (Half)0.01f, $"Default tolerance for a 2x2 Half matrix should be well under 1%, was {tolerance2}.");
+        Assert.IsTrue(tolerance10 > tolerance2, "The default tolerance should grow with matrix dimension.");
     }
 
     [TestMethod]
@@ -125,5 +144,19 @@ public class MatrixSolveTests
         // scale under Half's own limited precision, and must still be rejected.
         var a = new Matrix<Half>(new Half[,] { { (Half)1f, (Half)0f }, { (Half)0f, (Half)0.001f } });
         Assert.ThrowsException<InvalidOperationException>(() => a.Solve(new Vector<Half>((Half)1f, (Half)1f)));
+    }
+
+    [TestMethod]
+    public void Solve_Half_ModeratelyScaledInvertibleMatrix_DoesNotThrow()
+    {
+        // Regression: with the earlier flat 100x-machine-epsilon multiplier, the default relative
+        // tolerance for Half was close to 10% of the matrix's magnitude, so even an ordinary
+        // invertible matrix with a modest (20:1) ratio between its smallest and largest entries -
+        // nothing close to numerically dangerous, even at Half's limited precision - was wrongly
+        // rejected as singular.
+        var a = Matrix<Half>.Diagonal((Half)1f, (Half)0.05f);
+        var x = a.Solve(new Vector<Half>((Half)1f, (Half)0.05f));
+        Assert.AreEqual((Half)1f, x[0]);
+        Assert.AreEqual((Half)1f, x[1]);
     }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -230,6 +230,64 @@ namespace UtilsTest.Mathematics.LinearAlgebra
         }
 
         [TestMethod]
+        public void IsTriangularWithin_RoundingNoise_ReturnsTrueButExactReturnsFalse()
+        {
+            // A value that should be zero but carries rounding noise from prior arithmetic must
+            // fail the exact predicate while passing its explicit tolerance-aware counterpart -
+            // the two are separate, deliberately opt-in predicates, not one silently-tolerant check.
+            var m = new Matrix<double>(new double[,]
+            {
+                { 1d, 2d, 3d },
+                { 1e-13, 4d, 5d },
+                { 0d, 0d, 6d },
+            });
+
+            Assert.IsFalse(m.IsTriangular);
+            Assert.IsTrue(m.IsTriangularWithin(1e-9));
+            Assert.IsFalse(m.IsTriangularWithin(1e-15));
+        }
+
+        [TestMethod]
+        public void IsDiagonalWithin_RoundingNoise_ReturnsTrueButExactReturnsFalse()
+        {
+            var m = new Matrix<double>(new double[,]
+            {
+                { 2d, 1e-13 },
+                { 0d, 3d },
+            });
+
+            Assert.IsFalse(m.IsDiagonal);
+            Assert.IsTrue(m.IsDiagonalWithin(1e-9));
+        }
+
+        [TestMethod]
+        public void IsIdentityWithin_RoundingNoise_ReturnsTrueButExactReturnsFalse()
+        {
+            var m = new Matrix<double>(new double[,]
+            {
+                { 1d + 1e-13, 0d },
+                { 1e-13, 1d },
+            });
+
+            Assert.IsFalse(m.IsIdentity);
+            Assert.IsTrue(m.IsIdentityWithin(1e-9));
+        }
+
+        [TestMethod]
+        public void IsNormalSpaceWithin_RoundingNoise_ReturnsTrueButExactReturnsFalse()
+        {
+            var m = new Matrix<double>(new double[,]
+            {
+                { 1d, 0d, 0d },
+                { 0d, 1d, 0d },
+                { 1e-13, 1e-13, 1d + 1e-13 },
+            });
+
+            Assert.IsFalse(m.IsNormalSpace);
+            Assert.IsTrue(m.IsNormalSpaceWithin(1e-9));
+        }
+
+        [TestMethod]
         public void Determinant_IdentityMatrix_ReturnsOne()
         {
             var m = Matrix<double>.Identity(3);

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -126,6 +126,30 @@ namespace UtilsTest.Mathematics.LinearAlgebra
         }
 
         [TestMethod]
+        public void Invert_SingularMatrix_Throws()
+        {
+            var matrix = new Matrix<double>(new double[,] { { 1d, 2d }, { 2d, 4d } });
+            Assert.ThrowsException<InvalidOperationException>(() => matrix.Invert());
+        }
+
+        [TestMethod]
+        public void Invert_NearSingularMatrix_ThrowsInsteadOfReturningGarbage()
+        {
+            var matrix = new Matrix<double>(new double[,] { { 1d, 2d }, { 2d + 2e-13, 4d + 4e-13 } });
+            Assert.ThrowsException<InvalidOperationException>(() => matrix.Invert());
+        }
+
+        [TestMethod]
+        public void Determinant_NearSingularMatrix_ReturnsZeroInsteadOfGarbage()
+        {
+            // Previously, dividing by the tiny (but non-zero) pivot left after elimination could
+            // amplify rounding error into a huge/NaN determinant instead of the mathematically
+            // expected near-zero value for a near-singular matrix.
+            var matrix = new Matrix<double>(new double[,] { { 1d, 2d }, { 2d + 2e-13, 4d + 4e-13 } });
+            Assert.AreEqual(0d, matrix.Determinant, 1e-6);
+        }
+
+        [TestMethod]
         public void Identity_ProducesCorrectDiagonalAndFlags()
         {
             var m = Matrix<double>.Identity(3);

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -25,7 +25,7 @@ namespace UtilsTest.Mathematics.LinearAlgebra
             });
 
             double[,] original = matrix.ToArray();
-            (Matrix<double> L, Matrix<double> U) = matrix.DiagonalizeLU();
+            (Matrix<double> L, Matrix<double> U, Matrix<double> P) = matrix.DiagonalizeLU();
             AssertMatricesAreEqual(new Matrix<double>(original), matrix, 1e-12);
 
             for (int i = 0; i < matrix.Rows; i++)
@@ -36,6 +36,63 @@ namespace UtilsTest.Mathematics.LinearAlgebra
                     Assert.AreEqual(0d, U[i, j], 1e-12, $"Upper matrix contained non-zero value at [{i}, {j}].");
                 }
             }
+
+            AssertMatricesAreEqual(P * matrix, L * U, 1e-12);
+        }
+
+        /// <summary>
+        /// Regression for the previous DiagonalizeLU implementation, which applied elimination row
+        /// operations to an identity matrix instead of storing the elimination multipliers directly
+        /// in L, so L * U did not reconstruct the (possibly permuted) original matrix.
+        /// </summary>
+        [TestMethod]
+        public void DiagonalizeLUSatisfiesPermutedReconstructionIdentity_NoSwapNeeded()
+        {
+            // No pivoting occurs: |2| is already the largest first-column magnitude, so P must be
+            // the identity and L * U must equal the original matrix directly.
+            Matrix<double> matrix = new Matrix<double>(new double[,]
+            {
+                                { 2d, 1d },
+                                { 1d, 3d },
+            });
+
+            (Matrix<double> L, Matrix<double> U, Matrix<double> P) = matrix.DiagonalizeLU();
+
+            AssertMatricesAreEqual(MatrixTransformations.Identity<double>(2), P, 1e-12);
+            AssertMatricesAreEqual(matrix, L * U, 1e-12);
+        }
+
+        [TestMethod]
+        public void DiagonalizeLUSatisfiesPermutedReconstructionIdentity_WithSwap()
+        {
+            // Partial pivoting swaps rows here (|6| > |4|), so L * U reconstructs P * matrix, not
+            // matrix itself.
+            Matrix<double> matrix = new Matrix<double>(new double[,]
+            {
+                                { 4d, 3d },
+                                { 6d, 3d },
+            });
+
+            (Matrix<double> L, Matrix<double> U, Matrix<double> P) = matrix.DiagonalizeLU();
+
+            AssertMatricesAreEqual(P * matrix, L * U, 1e-12);
+            // Sanity check that a swap actually happened, i.e. P is not the identity.
+            Assert.AreNotEqual(1d, P[0, 0], 1e-12);
+        }
+
+        [TestMethod]
+        public void DiagonalizeLU3x3SatisfiesPermutedReconstructionIdentity()
+        {
+            Matrix<double> matrix = new Matrix<double>(new double[,]
+            {
+                                { 2d, -1d, -2d },
+                                { -4d, 6d, 3d },
+                                { -4d, -2d, 8d },
+            });
+
+            (Matrix<double> L, Matrix<double> U, Matrix<double> P) = matrix.DiagonalizeLU();
+
+            AssertMatricesAreEqual(P * matrix, L * U, 1e-9);
         }
 
         /// <summary>

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -288,6 +288,26 @@ namespace UtilsTest.Mathematics.LinearAlgebra
         }
 
         [TestMethod]
+        public void ToleranceAwarePredicates_InvalidTolerance_Throw()
+        {
+            // A NaN tolerance would make every ">" comparison false (vacuously "within tolerance"
+            // for everything), and a negative tolerance would reject even an exact match.
+            var m = Matrix<double>.Identity(2);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => m.IsTriangularWithin(double.NaN));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => m.IsTriangularWithin(-1d));
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => m.IsDiagonalWithin(double.NaN));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => m.IsDiagonalWithin(-1d));
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => m.IsIdentityWithin(double.NaN));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => m.IsIdentityWithin(-1d));
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => m.IsNormalSpaceWithin(double.NaN));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => m.IsNormalSpaceWithin(-1d));
+        }
+
+        [TestMethod]
         public void Determinant_IdentityMatrix_ReturnsOne()
         {
             var m = Matrix<double>.Identity(3);

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
@@ -60,29 +60,61 @@ public class MatrixTransformationsTests
     [TestMethod]
     public void Translation_TranslatesHomogeneousPoint()
     {
+        // The library uses standard matrix-times-column-vector multiplication
+        // (Matrix<T> * Vector<T> computes result[row] = sum_col m[row,col] * v[col]), so
+        // translation coefficients must live in the last COLUMN, not the last row.
         var m = MatrixTransformations.Translation<double>(5d, 7d);
         Assert.AreEqual(3, m.Rows);
         Assert.AreEqual(3, m.Columns);
 
-        // Point (1,2,1) in homogeneous coords → (1+tx, 2+ty, 1) after multiply
-        // MatrixTransformations uses row-vector convention: result = m * [1,2,1]ᵀ
+        // Point (1, 2, 1) in homogeneous coordinates must translate to (1+5, 2+7, 1).
         var v = new Vector<double>(1d, 2d, 1d);
         var result = m * v;
 
-        // Translation stored in last row: result[0]=1, result[1]=2, result[2]=1+5+7=15? No.
-        // Let's check: the translation matrix has identity top-left and values in last ROW.
-        // With column-vector convention: (m*v)[i] = sum(m[i,j]*v[j])
-        // m[0,0]=1,m[1,1]=1,m[2,2]=1, m[2,0]=5, m[2,1]=7 (last row)
-        // result[0] = m[0,0]*v[0] + m[0,1]*v[1] + m[0,2]*v[2] = 1*1 + 0*2 + 0*1 = 1
-        // result[1] = 0*1 + 1*2 + 0*1 = 2
-        // result[2] = 5*1 + 7*2 + 1*1 = 5+14+1 = 20 → this is the row-vector convention result
-        // The result in homogeneous form: divide result by w=result[2]... non trivial.
-        // Instead just check that the matrix has the expected structure.
+        Assert.AreEqual(6d, result[0], Delta);
+        Assert.AreEqual(9d, result[1], Delta);
+        Assert.AreEqual(1d, result[2], Delta);
+
         Assert.AreEqual(1d, m[0, 0], Delta);
         Assert.AreEqual(1d, m[1, 1], Delta);
         Assert.AreEqual(1d, m[2, 2], Delta);
-        Assert.AreEqual(5d, m[2, 0], Delta);
-        Assert.AreEqual(7d, m[2, 1], Delta);
+        Assert.AreEqual(5d, m[0, 2], Delta);
+        Assert.AreEqual(7d, m[1, 2], Delta);
+        Assert.AreEqual(0d, m[2, 0], Delta);
+        Assert.AreEqual(0d, m[2, 1], Delta);
+    }
+
+    [TestMethod]
+    public void Translation_3D_TranslatesHomogeneousPoint()
+    {
+        var m = MatrixTransformations.Translation<double>(1d, -2d, 3d);
+        Assert.AreEqual(4, m.Rows);
+        Assert.AreEqual(4, m.Columns);
+
+        var v = new Vector<double>(10d, 10d, 10d, 1d);
+        var result = m * v;
+
+        Assert.AreEqual(11d, result[0], Delta);
+        Assert.AreEqual(8d, result[1], Delta);
+        Assert.AreEqual(13d, result[2], Delta);
+        Assert.AreEqual(1d, result[3], Delta);
+    }
+
+    [TestMethod]
+    public void Translation_ComposedWithItself_AddsOffsets()
+    {
+        // Composition must remain consistent with the column-vector convention: applying two
+        // translations in sequence via matrix multiplication should add their offsets.
+        var m1 = MatrixTransformations.Translation<double>(2d, 0d);
+        var m2 = MatrixTransformations.Translation<double>(0d, 3d);
+        var composed = m1 * m2;
+
+        var v = new Vector<double>(0d, 0d, 1d);
+        var result = composed * v;
+
+        Assert.AreEqual(2d, result[0], Delta);
+        Assert.AreEqual(3d, result[1], Delta);
+        Assert.AreEqual(1d, result[2], Delta);
     }
 
     // ── Rotation ─────────────────────────────────────────────────────────────

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
@@ -55,6 +55,70 @@ public class MatrixTransformationsTests
         Assert.AreEqual(6d, m.Determinant, Delta);
     }
 
+    // ── Skew ─────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Skew_2D_ProducesHandCalculatedOffDiagonalCoefficients()
+    {
+        // Base dimension 2 needs d*(d-1) = 2 angles: one per off-diagonal position of the 2x2 block.
+        double a0 = Math.Atan(2d);
+        double a1 = Math.Atan(3d);
+        var m = MatrixTransformations.Skew<double>(a0, a1);
+
+        Assert.AreEqual(3, m.Rows);
+        Assert.AreEqual(3, m.Columns);
+
+        // Row-major order skipping the diagonal: [0,1] gets the first angle, [1,0] the second.
+        Assert.AreEqual(2d, m[0, 1], Delta);
+        Assert.AreEqual(3d, m[1, 0], Delta);
+
+        // Diagonal and homogeneous row/column must remain untouched.
+        Assert.AreEqual(1d, m[0, 0], Delta);
+        Assert.AreEqual(1d, m[1, 1], Delta);
+        Assert.AreEqual(1d, m[2, 2], Delta);
+        Assert.AreEqual(0d, m[0, 2], Delta);
+        Assert.AreEqual(0d, m[1, 2], Delta);
+        Assert.AreEqual(0d, m[2, 0], Delta);
+        Assert.AreEqual(0d, m[2, 1], Delta);
+    }
+
+    [TestMethod]
+    public void Skew_3D_ProducesHandCalculatedOffDiagonalCoefficients()
+    {
+        // Base dimension 3 needs d*(d-1) = 6 angles.
+        double[] tans = { 1d, 2d, 3d, 4d, 5d, 6d };
+        double[] angles = System.Array.ConvertAll(tans, Math.Atan);
+        var m = MatrixTransformations.Skew<double>(angles);
+
+        Assert.AreEqual(4, m.Rows);
+        Assert.AreEqual(4, m.Columns);
+
+        // Row-major order skipping the diagonal for each row:
+        // row 0 -> columns 1,2 ; row 1 -> columns 0,2 ; row 2 -> columns 0,1.
+        Assert.AreEqual(1d, m[0, 1], Delta);
+        Assert.AreEqual(2d, m[0, 2], Delta);
+        Assert.AreEqual(3d, m[1, 0], Delta);
+        Assert.AreEqual(4d, m[1, 2], Delta);
+        Assert.AreEqual(5d, m[2, 0], Delta);
+        Assert.AreEqual(6d, m[2, 1], Delta);
+
+        for (int i = 0; i < 3; i++)
+            Assert.AreEqual(1d, m[i, i], Delta, $"diagonal[{i}]");
+
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.AreEqual(i == 3 ? 1d : 0d, m[3, i], Delta, $"homogeneous row [3,{i}]");
+            Assert.AreEqual(i == 3 ? 1d : 0d, m[i, 3], Delta, $"homogeneous column [{i},3]");
+        }
+    }
+
+    [TestMethod]
+    public void Skew_InvalidAngleCount_Throws()
+    {
+        // 3 is not d*(d-1) for any integer d (0, 2, 6, 12, ...).
+        Assert.ThrowsException<ArgumentException>(() => MatrixTransformations.Skew<double>(1d, 2d, 3d));
+    }
+
     // ── Translation ──────────────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -298,5 +298,61 @@ public class VectorTests
         var v2 = new Vector<double>(0d, 0d);
         Assert.ThrowsException<InvalidOperationException>(() => v1.AngleWith(v2));
     }
+
+    [TestMethod]
+    public void EqualityOperator_BothNull_ReturnsTrue()
+    {
+        Vector<double> left = null;
+        Vector<double> right = null;
+        Assert.IsTrue(left == right);
+        Assert.IsFalse(left != right);
+    }
+
+    [TestMethod]
+    public void EqualityOperator_LeftNullRightNonNull_ReturnsFalse()
+    {
+        Vector<double> left = null;
+        var right = new Vector<double>(1d, 2d);
+        Assert.IsFalse(left == right);
+        Assert.IsTrue(left != right);
+    }
+
+    [TestMethod]
+    public void EqualityOperator_LeftNonNullRightNull_ReturnsFalse()
+    {
+        // Regression: the previous implementation returned true here (any non-null vector
+        // compared equal to null) because the second `|| vector2 is null` term short-circuited
+        // the whole expression to true regardless of vector1.
+        var left = new Vector<double>(1d, 2d);
+        Vector<double> right = null;
+        Assert.IsFalse(left == right);
+        Assert.IsTrue(left != right);
+    }
+
+    [TestMethod]
+    public void EqualityOperator_SameReference_ReturnsTrue()
+    {
+        var vector = new Vector<double>(1d, 2d);
+        Assert.IsTrue(vector == vector);
+        Assert.IsFalse(vector != vector);
+    }
+
+    [TestMethod]
+    public void EqualityOperator_EqualValues_ReturnsTrue()
+    {
+        var left = new Vector<double>(1d, 2d, 3d);
+        var right = new Vector<double>(1d, 2d, 3d);
+        Assert.IsTrue(left == right);
+        Assert.IsFalse(left != right);
+    }
+
+    [TestMethod]
+    public void EqualityOperator_UnequalValues_ReturnsFalse()
+    {
+        var left = new Vector<double>(1d, 2d, 3d);
+        var right = new Vector<double>(1d, 2d, 4d);
+        Assert.IsFalse(left == right);
+        Assert.IsTrue(left != right);
+    }
 }
 

--- a/UtilsTest/Mathematics/NumericalMethodsTests.cs
+++ b/UtilsTest/Mathematics/NumericalMethodsTests.cs
@@ -117,4 +117,34 @@ public class NumericalMethodsTests
     public void Lagrange_DuplicateX_Throws()
         => Assert.ThrowsException<ArgumentException>(
             () => NumericalMethods.Lagrange<double>([(0, 0), (0, 1)], 0.5));
+
+    [TestMethod]
+    public void Lagrange_NaNAbscissa_Throws()
+    {
+        // Regression: a NaN x value bypassed the old denom == T.Zero distinctness check (NaN is
+        // never equal to anything) and propagated NaN through the whole result instead of
+        // producing the documented distinct-point error.
+        Assert.ThrowsException<ArgumentException>(
+            () => NumericalMethods.Lagrange<double>([(0, 0), (double.NaN, 1)], 0.5));
+    }
+
+    [TestMethod]
+    public void Lagrange_InfiniteCoordinate_Throws()
+        => Assert.ThrowsException<ArgumentException>(
+            () => NumericalMethods.Lagrange<double>([(0, 0), (double.PositiveInfinity, 1)], 0.5));
+
+    [TestMethod]
+    public void Lagrange_NonFiniteEvaluationPoint_Throws()
+        => Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => NumericalMethods.Lagrange<double>([(0, 0), (1, 1)], double.NaN));
+
+    [TestMethod]
+    public void Lagrange_DuplicateXNotAdjacent_ThrowsBeforeEvaluating()
+    {
+        // The duplicate is between the first and last point (not caught by an inner-loop check
+        // that only compares against the immediately preceding index) - validation must scan all
+        // pairs up front rather than discovering it partway through result construction.
+        Assert.ThrowsException<ArgumentException>(
+            () => NumericalMethods.Lagrange<double>([(0, 0), (1, 1), (2, 2), (0, 5)], 0.5));
+    }
 }

--- a/UtilsTest/Mathematics/NumericalMethodsTests.cs
+++ b/UtilsTest/Mathematics/NumericalMethodsTests.cs
@@ -55,6 +55,30 @@ public class NumericalMethodsTests
         Assert.AreEqual(0.5, result, 1e-8);
     }
 
+    [TestMethod]
+    public void Integrate_OddIntMaxValueSteps_ThrowsInsteadOfOverflowing()
+    {
+        // int.MaxValue is odd; incrementing it to round up to an even count previously overflowed
+        // to int.MinValue instead of being rejected, silently corrupting every subsequent
+        // computation with a negative step count.
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => NumericalMethods.Integrate<double>(x => x, 0.0, 1.0, int.MaxValue));
+    }
+
+    [TestMethod]
+    public void Integrate_NullFunction_Throws()
+        => Assert.ThrowsException<ArgumentNullException>(
+            () => NumericalMethods.Integrate<double>(null!, 0.0, 1.0, 100));
+
+    [TestMethod]
+    public void Integrate_NonFiniteBounds_Throws()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => NumericalMethods.Integrate<double>(x => x, double.NaN, 1.0, 100));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => NumericalMethods.Integrate<double>(x => x, 0.0, double.PositiveInfinity, 100));
+    }
+
     // -------------------------------------------------------------------------
     // Lagrange
     // -------------------------------------------------------------------------

--- a/UtilsTest/Mathematics/PolynomialTests.cs
+++ b/UtilsTest/Mathematics/PolynomialTests.cs
@@ -110,6 +110,43 @@ public class PolynomialTests
     }
 
     [TestMethod]
+    public void FindRoot_NonPositiveMaxIterations_Throws()
+    {
+        var p = new Polynomial<double>(-4.0, 0.0, 1.0);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.FindRoot(1.5, maxIterations: 0));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.FindRoot(1.5, maxIterations: -1));
+    }
+
+    [TestMethod]
+    public void FindRoot_NonFiniteInitialGuess_Throws()
+    {
+        var p = new Polynomial<double>(-4.0, 0.0, 1.0);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.FindRoot(double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.FindRoot(double.PositiveInfinity));
+    }
+
+    [TestMethod]
+    public void FindRoot_InvalidTolerance_Throws()
+    {
+        var p = new Polynomial<double>(-4.0, 0.0, 1.0);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.FindRoot(1.5, tolerance: -1e-6));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.FindRoot(1.5, tolerance: 0.0));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.FindRoot(1.5, tolerance: double.NaN));
+    }
+
+    [TestMethod]
+    public void FindRoot_NearZeroDerivative_ReturnsNullInsteadOfHugeStep()
+    {
+        // p(x) = x^2 + 1000 never crosses zero. At x = 1e-5 the function value is nowhere near
+        // zero, but the derivative (2x = 2e-5) is already below the tolerance: the previous
+        // implementation only checked for an *exact* zero derivative, so it would take this as a
+        // valid Newton step and divide by a near-zero derivative, producing a wildly unstable jump.
+        var p = new Polynomial<double>(1000.0, 0.0, 1.0);
+        double? root = p.FindRoot(1e-5, tolerance: 1e-4);
+        Assert.IsNull(root);
+    }
+
+    [TestMethod]
     public void Equals_SameCoefficients_ReturnsTrue()
     {
         var p = new Polynomial<double>(1.0, 2.0, 3.0);

--- a/UtilsTest/Mathematics/PolynomialTests.cs
+++ b/UtilsTest/Mathematics/PolynomialTests.cs
@@ -49,6 +49,62 @@ public class PolynomialTests
     }
 
     [TestMethod]
+    public void Derive_NonZeroConstant_ReturnsCanonicalZeroPolynomial()
+    {
+        // The derivative of any constant (zero or not) is the canonical zero polynomial: degree 0,
+        // exactly equal (and hash-equal) to a directly constructed zero, and 0 everywhere.
+        var p = new Polynomial<double>(5.0);
+        var derivative = p.Derive();
+        var canonicalZero = new Polynomial<double>(0.0);
+
+        Assert.AreEqual(0, derivative.Degree);
+        Assert.AreEqual(0.0, derivative[0], Tol);
+        Assert.IsTrue(derivative.Equals(canonicalZero));
+        Assert.AreEqual(canonicalZero.GetHashCode(), derivative.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Derive_ZeroConstant_ReturnsCanonicalZeroPolynomial()
+    {
+        var p = new Polynomial<double>(0.0);
+        var derivative = p.Derive();
+        var canonicalZero = new Polynomial<double>(0.0);
+
+        Assert.AreEqual(0, derivative.Degree);
+        Assert.IsTrue(derivative.Equals(canonicalZero));
+        Assert.AreEqual(canonicalZero.GetHashCode(), derivative.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Derive_NegativeConstant_ReturnsCanonicalZeroPolynomial()
+    {
+        var p = new Polynomial<double>(-3.5);
+        var derivative = p.Derive();
+        Assert.AreEqual(0, derivative.Degree);
+        Assert.IsTrue(derivative.Equals(new Polynomial<double>(0.0)));
+    }
+
+    [TestMethod]
+    public void Derive_SecondDerivativeOfConstant_IsStillCanonicalZero()
+    {
+        var p = new Polynomial<double>(5.0);
+        var secondDerivative = p.Derive().Derive();
+        Assert.AreEqual(0, secondDerivative.Degree);
+        Assert.IsTrue(secondDerivative.Equals(new Polynomial<double>(0.0)));
+    }
+
+    [TestMethod]
+    public void Derive_LinearCollapsingToConstant_ReturnsCanonicalDegreeZero()
+    {
+        // d/dx (3 + 2x) = 2, a degree-0 constant, not a degree-1 polynomial with a trailing zero.
+        var p = new Polynomial<double>(3.0, 2.0);
+        var derivative = p.Derive();
+        Assert.AreEqual(0, derivative.Degree);
+        Assert.AreEqual(2.0, derivative[0], Tol);
+        Assert.IsTrue(derivative.Equals(new Polynomial<double>(2.0)));
+    }
+
+    [TestMethod]
     public void Integrate_Linear_ReturnsQuadratic()
     {
         // ∫ (2 + 6x) dx = 0 + 2x + 3x² (constant=0)

--- a/UtilsTest/Mathematics/PolynomialTests.cs
+++ b/UtilsTest/Mathematics/PolynomialTests.cs
@@ -184,6 +184,19 @@ public class PolynomialTests
     }
 
     [TestMethod]
+    public void ApproximatelyEquals_InvalidTolerance_Throws()
+    {
+        // A NaN tolerance would make every "> tolerance" comparison false, so any two
+        // same-degree polynomials would be reported approximately equal. A negative tolerance
+        // would reject even identical coefficients (0 > -1 is true).
+        var p = new Polynomial<double>(1.0, 2.0, 3.0);
+        var q = new Polynomial<double>(1.0, 2.0, 3.0);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.ApproximatelyEquals(q, double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.ApproximatelyEquals(q, double.NegativeInfinity));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => p.ApproximatelyEquals(q, -1.0));
+    }
+
+    [TestMethod]
     public void Subtract_PolynomialFromItself_IsCanonicalZero()
     {
         // Regression: internal operators used to bypass canonicalization, so p - p could retain

--- a/UtilsTest/Mathematics/PolynomialTests.cs
+++ b/UtilsTest/Mathematics/PolynomialTests.cs
@@ -118,6 +118,57 @@ public class PolynomialTests
     }
 
     [TestMethod]
+    public void Equals_EqualPolynomials_HaveEqualHashCodes()
+    {
+        // Required by the IEquatable/GetHashCode contract: equal objects must hash equal.
+        var p = new Polynomial<double>(1.0, 2.0, 3.0);
+        var q = new Polynomial<double>(1.0, 2.0, 3.0);
+        Assert.IsTrue(p.Equals(q));
+        Assert.AreEqual(p.GetHashCode(), q.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Equals_WithinOldToleranceButNotExact_ReturnsFalse()
+    {
+        // Equality is exact: two polynomials differing by a tiny amount must not compare equal,
+        // since a tolerance-based Equals would be inconsistent with an exact-valued GetHashCode.
+        var p = new Polynomial<double>(1.0, 2.0, 3.0);
+        var q = new Polynomial<double>(1.0 + 1e-11, 2.0, 3.0);
+        Assert.IsFalse(p.Equals(q));
+    }
+
+    [TestMethod]
+    public void ApproximatelyEquals_WithinTolerance_ReturnsTrue()
+    {
+        var p = new Polynomial<double>(1.0, 2.0, 3.0);
+        var q = new Polynomial<double>(1.0 + 1e-11, 2.0, 3.0);
+        Assert.IsTrue(p.ApproximatelyEquals(q, 1e-9));
+        Assert.IsFalse(p.ApproximatelyEquals(q, 1e-15));
+    }
+
+    [TestMethod]
+    public void Subtract_PolynomialFromItself_IsCanonicalZero()
+    {
+        // Regression: internal operators used to bypass canonicalization, so p - p could retain
+        // the original degree with trailing exact-zero coefficients instead of collapsing to the
+        // canonical zero polynomial (degree 0).
+        var p = new Polynomial<double>(1.0, 2.0, 3.0);
+        var zero = p - p;
+        Assert.AreEqual(0, zero.Degree);
+        Assert.AreEqual(0.0, zero[0], Tol);
+        Assert.IsTrue(zero.Equals(new Polynomial<double>(0.0)));
+    }
+
+    [TestMethod]
+    public void ScalarMultiplyByZero_IsCanonicalZero()
+    {
+        var p = new Polynomial<double>(1.0, 2.0, 3.0);
+        var zero = 0.0 * p;
+        Assert.AreEqual(0, zero.Degree);
+        Assert.IsTrue(zero.Equals(new Polynomial<double>(0.0)));
+    }
+
+    [TestMethod]
     public void NoCoefficients_Throws()
         => Assert.ThrowsException<ArgumentException>(() => new Polynomial<double>(System.Array.Empty<double>()));
 }

--- a/UtilsTest/Mathematics/StatisticsTests.cs
+++ b/UtilsTest/Mathematics/StatisticsTests.cs
@@ -83,7 +83,24 @@ public class StatisticsTests
     [TestMethod]
     public void Median_EvenLength_ReturnsLowerMiddle()
     {
+        // Documented contract: for an even-length sequence, return the LOWER of the two middle
+        // values. [1,3,5,7] sorted has middles 3 and 5; the lower one is 3.
         double[] data = [1, 3, 5, 7];
+        Assert.AreEqual(3.0, Statistics.Median<double>(data), Tol);
+    }
+
+    [TestMethod]
+    public void Median_TwoElements_ReturnsLowerMiddle()
+    {
+        double[] data = [10, 4];
+        Assert.AreEqual(4.0, Statistics.Median<double>(data), Tol);
+    }
+
+    [TestMethod]
+    public void Median_SixElements_ReturnsLowerMiddle()
+    {
+        double[] data = [9, 1, 5, 3, 7, 11];
+        // Sorted: 1,3,5,7,9,11 -> middles are 5 and 7, lower is 5.
         Assert.AreEqual(5.0, Statistics.Median<double>(data), Tol);
     }
 


### PR DESCRIPTION
## Summary
Addresses the findings from `Utils.Mathematics/TODO.md` + `TODO-2026-07-11-pass2.md` through `pass6.md` (2026-07-11 quality/numerical-correctness audit, 79 items across 6 files), one item per commit (coupled items folded together where a standalone fix would be incoherent, noted in the commit message). Working through P0 first, then P1/P2 in file order.

Progress is tracked below and updated as commits land.

## ⚠️ Breaking API change
**`Matrix<T>.DiagonalizeLU()` now returns `(L, U, P)` instead of `(L, U)`.** The old two-factor result could not reconstruct the input matrix whenever pivoting swapped rows (and `L` itself was computed wrong — see the #57 commit). The new contract is `P * A = L * U`. Any code deconstructing the old 2-tuple (`var (l, u) = matrix.DiagonalizeLU();`) will fail to compile. Documented in `CHANGELOG.md` under `omy.Utils.Mathematics (BREAKING)`; no package version bump proposed here (tracked for the coordinated `omy.Utils.*` 2.0.0 batch release instead).

### P0 (done first, regardless of source file)
- [x] #43 `Vector<T>.operator==` treats every non-null vector as equal to null
- [x] #16 `MatrixTransformations.Translation` wrong homogeneous-vector convention
- [x] #57 `DiagonalizeLU` doesn't build a real L factor (+ #58 permutation matrix, folded in)

### TODO.md (pass 1, items 1-15)
- [x] #1 `Statistics.Median<T>` off-by-one for even-length sequences
- [x] #2 `MatrixTransformations.Skew<T>` incompatible dimension/index formulas
- [x] #3 Approximate polynomial equality violates hash-code contract
- [x] #4 Fixed absolute polynomial epsilon invalid across generic types/scales
- [x] #5 `Polynomial.FindRoot` accepts invalid iteration/tolerance parameters
- [x] #6 Matrix solve/determinant singularity tests use exact zero
- [x] #7 Matrix structural flags rely on exact equality
- [x] #8 Simpson integration can overflow on odd step normalization
- [x] #9 Lagrange interpolation validates duplicates only mid-evaluation
- [ ] #10 FFT null/zero-length contracts implicit
- [ ] #11 Recursive FFT allocates at every recursion level
- [ ] #12 Correlation redundant passes/materialization
- [ ] #13 Statistical algorithms have no NaN/infinity policy
- [ ] #14 Matrix formatting rounds instead of formatting
- [ ] #15 Matrix equality unnecessarily depends on cached hash

### TODO-pass2.md (items 17-29, #16 done above)
- [ ] #17 General `Transform<T>` uses inconsistent row-vector layout
- [ ] #18 `Diagonal<T>` caches false structural metadata when a value is zero
- [ ] #19 Symmetric singular matrices cannot be eigen-decomposed
- [ ] #20 `ComputeEigenvalues` accepts non-positive iteration counts
- [ ] #21 QR/eigenvalue tolerances repeat fixed-epsilon defect
- [ ] #22 Vector normalization divides by zero for zero vector
- [ ] #23 `FromNormalSpace` divides by zero homogeneous coordinate
- [ ] #24 Matrix constructors fail unpredictably on empty inputs
- [ ] #25 Fourier-window doc incorrectly promises `[0,1]` range
- [ ] #26 Fourier windows compute in double despite generic output
- [ ] #27 Modified Gram-Schmidt has no re-orthogonalization
- [ ] #28 Eigenvalue QR iteration unshifted, converges slowly
- [ ] #29 Zero-dimensional behavior inconsistent across factories

### TODO-pass3.md (items 30-42)
- [ ] #30 Symbol lookup doesn't validate T supports requested function
- [ ] #31 Differentiation identifies variables by name not identity
- [ ] #32 Integration stateful, not safe for concurrent/re-entrant calls
- [ ] #33 Conversion nodes discarded without preserving type semantics
- [ ] #34 Integration introduces double constants into generic T trees
- [ ] #35 Symbolic power rules ignore domain restrictions
- [ ] #36 Finite-difference fallback silently approximates
- [ ] #37 `Line<T>` accepts zero direction vector
- [ ] #38 Line equality compares representations, not geometry
- [ ] #39 `Line<T>.ToString` ignores format/provider
- [ ] #40 Vector norm can overflow/underflow unnecessarily
- [ ] #41 Generalized cross product has factorial complexity
- [ ] #42 Symbolic transformation error behavior not explicit

### TODO-pass4.md (items 44-56, #43 done above)
- [ ] #44 Weighted barycenter divides by zero total weight
- [ ] #45 Barycenter selector/input validation incomplete
- [ ] #46 Non-generic symbolic convenience methods silently force double
- [ ] #47 Symbolic convenience methods select variables by nullable name
- [ ] #48 `AffineSubspace.Contains` accepts invalid tolerances
- [ ] #49 Affine-subspace factories lack null-member validation
- [ ] #50 Affine-subspace numerical-stability claims exceed implementation
- [ ] #51 Affine-subspace equality approximate but hashing coarse
- [ ] #52 `AffineSubspace<T>.IFormattable` ignores formatting inputs
- [ ] #53 Fourier metadata extensions don't validate inputs
- [ ] #54 One-sided frequency-bin semantics incomplete (missing Nyquist)
- [ ] #55 "Amplitude" helpers have no FFT normalization policy
- [ ] #56 Scalar vector/matrix division has no zero/non-finite policy

### TODO-pass5.md (items 59-69, #57/#58 done above)
- [x] #59 Polynomial operations bypass coefficient canonicalization
- [x] #60 Scalar multiplication by zero produces high-degree zero polynomial
- [ ] #61 `Matrix.Invert()` installs permanently false structural metadata
- [ ] #62 `MatrixTransformations.Identity` vs `Matrix<T>.Identity` disagree
- [ ] #63 Duplicate diagonal factories diverged in structural behavior
- [x] #64 `ApplyLinearTransformation` wrong validation - resolved as dead code removed in #57 commit
- [ ] #65 Polynomial formatting renders negative terms as "+ -"
- [ ] #66 Rotation dimension inference ambiguous for zero angles
- [ ] #67 `Matrix.Pad` also crops but contract only describes padding
- [ ] #68 Matrix metadata manually injected with no invariant checker
- [ ] #69 LU and inverse duplicate pivoted elimination

### TODO-pass6.md (items 70-79)
- [ ] #70 `AngleWith` can return wrong angle after norm-product overflow
- [ ] #71 `AngleWith` has only exact zero-vector detection
- [ ] #72 LU/inverse APIs return unreliable structural metadata (dup of #61, tracked there)
- [ ] #73 README examples don't compile against current API
- [ ] #74 README transformation examples advertise incorrect behavior
- [ ] #75 README LU identity assertion false for pivoted decompositions
- [ ] #76 Angle computation clamps non-finite cosine without explicit policy
- [ ] #77 Package metadata advertises features not present in project
- [ ] #78 README overstates generic type constraints
- [ ] #79 README examples rely on comments instead of executable assertions

## Follow-up from review
- `Polynomial.ApproximatelyEquals` and `Matrix<T>.IsTriangularWithin`/`IsDiagonalWithin`/`IsIdentityWithin`/`IsNormalSpaceWithin` now validate their `tolerance` parameter (finite, non-negative) — a `NaN` tolerance previously made every comparison vacuously "within tolerance", and a negative one rejected exact matches.
- `SingularityRelativeTolerance` (used by `Solve`/`Invert`/`Determinant`) is no longer a hard-coded `1e-10` literal, which underflowed to exactly zero for `Half` and collapsed the singularity check back to exact-zero comparison for that type. It's now derived generically from the scalar type's own machine epsilon. `Solve`/`Invert` also gained an optional `relativeSingularityTolerance` override parameter.

## Test plan
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` passes after each item
- [ ] Full suite green before merge
