### PR TITLE
Utils.Mathematics: implement real fix for TODO-pass2.md item #28 (shifted QR eigenvalues)

### DIFF
--- a/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
@@ -162,6 +162,16 @@ public sealed partial class Matrix<T>
                 throw new InvalidOperationException(
                     $"QR iteration did not converge after {maxIterations} iterations.");
 
+            // The deflation criterion only guarantees row/column m-1's off-diagonal coupling is within
+            // tolerance, not exactly zero, and this row/column is never read again: every later
+            // ExtractLeadingBlock/WriteLeadingBlock/WilkinsonShift/LastRowOffDiagonalNorm call is
+            // bounded to indices strictly less than the (now smaller) active size, and the returned
+            // eigenvalues/eigenvectors are built solely from `a`'s diagonal and from `v` (itself
+            // updated only from the active block's own Q, never from `a`'s frozen entries) - so this
+            // leftover residual cannot affect any later computation or the final output. Explicitly
+            // zeroing it here would therefore be inert busywork, not a correctness fix: verified
+            // empirically that doing so produces bit-identical Eigenvalues/Eigenvectors, including
+            // under a deliberately loosened convergenceTolerance and across multiple deflation stages.
             m--;
         }
 

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
@@ -15,17 +15,20 @@ public sealed partial class Matrix<T>
     /// Only real symmetric matrices are supported; all eigenvalues of such matrices are guaranteed real.
     /// Eigenvalues are returned in descending order of absolute value.
     /// <para>
-    /// <b>Known limitation - unshifted iteration:</b> this implementation repeatedly applies plain
-    /// <c>A ← R·Q</c> (from <c>A = Q·R</c>) with no spectral shift and no prior reduction to
-    /// tridiagonal form. This is simple and correct, but convergence is only linear and can become
-    /// very slow - potentially exhausting <paramref name="maxIterations"/> - when eigenvalues are
-    /// close in magnitude or clustered (the per-iteration convergence rate is governed by the ratio
-    /// of consecutive eigenvalue magnitudes). A production-grade implementation would use Wilkinson
-    /// shifts and deflation after a symmetric tridiagonal reduction, which converges cubically in the
-    /// typical case; that rewrite is out of scope here. If convergence fails for a matrix with
-    /// closely-spaced eigenvalues, increasing <paramref name="maxIterations"/> and/or relaxing
-    /// <paramref name="convergenceTolerance"/> are the available mitigations with the current
-    /// algorithm.
+    /// Uses the symmetric QR algorithm with a Wilkinson shift and deflation: each step shifts the
+    /// active (not-yet-deflated) leading submatrix by an estimate of the eigenvalue closest to its
+    /// trailing corner before applying <c>A ← R·Q</c>, which - unlike plain unshifted iteration -
+    /// gives locally cubic convergence and remains fast even for closely-spaced (clustered)
+    /// eigenvalues. Once the last row/column of the active submatrix decouples (goes to zero within
+    /// tolerance), that eigenvalue is locked in and the active submatrix shrinks by one, so later
+    /// eigenvalues do not have to pay for the cost of resolving earlier ones.
+    /// </para>
+    /// <para>
+    /// <b>Known limitation:</b> unlike a textbook implementation, this does not first reduce the
+    /// matrix to tridiagonal form, so each QR step still costs <c>O(m³)</c> for the current active
+    /// size <c>m</c> (via <see cref="DecomposeQR(T?)"/>) rather than the <c>O(m)</c> a tridiagonal
+    /// reduction would allow. This affects performance, not correctness or convergence rate: the
+    /// shift is still computed from (and applied to) the true active submatrix at each step.
     /// </para>
     /// </remarks>
     /// <param name="maxIterations">Maximum number of QR iterations before giving up. Must be greater than zero.</param>
@@ -95,35 +98,63 @@ public sealed partial class Matrix<T>
         T[,] v = new T[n, n];
         for (int i = 0; i < n; i++) v[i, i] = T.One;
 
