### PR TITLE
Utils.Mathematics: fix pass2 numerical-correctness findings (items 17-29)

### DIFF
--- a/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
@@ -126,9 +126,10 @@ public partial class Matrix<T>
     /// Inverts the matrix if it is invertible.
     /// </summary>
     /// <param name="relativeSingularityTolerance">
-    /// Overrides the default relative pivot tolerance (see <see cref="DefaultSingularityRelativeTolerance"/>)
-    /// used to reject a numerically near-singular matrix; the effective absolute threshold is this
-    /// value multiplied by the matrix's largest entry. Must be finite and non-negative when supplied.
+    /// Overrides the default relative-plus-absolute pivot tolerance (see <see cref="DefaultTolerance"/>)
+    /// used to reject a numerically near-singular matrix. When supplied, the effective absolute
+    /// threshold is this value multiplied by the matrix's largest entry (no absolute floor is added,
+    /// unlike the default). Must be finite and non-negative when supplied.
     /// </param>
     /// <returns>A new matrix representing the inverse of the current matrix.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the matrix is not square.</exception>
@@ -150,7 +151,9 @@ public partial class Matrix<T>
         int n = Rows;
         T[,] working = ToArray();
         T[,] inverse = new T[n, n];
-        T pivotTolerance = MaxAbsoluteEntry(working) * (relativeSingularityTolerance ?? DefaultSingularityRelativeTolerance(n));
+        T pivotTolerance = relativeSingularityTolerance is { } explicitInvertTolerance
+            ? MaxAbsoluteEntry(working) * explicitInvertTolerance
+            : DefaultTolerance(MaxAbsoluteEntry(working), n);
 
         for (int i = 0; i < n; i++)
         {

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Constructors.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Constructors.cs
@@ -54,10 +54,19 @@ public sealed partial class Matrix<T>
     /// <summary>
     /// Initializes a matrix from a jagged array.
     /// </summary>
-    /// <param name="array">Jagged array containing the matrix values.</param>
+    /// <param name="array">Jagged array containing the matrix values. Must be non-empty, with no null rows.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="array"/> has no rows, or contains a null row.</exception>
     public Matrix(T[][] array)
     {
         array.Arg().MustNotBeNull();
+        if (array.Length == 0)
+            throw new ArgumentException("At least one row is required.", nameof(array));
+        for (int i = 0; i < array.Length; i++)
+        {
+            if (array[i] is null)
+                throw new ArgumentException($"Row {i} is null.", nameof(array));
+        }
+
         int maxYLength = array.Select(a => a.Length).Max();
         components = new T[array.Length, maxYLength];
 
@@ -77,11 +86,20 @@ public sealed partial class Matrix<T>
     /// <summary>
     /// Initializes a matrix from column vectors.
     /// </summary>
-    /// <param name="vectors">Column vectors.</param>
-    /// <exception cref="ArgumentException">Thrown when vectors do not share the same dimension.</exception>
+    /// <param name="vectors">Column vectors. At least one is required, and none may be null.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when no vectors are provided, a vector is null, or vectors do not share the same dimension.
+    /// </exception>
     public Matrix(params Vector<T>[] vectors)
     {
         vectors.Arg().MustNotBeNull();
+        if (vectors.Length == 0)
+            throw new ArgumentException("At least one vector is required.", nameof(vectors));
+        for (int i = 0; i < vectors.Length; i++)
+        {
+            if (vectors[i] is null)
+                throw new ArgumentException($"Vector {i} is null.", nameof(vectors));
+        }
         if (vectors.Any(v => v.Dimension != vectors[0].Dimension))
             throw new ArgumentException("All vectors must have the same dimension", nameof(vectors));
         components = new T[vectors[0].Dimension, vectors.Length];

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
@@ -7,8 +7,6 @@ namespace Utils.Mathematics.LinearAlgebra;
 /// </summary>
 public sealed partial class Matrix<T>
 {
-    private static readonly T EigenEpsilon = T.CreateChecked(1e-10);
-
     /// <summary>
     /// Computes the real eigenvalues and corresponding eigenvectors of a symmetric matrix
     /// using the QR iteration algorithm.
@@ -40,13 +38,19 @@ public sealed partial class Matrix<T>
         // Working copy for QR iteration
         T[,] a = ToArray();
 
+        // Scale-aware (rather than a hard-coded 1e-10 absolute literal) convergence tolerance,
+        // fixed at the outset from the original matrix's magnitude: similarity transformations
+        // (A <- Q^T A Q at each step) preserve the Frobenius norm, so the initial scale remains a
+        // valid reference throughout the iteration.
+        T convergenceTolerance = MaxAbsoluteEntry(a) * MachineEpsilon * T.CreateChecked(n);
+
         // Accumulate eigenvectors: V = Q_0 · Q_1 · …
         T[,] v = new T[n, n];
         for (int i = 0; i < n; i++) v[i, i] = T.One;
 
         for (int iter = 0; iter < maxIterations; iter++)
         {
-            if (OffDiagonalNorm(a, n) <= EigenEpsilon) break;
+            if (OffDiagonalNorm(a, n) <= convergenceTolerance) break;
 
             // QR decompose the current A
             var (q, r) = new Matrix<T>(a).DecomposeQR();
@@ -70,7 +74,7 @@ public sealed partial class Matrix<T>
         // only inside the loop's final pass: that tied the check to iter == maxIterations - 1,
         // which never ran at all for maxIterations <= 0 (now rejected above regardless), and made
         // the check easy to accidentally skip if the loop's control flow changed.
-        if (OffDiagonalNorm(a, n) > EigenEpsilon)
+        if (OffDiagonalNorm(a, n) > convergenceTolerance)
             throw new InvalidOperationException(
                 $"QR iteration did not converge after {maxIterations} iterations.");
 
@@ -99,9 +103,11 @@ public sealed partial class Matrix<T>
     public bool IsSymmetric()
     {
         if (!IsSquare) return false;
+        T[,] array = ToArray();
+        T tolerance = MaxAbsoluteEntry(array) * MachineEpsilon * T.CreateChecked(Rows);
         for (int i = 0; i < Rows; i++)
             for (int j = i + 1; j < Columns; j++)
-                if (T.Abs(this[i, j] - this[j, i]) > EigenEpsilon) return false;
+                if (T.Abs(array[i, j] - array[j, i]) > tolerance) return false;
         return true;
     }
 

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
@@ -16,18 +16,30 @@ public sealed partial class Matrix<T>
     /// Eigenvalues are returned in descending order of absolute value.
     /// </remarks>
     /// <param name="maxIterations">Maximum number of QR iterations before giving up. Must be greater than zero.</param>
+    /// <param name="convergenceTolerance">
+    /// Overrides the default relative-plus-absolute convergence tolerance (see
+    /// <see cref="DefaultTolerance"/>) used to decide when the off-diagonal magnitude is small
+    /// enough to stop iterating. When supplied, the effective absolute threshold is this value
+    /// multiplied by the matrix's largest entry. This is a threshold on the QR-iteration's own
+    /// convergence and is independent of <see cref="IsSymmetric()"/>'s (separately configurable)
+    /// input-validation tolerance. Must be finite and non-negative when supplied.
+    /// </param>
     /// <returns>
     /// A tuple containing an array of eigenvalues (descending by magnitude) and a matrix whose
     /// columns are the corresponding eigenvectors.
     /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxIterations"/> is not positive.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="maxIterations"/> is not positive, or <paramref name="convergenceTolerance"/> is supplied but not finite or is negative.
+    /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the matrix is not square, not symmetric, or fails to converge.
     /// </exception>
-    public (T[] Eigenvalues, Matrix<T> Eigenvectors) ComputeEigenvalues(int maxIterations = 1000)
+    public (T[] Eigenvalues, Matrix<T> Eigenvectors) ComputeEigenvalues(int maxIterations = 1000, T? convergenceTolerance = null)
     {
         if (maxIterations <= 0)
             throw new ArgumentOutOfRangeException(nameof(maxIterations), maxIterations, "Must be greater than zero.");
+        if (convergenceTolerance is { } explicitConvergenceTolerance)
+            ValidateTolerance(explicitConvergenceTolerance, nameof(convergenceTolerance));
         if (!IsSquare)
             throw new InvalidOperationException("Eigenvalue decomposition requires a square matrix.");
 
@@ -42,7 +54,9 @@ public sealed partial class Matrix<T>
         // fixed at the outset from the original matrix's magnitude: similarity transformations
         // (A <- Q^T A Q at each step) preserve the Frobenius norm, so the initial scale remains a
         // valid reference throughout the iteration.
-        T convergenceTolerance = MaxAbsoluteEntry(a) * MachineEpsilon * T.CreateChecked(n);
+        T effectiveConvergenceTolerance = convergenceTolerance is { } explicitTolerance
+            ? MaxAbsoluteEntry(a) * explicitTolerance
+            : DefaultTolerance(MaxAbsoluteEntry(a), n);
 
         // Accumulate eigenvectors: V = Q_0 · Q_1 · …
         T[,] v = new T[n, n];
@@ -50,7 +64,7 @@ public sealed partial class Matrix<T>
 
         for (int iter = 0; iter < maxIterations; iter++)
         {
-            if (OffDiagonalNorm(a, n) <= convergenceTolerance) break;
+            if (OffDiagonalNorm(a, n) <= effectiveConvergenceTolerance) break;
 
             // QR decompose the current A
             var (q, r) = new Matrix<T>(a).DecomposeQR();
@@ -74,7 +88,7 @@ public sealed partial class Matrix<T>
         // only inside the loop's final pass: that tied the check to iter == maxIterations - 1,
         // which never ran at all for maxIterations <= 0 (now rejected above regardless), and made
         // the check easy to accidentally skip if the loop's control flow changed.
-        if (OffDiagonalNorm(a, n) > convergenceTolerance)
+        if (OffDiagonalNorm(a, n) > effectiveConvergenceTolerance)
             throw new InvalidOperationException(
                 $"QR iteration did not converge after {maxIterations} iterations.");
 
@@ -99,12 +113,34 @@ public sealed partial class Matrix<T>
         return (sortedValues, new Matrix<T>(sortedVectors));
     }
 
-    /// <summary>Returns <see langword="true"/> when this square matrix is symmetric (A[i,j] == A[j,i]).</summary>
-    public bool IsSymmetric()
+    /// <summary>
+    /// Returns <see langword="true"/> when this square matrix is symmetric (A[i,j] == A[j,i]) within
+    /// the default relative-plus-absolute tolerance (see <see cref="DefaultTolerance"/>).
+    /// </summary>
+    public bool IsSymmetric() => IsSymmetric(null);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when this square matrix is symmetric (A[i,j] == A[j,i]) within
+    /// <paramref name="symmetryTolerance"/>.
+    /// </summary>
+    /// <param name="symmetryTolerance">
+    /// Overrides the default relative-plus-absolute tolerance (see <see cref="DefaultTolerance"/>)
+    /// used to compare A[i,j] to A[j,i]. When supplied, the effective absolute threshold is this
+    /// value multiplied by the matrix's largest entry. This is independent of
+    /// <see cref="ComputeEigenvalues"/>'s (separately configurable) convergence tolerance. Must be
+    /// finite and non-negative when supplied.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="symmetryTolerance"/> is supplied but not finite or is negative.</exception>
+    public bool IsSymmetric(T? symmetryTolerance)
     {
         if (!IsSquare) return false;
+        if (symmetryTolerance is { } explicitSymmetryTolerance)
+            ValidateTolerance(explicitSymmetryTolerance, nameof(symmetryTolerance));
+
         T[,] array = ToArray();
-        T tolerance = MaxAbsoluteEntry(array) * MachineEpsilon * T.CreateChecked(Rows);
+        T tolerance = symmetryTolerance is { } explicitTolerance
+            ? MaxAbsoluteEntry(array) * explicitTolerance
+            : DefaultTolerance(MaxAbsoluteEntry(array), Rows);
         for (int i = 0; i < Rows; i++)
             for (int j = i + 1; j < Columns; j++)
                 if (T.Abs(array[i, j] - array[j, i]) > tolerance) return false;

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
@@ -17,16 +17,19 @@ public sealed partial class Matrix<T>
     /// Only real symmetric matrices are supported; all eigenvalues of such matrices are guaranteed real.
     /// Eigenvalues are returned in descending order of absolute value.
     /// </remarks>
-    /// <param name="maxIterations">Maximum number of QR iterations before giving up.</param>
+    /// <param name="maxIterations">Maximum number of QR iterations before giving up. Must be greater than zero.</param>
     /// <returns>
     /// A tuple containing an array of eigenvalues (descending by magnitude) and a matrix whose
     /// columns are the corresponding eigenvectors.
     /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxIterations"/> is not positive.</exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the matrix is not square, not symmetric, or fails to converge.
     /// </exception>
     public (T[] Eigenvalues, Matrix<T> Eigenvectors) ComputeEigenvalues(int maxIterations = 1000)
     {
+        if (maxIterations <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxIterations), maxIterations, "Must be greater than zero.");
         if (!IsSquare)
             throw new InvalidOperationException("Eigenvalue decomposition requires a square matrix.");
 
@@ -61,11 +64,15 @@ public sealed partial class Matrix<T>
                     newV[i, j] = sum;
                 }
             v = newV;
-
-            if (iter == maxIterations - 1 && OffDiagonalNorm(a, n) > EigenEpsilon)
-                throw new InvalidOperationException(
-                    $"QR iteration did not converge after {maxIterations} iterations.");
         }
+
+        // Check convergence independently of loop-entry/last-iteration conditions, rather than
+        // only inside the loop's final pass: that tied the check to iter == maxIterations - 1,
+        // which never ran at all for maxIterations <= 0 (now rejected above regardless), and made
+        // the check easy to accidentally skip if the loop's control flow changed.
+        if (OffDiagonalNorm(a, n) > EigenEpsilon)
+            throw new InvalidOperationException(
+                $"QR iteration did not converge after {maxIterations} iterations.");
 
         // Extract eigenvalues from the diagonal
         T[] eigenvalues = new T[n];

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
@@ -20,31 +20,51 @@ public sealed partial class Matrix<T>
     /// Overrides the default relative-plus-absolute convergence tolerance (see
     /// <see cref="DefaultTolerance"/>) used to decide when the off-diagonal magnitude is small
     /// enough to stop iterating. When supplied, the effective absolute threshold is this value
-    /// multiplied by the matrix's largest entry. This is a threshold on the QR-iteration's own
-    /// convergence and is independent of <see cref="IsSymmetric()"/>'s (separately configurable)
-    /// input-validation tolerance. Must be finite and non-negative when supplied.
+    /// multiplied by the matrix's largest entry. Independently configurable from
+    /// <paramref name="symmetryTolerance"/> and <paramref name="rankTolerance"/>. Must be finite and
+    /// non-negative when supplied.
+    /// </param>
+    /// <param name="symmetryTolerance">
+    /// Overrides the default tolerance (see <see cref="DefaultTolerance"/>) used by the upfront
+    /// <see cref="IsSymmetric(T?)"/> input-validation check. Forwarded directly to
+    /// <see cref="IsSymmetric(T?)"/>; independently configurable from
+    /// <paramref name="convergenceTolerance"/> and <paramref name="rankTolerance"/>. Must be finite
+    /// and non-negative when supplied.
+    /// </param>
+    /// <param name="rankTolerance">
+    /// Overrides the default tolerance (see <see cref="DefaultTolerance"/>) used by each QR
+    /// iteration's internal <see cref="DecomposeQR(T?)"/> call to decide whether a column is already
+    /// numerically rank-deficient. Forwarded directly to <see cref="DecomposeQR(T?)"/> at every
+    /// iteration; independently configurable from <paramref name="convergenceTolerance"/> and
+    /// <paramref name="symmetryTolerance"/>. Must be finite and non-negative when supplied.
     /// </param>
     /// <returns>
     /// A tuple containing an array of eigenvalues (descending by magnitude) and a matrix whose
     /// columns are the corresponding eigenvectors.
     /// </returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when <paramref name="maxIterations"/> is not positive, or <paramref name="convergenceTolerance"/> is supplied but not finite or is negative.
+    /// Thrown when <paramref name="maxIterations"/> is not positive, or any of
+    /// <paramref name="convergenceTolerance"/>, <paramref name="symmetryTolerance"/>,
+    /// <paramref name="rankTolerance"/> is supplied but not finite or is negative.
     /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the matrix is not square, not symmetric, or fails to converge.
     /// </exception>
-    public (T[] Eigenvalues, Matrix<T> Eigenvectors) ComputeEigenvalues(int maxIterations = 1000, T? convergenceTolerance = null)
+    public (T[] Eigenvalues, Matrix<T> Eigenvectors) ComputeEigenvalues(int maxIterations = 1000, T? convergenceTolerance = null, T? symmetryTolerance = null, T? rankTolerance = null)
     {
         if (maxIterations <= 0)
             throw new ArgumentOutOfRangeException(nameof(maxIterations), maxIterations, "Must be greater than zero.");
         if (convergenceTolerance is { } explicitConvergenceTolerance)
             ValidateTolerance(explicitConvergenceTolerance, nameof(convergenceTolerance));
+        if (symmetryTolerance is { } explicitSymmetryToleranceArg)
+            ValidateTolerance(explicitSymmetryToleranceArg, nameof(symmetryTolerance));
+        if (rankTolerance is { } explicitRankToleranceArg)
+            ValidateTolerance(explicitRankToleranceArg, nameof(rankTolerance));
         if (!IsSquare)
             throw new InvalidOperationException("Eigenvalue decomposition requires a square matrix.");
 
         int n = Rows;
-        if (!IsSymmetric())
+        if (!IsSymmetric(symmetryTolerance))
             throw new InvalidOperationException("This implementation only supports real symmetric matrices.");
 
         // Working copy for QR iteration
@@ -67,7 +87,7 @@ public sealed partial class Matrix<T>
             if (OffDiagonalNorm(a, n) <= effectiveConvergenceTolerance) break;
 
             // QR decompose the current A
-            var (q, r) = new Matrix<T>(a).DecomposeQR();
+            var (q, r) = new Matrix<T>(a).DecomposeQR(rankTolerance);
 
             // A ← R·Q  (this is A_{k+1} = R_k · Q_k)
             a = (r * q).ToArray();

--- a/Utils.Mathematics/LinearAlgebra/Matrix.QR.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.QR.cs
@@ -7,8 +7,6 @@ namespace Utils.Mathematics.LinearAlgebra;
 /// </summary>
 public sealed partial class Matrix<T>
 {
-    private static readonly T QrEpsilon = T.CreateChecked(1e-12);
-
     /// <summary>
     /// Performs a QR decomposition of this matrix using Householder reflections.
     /// </summary>
@@ -32,6 +30,11 @@ public sealed partial class Matrix<T>
         T[,] qFull = new T[m, m];
         for (int i = 0; i < m; i++) qFull[i, i] = T.One;
 
+        // Scale-aware (rather than a hard-coded 1e-12 absolute literal, meaningless across
+        // arbitrary IFloatingPoint<T> precision) tolerance for detecting a column that is already
+        // numerically zero below the diagonal.
+        T qrTolerance = MaxAbsoluteEntry(r) * MachineEpsilon * T.CreateChecked(m);
+
         int steps = Math.Min(m - 1, n);
         for (int k = 0; k < steps; k++)
         {
@@ -42,7 +45,7 @@ public sealed partial class Matrix<T>
             // The sub-column below the diagonal is already (numerically) zero: either genuinely
             // rank-deficient at this step, or already aligned with the target axis. Either way,
             // there is nothing to reflect, and R's diagonal entry here is correctly ~zero.
-            if (normX <= QrEpsilon)
+            if (normX <= qrTolerance)
                 continue;
 
             T alpha = r[k, k] >= T.Zero ? -normX : normX;
@@ -55,7 +58,7 @@ public sealed partial class Matrix<T>
             T normV = T.Zero;
             for (int i = 0; i < len; i++) normV += v[i] * v[i];
             normV = T.Sqrt(normV);
-            if (normV <= QrEpsilon)
+            if (normV <= qrTolerance)
                 continue;
             for (int i = 0; i < len; i++) v[i] /= normV;
 

--- a/Utils.Mathematics/LinearAlgebra/Matrix.QR.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.QR.cs
@@ -10,53 +10,85 @@ public sealed partial class Matrix<T>
     private static readonly T QrEpsilon = T.CreateChecked(1e-12);
 
     /// <summary>
-    /// Performs a QR decomposition of this matrix using the modified Gram–Schmidt algorithm.
+    /// Performs a QR decomposition of this matrix using Householder reflections.
     /// </summary>
     /// <remarks>
-    /// For an m×n matrix A with m ≥ n and full column rank, returns Q (m×n, orthonormal columns)
-    /// and R (n×n, upper triangular) such that A = Q·R.
+    /// For an m×n matrix A with m ≥ n, returns Q (m×n, orthonormal columns) and R (n×n, upper
+    /// triangular) such that A = Q·R. Unlike a Gram-Schmidt-based decomposition, Householder
+    /// reflections remain well-defined when a column is linearly dependent on the ones before it: a
+    /// rank-deficient column simply produces a (numerically) zero diagonal entry in R at that step
+    /// rather than requiring the decomposition to be rejected, which is what allows singular square
+    /// matrices to reach <see cref="ComputeEigenvalues"/>.
     /// </remarks>
     /// <returns>A tuple containing the orthogonal matrix Q and the upper-triangular matrix R.</returns>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when the matrix has more columns than rows, or when its columns are not linearly independent.
-    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown when the matrix has more columns than rows.</exception>
     public (Matrix<T> Q, Matrix<T> R) DecomposeQR()
     {
         if (Rows < Columns)
             throw new InvalidOperationException("QR decomposition requires Rows ≥ Columns.");
 
         int m = Rows, n = Columns;
-        T[,] q = new T[m, n];
-        T[,] r = new T[n, n];
-        T[,] a = ToArray();
+        T[,] r = ToArray();
+        T[,] qFull = new T[m, m];
+        for (int i = 0; i < m; i++) qFull[i, i] = T.One;
 
-        for (int j = 0; j < n; j++)
+        int steps = Math.Min(m - 1, n);
+        for (int k = 0; k < steps; k++)
         {
-            // Copy column j of A into q[:,j]
-            for (int i = 0; i < m; i++) q[i, j] = a[i, j];
+            T normX = T.Zero;
+            for (int i = k; i < m; i++) normX += r[i, k] * r[i, k];
+            normX = T.Sqrt(normX);
 
-            // Subtract projections onto already-computed orthonormal columns
-            for (int k = 0; k < j; k++)
+            // The sub-column below the diagonal is already (numerically) zero: either genuinely
+            // rank-deficient at this step, or already aligned with the target axis. Either way,
+            // there is nothing to reflect, and R's diagonal entry here is correctly ~zero.
+            if (normX <= QrEpsilon)
+                continue;
+
+            T alpha = r[k, k] >= T.Zero ? -normX : normX;
+
+            int len = m - k;
+            T[] v = new T[len];
+            for (int i = 0; i < len; i++) v[i] = r[k + i, k];
+            v[0] -= alpha;
+
+            T normV = T.Zero;
+            for (int i = 0; i < len; i++) normV += v[i] * v[i];
+            normV = T.Sqrt(normV);
+            if (normV <= QrEpsilon)
+                continue;
+            for (int i = 0; i < len; i++) v[i] /= normV;
+
+            // Apply the reflection H = I - 2vv^T to R, restricted to rows k..m-1 and columns k..n-1.
+            for (int col = k; col < n; col++)
             {
                 T dot = T.Zero;
-                for (int i = 0; i < m; i++) dot += q[i, k] * q[i, j];
-                r[k, j] = dot;
-                for (int i = 0; i < m; i++) q[i, j] -= dot * q[i, k];
+                for (int i = 0; i < len; i++) dot += v[i] * r[k + i, col];
+                T scale = dot + dot;
+                for (int i = 0; i < len; i++) r[k + i, col] -= scale * v[i];
             }
 
-            // Normalise
-            T norm = T.Zero;
-            for (int i = 0; i < m; i++) norm += q[i, j] * q[i, j];
-            norm = T.Sqrt(norm);
-
-            if (norm <= QrEpsilon)
-                throw new InvalidOperationException(
-                    "Matrix columns are linearly dependent; QR decomposition requires full column rank.");
-
-            r[j, j] = norm;
-            for (int i = 0; i < m; i++) q[i, j] /= norm;
+            // Accumulate the same reflection into Q (applied to columns k..m-1, every row).
+            for (int row = 0; row < m; row++)
+            {
+                T dot = T.Zero;
+                for (int i = 0; i < len; i++) dot += qFull[row, k + i] * v[i];
+                T scale = dot + dot;
+                for (int i = 0; i < len; i++) qFull[row, k + i] -= scale * v[i];
+            }
         }
 
-        return (new Matrix<T>(q), new Matrix<T>(r));
+        // Extract the thin (economy) form: the first n columns of Q and the n x n upper-triangular R.
+        T[,] q = new T[m, n];
+        for (int i = 0; i < m; i++)
+            for (int j = 0; j < n; j++)
+                q[i, j] = qFull[i, j];
+
+        T[,] rThin = new T[n, n];
+        for (int i = 0; i < n; i++)
+            for (int j = i; j < n; j++)
+                rThin[i, j] = r[i, j];
+
+        return (new Matrix<T>(q), new Matrix<T>(rThin));
     }
 }

--- a/Utils.Mathematics/LinearAlgebra/Matrix.QR.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.QR.cs
@@ -18,12 +18,21 @@ public sealed partial class Matrix<T>
     /// rather than requiring the decomposition to be rejected, which is what allows singular square
     /// matrices to reach <see cref="ComputeEigenvalues"/>.
     /// </remarks>
+    /// <param name="rankTolerance">
+    /// Overrides the default relative-plus-absolute tolerance (see <see cref="DefaultTolerance"/>)
+    /// used to decide whether a column's remaining sub-diagonal component is already numerically
+    /// zero (rank-deficient at that step). When supplied, the effective absolute threshold is this
+    /// value multiplied by the matrix's largest entry. Must be finite and non-negative when supplied.
+    /// </param>
     /// <returns>A tuple containing the orthogonal matrix Q and the upper-triangular matrix R.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the matrix has more columns than rows.</exception>
-    public (Matrix<T> Q, Matrix<T> R) DecomposeQR()
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="rankTolerance"/> is supplied but not finite or is negative.</exception>
+    public (Matrix<T> Q, Matrix<T> R) DecomposeQR(T? rankTolerance = null)
     {
         if (Rows < Columns)
             throw new InvalidOperationException("QR decomposition requires Rows ≥ Columns.");
+        if (rankTolerance is { } explicitRankTolerance)
+            ValidateTolerance(explicitRankTolerance, nameof(rankTolerance));
 
         int m = Rows, n = Columns;
         T[,] r = ToArray();
@@ -33,7 +42,9 @@ public sealed partial class Matrix<T>
         // Scale-aware (rather than a hard-coded 1e-12 absolute literal, meaningless across
         // arbitrary IFloatingPoint<T> precision) tolerance for detecting a column that is already
         // numerically zero below the diagonal.
-        T qrTolerance = MaxAbsoluteEntry(r) * MachineEpsilon * T.CreateChecked(m);
+        T qrTolerance = rankTolerance is { } explicitQrTolerance
+            ? MaxAbsoluteEntry(r) * explicitQrTolerance
+            : DefaultTolerance(MaxAbsoluteEntry(r), m);
 
         int steps = Math.Min(m - 1, n);
         for (int k = 0; k < steps; k++)

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
@@ -13,11 +13,11 @@ public sealed partial class Matrix<T>
     /// </summary>
     /// <param name="b">Right-hand-side vector. Its dimension must equal the number of rows.</param>
     /// <param name="relativeSingularityTolerance">
-    /// Overrides the default relative pivot tolerance (see <see cref="DefaultSingularityRelativeTolerance"/>)
-    /// used to reject a numerically near-singular matrix; the effective absolute threshold is this
-    /// value multiplied by the matrix's largest entry. Pass a smaller value to accept more
-    /// ill-conditioned systems, or a larger value to reject them more aggressively. Must be finite
-    /// and non-negative when supplied.
+    /// Overrides the default relative-plus-absolute pivot tolerance (see <see cref="DefaultTolerance"/>)
+    /// used to reject a numerically near-singular matrix. When supplied, the effective absolute
+    /// threshold is this value multiplied by the matrix's largest entry (no absolute floor is added,
+    /// unlike the default); pass a smaller value to accept more ill-conditioned systems, or a larger
+    /// value to reject them more aggressively. Must be finite and non-negative when supplied.
     /// </param>
     /// <returns>The solution vector <c>x</c>.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the matrix is not square or is singular.</exception>
@@ -37,7 +37,9 @@ public sealed partial class Matrix<T>
         T[] x = new T[n];
         for (int i = 0; i < n; i++) x[i] = b[i];
 
-        T pivotTolerance = MaxAbsoluteEntry(a) * (relativeSingularityTolerance ?? DefaultSingularityRelativeTolerance(n));
+        T pivotTolerance = relativeSingularityTolerance is { } explicitSolveTolerance
+            ? MaxAbsoluteEntry(a) * explicitSolveTolerance
+            : DefaultTolerance(MaxAbsoluteEntry(a), n);
 
         // Forward elimination with partial pivoting
         for (int col = 0; col < n; col++)

--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -21,41 +21,50 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
 
     /// <summary>
     /// The type's machine epsilon: the smallest positive value such that <c>1 + eps != 1</c> in
-    /// <typeparamref name="T"/>'s own arithmetic. Computed generically by successive halving rather
-    /// than a hard-coded literal such as <c>1e-10</c>, which is meaningless (and, for low-precision
-    /// types such as <see cref="Half"/>, would silently underflow to zero) across arbitrary
+    /// <typeparamref name="T"/>'s own arithmetic. Computed generically rather than a hard-coded
+    /// literal such as <c>1e-10</c>, which is meaningless (and, for low-precision types such as
+    /// <see cref="Half"/>, would silently underflow to zero) across arbitrary
     /// <see cref="IFloatingPoint{TSelf}"/> types with wildly different precision.
     /// </summary>
-    private static readonly T MachineEpsilon = ComputeMachineEpsilon();
-
-    private static T ComputeMachineEpsilon()
-    {
-        T two = T.One + T.One;
-        T eps = T.One;
-        while (T.One + eps / two != T.One)
-            eps /= two;
-        return eps;
-    }
+    private static readonly T MachineEpsilon = NumericPrecision.MachineEpsilon<T>();
 
     /// <summary>
-    /// Computes the default relative pivot tolerance for an <paramref name="dimension"/>-by-
-    /// <paramref name="dimension"/> elimination used by <see cref="Solve"/>, <see cref="Invert"/>,
-    /// and <see cref="Determinant"/> to reject a numerically near-singular matrix (magnitude
-    /// relative to the matrix's largest entry) instead of dividing by a pivot that is merely close
-    /// to zero, which would silently amplify rounding error into a huge, infinite, or NaN result
-    /// while still returning an apparently valid answer.
+    /// Computes a default relative-plus-absolute tolerance for an operation over a problem of the
+    /// given <paramref name="dimension"/> whose values have a maximum magnitude of
+    /// <paramref name="scale"/>. Used as the shared default for the pivot/rank tolerance in
+    /// <see cref="Solve"/>/<see cref="Invert"/>/<see cref="Determinant"/>, <see cref="DecomposeQR"/>'s
+    /// rank-deficiency threshold, <see cref="IsSymmetric()"/>'s comparison tolerance, and
+    /// <see cref="ComputeEigenvalues"/>'s convergence threshold - each of those members also accepts
+    /// its own explicit override for callers who need a different threshold for that specific concern.
     /// </summary>
     /// <remarks>
-    /// Scaled by <paramref name="dimension"/> rather than a flat constant, following the common
-    /// numerical-linear-algebra convention that accumulated round-off across elimination grows
-    /// roughly with problem size (e.g. LAPACK-style rank/near-singularity heuristics use
-    /// <c>n * eps</c> rather than a size-independent multiplier). A flat multiplier large enough to
-    /// be meaningful for bigger systems (an earlier version of this method used a fixed 100x) is far
-    /// too loose for small matrices of a low-precision type: for a 2x2 <see cref="Half"/> matrix, a
-    /// flat 100x its machine epsilon is already about 10% of the matrix's magnitude, misclassifying
-    /// ordinary invertible matrices (e.g. a diagonal with a 20:1 ratio between entries) as singular.
+    /// <para>
+    /// The relative term (<c>scale * dimension * eps</c>) follows the common numerical-linear-algebra
+    /// convention that accumulated round-off grows roughly with problem size (e.g. LAPACK-style
+    /// rank/near-singularity heuristics use <c>n * eps</c>). A flat multiplier large enough to be
+    /// meaningful for bigger systems (an earlier version of this method used a fixed 100x with no
+    /// dimension scaling) is far too loose for small matrices of a low-precision type: for a 2x2
+    /// <see cref="Half"/> matrix, a flat 100x its machine epsilon is already about 10% of the
+    /// matrix's magnitude, misclassifying ordinary invertible matrices as singular.
+    /// </para>
+    /// <para>
+    /// The additive <c>+ 1</c> is a fixed absolute floor: without it, an all-zero or near-zero-scale
+    /// matrix would compute a tolerance of exactly (or near) zero, collapsing the check back to exact
+    /// equality precisely for the inputs where that is least appropriate.
+    /// </para>
+    /// <para>
+    /// <b>Known limitation:</b> this uses a single scalar <paramref name="scale"/> (typically the
+    /// largest entry across the whole matrix) for the entire problem. For a matrix whose entries span
+    /// very different magnitudes (e.g. one huge diagonal entry alongside a small but numerically
+    /// significant off-diagonal block), a single global scale can make the effective tolerance too
+    /// loose for the smaller sub-problem, potentially treating it as already converged, singular, or
+    /// symmetric relative to the whole matrix's scale when it is not relative to its own. Properly
+    /// addressing that requires per-row/column equilibration or block-aware scaling, which this
+    /// method does not attempt.
+    /// </para>
     /// </remarks>
-    private static T DefaultSingularityRelativeTolerance(int dimension) => MachineEpsilon * T.CreateChecked(dimension);
+    private static T DefaultTolerance(T scale, int dimension)
+        => MachineEpsilon * T.CreateChecked(dimension) * (scale + T.One);
 
     /// <summary>
     /// Validates that a caller-supplied tolerance is usable as a comparison threshold: finite and
@@ -380,7 +389,7 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
         // Elimination divides by the pivot below, so a pivot that is merely close to zero (not
         // exactly zero) would otherwise amplify rounding error into a huge/infinite/NaN result
         // instead of the mathematically expected near-zero determinant of a near-singular matrix.
-        T pivotTolerance = MaxAbsoluteEntry(u) * DefaultSingularityRelativeTolerance(n);
+        T pivotTolerance = DefaultTolerance(MaxAbsoluteEntry(u), n);
 
         for (int k = 0; k < n; k++)
         {

--- a/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
+++ b/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
@@ -34,34 +34,18 @@ public static class MatrixTransformations
     /// <typeparam name="T">Numeric type of the matrix.</typeparam>
     /// <param name="values">Diagonal values.</param>
     /// <returns>New diagonal matrix.</returns>
+    /// <remarks>
+    /// Delegates to <see cref="Matrix{T}.Diagonal(IEnumerable{T})"/>, which is the single
+    /// implementation of diagonal-matrix construction: an earlier, independent implementation here
+    /// cached <c>isTriangular</c>/<c>isDiagonal</c> as <see langword="false"/> whenever any diagonal
+    /// value was zero, even though a matrix with zero diagonal entries is still diagonal and
+    /// triangular by definition (only its invertibility/determinant changes). Two independently
+    /// maintained factories for the same construction had already drifted into different, incorrect
+    /// behavior; keeping one implementation avoids a repeat.
+    /// </remarks>
     public static Matrix<T> Diagonal<T>(params IEnumerable<T> values)
         where T : struct, IFloatingPoint<T>, IRootFunctions<T>
-    {
-        T[] valuesArray = values.ToArray();
-        int dimension = valuesArray.Length;
-        var array = new T[dimension, dimension];
-        bool allOne = true;
-        bool oneZero = false;
-        T newDeterminant = T.One;
-        for (int i = 0; i < dimension; i++)
-        {
-            if (valuesArray[i] == T.Zero)
-            {
-                oneZero = true;
-                allOne = false;
-            }
-            else if (valuesArray[i] != T.One)
-            {
-                allOne = false;
-            }
-            for (int j = 0; j < dimension; j++)
-            {
-                array[i, j] = i == j ? valuesArray[i] : T.Zero;
-            }
-            newDeterminant *= valuesArray[i];
-        }
-        return new Matrix<T>(array, allOne, !oneZero, !oneZero, newDeterminant);
-    }
+        => Matrix<T>.Diagonal(values);
 
     /// <summary>
     /// Generates a scaling matrix.

--- a/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
+++ b/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
@@ -227,19 +227,35 @@ public static class MatrixTransformations
     }
 
     /// <summary>
-    /// Generates a transformation matrix.
+    /// Generates a general affine transformation matrix.
     /// </summary>
     /// <typeparam name="T">Numeric type of the matrix.</typeparam>
-    /// <param name="values">Transformation coefficients.</param>
-    /// <returns>New transformation matrix.</returns>
+    /// <param name="values">
+    /// Coefficients for the upper <c>d × (d+1)</c> affine block, in row-major order: for each of the
+    /// <c>d</c> base-dimension rows, <c>d</c> linear coefficients followed by that row's translation
+    /// coefficient (last column). The base dimension <c>d</c> is inferred from the count:
+    /// <c>d * (d + 1)</c> values are required. For example, a 2D transform needs 6 values
+    /// <c>[a, b, tx, c, d, ty]</c>, producing the matrix rows <c>[a, b, tx]</c>, <c>[c, d, ty]</c>.
+    /// </param>
+    /// <returns>
+    /// A new <c>(d+1) × (d+1)</c> homogeneous transformation matrix: the supplied coefficients fill
+    /// the upper affine block, and the final row is left as the homogeneous row <c>[0, …, 0, 1]</c>,
+    /// consistent with this library's matrix-times-column-vector multiplication convention (the
+    /// same convention <see cref="Translation{T}(IEnumerable{T})"/> uses for its translation column).
+    /// </returns>
+    /// <exception cref="ArgumentException">Thrown when the value count does not match <c>d * (d + 1)</c> for any integer <c>d</c>.</exception>
     public static Matrix<T> Transform<T>(params IEnumerable<T> values)
         where T : struct, IFloatingPoint<T>, IRootFunctions<T>
     {
         T[] valuesArray = values.ToArray();
-        var dimension = (Math.Sqrt(4 * valuesArray.Length + 1) + 1) / 2;
-        if (dimension != Math.Floor(dimension))
-            throw new ArgumentException("Invalid dimension for transformation matrix", nameof(values));
-        int matrixDimension = (int)dimension;
+        // Solve n = d * (d + 1) for the base dimension d, then verify with exact integer
+        // arithmetic (the closed-form root is only used to pick a candidate).
+        double baseDimensionEstimate = (Math.Sqrt(4 * valuesArray.Length + 1) - 1) / 2;
+        int baseDimension = (int)Math.Round(baseDimensionEstimate);
+        if (baseDimension <= 0 || baseDimension * (baseDimension + 1) != valuesArray.Length)
+            throw new ArgumentException("Invalid coefficient count for transformation matrix", nameof(values));
+
+        int matrixDimension = baseDimension + 1;
         var array = new T[matrixDimension, matrixDimension];
 
         for (int row = 0; row < matrixDimension; row++)
@@ -250,12 +266,14 @@ public static class MatrixTransformations
             }
         }
 
+        // Populate the upper d x (d+1) affine block; the final row is left untouched (homogeneous
+        // [0, ..., 0, 1]) rather than overwritten with supplied coefficients.
         int index = 0;
-        for (int x = 0; x < matrixDimension; x++)
+        for (int row = 0; row < baseDimension; row++)
         {
-            for (int y = 0; y < matrixDimension - 1; y++)
+            for (int col = 0; col < matrixDimension; col++)
             {
-                array[x, y] = valuesArray[index];
+                array[row, col] = valuesArray[index];
                 index++;
             }
         }

--- a/Utils.Mathematics/LinearAlgebra/NumericPrecision.cs
+++ b/Utils.Mathematics/LinearAlgebra/NumericPrecision.cs
@@ -1,0 +1,27 @@
+using System.Numerics;
+
+namespace Utils.Mathematics.LinearAlgebra;
+
+/// <summary>
+/// Shared generic-precision helpers used by <see cref="Matrix{T}"/> and <see cref="Vector{T}"/> to
+/// derive numerical tolerances from the scalar type itself, instead of a hard-coded literal (such as
+/// <c>1e-10</c>) that has no scale-independent meaning across arbitrary <see cref="IFloatingPoint{TSelf}"/>
+/// precision and can silently underflow to zero for low-precision types such as <see cref="Half"/>.
+/// </summary>
+internal static class NumericPrecision
+{
+    /// <summary>
+    /// Computes <typeparamref name="T"/>'s own machine epsilon: the smallest positive value such
+    /// that <c>1 + eps != 1</c> in <typeparamref name="T"/>'s own arithmetic, found generically by
+    /// successive halving using only <see cref="IFloatingPoint{TSelf}"/> operations (no per-type
+    /// branching required).
+    /// </summary>
+    public static T MachineEpsilon<T>() where T : struct, IFloatingPoint<T>
+    {
+        T two = T.One + T.One;
+        T eps = T.One;
+        while (T.One + eps / two != T.One)
+            eps /= two;
+        return eps;
+    }
+}

--- a/Utils.Mathematics/LinearAlgebra/Vector.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.cs
@@ -89,7 +89,14 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     /// Returns a normalized version of the vector.
     /// </summary>
     /// <returns>The normalized vector.</returns>
-    public Vector<T> Normalize() => this / Norm;
+    /// <exception cref="InvalidOperationException">Thrown when this is the zero vector.</exception>
+    public Vector<T> Normalize()
+    {
+        T norm = Norm;
+        if (norm == T.Zero)
+            throw new InvalidOperationException("Cannot normalize the zero vector.");
+        return this / norm;
+    }
 
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj switch

--- a/Utils.Mathematics/LinearAlgebra/Vector.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.cs
@@ -152,12 +152,20 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     /// Converts a vector usable in normal space to a vector usable in Cartesian space.
     /// </summary>
     /// <returns>The converted vector for Cartesian space.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the homogeneous coordinate (last component) is zero. A zero homogeneous
+    /// coordinate represents a direction at infinity, not a point, and has no Cartesian equivalent;
+    /// dividing by it would otherwise silently produce NaN/infinity components.
+    /// </exception>
     public Vector<T> FromNormalSpace()
     {
         var temp = this;
-        if (temp[temp.Dimension - 1] != T.One)
+        T w = temp[temp.Dimension - 1];
+        if (w == T.Zero)
+            throw new InvalidOperationException("Cannot convert a homogeneous direction (zero homogeneous coordinate) to a Cartesian point.");
+        if (w != T.One)
         {
-            temp /= temp[temp.Dimension - 1];
+            temp /= w;
         }
         Vector<T> result = new(Dimension - 1);
         Array.Copy(temp.components, result.components, Dimension - 1);

--- a/Utils.Mathematics/LinearAlgebra/Vector.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.cs
@@ -26,6 +26,46 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     private T? norm;
 
     /// <summary>
+    /// Smallest positive value such that <c>1 + MachineEpsilon != 1</c> for <typeparamref name="T"/>,
+    /// used to derive scale-aware default tolerances (see <see cref="DefaultNormTolerance"/>).
+    /// </summary>
+    private static readonly T MachineEpsilon = NumericPrecision.MachineEpsilon<T>();
+
+    /// <summary>
+    /// Validates that a caller-supplied tolerance is usable (finite and non-negative).
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is not finite or is negative.</exception>
+    private static void ValidateTolerance(T tolerance, string parameterName)
+    {
+        if (!T.IsFinite(tolerance) || tolerance < T.Zero)
+            throw new ArgumentOutOfRangeException(parameterName, tolerance, "Tolerance must be finite and non-negative.");
+    }
+
+    /// <summary>
+    /// Returns the largest absolute value among a component array, used as the scale reference for
+    /// <see cref="DefaultNormTolerance"/>.
+    /// </summary>
+    private static T MaxAbsoluteComponent(T[] components)
+    {
+        T max = T.Zero;
+        for (int i = 0; i < components.Length; i++)
+            max = T.Max(max, T.Abs(components[i]));
+        return max;
+    }
+
+    /// <summary>
+    /// Default relative-plus-absolute tolerance below which a norm or homogeneous coordinate is
+    /// treated as numerically zero, when the caller does not supply an explicit override. The
+    /// relative component (<see cref="MachineEpsilon"/> scaled by dimension and the components'
+    /// magnitude) rejects negligible-but-nonzero values proportionally to the vector's own scale; the
+    /// "+ 1" absolute floor keeps the tolerance non-zero even when every component is already close
+    /// to zero, so a vector like <c>(1e-300, 1e-300, 1e-300)</c> is still correctly rejected instead
+    /// of producing a technically-nonzero-but-meaningless normalized result.
+    /// </summary>
+    private static T DefaultNormTolerance(T[] components)
+        => MachineEpsilon * T.CreateChecked(components.Length) * (MaxAbsoluteComponent(components) + T.One);
+
+    /// <summary>
     /// Initializes a vector with the given dimension.
     /// </summary>
     /// <param name="dimensions">Number of dimensions.</param>
@@ -88,13 +128,26 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     /// <summary>
     /// Returns a normalized version of the vector.
     /// </summary>
+    /// <param name="tolerance">
+    /// Overrides the default relative-plus-absolute tolerance (see <see cref="DefaultNormTolerance"/>)
+    /// below which the norm is treated as zero. Pass <c>T.Zero</c> to reject only an exactly-zero
+    /// norm. Must be finite and non-negative when supplied.
+    /// </param>
     /// <returns>The normalized vector.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when this is the zero vector.</exception>
-    public Vector<T> Normalize()
+    /// <exception cref="InvalidOperationException">Thrown when the vector's norm is zero or, absent an
+    /// explicit <paramref name="tolerance"/>, numerically negligible relative to its components'
+    /// magnitude (e.g. a component like <c>1e-300</c> that underflows to zero once squared, which
+    /// would otherwise silently normalize to a wildly disproportionate result).</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is supplied but not finite or is negative.</exception>
+    public Vector<T> Normalize(T? tolerance = null)
     {
+        if (tolerance is { } explicitTolerance)
+            ValidateTolerance(explicitTolerance, nameof(tolerance));
+
         T norm = Norm;
-        if (norm == T.Zero)
-            throw new InvalidOperationException("Cannot normalize the zero vector.");
+        T effectiveTolerance = tolerance ?? DefaultNormTolerance(components);
+        if (norm <= effectiveTolerance)
+            throw new InvalidOperationException("Cannot normalize a vector whose norm is zero or numerically negligible.");
         return this / norm;
     }
 
@@ -151,18 +204,31 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     /// <summary>
     /// Converts a vector usable in normal space to a vector usable in Cartesian space.
     /// </summary>
+    /// <param name="tolerance">
+    /// Overrides the default relative-plus-absolute tolerance (see <see cref="DefaultNormTolerance"/>)
+    /// below which the homogeneous coordinate is treated as zero. Pass <c>T.Zero</c> to reject only
+    /// an exactly-zero coordinate. Must be finite and non-negative when supplied.
+    /// </param>
     /// <returns>The converted vector for Cartesian space.</returns>
     /// <exception cref="InvalidOperationException">
-    /// Thrown when the homogeneous coordinate (last component) is zero. A zero homogeneous
-    /// coordinate represents a direction at infinity, not a point, and has no Cartesian equivalent;
-    /// dividing by it would otherwise silently produce NaN/infinity components.
+    /// Thrown when the homogeneous coordinate (last component) is zero or, absent an explicit
+    /// <paramref name="tolerance"/>, numerically negligible relative to the vector's components
+    /// (e.g. <c>w = 1e-300</c>, which would otherwise silently divide the other components up to an
+    /// astronomically large, meaningless magnitude instead of being recognized as a direction at
+    /// infinity). A near-zero homogeneous coordinate represents a direction at infinity, not a point,
+    /// and has no meaningful Cartesian equivalent.
     /// </exception>
-    public Vector<T> FromNormalSpace()
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is supplied but not finite or is negative.</exception>
+    public Vector<T> FromNormalSpace(T? tolerance = null)
     {
+        if (tolerance is { } explicitTolerance)
+            ValidateTolerance(explicitTolerance, nameof(tolerance));
+
         var temp = this;
         T w = temp[temp.Dimension - 1];
-        if (w == T.Zero)
-            throw new InvalidOperationException("Cannot convert a homogeneous direction (zero homogeneous coordinate) to a Cartesian point.");
+        T effectiveTolerance = tolerance ?? DefaultNormTolerance(temp.components);
+        if (T.Abs(w) <= effectiveTolerance)
+            throw new InvalidOperationException("Cannot convert a homogeneous direction (zero or numerically negligible homogeneous coordinate) to a Cartesian point.");
         if (w != T.One)
         {
             temp /= w;

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
@@ -200,6 +200,54 @@ public class MatrixEigenvaluesTests
     }
 
     [TestMethod]
+    public void ComputeEigenvalues_ExplicitSymmetryTolerance_IsForwardedToInputValidation()
+    {
+        // Regression: ComputeEigenvalues used to call the no-arg IsSymmetric() overload internally,
+        // so its own symmetryTolerance parameter (once added) had no effect - the upfront symmetry
+        // check always used the tight default tolerance regardless of what the caller passed. This
+        // matrix's asymmetry (~1e-7) comfortably exceeds double's tight default tolerance (~1e-15),
+        // so it must still throw with no override, but must be accepted once symmetryTolerance is
+        // loosened. convergenceTolerance is loosened too, purely so QR iteration settles quickly
+        // given the same residual asymmetry - the point under test is the symmetryTolerance forwarding,
+        // not convergence behavior.
+        var a = new Matrix<double>(new double[,] { { 4, 2.0000001 }, { 2.0000002, 3 } });
+        Assert.ThrowsException<InvalidOperationException>(() => a.ComputeEigenvalues());
+
+        var (values, _) = a.ComputeEigenvalues(symmetryTolerance: 1e-6, convergenceTolerance: 1e-6);
+        Assert.AreEqual(2, values.Length);
+        Assert.IsTrue(values[0] > values[1]);
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_InvalidSymmetryTolerance_Throws()
+    {
+        var a = new Matrix<double>(new double[,] { { 2, 1 }, { 1, 2 } });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.ComputeEigenvalues(symmetryTolerance: double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.ComputeEigenvalues(symmetryTolerance: -1d));
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_ExplicitRankTolerance_StillProducesValidResult()
+    {
+        // Regression: ComputeEigenvalues used to call DecomposeQR() with no argument at every QR
+        // iteration, so its own rankTolerance parameter (once added) had no effect on the internal
+        // decomposition. A generous explicit rankTolerance must still let a well-conditioned matrix
+        // converge to the correct eigenvalues.
+        var a = new Matrix<double>(new double[,] { { 2, 1 }, { 1, 2 } });
+        var (values, _) = a.ComputeEigenvalues(rankTolerance: 1e-3);
+        Assert.AreEqual(3.0, values[0], 1e-2);
+        Assert.AreEqual(1.0, values[1], 1e-2);
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_InvalidRankTolerance_Throws()
+    {
+        var a = new Matrix<double>(new double[,] { { 2, 1 }, { 1, 2 } });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.ComputeEigenvalues(rankTolerance: double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.ComputeEigenvalues(rankTolerance: -1d));
+    }
+
+    [TestMethod]
     public void ComputeEigenvalues_Half_DiagonalMatrix_Succeeds()
     {
         // Regression: a hard-coded 1e-10 absolute tolerance is meaningless for Half; this exercises

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
@@ -23,6 +23,24 @@ public class MatrixEigenvaluesTests
     }
 
     [TestMethod]
+    public void IsSymmetric_ExplicitTolerance_AcceptsAsymmetryWithinOverride()
+    {
+        // A[0,1] and A[1,0] differ by 0.01, which the default tolerance would reject for a matrix of
+        // this scale, but an explicit, sufficiently generous override accepts.
+        var a = new Matrix<double>(new double[,] { { 4, 2.00 }, { 2.01, 3 } });
+        Assert.IsFalse(a.IsSymmetric());
+        Assert.IsTrue(a.IsSymmetric(symmetryTolerance: 0.1));
+    }
+
+    [TestMethod]
+    public void IsSymmetric_InvalidTolerance_Throws()
+    {
+        var a = new Matrix<double>(new double[,] { { 4, 2 }, { 2, 3 } });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.IsSymmetric(symmetryTolerance: double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.IsSymmetric(symmetryTolerance: -1d));
+    }
+
+    [TestMethod]
     public void ComputeEigenvalues_2x2_CorrectValues()
     {
         // [[2, 1], [1, 2]]  eigenvalues = 3, 1
@@ -165,6 +183,23 @@ public class MatrixEigenvaluesTests
     }
 
     [TestMethod]
+    public void ComputeEigenvalues_ExplicitConvergenceTolerance_ProducesValidResult()
+    {
+        var a = new Matrix<double>(new double[,] { { 2, 1 }, { 1, 2 } });
+        var (values, _) = a.ComputeEigenvalues(convergenceTolerance: 1e-3);
+        Assert.AreEqual(3.0, values[0], 1e-2);
+        Assert.AreEqual(1.0, values[1], 1e-2);
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_InvalidConvergenceTolerance_Throws()
+    {
+        var a = new Matrix<double>(new double[,] { { 2, 1 }, { 1, 2 } });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.ComputeEigenvalues(convergenceTolerance: double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.ComputeEigenvalues(convergenceTolerance: -1d));
+    }
+
+    [TestMethod]
     public void ComputeEigenvalues_Half_DiagonalMatrix_Succeeds()
     {
         // Regression: a hard-coded 1e-10 absolute tolerance is meaningless for Half; this exercises
@@ -174,5 +209,25 @@ public class MatrixEigenvaluesTests
         var (values, _) = a.ComputeEigenvalues();
         Assert.AreEqual((Half)5f, values[0]);
         Assert.AreEqual((Half)3f, values[1]);
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_Half_NonDiagonalScaledMatrix_Succeeds()
+    {
+        // Regression: previous Half coverage only exercised an already-diagonal matrix, which
+        // trivially satisfies every invariant regardless of whether the scale-aware tolerance formula
+        // is actually correct. This matrix has a large diagonal entry (100) alongside a small
+        // off-diagonal coupling (1) - the exact "large scale next to a small but significant value"
+        // shape the default-tolerance formula's documented known limitation is about - and requires
+        // genuine (non-trivial) QR iteration to converge.
+        // Characteristic equation lambda^2 - 102*lambda + 199 = 0 -> lambda ~= 100.01, ~= 1.99.
+        var a = new Matrix<Half>(new Half[,]
+        {
+            { (Half)100f, (Half)1f },
+            { (Half)1f, (Half)2f }
+        });
+        var (values, _) = a.ComputeEigenvalues();
+        Assert.AreEqual(100.01, (double)values[0], 1.0);
+        Assert.AreEqual(1.99, (double)values[1], 0.5);
     }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
@@ -117,6 +117,40 @@ public class MatrixEigenvaluesTests
     }
 
     [TestMethod]
+    public void ComputeEigenvalues_NonPositiveMaxIterations_Throws()
+    {
+        // Regression: maxIterations <= 0 made the QR-iteration loop never execute at all, so the
+        // method silently returned the raw diagonal entries of the un-diagonalized input as
+        // "eigenvalues", with no convergence check ever running.
+        var a = new Matrix<double>(new double[,] { { 2, 1 }, { 1, 2 } });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.ComputeEigenvalues(0));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.ComputeEigenvalues(-1));
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_InsufficientIterations_ThrowsInsteadOfReturningRawDiagonal()
+    {
+        // A non-diagonal matrix needs at least one QR-iteration step; with maxIterations = 1 it may
+        // not have converged. Whether it throws or not is not the point of this test - the point is
+        // that if it does not throw, the result must actually be validated as converged, not just
+        // whatever the diagonal happens to be after too few iterations.
+        var a = new Matrix<double>(new double[,] { { 2, 1 }, { 1, 2 } });
+        try
+        {
+            var (values, _) = a.ComputeEigenvalues(1);
+            // If it didn't throw, convergence was genuinely reached; the known eigenvalues (3, 1)
+            // must hold.
+            Assert.AreEqual(3.0, values[0], Tol);
+            Assert.AreEqual(1.0, values[1], Tol);
+        }
+        catch (InvalidOperationException)
+        {
+            // Also an acceptable outcome: correctly reporting non-convergence instead of returning
+            // an unvalidated result.
+        }
+    }
+
+    [TestMethod]
     public void ComputeEigenvalues_NonSquare_Throws()
     {
         var a = new Matrix<double>(new double[,] { { 1, 2, 3 }, { 4, 5, 6 } });

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
@@ -163,4 +163,16 @@ public class MatrixEigenvaluesTests
         var a = new Matrix<double>(new double[,] { { 1, 2 }, { 3, 4 } });
         Assert.ThrowsException<InvalidOperationException>(() => a.ComputeEigenvalues());
     }
+
+    [TestMethod]
+    public void ComputeEigenvalues_Half_DiagonalMatrix_Succeeds()
+    {
+        // Regression: a hard-coded 1e-10 absolute tolerance is meaningless for Half; this exercises
+        // both IsSymmetric's and the convergence check's tolerance for a type whose own machine
+        // epsilon (~0.001) is far coarser than any fixed double-oriented literal.
+        var a = new Matrix<Half>(new Half[,] { { (Half)5f, (Half)0f }, { (Half)0f, (Half)3f } });
+        var (values, _) = a.ComputeEigenvalues();
+        Assert.AreEqual((Half)5f, values[0]);
+        Assert.AreEqual((Half)3f, values[1]);
+    }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
@@ -79,6 +79,44 @@ public class MatrixEigenvaluesTests
     }
 
     [TestMethod]
+    public void ComputeEigenvalues_SingularDiagonalMatrix_Succeeds()
+    {
+        // Minimal rank-deficient symmetric example: previously failed because DecomposeQR rejected
+        // the linearly dependent second column during QR iteration.
+        var a = new Matrix<double>(new double[,] { { 1, 0 }, { 0, 0 } });
+        var (values, _) = a.ComputeEigenvalues();
+        Assert.AreEqual(1.0, values[0], Tol);
+        Assert.AreEqual(0.0, values[1], Tol);
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_SingularSymmetricMatrix_Succeeds()
+    {
+        // [[1,1],[1,1]] is symmetric and rank-1 (determinant 0); eigenvalues are 2 and 0.
+        var a = new Matrix<double>(new double[,] { { 1, 1 }, { 1, 1 } });
+        var (values, vecs) = a.ComputeEigenvalues();
+        Assert.AreEqual(2.0, values[0], Tol);
+        Assert.AreEqual(0.0, values[1], Tol);
+
+        for (int j = 0; j < 2; j++)
+        {
+            var v = new Vector<double>(vecs[0, j], vecs[1, j]);
+            var av = a * v;
+            Assert.AreEqual(values[j] * v[0], av[0], Tol);
+            Assert.AreEqual(values[j] * v[1], av[1], Tol);
+        }
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_ZeroMatrix_Succeeds()
+    {
+        var a = Matrix<double>.Zero(2, 2);
+        var (values, _) = a.ComputeEigenvalues();
+        Assert.AreEqual(0.0, values[0], Tol);
+        Assert.AreEqual(0.0, values[1], Tol);
+    }
+
+    [TestMethod]
     public void ComputeEigenvalues_NonSquare_Throws()
     {
         var a = new Matrix<double>(new double[,] { { 1, 2, 3 }, { 4, 5, 6 } });

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixQRTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixQRTests.cs
@@ -81,9 +81,45 @@ public class MatrixQRTests
     }
 
     [TestMethod]
-    public void DecomposeQR_SingularMatrix_Throws()
+    public void DecomposeQR_SingularMatrix_StillProducesValidFactorization()
     {
+        // Regression: the previous Gram-Schmidt-based implementation rejected rank-deficient
+        // columns outright. Householder reflections remain well-defined for a singular matrix - the
+        // dependent column simply yields a (numerically) zero R diagonal entry - which is required
+        // for ComputeEigenvalues to reach singular symmetric matrices at all.
         var a = new Matrix<double>(new double[,] { { 1, 2 }, { 2, 4 } });
-        Assert.ThrowsException<InvalidOperationException>(() => a.DecomposeQR());
+        var (q, r) = a.DecomposeQR();
+
+        var qtq = q.Transpose() * q;
+        Assert.AreEqual(1.0, qtq[0, 0], Tol);
+        Assert.AreEqual(0.0, qtq[0, 1], Tol);
+        Assert.AreEqual(0.0, qtq[1, 0], Tol);
+        Assert.AreEqual(1.0, qtq[1, 1], Tol);
+
+        Assert.AreEqual(0.0, r[1, 0], Tol);
+
+        var product = q * r;
+        Assert.AreEqual(a[0, 0], product[0, 0], Tol);
+        Assert.AreEqual(a[0, 1], product[0, 1], Tol);
+        Assert.AreEqual(a[1, 0], product[1, 0], Tol);
+        Assert.AreEqual(a[1, 1], product[1, 1], Tol);
+    }
+
+    [TestMethod]
+    public void DecomposeQR_ZeroMatrix_ProducesOrthogonalQAndZeroR()
+    {
+        // The most degenerate rank-deficient case: every column dependent (zero). Q must still be
+        // orthogonal (falls back to an arbitrary orthonormal basis) and R must be exactly zero.
+        var a = Matrix<double>.Zero(3, 2);
+        var (q, r) = a.DecomposeQR();
+
+        var qtq = q.Transpose() * q;
+        for (int i = 0; i < 2; i++)
+            for (int j = 0; j < 2; j++)
+                Assert.AreEqual(i == j ? 1.0 : 0.0, qtq[i, j], Tol, $"[{i},{j}]");
+
+        for (int i = 0; i < 2; i++)
+            for (int j = 0; j < 2; j++)
+                Assert.AreEqual(0.0, r[i, j], Tol, $"[{i},{j}]");
     }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixQRTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixQRTests.cs
@@ -122,4 +122,54 @@ public class MatrixQRTests
             for (int j = 0; j < 2; j++)
                 Assert.AreEqual(0.0, r[i, j], Tol, $"[{i},{j}]");
     }
+
+    [TestMethod]
+    public void DecomposeQR_ExplicitRankTolerance_StillProducesValidFactorization()
+    {
+        // The explicit override replaces the default relative-plus-absolute tolerance with
+        // scale * rankTolerance. A generous tolerance must still yield a valid Q/R factorization for
+        // a well-conditioned matrix.
+        var a = new Matrix<double>(new double[,] { { 1, 2 }, { 3, 4 } });
+        var (q, r) = a.DecomposeQR(rankTolerance: 1e-3);
+        var product = q * r;
+        Assert.AreEqual(a[0, 0], product[0, 0], Tol);
+        Assert.AreEqual(a[0, 1], product[0, 1], Tol);
+        Assert.AreEqual(a[1, 0], product[1, 0], Tol);
+        Assert.AreEqual(a[1, 1], product[1, 1], Tol);
+    }
+
+    [TestMethod]
+    public void DecomposeQR_InvalidRankTolerance_Throws()
+    {
+        var a = new Matrix<double>(new double[,] { { 1, 2 }, { 3, 4 } });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.DecomposeQR(rankTolerance: double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.DecomposeQR(rankTolerance: -1d));
+    }
+
+    [TestMethod]
+    public void DecomposeQR_Half_NonDiagonalScaledMatrix_ProducesValidFactorization()
+    {
+        // Regression: previous Half-precision coverage for this area only exercised an
+        // already-diagonal matrix, which trivially satisfies QR/eigen invariants regardless of
+        // whether the tolerance formula's scale term is computed correctly. This uses a symmetric,
+        // non-diagonal matrix with a large-magnitude entry alongside small ones, closer to the
+        // scale-disparity scenario the tolerance formula is meant to handle.
+        var a = new Matrix<Half>(new Half[,]
+        {
+            { (Half)100f, (Half)1f },
+            { (Half)1f, (Half)2f }
+        });
+        var (q, r) = a.DecomposeQR();
+
+        var qtq = q.Transpose() * q;
+        Assert.AreEqual(1.0, (double)qtq[0, 0], 1e-2);
+        Assert.AreEqual(0.0, (double)qtq[0, 1], 1e-2);
+        Assert.AreEqual(1.0, (double)qtq[1, 1], 1e-2);
+
+        var product = q * r;
+        Assert.AreEqual((double)a[0, 0], (double)product[0, 0], 1.0);
+        Assert.AreEqual((double)a[0, 1], (double)product[0, 1], 1e-1);
+        Assert.AreEqual((double)a[1, 0], (double)product[1, 0], 1e-1);
+        Assert.AreEqual((double)a[1, 1], (double)product[1, 1], 1e-1);
+    }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs
@@ -111,20 +111,33 @@ public class MatrixSolveTests
     }
 
     [TestMethod]
-    public void DefaultSingularityRelativeTolerance_ScalesWithDimensionNotFlatConstant()
+    public void DefaultTolerance_ScalesWithDimensionNotFlatConstant()
     {
         // Regression: an earlier version used a flat 100x-machine-epsilon multiplier regardless of
         // matrix size. For Half specifically that made the default relative tolerance for even a
         // small 2x2 matrix close to 10% of its magnitude, misclassifying ordinary invertible
         // matrices as singular. The default must scale with dimension instead of a fixed multiplier
         // so a small matrix gets a correspondingly small (tight) default tolerance.
-        var method = typeof(Matrix<Half>).GetMethod("DefaultSingularityRelativeTolerance", BindingFlags.NonPublic | BindingFlags.Static);
+        var method = typeof(Matrix<Half>).GetMethod("DefaultTolerance", BindingFlags.NonPublic | BindingFlags.Static);
         Assert.IsNotNull(method);
-        var tolerance2 = (Half)method!.Invoke(null, [2])!;
-        var tolerance10 = (Half)method!.Invoke(null, [10])!;
+        var tolerance2 = (Half)method!.Invoke(null, [(Half)1f, 2])!;
+        var tolerance10 = (Half)method!.Invoke(null, [(Half)1f, 10])!;
 
         Assert.IsTrue(tolerance2 < (Half)0.01f, $"Default tolerance for a 2x2 Half matrix should be well under 1%, was {tolerance2}.");
         Assert.IsTrue(tolerance10 > tolerance2, "The default tolerance should grow with matrix dimension.");
+    }
+
+    [TestMethod]
+    public void DefaultTolerance_HasAbsoluteFloorIndependentOfScale()
+    {
+        // The formula is eps * dimension * (scale + 1): the "+ 1" provides an absolute floor so that
+        // a matrix whose largest entry is exactly zero (or otherwise tiny) still gets a non-zero
+        // tolerance, rather than collapsing the whole check back to an exact-zero comparison.
+        var method = typeof(Matrix<Half>).GetMethod("DefaultTolerance", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.IsNotNull(method);
+        var toleranceAtZeroScale = (Half)method!.Invoke(null, [(Half)0f, 4])!;
+
+        Assert.AreNotEqual((Half)0, toleranceAtZeroScale);
     }
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -385,6 +385,40 @@ namespace UtilsTest.Mathematics.LinearAlgebra
             Assert.AreEqual(6d, col[1], 1e-12);
         }
 
+        // ── Empty/null input validation (jagged array and vector constructors) ─────
+
+        [TestMethod]
+        public void JaggedArrayConstructor_EmptyArray_ThrowsClearArgumentException()
+        {
+            // Regression: previously threw an incidental InvalidOperationException from
+            // Enumerable.Max() on an empty sequence instead of a clear, documented rejection.
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(System.Array.Empty<double[]>()));
+        }
+
+        [TestMethod]
+        public void JaggedArrayConstructor_NullRow_ThrowsClearArgumentException()
+        {
+            // Regression: previously threw an incidental NullReferenceException when computing the
+            // null row's length.
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(new double[][] { new[] { 1d, 2d }, null! }));
+        }
+
+        [TestMethod]
+        public void VectorConstructor_NoVectors_ThrowsClearArgumentException()
+        {
+            // Regression: previously threw an incidental IndexOutOfRangeException from accessing
+            // vectors[0] unconditionally.
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(System.Array.Empty<Vector<double>>()));
+        }
+
+        [TestMethod]
+        public void VectorConstructor_NullVector_ThrowsClearArgumentException()
+        {
+            // Regression: previously threw an incidental NullReferenceException when reading the
+            // null vector's Dimension.
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(new Vector<double>(1d, 2d), null!));
+        }
+
         /// <summary>
         /// Asserts that two matrices contain the same components within the provided tolerance.
         /// </summary>

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
@@ -206,4 +206,65 @@ public class MatrixTransformationsTests
             for (int j = 0; j < 3; j++)
                 Assert.AreEqual(i == j ? 1d : 0d, m[i, j], Delta, $"[{i},{j}]");
     }
+
+    // ── Transform ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Transform_2D_ProducesHandCalculatedAffineBlockAndHomogeneousLastRow()
+    {
+        // Row-major [a, b, tx, c, d, ty]: row0 = [a,b,tx], row1 = [c,d,ty].
+        var m = MatrixTransformations.Transform<double>(2d, 3d, 5d, 4d, 6d, 7d);
+
+        Assert.AreEqual(3, m.Rows);
+        Assert.AreEqual(3, m.Columns);
+
+        Assert.AreEqual(2d, m[0, 0], Delta);
+        Assert.AreEqual(3d, m[0, 1], Delta);
+        Assert.AreEqual(5d, m[0, 2], Delta);
+        Assert.AreEqual(4d, m[1, 0], Delta);
+        Assert.AreEqual(6d, m[1, 1], Delta);
+        Assert.AreEqual(7d, m[1, 2], Delta);
+
+        // The final row must remain the homogeneous row, not be overwritten with supplied values.
+        Assert.AreEqual(0d, m[2, 0], Delta);
+        Assert.AreEqual(0d, m[2, 1], Delta);
+        Assert.AreEqual(1d, m[2, 2], Delta);
+    }
+
+    [TestMethod]
+    public void Transform_2D_MatchesManualMultiplicationOnHomogeneousPoint()
+    {
+        // Affine map: x' = 2x + 3y + 5, y' = 4x + 6y + 7.
+        var m = MatrixTransformations.Transform<double>(2d, 3d, 5d, 4d, 6d, 7d);
+        var v = new Vector<double>(1d, 1d, 1d);
+        var result = m * v;
+
+        Assert.AreEqual(2d * 1 + 3d * 1 + 5d, result[0], Delta);
+        Assert.AreEqual(4d * 1 + 6d * 1 + 7d, result[1], Delta);
+        Assert.AreEqual(1d, result[2], Delta);
+    }
+
+    [TestMethod]
+    public void Transform_MatchesTranslationForIdentityLinearPart()
+    {
+        // An affine transform with the identity linear part and translation (5, 7) must behave
+        // exactly like MatrixTransformations.Translation(5, 7).
+        var transform = MatrixTransformations.Transform<double>(1d, 0d, 5d, 0d, 1d, 7d);
+        var translation = MatrixTransformations.Translation<double>(5d, 7d);
+
+        var v = new Vector<double>(2d, 3d, 1d);
+        var transformResult = transform * v;
+        var translationResult = translation * v;
+
+        Assert.AreEqual(translationResult[0], transformResult[0], Delta);
+        Assert.AreEqual(translationResult[1], transformResult[1], Delta);
+        Assert.AreEqual(translationResult[2], transformResult[2], Delta);
+    }
+
+    [TestMethod]
+    public void Transform_InvalidValueCount_Throws()
+    {
+        // 5 is not d*(d+1) for any integer d (0, 2, 6, 12, ...).
+        Assert.ThrowsException<ArgumentException>(() => MatrixTransformations.Transform<double>(1d, 2d, 3d, 4d, 5d));
+    }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
@@ -29,6 +29,39 @@ public class MatrixTransformationsTests
         Assert.AreEqual(1d, m.Determinant, Delta);
     }
 
+    // ── Diagonal ─────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Diagonal_WithZeroEntry_IsStillTriangularAndDiagonal()
+    {
+        // A diagonal matrix with a zero entry is still diagonal and triangular by definition; only
+        // its invertibility/determinant is affected.
+        var m = MatrixTransformations.Diagonal<double>(2d, 0d, 3d);
+        Assert.IsTrue(m.IsDiagonal);
+        Assert.IsTrue(m.IsTriangular);
+        Assert.IsFalse(m.IsIdentity);
+        Assert.AreEqual(0d, m.Determinant, Delta);
+    }
+
+    [TestMethod]
+    public void Diagonal_MatchesMatrixDiagonalFactory()
+    {
+        var viaTransformations = MatrixTransformations.Diagonal<double>(2d, 0d, 3d);
+        var viaMatrix = Matrix<double>.Diagonal(2d, 0d, 3d);
+
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                Assert.AreEqual(viaMatrix[i, j], viaTransformations[i, j], Delta, $"[{i},{j}]");
+
+        Assert.AreEqual(viaMatrix.IsDiagonal, viaTransformations.IsDiagonal);
+        Assert.AreEqual(viaMatrix.IsTriangular, viaTransformations.IsTriangular);
+        Assert.AreEqual(viaMatrix.IsIdentity, viaTransformations.IsIdentity);
+    }
+
+    [TestMethod]
+    public void Diagonal_NoValues_Throws()
+        => Assert.ThrowsException<ArgumentException>(() => MatrixTransformations.Diagonal<double>());
+
     // ── Scaling ──────────────────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -91,6 +91,16 @@ public class VectorTests
     }
 
     [TestMethod]
+    public void Normalize_ZeroVector_Throws()
+    {
+        // Regression: Normalize() used to divide by Norm unconditionally (this / Norm), producing
+        // NaN/infinity components for the zero vector instead of the explicit failure ProjectOnto
+        // already uses for its own zero-vector case.
+        var vector = new Vector<double>(0d, 0d, 0d);
+        Assert.ThrowsException<InvalidOperationException>(() => vector.Normalize());
+    }
+
+    [TestMethod]
     public void Zero_ReturnsAllZeroComponents()
     {
         var v = Vector<double>.Zero(3);

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -197,6 +197,16 @@ public class VectorTests
             Assert.AreEqual(v[i], roundtrip[i], 1e-12);
     }
 
+    [TestMethod]
+    public void FromNormalSpace_ZeroHomogeneousCoordinate_Throws()
+    {
+        // A zero homogeneous coordinate represents a direction at infinity, not a Cartesian point;
+        // the previous implementation divided by it unconditionally, silently producing
+        // NaN/infinity components instead of signaling that no Cartesian equivalent exists.
+        var h = new Vector<double>(1d, 2d, 3d, 0d);
+        Assert.ThrowsException<InvalidOperationException>(() => h.FromNormalSpace());
+    }
+
     // ── ProjectOnto ───────────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -101,6 +101,34 @@ public class VectorTests
     }
 
     [TestMethod]
+    public void Normalize_NearZeroButNonzeroNorm_ThrowsByDefault()
+    {
+        // Regression: an earlier fix only rejected an exactly-zero norm. A vector whose norm is
+        // technically nonzero but negligible relative to its own components' scale (e.g. every
+        // component around 1e-150) must be rejected too, rather than producing a "normalized" result
+        // that is only an artifact of floating-point noise.
+        var vector = new Vector<double>(1e-150, 1e-150, 1e-150);
+        Assert.ThrowsException<InvalidOperationException>(() => vector.Normalize());
+    }
+
+    [TestMethod]
+    public void Normalize_ExplicitZeroTolerance_AcceptsNearZeroButNonzeroNorm()
+    {
+        // The explicit tolerance override lets a caller opt back into the old exact-zero-only check.
+        var vector = new Vector<double>(1e-150, 1e-150, 1e-150);
+        Vector<double> normalized = vector.Normalize(tolerance: 0d);
+        Assert.AreEqual(1d, normalized.Norm, 1e-9);
+    }
+
+    [TestMethod]
+    public void Normalize_InvalidTolerance_Throws()
+    {
+        var vector = new Vector<double>(1d, 0d, 0d);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => vector.Normalize(tolerance: double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => vector.Normalize(tolerance: -1d));
+    }
+
+    [TestMethod]
     public void Zero_ReturnsAllZeroComponents()
     {
         var v = Vector<double>.Zero(3);
@@ -205,6 +233,34 @@ public class VectorTests
         // NaN/infinity components instead of signaling that no Cartesian equivalent exists.
         var h = new Vector<double>(1d, 2d, 3d, 0d);
         Assert.ThrowsException<InvalidOperationException>(() => h.FromNormalSpace());
+    }
+
+    [TestMethod]
+    public void FromNormalSpace_NearZeroButNonzeroHomogeneousCoordinate_ThrowsByDefault()
+    {
+        // Regression: an earlier fix only rejected an exactly-zero homogeneous coordinate. A
+        // technically-nonzero-but-negligible w (e.g. 1e-300) still produced coordinates of an
+        // astronomically large, meaningless magnitude instead of being recognized as a direction at
+        // infinity.
+        var h = new Vector<double>(1d, 2d, 3d, 1e-300);
+        Assert.ThrowsException<InvalidOperationException>(() => h.FromNormalSpace());
+    }
+
+    [TestMethod]
+    public void FromNormalSpace_ExplicitZeroTolerance_AcceptsNearZeroButNonzeroCoordinate()
+    {
+        // The explicit tolerance override lets a caller opt back into the old exact-zero-only check.
+        var h = new Vector<double>(1d, 2d, 3d, 1e-300);
+        Vector<double> v = h.FromNormalSpace(tolerance: 0d);
+        Assert.AreEqual(3, v.Dimension);
+    }
+
+    [TestMethod]
+    public void FromNormalSpace_InvalidTolerance_Throws()
+    {
+        var h = new Vector<double>(1d, 2d, 3d, 1d);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => h.FromNormalSpace(tolerance: double.NaN));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => h.FromNormalSpace(tolerance: -1d));
     }
 
     // ── ProjectOnto ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Addresses the findings from `Utils.Mathematics/TODO-2026-07-11-pass2.md` (items 17-29; item 16 was already handled in the previous PR's P0 batch). Same workflow as the first PR: one commit per item, tests, push after each.

### Items
- [x] #17 General `Transform<T>` uses inconsistent row-vector layout
- [x] #18 `Diagonal<T>` caches false structural metadata when a value is zero (also resolves pass5 #63)
- [x] #19 Symmetric singular matrices cannot be eigen-decomposed (Gram-Schmidt QR -> Householder; also resolves pass5 #27)
- [x] #20 `ComputeEigenvalues` accepts non-positive iteration counts
- [x] #21 QR/eigenvalue tolerances repeat fixed-epsilon defect
- [x] #22 Vector normalization divides by zero for zero vector
- [x] #23 `FromNormalSpace` divides by zero homogeneous coordinate
- [x] #24 Matrix constructors fail unpredictably on empty inputs
- [ ] #25 Fourier-window doc incorrectly promises `[0,1]` range
- [ ] #26 Fourier windows compute in double despite generic output
- [ ] #27 Modified Gram-Schmidt has no re-orthogonalization
- [ ] #28 Eigenvalue QR iteration unshifted, converges slowly
- [ ] #29 Zero-dimensional behavior inconsistent across factories

All P1 items in this pass (17-24) are done. Remaining items (25-29) are P2.

### Review follow-up #1 (tolerance/near-zero work revised after a review round)
A review round found the initial pass at #21-23 incomplete. Addressed:
- **#21**: Tolerance formula redesigned from a purely relative term to
  `DefaultTolerance(scale, dimension) = eps * dimension * (scale + 1)` (relative + absolute
  floor). `DecomposeQR` and `IsSymmetric` each gained an independent optional override
  parameter, matching the existing `Solve`/`Invert` pattern. `NumericPrecision.MachineEpsilon<T>()`
  extracted as a shared helper.
  - **Known, documented limitation (not solved)**: a single global max-magnitude scale can
    still mask a small-but-numerically-significant sub-block in a matrix with large scale
    disparity (e.g. a large diagonal entry next to a small but meaningful off-diagonal
    coupling). Fixing this properly would require per-row/column equilibration, which is out
    of scope here. This is now called out explicitly in `DefaultTolerance`'s XML doc instead
    of being silently unaddressed. A new Half-precision, non-diagonal, scaled test exercises
    exactly this shape, rather than only an already-diagonal matrix as before.
- **#22/#23**: `Normalize()` and `FromNormalSpace()` previously rejected only an *exactly*
  zero norm/homogeneous coordinate; a value like `w = 1e-300` passed through and produced
  coordinates of meaningless magnitude. Both now take an optional tolerance parameter
  defaulting to a new `DefaultNormTolerance` (component-scaled, with the same
  relative+absolute-floor shape); passing `tolerance: 0` opts back into the old exact-zero
  behavior.

### Review follow-up #2 (ComputeEigenvalues tolerance forwarding)
The first follow-up added a `convergenceTolerance` parameter to `ComputeEigenvalues` but
still called `IsSymmetric()` (no-arg) and `DecomposeQR()` (no-arg) internally, so a caller
had no actual way to influence the symmetry or rank tolerances used *inside*
`ComputeEigenvalues` itself - only `Solve`/`Invert`/`DecomposeQR`/`IsSymmetric` called
directly were affected. `ComputeEigenvalues` now takes `symmetryTolerance` and
`rankTolerance` parameters as well, forwarded to `IsSymmetric(T?)` and to every internal
`DecomposeQR(T?)` call, so all three tolerances are genuinely and independently
configurable as documented.

## Test plan
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` passes after each item (local run, not CI)
- [x] Full suite green locally (3654 passed, 3 pre-existing ignored) after both review follow-ups
