### PR TITLE
Utils.Mathematics: address remaining P2 items in TODO.md and TODO-pass2.md

### DIFF
--- a/Utils.Mathematics/Fourier/FastFourierTransform.cs
+++ b/Utils.Mathematics/Fourier/FastFourierTransform.cs
@@ -10,12 +10,14 @@ public static class FastFourierTransform
     /// <summary>
     /// Performs an in-place FFT on the provided sample array.
     /// </summary>
-    /// <param name="array">Sample array to transform in place. Its length must be a power of two.</param>
+    /// <param name="array">Sample array to transform in place. Its length must be a power of two (a zero-length array is rejected, not treated as a no-op).</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="array"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="array"/> length is not a power of two.
+    /// Thrown when <paramref name="array"/> length is not a power of two (this includes length zero).
     /// </exception>
     public static void Transform(Complex[] array)
     {
+        ArgumentNullException.ThrowIfNull(array);
         if (!Mathematics.MathEx.IsPowerOfTwo(array.Length))
             throw new ArgumentException("Array length must be a power of two.", nameof(array));
         Transform(array.AsSpan());
@@ -24,12 +26,14 @@ public static class FastFourierTransform
     /// <summary>
     /// Performs an in-place inverse FFT on the provided sample array.
     /// </summary>
-    /// <param name="array">Frequency-domain array to transform back to the time domain. Its length must be a power of two.</param>
+    /// <param name="array">Frequency-domain array to transform back to the time domain. Its length must be a power of two (a zero-length array is rejected, not treated as a no-op).</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="array"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="array"/> length is not a power of two.
+    /// Thrown when <paramref name="array"/> length is not a power of two (this includes length zero).
     /// </exception>
     public static void InverseTransform(Complex[] array)
     {
+        ArgumentNullException.ThrowIfNull(array);
         if (!Mathematics.MathEx.IsPowerOfTwo(array.Length))
             throw new ArgumentException("Array length must be a power of two.", nameof(array));
 
@@ -45,13 +49,24 @@ public static class FastFourierTransform
 
     private static void Transform(Span<Complex> span)
     {
+        if (span.Length < 2) return;
+        // Single scratch buffer sized for the largest recursion level (half the top-level length),
+        // reused by every recursive call instead of each level allocating its own half-size buffer:
+        // sibling recursive calls run sequentially (never concurrently), so reusing the same buffer
+        // is safe and turns O(n) allocations across the whole transform into one.
+        Complex[] scratch = new Complex[span.Length >> 1];
+        Transform(span, scratch);
+    }
+
+    private static void Transform(Span<Complex> span, Span<Complex> scratch)
+    {
         int n = span.Length;
         if (n < 2) return;
 
         int n2 = n >> 1;
-        Separate(span);
-        Transform(span[..n2]);
-        Transform(span[n2..]);
+        Separate(span, scratch[..n2]);
+        Transform(span[..n2], scratch);
+        Transform(span[n2..], scratch);
 
         for (int k = 0; k < n2; k++)
         {
@@ -65,12 +80,12 @@ public static class FastFourierTransform
 
     /// <summary>
     /// Rearranges <paramref name="span"/> so that even-indexed elements occupy the first half
-    /// and odd-indexed elements occupy the second half.
+    /// and odd-indexed elements occupy the second half, using <paramref name="buffer"/> (at least
+    /// half of <paramref name="span"/>'s length) as scratch space instead of allocating.
     /// </summary>
-    private static void Separate(Span<Complex> span)
+    private static void Separate(Span<Complex> span, Span<Complex> buffer)
     {
         int n2 = span.Length >> 1;
-        Complex[] buffer = new Complex[n2];
         for (int i = 0; i < n2; i++)
             buffer[i] = span[(i << 1) | 1];
         for (int i = 0; i < n2; i++)

--- a/Utils.Mathematics/Fourier/FourierWindow.cs
+++ b/Utils.Mathematics/Fourier/FourierWindow.cs
@@ -4,8 +4,27 @@ namespace Utils.Mathematics.Fourier;
 
 /// <summary>
 /// Provides standard spectral windowing functions for FFT preprocessing.
-/// Each method returns an array of weights in [0, 1].
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Coefficient range:</b> not every window is bounded to [0, 1]. Hann, Hamming, and Blackman are
+/// (modulo floating-point rounding noise of at most a few ulps right at the edges, where the ideal
+/// mathematical value is exactly zero) non-negative and never exceed 1. <see cref="FlatTop{T}"/>,
+/// however, is defined by IEC 61672 with coefficients that are negative by design near its edges;
+/// callers must not assume a shared [0, 1] range across every window in this class.
+/// </para>
+/// <para>
+/// <b>Precision:</b> every window is computed using <see cref="double"/>-precision trigonometry
+/// (<see cref="Math.Cos(double)"/>) regardless of the requested output type <c>T</c>, then converted
+/// with <c>T.CreateChecked</c>. This is a deliberate choice, not an accidental precision leak: it
+/// gives every output type (including <see cref="decimal"/>, which has no
+/// <see cref="ITrigonometricFunctions{TSelf}"/> implementation and could not use a generic-precision
+/// cosine anyway) the same double-precision-accurate standard window coefficients, rather than
+/// constraining <c>T</c> to <see cref="ITrigonometricFunctions{TSelf}"/> and losing accuracy (and
+/// decimal support) for low-precision output types whose own trigonometric implementation would be
+/// no more accurate than double's in the first place.
+/// </para>
+/// </remarks>
 public static class FourierWindow
 {
     private const double TwoPi = 2.0 * Math.PI;
@@ -15,6 +34,7 @@ public static class FourierWindow
     /// <summary>
     /// Computes the Hann (Hanning) window: w[n] = 0.5 · (1 − cos(2πn/(N−1))).
     /// Good general-purpose window with −18 dB/octave roll-off.
+    /// Coefficients lie in [0, 1] (touching 0 at both edges), modulo floating-point rounding noise.
     /// </summary>
     /// <typeparam name="T">Floating-point output type.</typeparam>
     /// <param name="size">Number of samples. Must be at least 2.</param>
@@ -25,6 +45,7 @@ public static class FourierWindow
     /// <summary>
     /// Computes the Hamming window: w[n] = 0.54 − 0.46 · cos(2πn/(N−1)).
     /// Reduced side-lobe leakage compared to Hann; does not go to zero at the edges.
+    /// Coefficients lie in [0.08, 1].
     /// </summary>
     /// <typeparam name="T">Floating-point output type.</typeparam>
     /// <param name="size">Number of samples. Must be at least 2.</param>
@@ -35,6 +56,8 @@ public static class FourierWindow
     /// <summary>
     /// Computes the Blackman window: w[n] = 0.42 − 0.5·cos(2πn/(N−1)) + 0.08·cos(4πn/(N−1)).
     /// Very low side-lobes (−58 dB); wider main lobe than Hann.
+    /// Coefficients lie in [0, 1] (touching 0 at both edges) in exact arithmetic; floating-point
+    /// rounding can produce a coefficient a few ulps below zero right at the edges.
     /// </summary>
     /// <typeparam name="T">Floating-point output type.</typeparam>
     /// <param name="size">Number of samples. Must be at least 2.</param>
@@ -50,6 +73,8 @@ public static class FourierWindow
     /// w[n] = 0.21557895 − 0.41663158·cos(2πn/N) + 0.277263158·cos(4πn/N)
     ///        − 0.083578947·cos(6πn/N) + 0.006947368·cos(8πn/N).
     /// Excellent amplitude accuracy; broadest main lobe.
+    /// Unlike the other windows in this class, coefficients are <b>not</b> confined to [0, 1]: the
+    /// flat-top shape is negative by design near its edges (down to roughly −0.2).
     /// </summary>
     /// <typeparam name="T">Floating-point output type.</typeparam>
     /// <param name="size">Number of samples. Must be at least 2.</param>

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Constructors.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Constructors.cs
@@ -10,10 +10,19 @@ public sealed partial class Matrix<T>
     /// <summary>
     /// Initializes a matrix with the specified dimensions.
     /// </summary>
-    /// <param name="dimensionX">Number of rows.</param>
-    /// <param name="dimensionY">Number of columns.</param>
+    /// <param name="dimensionX">Number of rows. Must be positive.</param>
+    /// <param name="dimensionY">Number of columns. Must be positive.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="dimensionX"/> or <paramref name="dimensionY"/> is not positive.
+    /// 0×0 (and other zero/negative-dimensioned) matrices are not a supported construction, matching
+    /// the same policy already enforced by <see cref="Identity(int)"/>, <see cref="Zero(int, int)"/>,
+    /// and <see cref="Diagonal(IEnumerable{T})"/>, rather than relying on the CLR's own
+    /// exception-type-inconsistent behavior for invalid multidimensional array allocation.
+    /// </exception>
     public Matrix(int dimensionX, int dimensionY)
     {
+        if (dimensionX <= 0) throw new ArgumentException("Row count must be positive", nameof(dimensionX));
+        if (dimensionY <= 0) throw new ArgumentException("Column count must be positive", nameof(dimensionY));
         components = new T[dimensionX, dimensionY];
     }
 
@@ -38,10 +47,13 @@ public sealed partial class Matrix<T>
     /// <summary>
     /// Initializes a matrix from a 2D array.
     /// </summary>
-    /// <param name="array">Array containing the matrix values.</param>
+    /// <param name="array">Array containing the matrix values. Must have at least one row and one column.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="array"/> has zero rows or zero columns.</exception>
     public Matrix(T[,] array)
     {
         array.Arg().MustNotBeNull();
+        if (array.GetLength(0) == 0 || array.GetLength(1) == 0)
+            throw new ArgumentException("The array must have at least one row and one column.", nameof(array));
         components = new T[array.GetLength(0), array.GetLength(1)];
         Array.Copy(array, this.components, array.Length);
         var isSquare = IsSquare;
@@ -54,8 +66,8 @@ public sealed partial class Matrix<T>
     /// <summary>
     /// Initializes a matrix from a jagged array.
     /// </summary>
-    /// <param name="array">Jagged array containing the matrix values. Must be non-empty, with no null rows.</param>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="array"/> has no rows, or contains a null row.</exception>
+    /// <param name="array">Jagged array containing the matrix values. Must be non-empty, with no null rows, and at least one row must be non-empty.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="array"/> has no rows, contains a null row, or every row is empty.</exception>
     public Matrix(T[][] array)
     {
         array.Arg().MustNotBeNull();
@@ -68,6 +80,8 @@ public sealed partial class Matrix<T>
         }
 
         int maxYLength = array.Select(a => a.Length).Max();
+        if (maxYLength == 0)
+            throw new ArgumentException("At least one row must be non-empty.", nameof(array));
         components = new T[array.Length, maxYLength];
 
         for (int i = 0; i < array.Length; i++)

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
@@ -14,6 +14,19 @@ public sealed partial class Matrix<T>
     /// <remarks>
     /// Only real symmetric matrices are supported; all eigenvalues of such matrices are guaranteed real.
     /// Eigenvalues are returned in descending order of absolute value.
+    /// <para>
+    /// <b>Known limitation - unshifted iteration:</b> this implementation repeatedly applies plain
+    /// <c>A ← R·Q</c> (from <c>A = Q·R</c>) with no spectral shift and no prior reduction to
+    /// tridiagonal form. This is simple and correct, but convergence is only linear and can become
+    /// very slow - potentially exhausting <paramref name="maxIterations"/> - when eigenvalues are
+    /// close in magnitude or clustered (the per-iteration convergence rate is governed by the ratio
+    /// of consecutive eigenvalue magnitudes). A production-grade implementation would use Wilkinson
+    /// shifts and deflation after a symmetric tridiagonal reduction, which converges cubically in the
+    /// typical case; that rewrite is out of scope here. If convergence fails for a matrix with
+    /// closely-spaced eigenvalues, increasing <paramref name="maxIterations"/> and/or relaxing
+    /// <paramref name="convergenceTolerance"/> are the available mitigations with the current
+    /// algorithm.
+    /// </para>
     /// </remarks>
     /// <param name="maxIterations">Maximum number of QR iterations before giving up. Must be greater than zero.</param>
     /// <param name="convergenceTolerance">

--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -458,27 +458,49 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     /// <summary>
     /// Returns a formatted string representation of the matrix using the specified format provider.
     /// </summary>
+    /// <param name="format">
+    /// A composite format string: an optional layout token (<c>""</c>, <c>"S"</c>, <c>"C"</c>, or
+    /// <c>"SC"</c>, selecting the row separator) optionally followed by <c>:</c> and a standard
+    /// numeric format string (e.g. <c>"S:F2"</c>) forwarded verbatim to each element's own
+    /// <see cref="IFormattable.ToString(string?, IFormatProvider?)"/>. When no numeric format is
+    /// given, elements are formatted with their own default (<see langword="null"/>) format rather
+    /// than being rounded to a culture-dependent number of decimals first: unlike the previous
+    /// behavior, this never silently discards precision the caller did not ask to lose.
+    /// </param>
+    /// <param name="formatProvider">
+    /// Culture or number-format info controlling the row/column separators and forwarded to each
+    /// element's own formatter alongside the numeric format.
+    /// </param>
+    /// <exception cref="FormatException">Thrown when the layout token is not one of the recognized values.</exception>
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
         format ??= "";
+        string layoutToken = format;
+        string? numericFormat = null;
+        int colonIndex = format.IndexOf(':');
+        if (colonIndex >= 0)
+        {
+            layoutToken = format[..colonIndex];
+            numericFormat = format[(colonIndex + 1)..];
+        }
+
         StringBuilder sb = new StringBuilder();
         string componentsSeparator = ", ";
         string lineSeparator = Environment.NewLine;
-        int decimals = 2;
 
         if (formatProvider is CultureInfo culture)
         {
             componentsSeparator = culture.TextInfo.ListSeparator;
-            decimals = culture.NumberFormat.NumberDecimalDigits;
         }
         else if (formatProvider is NumberFormatInfo numberFormat)
         {
             componentsSeparator = numberFormat.CurrencyDecimalSeparator == "," ? ";" : componentsSeparator;
-            decimals = numberFormat.NumberDecimalDigits;
         }
 
-        switch (format.ToUpper())
+        switch (layoutToken.ToUpperInvariant())
         {
+            case "":
+                break;
             case "S":
                 lineSeparator = " ";
                 break;
@@ -488,6 +510,8 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
             case "SC":
                 lineSeparator = " ; ";
                 break;
+            default:
+                throw new FormatException($"Unrecognized matrix layout token '{layoutToken}'. Expected \"\", \"S\", \"C\", or \"SC\", optionally followed by \":<numeric format>\".");
         }
 
         sb.Append("{ ");
@@ -498,7 +522,7 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
             for (int col = 0; col < Columns; col++)
             {
                 if (col > 0) sb.Append(componentsSeparator);
-                sb.Append(T.Round(components[row, col], decimals));
+                sb.Append(components[row, col].ToString(numericFormat, formatProvider));
             }
             sb.Append(" }");
         }
@@ -521,11 +545,18 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     /// <summary>
     /// Checks if this matrix is equal to another matrix.
     /// </summary>
+    /// <remarks>
+    /// Compares dimensions and elements directly rather than gating on cached hash-code equality
+    /// first. A correct hash implementation guarantees equal values hash equally, so a hash
+    /// precondition here adds no correctness value; it only makes it hazardous to later introduce a
+    /// tolerance-aware equality or hashing policy where two "equal" matrices might legitimately hash
+    /// differently.
+    /// </remarks>
     public bool Equals(Matrix<T>? other)
     {
         if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
-        return GetHashCode() == other.GetHashCode() && Equals(other.components);
+        return Equals(other.components);
     }
 
     /// <summary>

--- a/Utils.Mathematics/Statistics.cs
+++ b/Utils.Mathematics/Statistics.cs
@@ -5,16 +5,46 @@ namespace Utils.Mathematics;
 /// <summary>
 /// Descriptive statistics computed over sequences of floating-point values.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Non-finite value policy:</b> every operation here that constrains <c>T</c> to
+/// <see cref="IFloatingPoint{TSelf}"/> validates each input value with <c>T.IsFinite(value)</c>
+/// as it is enumerated and rejects the sequence with an <see cref="ArgumentException"/> on the first
+/// NaN or infinite value found, rather than letting it propagate into a NaN/infinite (and
+/// implementation-dependent, since propagation depends on where the value falls relative to sort
+/// order or accumulation order) result. This is a single consistent policy applied uniformly across
+/// <see cref="Mean{T}"/>, <see cref="Variance{T}"/>, <see cref="Covariance{T}"/>, and
+/// <see cref="Correlation{T}"/>.
+/// </para>
+/// <para>
+/// <see cref="Median{T}"/> is generic over any <see cref="IComparable{T}"/>, not just floating-point
+/// types, so it cannot apply the same finiteness check; its behavior for a type whose
+/// <see cref="IComparable{T}.CompareTo"/> does not define a total order (floating-point NaN under the
+/// default comparer being the standard example) is therefore whatever <see cref="Array.Sort{T}(T[])"/>
+/// does with such values, which is unspecified. Validate finiteness before calling if that matters.
+/// </para>
+/// </remarks>
 public static class Statistics
 {
+    /// <summary>
+    /// Throws <see cref="ArgumentException"/> when <paramref name="value"/> is NaN or infinite. See
+    /// the non-finite value policy documented on <see cref="Statistics"/>.
+    /// </summary>
+    private static void ValidateFinite<T>(T value, string paramName)
+        where T : struct, IFloatingPoint<T>
+    {
+        if (!T.IsFinite(value))
+            throw new ArgumentException($"Sequence contains a non-finite value ({value}).", paramName);
+    }
+
     /// <summary>
     /// Returns the arithmetic mean of the sequence.
     /// Uses Welford's online algorithm for numerical stability.
     /// </summary>
     /// <typeparam name="T">Floating-point element type.</typeparam>
-    /// <param name="values">Input sequence. Must contain at least one element.</param>
+    /// <param name="values">Input sequence. Must contain at least one element, all finite.</param>
     /// <returns>The mean value.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="values"/> is empty.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="values"/> is empty or contains a non-finite value.</exception>
     public static T Mean<T>(IEnumerable<T> values)
         where T : struct, IFloatingPoint<T>
     {
@@ -22,6 +52,7 @@ public static class Statistics
         int count = 0;
         foreach (var v in values)
         {
+            ValidateFinite(v, nameof(values));
             count++;
             mean += (v - mean) / T.CreateChecked(count);
         }
@@ -35,9 +66,9 @@ public static class Statistics
     /// Uses Welford's online algorithm for numerical stability.
     /// </summary>
     /// <typeparam name="T">Floating-point element type.</typeparam>
-    /// <param name="values">Input sequence. Must contain at least two elements.</param>
+    /// <param name="values">Input sequence. Must contain at least two elements, all finite.</param>
     /// <returns>The sample variance.</returns>
-    /// <exception cref="ArgumentException">Thrown when fewer than two elements are provided.</exception>
+    /// <exception cref="ArgumentException">Thrown when fewer than two elements are provided, or a value is non-finite.</exception>
     public static T Variance<T>(IEnumerable<T> values)
         where T : struct, IFloatingPoint<T>
     {
@@ -46,6 +77,7 @@ public static class Statistics
         int count = 0;
         foreach (var v in values)
         {
+            ValidateFinite(v, nameof(values));
             count++;
             T delta = v - mean;
             mean += delta / T.CreateChecked(count);
@@ -70,10 +102,10 @@ public static class Statistics
     /// Returns the sample covariance between two sequences of equal length.
     /// </summary>
     /// <typeparam name="T">Floating-point element type.</typeparam>
-    /// <param name="x">First sequence.</param>
-    /// <param name="y">Second sequence.</param>
+    /// <param name="x">First sequence, all values finite.</param>
+    /// <param name="y">Second sequence, all values finite.</param>
     /// <returns>The sample covariance.</returns>
-    /// <exception cref="ArgumentException">Thrown when sequences have different lengths or fewer than two elements.</exception>
+    /// <exception cref="ArgumentException">Thrown when sequences have different lengths, fewer than two elements, or a value is non-finite.</exception>
     public static T Covariance<T>(IEnumerable<T> x, IEnumerable<T> y)
         where T : struct, IFloatingPoint<T>
     {
@@ -85,6 +117,8 @@ public static class Statistics
         {
             if (!ey.MoveNext())
                 throw new ArgumentException("Sequences must have the same length.", nameof(y));
+            ValidateFinite(ex.Current, nameof(x));
+            ValidateFinite(ey.Current, nameof(y));
             count++;
             T cx = T.CreateChecked(count);
             T dx = ex.Current - meanX;
@@ -103,23 +137,51 @@ public static class Statistics
     /// <summary>
     /// Returns the Pearson correlation coefficient between two sequences of equal length.
     /// </summary>
+    /// <remarks>
+    /// Computes both variances and the covariance in a single online pass (rather than materializing
+    /// both sequences and separately calling <see cref="Covariance{T}"/> and <see cref="StdDev{T}"/>,
+    /// each of which would re-enumerate and independently recompute its own mean).
+    /// </remarks>
     /// <typeparam name="T">Floating-point element type.</typeparam>
-    /// <param name="x">First sequence.</param>
-    /// <param name="y">Second sequence.</param>
+    /// <param name="x">First sequence, all values finite.</param>
+    /// <param name="y">Second sequence, all values finite.</param>
     /// <returns>The correlation coefficient in [−1, 1].</returns>
+    /// <exception cref="ArgumentException">Thrown when the sequences have different lengths, fewer than two elements, or a value is non-finite.</exception>
     /// <exception cref="InvalidOperationException">Thrown when either sequence has zero variance.</exception>
     public static T Correlation<T>(IEnumerable<T> x, IEnumerable<T> y)
         where T : struct, IFloatingPoint<T>, IRootFunctions<T>
     {
-        // Materialise both sequences once to allow multiple passes
-        T[] xa = x.ToArray();
-        T[] ya = y.ToArray();
-        T cov = Covariance<T>(xa, ya);
-        T sx = StdDev<T>(xa);
-        T sy = StdDev<T>(ya);
+        T meanX = T.Zero, meanY = T.Zero;
+        T m2X = T.Zero, m2Y = T.Zero, cov = T.Zero;
+        int count = 0;
+        using var ex = x.GetEnumerator();
+        using var ey = y.GetEnumerator();
+        while (ex.MoveNext())
+        {
+            if (!ey.MoveNext())
+                throw new ArgumentException("Sequences must have the same length.", nameof(y));
+            ValidateFinite(ex.Current, nameof(x));
+            ValidateFinite(ey.Current, nameof(y));
+            count++;
+            T cn = T.CreateChecked(count);
+            T dx = ex.Current - meanX;
+            meanX += dx / cn;
+            T dy = ey.Current - meanY;
+            meanY += dy / cn;
+            m2X += dx * (ex.Current - meanX);
+            m2Y += dy * (ey.Current - meanY);
+            cov += dx * (ey.Current - meanY);
+        }
+        if (ey.MoveNext())
+            throw new ArgumentException("Sequences must have the same length.", nameof(y));
+        if (count < 2)
+            throw new ArgumentException("Correlation requires at least two elements.", nameof(x));
+
+        T sx = T.Sqrt(m2X / T.CreateChecked(count - 1));
+        T sy = T.Sqrt(m2Y / T.CreateChecked(count - 1));
         if (sx == T.Zero || sy == T.Zero)
             throw new InvalidOperationException("Correlation is undefined when a sequence has zero variance.");
-        return cov / (sx * sy);
+        return (cov / T.CreateChecked(count - 1)) / (sx * sy);
     }
 
     /// <summary>

--- a/Utils.Mathematics/TODO-2026-07-11-pass2.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass2.md
@@ -193,14 +193,18 @@ The iteration repeatedly applies unshifted `A ← RQ`. Even for symmetric matric
 
 **Priority: P2 performance and stability.**
 
-**Documented, not fully solved.** A proper fix (Wilkinson shifts and deflation after symmetric
-tridiagonal reduction, converging cubically) would be a substantial rewrite out of proportion to a P2
-item. The slow-convergence-for-clustered-eigenvalues limitation is now documented explicitly on
-`ComputeEigenvalues`'s XML remarks, with a regression test demonstrating both the failure mode
-(exhausting the default 1000-iteration budget) and its only available mitigation
-(`maxIterations`/`convergenceTolerance`). Test:
+**NOT fixed - documented technical debt only.** The algorithm itself is unchanged: still plain
+unshifted `A ← R·Q` with no tridiagonal reduction or Wilkinson shifts, and it still fails on the
+exact kind of input this item describes (see the regression test below, which asserts the
+`InvalidOperationException` rather than a converged result). A proper fix (shifted QR with deflation
+after symmetric tridiagonal reduction, converging cubically) would be a substantial algorithmic
+rewrite, judged out of proportion to implement as part of this audit pass. What was done instead:
+the limitation is now documented explicitly on `ComputeEigenvalues`'s XML remarks (previously it was
+undocumented), and a regression test locks in the failure mode on a concrete clustered-eigenvalue
+matrix so this limitation is visible and tracked rather than silent. This item should remain open
+until the algorithm is actually replaced. Test:
 `UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs`
-(`ComputeEigenvalues_ClusteredEigenvalues_*`).
+(`ComputeEigenvalues_ClusteredEigenvalues_FailsToConvergeWithinDefaultIterations`).
 
 ### 29. Zero-dimensional behavior is inconsistent across vector and matrix factories
 
@@ -260,7 +264,8 @@ normalization, or homogeneous conversion with zero final coordinate.
 
 ## Status
 
-All 14 findings in this file are resolved as of 2026-07-12: items 16–24 (P0/P1) are fixed, and items
-25–29 (P2) are fixed or explicitly documented where a full fix was out of proportion to the item (see
-the **Fixed.**/**Documented** note under each item above). PR references: items 16–24 in PR #443,
-items 25–29 in PR #445.
+As of 2026-07-12: items 16–24 (P0/P1) are fixed. Of the P2 items, 25, 26, 27, and 29 are fixed or
+explicitly documented as a deliberate, adequate design decision. **Item #28 is NOT fixed** - its
+underlying algorithm is unchanged and still fails on the exact input class it describes; only
+documentation and a regression test locking in the current failure mode were added. See the note
+under each item above for specifics. PR references: items 16–24 in PR #443, items 25–29 in PR #445.

--- a/Utils.Mathematics/TODO-2026-07-11-pass2.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass2.md
@@ -16,6 +16,9 @@ Follow-up review focused on homogeneous transformations, vector edge cases, matr
 
 **Priority: P0 transformation correctness.**
 
+**Fixed.** `Translation` now writes to `array[i, lastColumn]`. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs`.
+
 ### 17. General `Transform<T>` uses the same inconsistent row-vector layout
 
 `Transform` fills every row across all columns except the last one, leaving the last column mostly as the identity column. Under the library's matrix-times-column-vector convention, affine coefficients and translations belong in a layout whose last row remains homogeneous and whose translation occupies the last column.
@@ -27,6 +30,10 @@ The input-count formula and loop currently describe a matrix with `m × (m−1)`
 **Fix:** define the coefficient order and homogeneous convention explicitly, then populate the upper `d × (d+1)` affine block for a `(d+1) × (d+1)` matrix while preserving the final row.
 
 **Priority: P1 transformation correctness.**
+
+**Fixed.** `Transform` now solves the base dimension from `d*(d+1)=n` and populates the upper
+`d×(d+1)` affine block row-major, preserving the homogeneous last row. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs`.
 
 ### 18. `Diagonal<T>` caches false structural metadata when any diagonal value is zero
 
@@ -40,6 +47,10 @@ Because these flags are cached as non-null, later `IsDiagonal` and `IsTriangular
 
 **Priority: P1 linear-algebra correctness.**
 
+**Fixed.** `Diagonal` now always caches `isTriangular: true, isDiagonal: true` regardless of zero
+entries; identity is cached only when every value is one. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs`.
+
 ### 19. Symmetric singular matrices cannot be eigen-decomposed
 
 `ComputeEigenvalues` claims to support real symmetric matrices generally, but each QR iteration calls `DecomposeQR`, which rejects linearly dependent columns. Symmetric matrices may legitimately be singular and have zero eigenvalues; `diag(1, 0)` is a minimal valid example that fails.
@@ -50,6 +61,11 @@ Because these flags are cached as non-null, later `IsDiagonal` and `IsTriangular
 
 **Priority: P1 eigenvalue correctness.**
 
+**Fixed.** `DecomposeQR` rewritten from modified Gram-Schmidt to Householder reflections, which remain
+well-defined for rank-deficient columns instead of rejecting them; this also resolves item #27 below.
+Test: `UtilsTest/Mathematics/LinearAlgebra/MatrixQRTests.cs`,
+`UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs`.
+
 ### 20. `ComputeEigenvalues` accepts non-positive iteration counts and returns unvalidated diagonal entries
 
 When `maxIterations <= 0`, the iteration loop is skipped and the current diagonal is returned as “eigenvalues”, even when the input is not diagonal. No convergence check runs.
@@ -57,6 +73,10 @@ When `maxIterations <= 0`, the iteration loop is skipped and the current diagona
 **Fix:** require a positive iteration count and perform a final convergence check independently of loop-entry/last-iteration conditions.
 
 **Priority: P1 API correctness.**
+
+**Fixed.** `ComputeEigenvalues` now requires `maxIterations > 0` and performs a final convergence check
+independently of loop-entry/last-iteration conditions. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs`.
 
 ### 21. QR and eigenvalue tolerances repeat the generic fixed-epsilon defect
 
@@ -68,6 +88,19 @@ When `maxIterations <= 0`, the iteration loop is skipped and the current diagona
 
 **Priority: P1 generic numerical correctness.**
 
+**Fixed.** Replaced the fixed `QrEpsilon`/`EigenEpsilon` literals with a shared, generically-computed
+`NumericPrecision.MachineEpsilon<T>()` and a relative-plus-absolute `DefaultTolerance(scale,
+dimension) = eps * dimension * (scale + 1)` formula. `DecomposeQR`, `ComputeEigenvalues` (separate
+`convergenceTolerance`/`symmetryTolerance`/`rankTolerance` parameters), and `IsSymmetric` each accept
+an independent optional override. **Known, documented limitation (not solved):** a single global
+max-magnitude scale can still mask a small-but-numerically-significant sub-block in a matrix with
+large scale disparity (e.g. a large diagonal entry next to a small but meaningful off-diagonal
+coupling); fixing this would require per-row/column equilibration, out of scope here, and is called
+out explicitly in `DefaultTolerance`'s XML doc. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixQRTests.cs`,
+`UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs`,
+`UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs`.
+
 ### 22. Vector normalization divides by zero for the zero vector
 
 `Normalize()` blindly divides by `Norm`. For a zero vector this produces NaN/infinity or a type-specific failure rather than the explicit error used by `ProjectOnto`.
@@ -76,6 +109,10 @@ When `maxIterations <= 0`, the iteration loop is skipped and the current diagona
 
 **Priority: P1 vector correctness.**
 
+**Fixed.** `Normalize` rejects a zero norm, and (via an optional `tolerance` parameter defaulting to a
+scale-aware `DefaultNormTolerance`) a near-zero-but-nonzero norm too; passing `tolerance: 0` opts back
+into exact-zero-only behavior. Test: `UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs`.
+
 ### 23. `FromNormalSpace` divides by a zero homogeneous coordinate
 
 The method divides by the final component whenever it is not exactly one. A homogeneous direction/point at infinity has final coordinate zero and therefore causes division by zero. Near-zero values are also numerically unstable.
@@ -83,6 +120,10 @@ The method divides by the final component whenever it is not exactly one. A homo
 **Fix:** distinguish points (`w != 0`) from directions (`w == 0`), expose separate conversion APIs or return failure for non-Cartesian homogeneous vectors, and use an explicit tolerance policy.
 
 **Priority: P1 geometric correctness.**
+
+**Fixed.** `FromNormalSpace` rejects a zero or (via the same optional `tolerance` parameter/default as
+`Normalize`) near-zero homogeneous coordinate instead of dividing by it. Test:
+`UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs`.
 
 ### 24. Matrix constructors fail unpredictably on empty jagged/vector inputs
 
@@ -94,6 +135,12 @@ The jagged-array constructor calls `Max()` on an empty outer array. The vector c
 
 **Priority: P1 API robustness.**
 
+**Fixed.** Jagged-array and vector-array constructors validate null/empty inputs and null members
+explicitly. As part of item #29 below, the raw `(rows, columns)` constructor and the `T[,]`
+constructor now also reject zero/negative dimensions explicitly (a consistent "no zero-dimensioned
+matrices" policy across every public constructor, matching what `Identity`/`Zero`/`Diagonal` already
+enforced). Test: `UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs`.
+
 ## Medium-priority findings
 
 ### 25. Fourier-window documentation incorrectly promises every coefficient is in `[0, 1]`
@@ -104,6 +151,11 @@ The class summary applies this range to all windows, but a standard flat-top win
 
 **Priority: P2 documentation correctness.**
 
+**Fixed.** Removed the misleading shared `[0, 1]` claim from the class summary; each window's doc
+comment now states its actual range (`FlatTop` is negative by design near its edges; `Blackman`'s
+edges are exactly zero in theory but can round a few ulps negative in floating point). Test:
+`UtilsTest/Mathematics/Fourier/FourierWindowTests.cs`.
+
 ### 26. Fourier windows compute in `double` despite generic output types
 
 All trigonometric calculations occur through `Math.Cos(double)` and are converted afterward with `T.CreateChecked`. The API therefore is generic only in storage/output, not in calculation precision, and cannot exploit `T`'s trigonometric implementation.
@@ -111,6 +163,11 @@ All trigonometric calculations occur through `Math.Cos(double)` and are converte
 **Fix:** either document double-precision generation explicitly or constrain to `ITrigonometricFunctions<T>` and compute in `T`. Consider whether deterministic standard coefficients or maximum generic precision is the intended contract.
 
 **Priority: P2 generic API clarity.**
+
+**Documented, not changed.** Kept as double-precision `Math.Cos` internally and explicitly documented
+as a deliberate choice: constraining `T` to `ITrigonometricFunctions<T>` would drop `decimal` support
+(no such implementation exists) for no accuracy gain, since a low-precision `T`'s own trigonometric
+implementation would not be more accurate than converting from double anyway.
 
 ### 27. Modified Gram–Schmidt has no re-orthogonalization or quality diagnostics
 
@@ -120,6 +177,14 @@ The QR implementation performs one projection pass. For ill-conditioned columns,
 
 **Priority: P2 numerical stability.**
 
+**Fixed** (as a side effect of item #19's Householder rewrite above; Householder reflections don't
+suffer the loss-of-orthogonality problem plain/modified Gram-Schmidt has, so no re-orthogonalization
+pass is needed). Added the specific regression test this item asked for: the classic Trefethen & Bau
+ill-conditioned example (three columns agreeing in their first row, differing only by `1e-8` in three
+otherwise orthogonal directions), verifying `Qᵀ Q` and `QR − A` stay accurate to `1e-12`. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixQRTests.cs`
+(`DecomposeQR_IllConditionedColumns_QRemainsOrthogonalToMachinePrecision`).
+
 ### 28. Eigenvalue QR iteration is unshifted and can converge very slowly
 
 The iteration repeatedly applies unshifted `A ← RQ`. Even for symmetric matrices, convergence may be slow or stall near clustered eigenvalues, while the hard-coded iteration cap is unrelated to dimension or requested tolerance.
@@ -128,6 +193,15 @@ The iteration repeatedly applies unshifted `A ← RQ`. Even for symmetric matric
 
 **Priority: P2 performance and stability.**
 
+**Documented, not fully solved.** A proper fix (Wilkinson shifts and deflation after symmetric
+tridiagonal reduction, converging cubically) would be a substantial rewrite out of proportion to a P2
+item. The slow-convergence-for-clustered-eigenvalues limitation is now documented explicitly on
+`ComputeEigenvalues`'s XML remarks, with a regression test demonstrating both the failure mode
+(exhausting the default 1000-iteration budget) and its only available mitigation
+(`maxIterations`/`convergenceTolerance`). Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs`
+(`ComputeEigenvalues_ClusteredEigenvalues_*`).
+
 ### 29. Zero-dimensional behavior is inconsistent across vector and matrix factories
 
 Vectors reject zero components. `Diagonal` with no values can create a `0×0` matrix, while `Identity` and raw matrix constructors rely on array-allocation behavior for zero/negative dimensions. Determinant and identity semantics for `0×0` matrices are not documented.
@@ -135,6 +209,12 @@ Vectors reject zero components. `Diagonal` with no values can create a `0×0` ma
 **Fix:** define one dimensional-domain policy and validate it consistently. If `0×0` matrices are mathematically supported, test determinant/identity/solve behavior explicitly; otherwise reject them at every public boundary.
 
 **Priority: P2 API consistency.**
+
+**Fixed.** Chosen policy: zero/negative-dimensioned matrices are not supported, consistently. This was
+already true for `Identity`/`Zero`/`Diagonal`/`Vector`; the raw `(rows, columns)` constructor and the
+`T[,]`/`T[][]` constructors now reject zero dimensions (all-empty jagged rows included) the same way,
+instead of relying on the CLR's own inconsistent behavior for invalid array allocation. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs`.
 
 ## Additional duplicated intent to reduce
 
@@ -173,4 +253,14 @@ Vectors reject zero components. `Diagonal` with no values can create a `0×0` ma
 
 ## Deployment warning
 
-Until items 16–24 are addressed, do not rely on translation/general transformation factories, cached structural flags from singular diagonal matrices, eigenvalue decomposition of singular symmetric matrices, zero-vector normalization, or homogeneous conversion with zero final coordinate. These APIs can produce mathematically incorrect results or fail outside their documented contracts.
+Historical warning, kept for context: until items 16–24 were addressed, this package should not have
+been relied upon for translation/general transformation factories, cached structural flags from
+singular diagonal matrices, eigenvalue decomposition of singular symmetric matrices, zero-vector
+normalization, or homogeneous conversion with zero final coordinate.
+
+## Status
+
+All 14 findings in this file are resolved as of 2026-07-12: items 16–24 (P0/P1) are fixed, and items
+25–29 (P2) are fixed or explicitly documented where a full fix was out of proportion to the item (see
+the **Fixed.**/**Documented** note under each item above). PR references: items 16–24 in PR #443,
+items 25–29 in PR #445.

--- a/Utils.Mathematics/TODO.md
+++ b/Utils.Mathematics/TODO.md
@@ -14,6 +14,8 @@ The existing test named `Median_EvenLength_ReturnsLowerMiddle` expects `5`, so i
 
 **Priority: P1 statistical correctness.**
 
+**Fixed.** `Median` now returns `sorted[(sorted.Length - 1) / 2]`. Test: `UtilsTest/Mathematics/StatisticsTests.cs`.
+
 ### 2. `MatrixTransformations.Skew<T>` has incompatible dimension and index formulas
 
 The inferred dimension formula does not match the number of angles consumed by the nested loops. In addition, the column-skipping expression uses `y >= x ? y : y + 1`, which fails to skip the diagonal for the first row and writes values into the wrong columns.
@@ -24,6 +26,9 @@ The inferred dimension formula does not match the number of angles consumed by t
 
 **Priority: P1 functional correctness.**
 
+**Fixed.** `Skew` dimension and index formulas corrected in `MatrixTransformations.cs`. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs`.
+
 ### 3. Approximate polynomial equality violates the hash-code contract
 
 `Polynomial<T>.Equals` considers coefficients equal when their absolute difference is at most `Epsilon`. `GetHashCode`, however, hashes the exact degree and exact first coefficient. Two polynomials can therefore compare equal while returning different hash codes.
@@ -33,6 +38,11 @@ The inferred dimension formula does not match the number of angles consumed by t
 **Fix:** either make object equality exact and expose a separate approximate comparer, or quantize every coefficient consistently for both equality and hashing. A separate tolerance-aware comparer is strongly preferred.
 
 **Priority: P1 .NET contract correctness.**
+
+**Fixed.** `Equals` is now exact (no tolerance) and consistent with `GetHashCode`, which hashes every
+coefficient. A separate, explicitly opt-in `ApproximatelyEquals(other, tolerance)` provides
+tolerance-aware comparison and is never used by `Equals`/`GetHashCode`. Test:
+`UtilsTest/Mathematics/PolynomialTests.cs`.
 
 ### 4. One fixed absolute polynomial epsilon is invalid across generic floating-point types and scales
 
@@ -46,6 +56,12 @@ The same value controls constructor trimming, degree, equality, zero-term format
 
 **Priority: P1 generic numerical correctness.**
 
+**Fixed.** Canonical storage (constructor trimming, degree, `Equals`, `GetHashCode`) now uses exact
+zero rather than an epsilon, so it is no longer coupled to any tolerance. `FindRoot` has its own
+explicit, independently configurable `tolerance` parameter. The one remaining use of the fixed
+`Epsilon` field is purely cosmetic (`ToString`'s near-zero coefficient suppression when printing);
+it does not affect degree, equality, or hashing. Test: `UtilsTest/Mathematics/PolynomialTests.cs`.
+
 ### 5. `Polynomial.FindRoot` accepts invalid iteration and tolerance parameters
 
 Negative or zero `maxIterations` silently returns `null`. A negative or non-finite tolerance prevents meaningful convergence checks. The method also compares the derivative exactly with zero, which is numerically fragile near stationary points.
@@ -53,6 +69,10 @@ Negative or zero `maxIterations` silently returns `null`. A negative or non-fini
 **Fix:** require `maxIterations > 0`, finite positive tolerance, and finite initial guess. Use a derivative threshold based on an explicit numerical policy and reject/propagate non-finite iterates deterministically.
 
 **Priority: P1 root-finding correctness.**
+
+**Fixed.** `FindRoot` now requires `maxIterations > 0` and a finite, positive `tolerance`, requires a
+finite `initialGuess`, and rejects a derivative merely close to (not just exactly) zero using the same
+tolerance as the convergence threshold. Test: `UtilsTest/Mathematics/PolynomialTests.cs`.
 
 ### 6. Matrix solve/determinant singularity tests use exact floating-point zero
 
@@ -62,6 +82,12 @@ Gaussian elimination and determinant computation treat a pivot as singular only 
 
 **Priority: P1 linear-algebra correctness.**
 
+**Fixed.** `Solve`, `Invert`, and `ComputeDeterminant` now use a scale-aware relative-plus-absolute
+pivot tolerance (`DefaultTolerance(scale, dimension) = eps * dimension * (scale + 1)`, machine epsilon
+computed generically) instead of comparing to exact `T.Zero`, and `Solve`/`Invert` accept an optional
+explicit override. Test: `UtilsTest/Mathematics/LinearAlgebra/MatrixSolveTests.cs`,
+`UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs`.
+
 ### 7. Matrix structural flags also rely on exact equality
 
 `IsTriangular`, `IsDiagonal`, `IsIdentity`, and `IsNormalSpace` compare floating-point values exactly to zero or one. Results from normal arithmetic/decomposition that differ by rounding noise are classified as structurally false.
@@ -69,6 +95,11 @@ Gaussian elimination and determinant computation treat a pivot as singular only 
 **Fix:** distinguish exact structural predicates from tolerance-aware predicates. Do not silently choose one global tolerance; expose explicit numerical options/comparers.
 
 **Priority: P1 API semantics.**
+
+**Fixed.** Added tolerance-aware `IsTriangularWithin`/`IsDiagonalWithin`/`IsIdentityWithin`/
+`IsNormalSpaceWithin` predicates alongside the existing exact ones, each taking an explicit
+`tolerance` parameter rather than an implicit global default. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs`.
 
 ### 8. Simpson integration can overflow while normalizing an odd step count
 
@@ -80,6 +111,10 @@ The method also does not reject a null function or non-finite bounds/results des
 
 **Priority: P1 numerical-method robustness.**
 
+**Fixed.** Simpson `Integrate` now validates for `null`/non-finite bounds and function values up
+front and normalizes an odd step count through overflow-safe arithmetic instead of an unchecked
+`steps++`. Test: `UtilsTest/Mathematics/NumericalMethodsTests.cs`.
+
 ### 9. Lagrange interpolation validates duplicate abscissas only during partial evaluation
 
 Duplicate `x` values are detected inside the nested basis loop after result construction has begun. Non-finite values, especially NaN, bypass `denom == T.Zero` and propagate invalid output rather than producing the documented distinct-point error.
@@ -87,6 +122,9 @@ Duplicate `x` values are detected inside the nested basis loop after result cons
 **Fix:** validate all points first, including finiteness and uniqueness under a clearly defined exact/tolerance policy, then evaluate. For repeated evaluations, expose a precomputed interpolation object or barycentric form.
 
 **Priority: P1 correctness and diagnostics.**
+
+**Fixed.** `Lagrange` now validates finiteness and pairwise distinctness of every abscissa up front,
+before evaluating any basis term. Test: `UtilsTest/Mathematics/NumericalMethodsTests.cs`.
 
 ## Medium-priority findings
 
@@ -98,6 +136,11 @@ Duplicate `x` values are detected inside the nested basis loop after result cons
 
 **Priority: P2 API quality.**
 
+**Fixed.** `Transform`/`InverseTransform` now throw `ArgumentNullException` explicitly instead of
+dereferencing `array.Length` before any guard runs. Zero-length was already implicitly rejected
+(`IsPowerOfTwo(0)` is `false`); this is now a deliberate, tested contract rather than an accident of
+the helper it happens to call. Test: `UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs`.
+
 ### 11. Recursive FFT allocates at every recursion level
 
 `Separate` allocates a new half-size array for every recursive call. Across the transform this creates substantial allocation pressure and repeated copying despite the API being described as in-place.
@@ -105,6 +148,11 @@ Duplicate `x` values are detected inside the nested basis loop after result cons
 **Fix:** use iterative bit-reversal plus butterfly stages, or rent/reuse a single workspace. Clarify that the current algorithm mutates in place but is not allocation-free.
 
 **Priority: P2 performance.**
+
+**Fixed.** `Separate` no longer allocates a new half-size buffer at every recursion level; a single
+scratch buffer sized for the top-level recursion is allocated once and threaded through every
+recursive call via `Span` slicing. Test: `UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs`
+(`Transform_16Samples_RoundTripsThroughInverse` exercises multiple recursion levels).
 
 ### 12. Correlation performs redundant passes and materialization
 
@@ -114,6 +162,10 @@ Duplicate `x` values are detected inside the nested basis loop after result cons
 
 **Priority: P2 performance and consistency.**
 
+**Fixed.** `Correlation` no longer materializes both sequences and calls `Covariance`/`StdDev`
+separately; it now computes both variances and the covariance together in a single online pass. Test:
+`UtilsTest/Mathematics/StatisticsTests.cs`.
+
 ### 13. Statistical algorithms have no explicit NaN/infinity policy
 
 Mean, variance, covariance, correlation, and median accept non-finite values. Depending on position and sort behavior, results become NaN or otherwise implementation-dependent without a diagnostic.
@@ -121,6 +173,13 @@ Mean, variance, covariance, correlation, and median accept non-finite values. De
 **Fix:** document propagation semantics or reject non-finite samples through an option. Apply one consistent policy across all statistical operations.
 
 **Priority: P2 statistical contract.**
+
+**Fixed.** `Mean`, `Variance`, `Covariance`, and `Correlation` now reject NaN/infinite input values via
+a shared `ValidateFinite` helper, applied consistently and documented on the `Statistics` class.
+`Median` is generic over any `IComparable<T>` (not just floating-point types) and cannot apply the
+same check; its behavior for a type whose `CompareTo` does not define a total order (NaN being the
+standard example) is documented as unspecified instead. Test:
+`UtilsTest/Mathematics/StatisticsTests.cs`.
 
 ### 14. Matrix formatting rounds values instead of formatting them
 
@@ -130,6 +189,11 @@ Mean, variance, covariance, correlation, and median accept non-finite values. De
 
 **Priority: P2 API correctness.**
 
+**Fixed.** `ToString(format, provider)` no longer calls `T.Round` before appending. `format` is now a
+composite string (`"<layout>:<numeric format>"`); the part after `:` is forwarded verbatim to each
+element's own `IFormattable.ToString`, and no numeric format means no rounding at all. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs`.
+
 ### 15. Matrix equality unnecessarily depends on cached hash equality
 
 `Matrix.Equals(Matrix<T>)` first requires equal hash codes before comparing elements. Correct hash implementations guarantee equal values have equal hashes, but using a cached hash as a semantic precondition makes future tolerance-aware equality or hashing changes hazardous and adds no correctness value.
@@ -137,6 +201,10 @@ Mean, variance, covariance, correlation, and median accept non-finite values. De
 **Fix:** compare dimensions/elements directly; use hashes only as collection infrastructure or an optional optimization proven consistent with the exact equality policy.
 
 **Priority: P2 maintainability.**
+
+**Fixed.** `Equals(Matrix<T>)` compares dimensions/elements directly and no longer requires
+`GetHashCode()` equality as a precondition. Test:
+`UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs`.
 
 ## Duplications of intent to reduce
 
@@ -174,4 +242,13 @@ Mean, variance, covariance, correlation, and median accept non-finite values. De
 
 ## Deployment warning
 
-Until items 1–9 are addressed, avoid relying on even-length median results, `Skew`, approximate polynomial equality in hashed collections, near-singular matrix solutions, or generic numerical behavior across very different floating-point types. Several methods can return mathematically incorrect or non-finite results without a clear failure signal.
+Historical warning, kept for context: until items 1–9 were addressed, this package should not have been
+relied upon for even-length median results, `Skew`, approximate polynomial equality in hashed
+collections, near-singular matrix solutions, or generic numerical behavior across very different
+floating-point types.
+
+## Status
+
+All 15 findings in this file (P1 items 1–9, P2 items 10–15) are fixed as of 2026-07-12. See the
+**Fixed.** note under each item above for what changed and where the regression test lives. PR
+references: items 1–9 in PR #442, items 10–15 in PR #445.

--- a/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
+++ b/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
@@ -60,6 +60,53 @@ public class FastFourierTransformTests
         Assert.ThrowsException<ArgumentException>(() => FastFourierTransform.Transform(samples));
     }
 
+    [TestMethod]
+    public void Transform_Null_ThrowsArgumentNullException()
+    {
+        // Regression: previously dereferenced array.Length before any guard ran, producing an
+        // incidental NullReferenceException instead of a documented ArgumentNullException.
+        Assert.ThrowsException<ArgumentNullException>(() => FastFourierTransform.Transform(null!));
+    }
+
+    [TestMethod]
+    public void Transform_ZeroLength_Throws()
+    {
+        // Zero is not a power of two under this library's IsPowerOfTwo (0 > 0 is false), so a
+        // zero-length array is rejected rather than silently treated as a no-op.
+        Assert.ThrowsException<ArgumentException>(() => FastFourierTransform.Transform(System.Array.Empty<Complex>()));
+    }
+
+    [TestMethod]
+    public void Transform_SingleElement_IsUnchanged()
+    {
+        // Length 1 is a power of two (2^0); the transform of a single sample is itself.
+        Complex[] samples = [Complex.Zero + 3];
+        FastFourierTransform.Transform(samples);
+        Assert.AreEqual(3.0, samples[0].Real, Delta);
+        Assert.AreEqual(0.0, samples[0].Imaginary, Delta);
+    }
+
+    [TestMethod]
+    public void Transform_16Samples_RoundTripsThroughInverse()
+    {
+        // Regression coverage for the scratch-buffer reuse fix: exercises more than one recursion
+        // level (16 = 2^4) to ensure every level's Separate call gets a correctly-sized slice of the
+        // single shared buffer rather than reading/writing past what it's entitled to.
+        int n = 16;
+        Complex[] original = new Complex[n];
+        for (int i = 0; i < n; i++) original[i] = new Complex(i, -i);
+        Complex[] samples = (Complex[])original.Clone();
+
+        FastFourierTransform.Transform(samples);
+        FastFourierTransform.InverseTransform(samples);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.AreEqual(original[i].Real, samples[i].Real, Delta, $"real[{i}]");
+            Assert.AreEqual(original[i].Imaginary, samples[i].Imaginary, Delta, $"imag[{i}]");
+        }
+    }
+
     // ── Extensions ────────────────────────────────────────────────────────────
 
     [TestMethod]
@@ -168,5 +215,17 @@ public class FastFourierTransformTests
     {
         var spectrum = new Complex[3];
         Assert.ThrowsException<ArgumentException>(() => FastFourierTransform.InverseTransform(spectrum));
+    }
+
+    [TestMethod]
+    public void InverseTransform_Null_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => FastFourierTransform.InverseTransform(null!));
+    }
+
+    [TestMethod]
+    public void InverseTransform_ZeroLength_Throws()
+    {
+        Assert.ThrowsException<ArgumentException>(() => FastFourierTransform.InverseTransform(System.Array.Empty<Complex>()));
     }
 }

--- a/UtilsTest/Mathematics/Fourier/FourierWindowTests.cs
+++ b/UtilsTest/Mathematics/Fourier/FourierWindowTests.cs
@@ -56,6 +56,29 @@ public class FourierWindowTests
     }
 
     [TestMethod]
+    public void FlatTop_ContainsNegativeValues()
+    {
+        // Regression for documentation accuracy: the class summary previously claimed every window's
+        // coefficients lie in [0, 1], which is false for FlatTop by design (IEC 61672 defines it with
+        // negative edge lobes). Assert a negative value actually occurs, not just that every value
+        // happens to fall within the wide range checked above.
+        double[] w = FourierWindow.FlatTop<double>(64);
+        bool anyNegative = false;
+        foreach (double v in w)
+        {
+            if (v < 0) { anyNegative = true; break; }
+        }
+        Assert.IsTrue(anyNegative, "Expected at least one negative FlatTop coefficient.");
+    }
+
+    [TestMethod]
+    public void Blackman_NeverExceedsOne()
+    {
+        double[] w = FourierWindow.Blackman<double>(64);
+        foreach (double v in w) Assert.IsTrue(v <= 1.0 + 1e-9, $"Out of range: {v}");
+    }
+
+    [TestMethod]
     public void AllWindows_CorrectLength()
     {
         int n = 32;

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
@@ -262,33 +262,23 @@ public class MatrixEigenvaluesTests
     [TestMethod]
     public void ComputeEigenvalues_ClusteredEigenvalues_FailsToConvergeWithinDefaultIterations()
     {
-        // Regression/documentation test for the documented "unshifted iteration converges slowly for
-        // clustered eigenvalues" known limitation. M = R * diag(1.0, 1.0001) * R^T for a 45-degree
-        // rotation R has eigenvalues 1.0 and 1.0001 (ratio 0.9999...), which unshifted QR iteration
-        // approaches only linearly - convergence at this ratio needs on the order of hundreds of
-        // thousands of iterations, well past the default 1000-iteration budget.
+        // Regression/documentation test for the unresolved "unshifted iteration converges slowly for
+        // clustered eigenvalues" limitation (TODO-pass2.md #28 - documented, NOT fixed: this
+        // implementation is still plain unshifted A <- R*Q with no tridiagonal reduction or Wilkinson
+        // shifts). M = R * diag(1.0, 1.0001) * R^T for a 45-degree rotation R has eigenvalues 1.0 and
+        // 1.0001 (ratio 0.9999...), which unshifted QR iteration approaches only linearly -
+        // convergence at this ratio needs on the order of hundreds of thousands of iterations, well
+        // past the default 1000-iteration budget. A "mitigation" test that actually runs enough
+        // iterations to converge (~250,000+) is deliberately not included here: it would inflate this
+        // test suite's runtime for no correctness value beyond what this failure-mode test already
+        // demonstrates. A real fix (shifted QR + tridiagonal reduction, converging cubically) is what
+        // would let a fast convergence test exist.
         var m = new Matrix<double>(new double[,]
         {
             { 1.00005, 0.00005 },
             { 0.00005, 1.00005 },
         });
         Assert.ThrowsException<InvalidOperationException>(() => m.ComputeEigenvalues());
-    }
-
-    [TestMethod]
-    public void ComputeEigenvalues_ClusteredEigenvalues_ConvergesGivenEnoughIterations()
-    {
-        // The documented mitigation for the case above: raising maxIterations lets the same
-        // slowly-converging matrix eventually reach the correct eigenvalues with the current
-        // (unshifted) algorithm.
-        var m = new Matrix<double>(new double[,]
-        {
-            { 1.00005, 0.00005 },
-            { 0.00005, 1.00005 },
-        });
-        var (values, _) = m.ComputeEigenvalues(maxIterations: 1_000_000);
-        Assert.AreEqual(1.0001, values[0], 1e-6);
-        Assert.AreEqual(1.0, values[1], 1e-6);
     }
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
@@ -260,6 +260,38 @@ public class MatrixEigenvaluesTests
     }
 
     [TestMethod]
+    public void ComputeEigenvalues_ClusteredEigenvalues_FailsToConvergeWithinDefaultIterations()
+    {
+        // Regression/documentation test for the documented "unshifted iteration converges slowly for
+        // clustered eigenvalues" known limitation. M = R * diag(1.0, 1.0001) * R^T for a 45-degree
+        // rotation R has eigenvalues 1.0 and 1.0001 (ratio 0.9999...), which unshifted QR iteration
+        // approaches only linearly - convergence at this ratio needs on the order of hundreds of
+        // thousands of iterations, well past the default 1000-iteration budget.
+        var m = new Matrix<double>(new double[,]
+        {
+            { 1.00005, 0.00005 },
+            { 0.00005, 1.00005 },
+        });
+        Assert.ThrowsException<InvalidOperationException>(() => m.ComputeEigenvalues());
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_ClusteredEigenvalues_ConvergesGivenEnoughIterations()
+    {
+        // The documented mitigation for the case above: raising maxIterations lets the same
+        // slowly-converging matrix eventually reach the correct eigenvalues with the current
+        // (unshifted) algorithm.
+        var m = new Matrix<double>(new double[,]
+        {
+            { 1.00005, 0.00005 },
+            { 0.00005, 1.00005 },
+        });
+        var (values, _) = m.ComputeEigenvalues(maxIterations: 1_000_000);
+        Assert.AreEqual(1.0001, values[0], 1e-6);
+        Assert.AreEqual(1.0, values[1], 1e-6);
+    }
+
+    [TestMethod]
     public void ComputeEigenvalues_Half_NonDiagonalScaledMatrix_Succeeds()
     {
         // Regression: previous Half coverage only exercised an already-diagonal matrix, which

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixQRTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixQRTests.cs
@@ -147,6 +147,35 @@ public class MatrixQRTests
     }
 
     [TestMethod]
+    public void DecomposeQR_IllConditionedColumns_QRemainsOrthogonalToMachinePrecision()
+    {
+        // Classic Trefethen & Bau example demonstrating that (unlike modified Gram-Schmidt, which
+        // loses orthogonality substantially for nearly-parallel columns) Householder reflections
+        // remain accurate to machine precision without needing a re-orthogonalization pass: three
+        // columns that agree in their first row and differ only by a tiny epsilon in three otherwise
+        // orthogonal directions.
+        const double eps = 1e-8;
+        var a = new Matrix<double>(new double[,]
+        {
+            { 1, 1, 1 },
+            { eps, 0, 0 },
+            { 0, eps, 0 },
+            { 0, 0, eps },
+        });
+        var (q, r) = a.DecomposeQR();
+
+        var qtq = q.Transpose() * q;
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                Assert.AreEqual(i == j ? 1.0 : 0.0, qtq[i, j], 1e-12, $"Q^T Q [{i},{j}] lost orthogonality");
+
+        var product = q * r;
+        for (int i = 0; i < 4; i++)
+            for (int j = 0; j < 3; j++)
+                Assert.AreEqual(a[i, j], product[i, j], 1e-12, $"QR - A [{i},{j}]");
+    }
+
+    [TestMethod]
     public void DecomposeQR_Half_NonDiagonalScaledMatrix_ProducesValidFactorization()
     {
         // Regression: previous Half-precision coverage for this area only exercised an

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -419,6 +419,101 @@ namespace UtilsTest.Mathematics.LinearAlgebra
             Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(new Vector<double>(1d, 2d), null!));
         }
 
+        [TestMethod]
+        public void RawConstructor_NonPositiveDimensions_ThrowsClearArgumentException()
+        {
+            // Regression: the raw (rows, columns) constructor previously performed no validation at
+            // all, relying on the CLR's own (undocumented, exception-type-inconsistent) behavior for
+            // non-positive multidimensional array allocation instead of the explicit contract already
+            // enforced by Identity/Zero/Diagonal.
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(0, 3));
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(3, 0));
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(-1, 3));
+        }
+
+        [TestMethod]
+        public void ArrayConstructor_ZeroSizedArray_ThrowsClearArgumentException()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(new double[0, 0]));
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(new double[0, 3]));
+        }
+
+        [TestMethod]
+        public void JaggedArrayConstructor_AllRowsEmpty_ThrowsClearArgumentException()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new Matrix<double>(new double[][] { System.Array.Empty<double>() }));
+        }
+
+        [TestMethod]
+        public void Equals_EqualMatrices_ReturnsTrue()
+        {
+            // Regression: Equals(Matrix<T>) used to require GetHashCode() equality before comparing
+            // elements. A correct hash is a pure function of the components so this never produced a
+            // wrong *answer* here, but the precondition was hazardous (and unnecessary) for any future
+            // tolerance-aware equality/hashing change. Elements are compared directly now.
+            var a = new Matrix<double>(new double[,] { { 1, 2 }, { 3, 4 } });
+            var b = new Matrix<double>(new double[,] { { 1, 2 }, { 3, 4 } });
+            Assert.IsTrue(a.Equals(b));
+        }
+
+        [TestMethod]
+        public void Equals_DifferentValues_ReturnsFalse()
+        {
+            var a = new Matrix<double>(new double[,] { { 1, 2 }, { 3, 4 } });
+            var b = new Matrix<double>(new double[,] { { 1, 2 }, { 3, 5 } });
+            Assert.IsFalse(a.Equals(b));
+        }
+
+        [TestMethod]
+        public void Equals_Null_ReturnsFalse()
+        {
+            var a = new Matrix<double>(new double[,] { { 1, 2 }, { 3, 4 } });
+            Assert.IsFalse(a.Equals((Matrix<double>?)null));
+        }
+
+        [TestMethod]
+        public void Equals_SameReference_ReturnsTrue()
+        {
+            var a = new Matrix<double>(new double[,] { { 1, 2 }, { 3, 4 } });
+            Assert.IsTrue(a.Equals(a));
+        }
+
+        [TestMethod]
+        public void ToString_DefaultFormat_DoesNotRoundValues()
+        {
+            // Regression: ToString used to call T.Round(value, culture.NumberDecimalDigits) before
+            // appending, silently discarding precision the caller never asked to lose.
+            var m = new Matrix<double>(new double[,] { { 1.23456789012345 } });
+            string s = m.ToString("", System.Globalization.CultureInfo.InvariantCulture);
+            StringAssert.Contains(s, "1.23456789012345");
+        }
+
+        [TestMethod]
+        public void ToString_NumericFormatAfterColon_IsForwardedToElements()
+        {
+            // The part of the composite format string after ':' is forwarded verbatim to each
+            // element's own IFormattable.ToString, rather than being silently ignored.
+            var m = new Matrix<double>(new double[,] { { 1.23456, 2.5 } });
+            string s = m.ToString("S:F2", System.Globalization.CultureInfo.InvariantCulture);
+            StringAssert.Contains(s, "1.23");
+            StringAssert.Contains(s, "2.50");
+        }
+
+        [TestMethod]
+        public void ToString_LayoutTokenOnly_UsesCorrectRowSeparator()
+        {
+            var m = new Matrix<double>(new double[,] { { 1 }, { 2 } });
+            string s = m.ToString("C", null);
+            Assert.AreEqual("{ { 1 }, { 2 } }", s);
+        }
+
+        [TestMethod]
+        public void ToString_UnrecognizedLayoutToken_ThrowsFormatException()
+        {
+            var m = new Matrix<double>(new double[,] { { 1 } });
+            Assert.ThrowsException<FormatException>(() => m.ToString("bogus", null));
+        }
+
         /// <summary>
         /// Asserts that two matrices contain the same components within the provided tolerance.
         /// </summary>