-        for (int iter = 0; iter < maxIterations; iter++)
+        // Active-submatrix size: the leading m x m block of `a` still under iteration. Once the last
+        // row/column of that block decouples (its off-diagonal entries vanish within tolerance), the
+        // corresponding eigenvalue is already correct on the diagonal and the active size shrinks by
+        // one, so later (already-resolved) eigenvalues never have to be revisited.
+        int m = n;
+        int totalIterations = 0;
+        while (m > 1)
         {
-            if (OffDiagonalNorm(a, n) <= effectiveConvergenceTolerance) break;
-
-            // QR decompose the current A
-            var (q, r) = new Matrix<T>(a).DecomposeQR(rankTolerance);
-
-            // A ← R·Q  (this is A_{k+1} = R_k · Q_k)
-            a = (r * q).ToArray();
-
-            // V ← V·Q
-            T[,] newV = new T[n, n];
-            for (int i = 0; i < n; i++)
-                for (int j = 0; j < n; j++)
+            bool deflated = false;
+            for (; totalIterations < maxIterations; totalIterations++)
+            {
+                if (LastRowOffDiagonalNorm(a, m) <= effectiveConvergenceTolerance)
                 {
-                    T sum = T.Zero;
-                    for (int k = 0; k < n; k++) sum += v[i, k] * q[k, j];
-                    newV[i, j] = sum;
+                    deflated = true;
+                    break;
                 }
-            v = newV;
-        }
 
-        // Check convergence independently of loop-entry/last-iteration conditions, rather than
-        // only inside the loop's final pass: that tied the check to iter == maxIterations - 1,
-        // which never ran at all for maxIterations <= 0 (now rejected above regardless), and made
-        // the check easy to accidentally skip if the loop's control flow changed.
-        if (OffDiagonalNorm(a, n) > effectiveConvergenceTolerance)
-            throw new InvalidOperationException(
-                $"QR iteration did not converge after {maxIterations} iterations.");
+                // Wilkinson shift: an estimate of the eigenvalue of the trailing 2x2 block closest to
+                // its bottom-right corner. Shifting by (an estimate of) an eigenvalue makes A - shift*I
+                // nearly singular, which drives Householder QR to decouple the last row/column far
+                // faster than unshifted iteration - typically within a handful of steps per
+                // deflation, instead of a number of steps governed by how close consecutive
+                // eigenvalues are to each other.
+                T shift = WilkinsonShift(a, m);
+
+                for (int i = 0; i < m; i++) a[i, i] -= shift;
+
+                var (q, r) = new Matrix<T>(ExtractLeadingBlock(a, m)).DecomposeQR(rankTolerance);
+                T[,] qArray = q.ToArray();
+
+                // A_active ← R·Q + shift·I  (this is the shifted analogue of A_{k+1} = R_k · Q_k;
+                // adding the shift back preserves the eigenvalues of the *unshifted* active block).
+                WriteLeadingBlock(a, m, (r * q).ToArray());
+                for (int i = 0; i < m; i++) a[i, i] += shift;
+
+                // V[:, 0:m) ← V[:, 0:m) · Q  (columns m..n-1 are untouched: Q is block-diagonal with
+                // an implicit identity outside the active block).
+                T[,] newV = new T[n, n];
+                for (int i = 0; i < n; i++)
+                {
+                    for (int j = 0; j < m; j++)
+                    {
+                        T sum = T.Zero;
+                        for (int k = 0; k < m; k++) sum += v[i, k] * qArray[k, j];
+                        newV[i, j] = sum;
+                    }
+                    for (int j = m; j < n; j++) newV[i, j] = v[i, j];
+                }
+                v = newV;
+            }
+
+            if (!deflated)
+                throw new InvalidOperationException(
+                    $"QR iteration did not converge after {maxIterations} iterations.");
+
+            m--;
+        }
 
         // Extract eigenvalues from the diagonal
         T[] eigenvalues = new T[n];
@@ -180,13 +211,56 @@ public sealed partial class Matrix<T>
         return true;
     }
 
-    /// <summary>Frobenius norm of strictly off-diagonal elements of the working array.</summary>
-    private static T OffDiagonalNorm(T[,] a, int n)
+    /// <summary>
+    /// Norm of the off-diagonal entries of the last row of the leading <paramref name="m"/> x
+    /// <paramref name="m"/> active submatrix (equivalently, by symmetry, its last column). Used as the
+    /// deflation test: once this vanishes within tolerance, the active block's last row/column has
+    /// decoupled from the rest and <c>a[m-1, m-1]</c> is already a converged eigenvalue.
+    /// </summary>
+    private static T LastRowOffDiagonalNorm(T[,] a, int m)
     {
         T sum = T.Zero;
-        for (int i = 0; i < n; i++)
-            for (int j = 0; j < n; j++)
-                if (i != j) sum += a[i, j] * a[i, j];
+        for (int j = 0; j < m - 1; j++) sum += a[m - 1, j] * a[m - 1, j];
         return T.Sqrt(sum);
+    }
+
+    /// <summary>
+    /// Computes the Wilkinson shift for the active <paramref name="m"/> x <paramref name="m"/>
+    /// submatrix: the eigenvalue of its trailing 2x2 block closest to the block's bottom-right entry.
+    /// Shifting by (an estimate of) an eigenvalue of the active block drives that block's QR iteration
+    /// to converge locally cubically instead of only linearly.
+    /// </summary>
+    private static T WilkinsonShift(T[,] a, int m)
+    {
+        if (m < 2) return a[m - 1, m - 1];
+
+        T two = T.One + T.One;
+        T a11 = a[m - 2, m - 2];
+        T a12 = a[m - 2, m - 1];
+        T a22 = a[m - 1, m - 1];
+        T delta = (a11 - a22) / two;
+        T sign = delta >= T.Zero ? T.One : -T.One;
+        T denom = delta + sign * T.Sqrt(delta * delta + a12 * a12);
+        // denom is zero only when delta and a12 are both already zero, i.e. the trailing 2x2 block is
+        // already diagonal (a11 == a22, no coupling) - any shift works then, so fall back to a22.
+        return denom == T.Zero ? a22 : a22 - (a12 * a12) / denom;
+    }
+
+    /// <summary>Copies the leading <paramref name="size"/> x <paramref name="size"/> block of <paramref name="source"/>.</summary>
+    private static T[,] ExtractLeadingBlock(T[,] source, int size)
+    {
+        T[,] block = new T[size, size];
+        for (int i = 0; i < size; i++)
+            for (int j = 0; j < size; j++)
+                block[i, j] = source[i, j];
+        return block;
+    }
+
+    /// <summary>Writes <paramref name="block"/> back into the leading <paramref name="size"/> x <paramref name="size"/> region of <paramref name="destination"/>.</summary>
+    private static void WriteLeadingBlock(T[,] destination, int size, T[,] block)
+    {
+        for (int i = 0; i < size; i++)
+            for (int j = 0; j < size; j++)
+                destination[i, j] = block[i, j];
     }
 }

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Eigenvalues.cs
@@ -149,6 +149,15 @@ public sealed partial class Matrix<T>
                 v = newV;
             }
 
+            // The deflation check above runs BEFORE each step, not after the last permitted one, so
+            // a matrix that first reaches convergence exactly on the maxIterations-th step would
+            // otherwise exit the loop (budget exhausted) without ever re-checking that final state.
+            // Re-check independently here rather than trusting `deflated`'s value from inside the
+            // loop, matching the same "final check independent of loop-exit reason" fix already
+            // applied for the non-shifted algorithm this replaced.
+            if (!deflated && LastRowOffDiagonalNorm(a, m) <= effectiveConvergenceTolerance)
+                deflated = true;
+
             if (!deflated)
                 throw new InvalidOperationException(
                     $"QR iteration did not converge after {maxIterations} iterations.");

--- a/Utils.Mathematics/TODO-2026-07-11-pass2.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass2.md
@@ -193,18 +193,23 @@ The iteration repeatedly applies unshifted `A ← RQ`. Even for symmetric matric
 
 **Priority: P2 performance and stability.**
 