--- a/UtilsTest/Mathematics/StatisticsTests.cs
+++ b/UtilsTest/Mathematics/StatisticsTests.cs
@@ -21,6 +21,14 @@ public class StatisticsTests
         => Assert.ThrowsException<ArgumentException>(() => Statistics.Mean<double>([]));
 
     [TestMethod]
+    public void Mean_ContainsNaN_Throws()
+        => Assert.ThrowsException<ArgumentException>(() => Statistics.Mean<double>([1, double.NaN, 3]));
+
+    [TestMethod]
+    public void Mean_ContainsInfinity_Throws()
+        => Assert.ThrowsException<ArgumentException>(() => Statistics.Mean<double>([1, double.PositiveInfinity, 3]));
+
+    [TestMethod]
     public void Variance_KnownSample()
     {
         // [2,4,4,4,5,5,7,9]: mean=5, Σ(xᵢ-x̄)²=32 → sample variance = 32/7
@@ -35,6 +43,10 @@ public class StatisticsTests
     [TestMethod]
     public void Variance_SingleElement_Throws()
         => Assert.ThrowsException<ArgumentException>(() => Statistics.Variance<double>([1.0]));
+
+    [TestMethod]
+    public void Variance_ContainsNaN_Throws()
+        => Assert.ThrowsException<ArgumentException>(() => Statistics.Variance<double>([1, double.NaN, 3]));
 
     [TestMethod]
     public void StdDev_IsSquareRootOfVariance()
@@ -58,6 +70,11 @@ public class StatisticsTests
             () => Statistics.Covariance<double>([1, 2, 3], [1, 2]));
 
     [TestMethod]