-**NOT fixed - documented technical debt only.** The algorithm itself is unchanged: still plain
-unshifted `A ← R·Q` with no tridiagonal reduction or Wilkinson shifts, and it still fails on the
-exact kind of input this item describes (see the regression test below, which asserts the
-`InvalidOperationException` rather than a converged result). A proper fix (shifted QR with deflation
-after symmetric tridiagonal reduction, converging cubically) would be a substantial algorithmic
-rewrite, judged out of proportion to implement as part of this audit pass. What was done instead:
-the limitation is now documented explicitly on `ComputeEigenvalues`'s XML remarks (previously it was
-undocumented), and a regression test locks in the failure mode on a concrete clustered-eigenvalue
-matrix so this limitation is visible and tracked rather than silent. This item should remain open
-until the algorithm is actually replaced. Test:
+**Fixed.** `ComputeEigenvalues` now uses a Wilkinson-shifted, deflating QR iteration instead of plain
+unshifted `A ← R·Q`: each step shifts the active (not-yet-deflated) leading submatrix by an estimate
+of the eigenvalue closest to its trailing corner (computed from the trailing 2x2 block) before
+applying the QR step, which gives locally cubic convergence instead of linear. Once the last
+row/column of the active submatrix decouples within tolerance, that eigenvalue is locked in and the
+active size shrinks by one, so later eigenvalues do not pay for the cost of resolving earlier ones.
+The matrix from the previous (failing) regression test - eigenvalues 1.0 and 1.0001, previously
+needing on the order of 250,000+ unshifted iterations and exhausting the default 1000-iteration
+budget - now converges within single-digit iterations.
+**Remaining, much smaller limitation:** unlike a textbook implementation, this does not first reduce
+the matrix to tridiagonal form, so each QR step still costs `O(m³)` for the active size `m` rather
+than the `O(m)` a tridiagonal reduction would allow - a performance gap, not a convergence-rate or
+correctness one, and it is documented as such on `ComputeEigenvalues`'s XML remarks. Test:
 `UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs`
-(`ComputeEigenvalues_ClusteredEigenvalues_FailsToConvergeWithinDefaultIterations`).
+(`ComputeEigenvalues_ClusteredEigenvalues_ConvergesWithinASmallIterationBudget`,
+`ComputeEigenvalues_MixOfWellSeparatedAndClusteredEigenvalues_ConvergesCorrectly` for multi-stage
+deflation).
 
 ### 29. Zero-dimensional behavior is inconsistent across vector and matrix factories
 
@@ -264,8 +269,9 @@ normalization, or homogeneous conversion with zero final coordinate.
 
 ## Status
 
-As of 2026-07-12: items 16–24 (P0/P1) are fixed. Of the P2 items, 25, 26, 27, and 29 are fixed or
-explicitly documented as a deliberate, adequate design decision. **Item #28 is NOT fixed** - its
-underlying algorithm is unchanged and still fails on the exact input class it describes; only
-documentation and a regression test locking in the current failure mode were added. See the note
-under each item above for specifics. PR references: items 16–24 in PR #443, items 25–29 in PR #445.
+All 14 findings in this file are resolved as of 2026-07-12: items 16–24 (P0/P1) are fixed, and items
+25–29 (P2) are fixed or explicitly documented as a deliberate, adequate design decision (see the note
+under each item above for specifics). Item #28 (unshifted QR iteration) was initially only documented
+without an algorithmic change, which review correctly flagged as an overstated "fixed" claim; it has
+since been genuinely fixed with a Wilkinson-shifted, deflating QR iteration. PR references: items
+16–24 in PR #443, items 25–29 in PR #445, item #28's actual algorithmic fix in a follow-up PR.

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
@@ -260,25 +260,59 @@ public class MatrixEigenvaluesTests
     }
 
     [TestMethod]
-    public void ComputeEigenvalues_ClusteredEigenvalues_FailsToConvergeWithinDefaultIterations()
+    public void ComputeEigenvalues_ClusteredEigenvalues_ConvergesWithinASmallIterationBudget()
     {
-        // Regression/documentation test for the unresolved "unshifted iteration converges slowly for
-        // clustered eigenvalues" limitation (TODO-pass2.md #28 - documented, NOT fixed: this
-        // implementation is still plain unshifted A <- R*Q with no tridiagonal reduction or Wilkinson
-        // shifts). M = R * diag(1.0, 1.0001) * R^T for a 45-degree rotation R has eigenvalues 1.0 and
-        // 1.0001 (ratio 0.9999...), which unshifted QR iteration approaches only linearly -
-        // convergence at this ratio needs on the order of hundreds of thousands of iterations, well
-        // past the default 1000-iteration budget. A "mitigation" test that actually runs enough
-        // iterations to converge (~250,000+) is deliberately not included here: it would inflate this
-        // test suite's runtime for no correctness value beyond what this failure-mode test already
-        // demonstrates. A real fix (shifted QR + tridiagonal reduction, converging cubically) is what
-        // would let a fast convergence test exist.
+        // Regression test for TODO-pass2.md #28, now actually fixed: ComputeEigenvalues previously
+        // used plain unshifted A <- R*Q, whose convergence rate is governed by the ratio between
+        // consecutive eigenvalues - for this matrix (eigenvalues 1.0 and 1.0001, ratio 0.9999...) that
+        // meant hundreds of thousands of iterations were needed, well past the default 1000-iteration
+        // budget, and the method threw. With a Wilkinson-shifted, deflating QR iteration, shifting by
+        // (an estimate of) an eigenvalue drives local convergence to cubic, so the same matrix now
+        // converges in a handful of iterations - verified here with a maxIterations budget far smaller
+        // than the default, let alone the ~250,000+ the old algorithm would have needed.
+        // M = R * diag(1.0, 1.0001) * R^T for a 45-degree rotation R.
         var m = new Matrix<double>(new double[,]
         {
             { 1.00005, 0.00005 },
             { 0.00005, 1.00005 },
         });
-        Assert.ThrowsException<InvalidOperationException>(() => m.ComputeEigenvalues());
+        var (values, _) = m.ComputeEigenvalues(maxIterations: 20);
+        Assert.AreEqual(1.0001, values[0], 1e-9);
+        Assert.AreEqual(1.0, values[1], 1e-9);
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_MixOfWellSeparatedAndClusteredEigenvalues_ConvergesCorrectly()
+    {
+        // Exercises multi-stage deflation: one well-separated eigenvalue (5) plus two clustered ones
+        // (1.0001, 1.0) coupled through a small off-diagonal block. Built as
+        // R * diag(5, 1.0001, 1.0) * R^T for a rotation R that only mixes the two close eigenvalues'
+        // subspace (indices 1, 2), leaving index 0 already decoupled. The outer active submatrix
+        // (size 3) must first deflate index 2 via iteration before the remaining 2x2 clustered block
+        // is resolved on its own.
+        var m = new Matrix<double>(new double[,]
+        {
+            { 5, 0, 0 },
+            { 0, 1.00005, -0.00005 },
+            { 0, -0.00005, 1.00005 },
+        });
+        var (values, vecs) = m.ComputeEigenvalues(maxIterations: 100);
+        Assert.AreEqual(5.0, values[0], 1e-9);
+        Assert.AreEqual(1.0001, values[1], 1e-9);
+        Assert.AreEqual(1.0, values[2], 1e-9);
+
+        var vtv = vecs.Transpose() * vecs;
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                Assert.AreEqual(i == j ? 1.0 : 0.0, vtv[i, j], 1e-9, $"V^T V [{i},{j}]");
+
+        for (int j = 0; j < 3; j++)
+        {
+            var v = new Vector<double>(vecs[0, j], vecs[1, j], vecs[2, j]);
+            var av = m * v;
+            for (int i = 0; i < 3; i++)
+                Assert.AreEqual(values[j] * v[i], av[i], 1e-8, $"Av=lambda*v failed at eigenpair {j}, component {i}");
+        }
     }
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixEigenvaluesTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Mathematics.LinearAlgebra;
 
@@ -277,6 +278,73 @@ public class MatrixEigenvaluesTests
             { 0.00005, 1.00005 },
         });
         var (values, _) = m.ComputeEigenvalues(maxIterations: 20);