+    public void Covariance_ContainsNaN_Throws()
+        => Assert.ThrowsException<ArgumentException>(
+            () => Statistics.Covariance<double>([1, double.NaN, 3], [1, 2, 3]));
+
+    [TestMethod]
     public void Correlation_PerfectlyCorrelated_IsOne()
     {
         double[] x = [1, 2, 3, 4, 5];
@@ -72,6 +89,42 @@ public class StatisticsTests
         double[] y = [-1, -2, -3, -4, -5];
         Assert.AreEqual(-1.0, Statistics.Correlation<double>(x, y), Tol);
     }
+
+    [TestMethod]
+    public void Correlation_PartiallyCorrelated_MatchesManualPearsonComputation()
+    {
+        // Regression coverage for the rewrite from three separate passes (Covariance + two StdDev
+        // calls, each re-enumerating and independently recomputing a mean) to a single combined
+        // online pass: verified against a hand-computed Pearson coefficient rather than just the
+        // trivial +/-1 cases, which a broken cross-term could still satisfy by accident.
+        // x=[1,2,3,4,5] (mean 3), y=[2,1,4,3,5] (mean 3)
+        // cov = sum((x-3)(y-3))/(n-1) = (2+2+0+0+4)/4 = 2
+        // varX = sum((x-3)^2)/(n-1) = 10/4 = 2.5 ; varY = sum((y-3)^2)/(n-1) = 10/4 = 2.5
+        // r = 2 / sqrt(2.5*2.5) = 0.8
+        double[] x = [1, 2, 3, 4, 5];
+        double[] y = [2, 1, 4, 3, 5];
+        Assert.AreEqual(0.8, Statistics.Correlation<double>(x, y), Tol);
+    }
+
+    [TestMethod]
+    public void Correlation_DifferentLengths_Throws()
+        => Assert.ThrowsException<ArgumentException>(
+            () => Statistics.Correlation<double>([1, 2, 3], [1, 2]));
+
+    [TestMethod]
+    public void Correlation_FewerThanTwoElements_Throws()
+        => Assert.ThrowsException<ArgumentException>(
+            () => Statistics.Correlation<double>([1], [1]));
+
+    [TestMethod]
+    public void Correlation_ZeroVarianceSequence_Throws()
+        => Assert.ThrowsException<InvalidOperationException>(
+            () => Statistics.Correlation<double>([1, 1, 1], [1, 2, 3]));
+
+    [TestMethod]
+    public void Correlation_ContainsInfinity_Throws()
+        => Assert.ThrowsException<ArgumentException>(
+            () => Statistics.Correlation<double>([1, 2, 3], [1, double.PositiveInfinity, 3]));
 
     [TestMethod]
     public void Median_OddLength_ReturnsMiddle()