+        Assert.AreEqual(1.0001, values[0], 1e-9);
+        Assert.AreEqual(1.0, values[1], 1e-9);
+    }
+
+    [TestMethod]
+    public void ComputeEigenvalues_ConvergesExactlyOnTheIterationItNeeds_NoOffByOne()
+    {
+        // Regression: the deflation check ran BEFORE each QR step but not after the last permitted
+        // one, so a matrix that first reached convergence exactly on the maxIterations-th step would
+        // exit the loop (budget exhausted) without the final state ever being re-checked, and
+        // incorrectly threw instead of succeeding.
+        //
+        // A naive "search upward for the smallest maxIterations that succeeds, then assert N-1
+        // fails" test would NOT catch this bug: under the buggy code the search simply finds a
+        // *different* minimal N (one step later than the true minimum, because the true minimum
+        // incorrectly fails and only gets caught as "already converged" on the *next* call's
+        // pre-step check), and "N-1 fails" still holds trivially for whatever N the search lands on
+        // - the assertion is tautological with respect to how the search is defined, in both the
+        // buggy and fixed code.
+        //
+        // Instead, this independently replicates the algorithm's shift/QR/deflation-check steps -
+        // via reflection into the same private helpers ComputeEigenvalues itself uses - to compute
+        // the true number of steps K this matrix needs external to ComputeEigenvalues's own
+        // pass/fail behavior, then asserts ComputeEigenvalues(K - 1) fails while
+        // ComputeEigenvalues(K) succeeds.
+        double[,] original =
+        {
+            { 1.00005, 0.00005 },
+            { 0.00005, 1.00005 },
+        };
+
+        const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Static;
+        var matrixType = typeof(Matrix<double>);
+        var lastRowOffDiagonalNorm = matrixType.GetMethod("LastRowOffDiagonalNorm", flags)!;
+        var wilkinsonShift = matrixType.GetMethod("WilkinsonShift", flags)!;
+        var maxAbsoluteEntry = matrixType.GetMethod("MaxAbsoluteEntry", flags)!;
+        var defaultTolerance = matrixType.GetMethod("DefaultTolerance", flags)!;
+
+        double scale = (double)maxAbsoluteEntry.Invoke(null, [original])!;
+        double tolerance = (double)defaultTolerance.Invoke(null, [scale, 2])!;
+
+        double[,] a = (double[,])original.Clone();
+        int steps = 0;
+        while ((double)lastRowOffDiagonalNorm.Invoke(null, [a, 2])! > tolerance)
+        {
+            double shift = (double)wilkinsonShift.Invoke(null, [a, 2])!;
+            a[0, 0] -= shift;
+            a[1, 1] -= shift;
+            var (q, r) = new Matrix<double>(a).DecomposeQR();
+            double[,] stepped = (r * q).ToArray();
+            stepped[0, 0] += shift;
+            stepped[1, 1] += shift;
+            a = stepped;
+            steps++;
+            Assert.IsTrue(steps <= 50, "Reference replication did not converge within 50 steps.");
+        }
+        Assert.IsTrue(steps >= 1, "Expected at least one step to be required for this matrix.");
+
+        var m = new Matrix<double>(original);
+        if (steps > 1)
+        {
+            Assert.ThrowsException<InvalidOperationException>(
+                () => m.ComputeEigenvalues(maxIterations: steps - 1),
+                $"maxIterations={steps - 1} should still be one step short of the {steps} steps this matrix needs.");
+        }
+
+        var (values, _) = m.ComputeEigenvalues(maxIterations: steps);
         Assert.AreEqual(1.0001, values[0], 1e-9);
         Assert.AreEqual(1.0, values[1], 1e-9);
     }


### PR DESCRIPTION
## Summary
Follow-up to PR #445, where review correctly flagged that item #28 (Eigenvalue QR iteration is unshifted and can converge very slowly) was marked resolved despite the algorithm itself being untouched - the PR had only added documentation and a regression test asserting the failure. This PR implements the actual algorithmic fix the TODO asked for.

### What changed
ComputeEigenvalues now uses the standard symmetric QR algorithm's shift + deflation strategy instead of plain unshifted A <- R*Q:
- Each step computes a Wilkinson shift from the trailing 2x2 block of the active (not-yet-deflated) leading submatrix - an estimate of the eigenvalue closest to that corner - and runs QR on the shifted submatrix. Shifting by an eigenvalue estimate makes the shifted matrix nearly singular, which drives local convergence from linear to cubic.
- Once the active submatrix's last row/column decouples (its off-diagonal entries vanish within tolerance), that eigenvalue is locked in and the active size shrinks by one (deflation), so later eigenvalues never pay for the cost of resolving earlier ones.
- maxIterations remains a shared budget across all deflation stages; failure to converge within budget still throws InvalidOperationException as before - this fix changes the convergence rate, not the failure-mode contract.

### Result
The clustered-eigenvalue matrix from the previous (failing) regression test - eigenvalues 1.0 and 1.0001, a ratio close enough to 1 that unshifted iteration needed on the order of 250,000+ iterations and exhausted the default 1000-iteration budget - now converges within single-digit iterations. That test is rewritten from asserting failure to asserting success within a 20-iteration budget (ComputeEigenvalues_ClusteredEigenvalues_ConvergesWithinASmallIterationBudget). A new test (ComputeEigenvalues_MixOfWellSeparatedAndClusteredEigenvalues_ConvergesCorrectly) verifies multi-stage deflation on a matrix mixing one well-separated eigenvalue with a clustered pair, checking both eigenvalues and eigenvector orthonormality/Av = lambda*v.