### PR DESCRIPTION
## Summary
Addresses the remaining P2 findings in `Utils.Mathematics/TODO.md` (items 10-15; items 1-9 were already resolved in PR #442) and `Utils.Mathematics/TODO-2026-07-11-pass2.md` (items 25-29; items 16-24 were already resolved in PR #443). One commit per item (or per closely related item pair sharing a file), tests, push after each.

### TODO.md
- [x] #10 FFT null and zero-length contracts are implicit
- [x] #11 Recursive FFT allocates at every recursion level
- [x] #12 Correlation performs redundant passes and materialization
- [x] #13 Statistical algorithms have no explicit NaN/infinity policy
- [x] #14 Matrix formatting rounds values instead of formatting them
- [x] #15 Matrix equality unnecessarily depends on cached hash equality

### TODO-pass2.md
- [x] #25 Fourier-window doc incorrectly promises `[0,1]` range
- [x] #26 Fourier windows compute in double despite generic output
- [x] #27 Modified Gram-Schmidt has no re-orthogonalization
- [ ] #28 Eigenvalue QR iteration unshifted, converges slowly - **NOT fixed**, see note below
- [x] #29 Zero-dimensional behavior inconsistent across factories

### Notes on how individual items were resolved
- **#10/#11** (FastFourierTransform): added an explicit `ArgumentNullException` guard; replaced
  per-recursion-level buffer allocation in `Separate` with a single scratch buffer reused across the
  whole transform via `Span` slicing.
- **#12/#13** (Statistics): `Correlation` rewritten as one combined online pass instead of
  materializing both sequences and calling `Covariance`/`StdDev` separately; `Mean`, `Variance`,
  `Covariance`, `Correlation` now reject non-finite values via a shared `ValidateFinite` helper - one
  consistent policy, documented on the `Statistics` class. `Median` is generic over any
  `IComparable<T>` and can't apply the same check; its behavior for non-totally-ordered types is
  documented as unspecified instead.
- **#14/#15** (Matrix): `ToString` redesigned as a composite format (`"<layout>:<numeric format>"`)
  forwarded to `IFormattable`, no longer silently rounding via `T.Round`. `Equals(Matrix<T>)` no
  longer requires `GetHashCode()` equality before comparing elements.
- **#25/#26** (FourierWindow): corrected the misleading shared `[0,1]` range claim (FlatTop is
  negative by design); documented the deliberate double-precision internal computation instead of
  constraining `T` (which would drop `decimal` support for no accuracy gain).
- **#27** (QR): already resolved as a side effect of the Householder rewrite done for pass2 #19 (PR
  #443) - added the specific regression test this item asked for (the classic
  Trefethen & Bau ill-conditioned example, verifying `Q^T Q` and `QR - A` stay accurate to
  machine precision without needing a re-orthogonalization pass).
- **#28** (eigenvalues) - ***NOT fixed***: caught in review. The TODO asked for an actual
  algorithmic fix (shifted QR with deflation after tridiagonal reduction) or at minimum returned
  convergence metadata; this PR only documents the limitation on `ComputeEigenvalues`'s XML remarks
  and adds a regression test that asserts the *failure* (an `InvalidOperationException`) on a
  clustered-eigenvalue matrix within the default iteration budget. The algorithm itself is
  unchanged. `TODO-2026-07-11-pass2.md` now marks this item explicitly as **NOT fixed - documented
  technical debt only**, and it should stay open until the algorithm is actually replaced. (An
  earlier revision of this PR also included a test running up to 1,000,000 QR iterations to show
  eventual convergence; that was removed as disproportionate for a unit test and misleading about
  what was actually accomplished.)
- **#29** (zero-dimensional consistency): `Identity`/`Zero`/`Diagonal` already rejected non-positive
  sizes; the raw `(rows, columns)` constructor and the `T[,]`/`T[][]` constructors previously did not,
  relying on the CLR's own inconsistent behavior for invalid array allocation. All matrix construction
  paths now enforce the same "no zero/negative-dimensioned matrices" policy.

## Test plan
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` passes after each item (local run only - no CI workflow is configured for this repo, so these results are not independently verifiable from GitHub checks)
- [x] Full suite green locally (3684 passed, 3 pre-existing ignored) after the last item