### Review round 2: off-by-one in the iteration budget (fixed)
A second review round caught a genuine bug in the deflation-budget bookkeeping: the deflation
check ran only before each QR step, never after the last permitted one. A matrix that first
converged exactly on the maxIterations-th step exited the loop (budget exhausted) without that
final state ever being re-checked, so it incorrectly threw InvalidOperationException instead of
succeeding - contradicting the "fails only when not converged within budget" contract.

Fixed by adding one more deflation check right after the inner loop exits, independent of whether
it broke on convergence or exhausted its budget - mirroring the same "final check independent of
loop-exit reason" pattern item #20's original fix already established, which this rewrite had
regressed.

The regression test added for this deliberately avoids a "search upward for the smallest
maxIterations that succeeds, then assert N-1 fails" design, since that assertion turned out to be
tautological by construction (whatever N the search lands on, N-1 necessarily failed in the search
itself, in both the buggy and fixed code - it does not actually distinguish the two, and an earlier
draft of this fix's test suffered exactly this flaw before being caught and rewritten). Instead,
ComputeEigenvalues_ConvergesExactlyOnTheIterationItNeeds_NoOffByOne independently replicates the
algorithm's shift/QR/deflation-check steps - via reflection into the same private helpers
ComputeEigenvalues uses - to compute the true number of steps K a clustered-eigenvalue matrix needs,
external to ComputeEigenvalues's own pass/fail behavior, then asserts ComputeEigenvalues(K) succeeds
(and ComputeEigenvalues(K - 1) fails, when K > 1). Verified this test fails against the pre-fix code
(K = 1 for this matrix, exactly where the bug bites) and passes against the fix.

### Review round 3: deflated residuals left unzeroed (investigated, no change needed)
A third review round suggested explicitly zeroing a deflated row/column's small residual
off-diagonal entries in the working matrix, worried that leaving them could let A*v - lambda*v
degrade across multiple deflations or under a loosened convergenceTolerance.

Investigated by implementing the suggested zeroing and comparing output bit-for-bit with and
without it: for a case where deflation happens with zero QR iterations (loose tolerance) and one
requiring several real iterations across multiple deflation stages (moderate tolerance, 3x3 matrix
mixing a well-separated and a clustered eigenvalue pair), output (Eigenvalues and Eigenvectors) was
identical in every case. This matches the code's data flow: once a row/column is deflated, every
later step (ExtractLeadingBlock/WriteLeadingBlock/WilkinsonShift/LastRowOffDiagonalNorm) is bounded
to indices strictly less than the shrunk active size, so the frozen entries are never read again -
the returned eigenvalues come solely from the diagonal (unaffected by off-diagonal zeroing) and the
returned eigenvectors come solely from the accumulated Q's (never from the frozen entries). The
"leaked" residual is real, but it reflects when the algorithm chose to stop refining (governed by
the tolerance actually used at that deflation), not something the internal bookkeeping's zeroing
state changes. No functional change was made; a comment now records this so the question doesn't
need re-investigating from scratch in a future review.

### Remaining, smaller limitation
Unlike a textbook implementation, this does not first reduce the matrix to tridiagonal form, so each QR step still costs O(m^3) for the active size m (via the existing Householder DecomposeQR) rather than the O(m) a tridiagonal reduction would allow. That's a performance gap, not a convergence-rate or correctness one, and it's documented on ComputeEigenvalues's XML remarks and in TODO-2026-07-11-pass2.md.

TODO-2026-07-11-pass2.md item #28 and its Status section are updated to reflect this as genuinely fixed.

## Test plan
- [x] dotnet test UtilsTest/UtilsTest.Unit.csproj --filter FullyQualifiedName~MatrixEigenvaluesTests - all pass (26/26), including all pre-existing eigenvalue/symmetry/tolerance tests unaffected by the algorithm change
- [x] Full suite green locally (3686 passed, 3 pre-existing ignored) after every fix in this PR
- **Note:** all test results in this PR are from local dotnet test runs only. No CI workflow is configured for this repository, so there is no GitHub check/status to independently verify these numbers from.
