### PR TITLE
Utils.Mathematics: address TODO-pass3.md findings

### DIFF
--- a/Utils.Mathematics/Expressions/ExpressionDerivation.cs
+++ b/Utils.Mathematics/Expressions/ExpressionDerivation.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Numerics;
 using Utils.Expressions;
+using Utils.Objects;
 
 namespace Utils.Mathematics.Expressions;
 #pragma warning disable CS8604
@@ -140,33 +141,73 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     }
 
     /// <summary>
-    /// Ignores conversion wrappers by differentiating the wrapped operand directly.
+    /// Differentiates the wrapped operand and re-applies the conversion's declared result type when the
+    /// derivative's type does not already match it, so the derivative expression stays type-consistent
+    /// with the original conversion node.
     /// </summary>
     /// <param name="e">Conversion expression to transform.</param>
     /// <param name="operand">Wrapped expression operand.</param>
-    /// <returns>The derivative of the wrapped operand.</returns>
+    /// <returns>The derivative of the wrapped operand, converted back to <c>e.Type</c> if needed.</returns>
     [ExpressionSignature(ExpressionType.Convert)]
     protected Expression Convert(
         UnaryExpression e,
         Expression operand
     )
     {
-        return Transform(operand);
+        return PreserveConversion(e, Transform(operand), isChecked: false);
     }
 
     /// <summary>
-    /// Ignores checked conversion wrappers by differentiating the wrapped operand directly.
+    /// Differentiates the wrapped operand through a checked conversion. Checked conversions exist
+    /// specifically to guard against narrowing/overflow, which has no well-defined symbolic derivative;
+    /// only a trivial same-type checked conversion is passed through, anything else is rejected instead
+    /// of silently stripped.
     /// </summary>
     /// <param name="e">Checked conversion expression to transform.</param>
     /// <param name="operand">Wrapped expression operand.</param>
-    /// <returns>The derivative of the wrapped operand.</returns>
+    /// <returns>The derivative of the wrapped operand when the checked conversion is a same-type no-op.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the checked conversion actually changes the type (a narrowing or otherwise
+    /// non-trivial conversion), since differentiating through it is not well-defined.
+    /// </exception>
     [ExpressionSignature(ExpressionType.ConvertChecked)]
     protected Expression ConvertChecked(
         UnaryExpression e,
         Expression operand
     )
     {
-        return Transform(operand);
+        return PreserveConversion(e, Transform(operand), isChecked: true);
+    }
+
+    /// <summary>
+    /// Reconciles the type of a transformed derivative with the declared result type of the original
+    /// conversion node it replaces.
+    /// </summary>
+    /// <param name="original">The original <c>Convert</c>/<c>ConvertChecked</c> expression being replaced.</param>
+    /// <param name="transformedOperand">The already-differentiated operand.</param>
+    /// <param name="isChecked"><see langword="true"/> for <c>ConvertChecked</c>; <see langword="false"/> for <c>Convert</c>.</param>
+    /// <returns><paramref name="transformedOperand"/>, converted back to <c>original.Type</c> if needed.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the types differ and the conversion is either checked (narrowing/overflow-prone) or
+    /// not a recognized numeric-to-numeric widening.
+    /// </exception>
+    private static Expression PreserveConversion(UnaryExpression original, Expression transformedOperand, bool isChecked)
+    {
+        if (transformedOperand.Type == original.Type)
+        {
+            return transformedOperand;
+        }
+
+        if (!isChecked
+            && NumberUtils.IsNativeNumericType(transformedOperand.Type)
+            && NumberUtils.IsNativeNumericType(original.Type))
+        {
+            return Expression.Convert(transformedOperand, original.Type);
+        }
+
+        throw new NotSupportedException(
+            $"Cannot preserve the {(isChecked ? "checked " : string.Empty)}conversion from '{transformedOperand.Type}' " +
+            $"to '{original.Type}': only same-type conversions and unchecked numeric widenings are supported.");
     }
 
     /// <summary>

--- a/Utils.Mathematics/Expressions/ExpressionDerivation.cs
+++ b/Utils.Mathematics/Expressions/ExpressionDerivation.cs
@@ -12,12 +12,50 @@ namespace Utils.Mathematics.Expressions;
 /// </summary>
 public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloatingPoint<T>
 {
-    private static readonly double FiniteDifferenceEpsilon = typeof(T) == typeof(float) ? 1e-4 : 1e-7;
+    /// <summary>
+    /// Smallest positive value such that <c>1 + MachineEpsilon != 1</c> for <typeparamref name="T"/>,
+    /// computed generically (rather than hard-coded per type) so the finite-difference fallback step
+    /// (see <see cref="FiniteDifferenceStepBase"/>) scales correctly with <typeparamref name="T"/>'s own
+    /// precision instead of only special-casing <see cref="float"/>.
+    /// </summary>
+    private static readonly T MachineEpsilon = ComputeMachineEpsilon();
+
+    /// <summary>
+    /// Base step size for the centered finite-difference fallback (see <see cref="DeriveUnknownMethodCall"/>),
+    /// equal to <c>MachineEpsilon^(1/3)</c> — the standard step that balances truncation error (which
+    /// grows with the step) against floating-point rounding error (which grows as the step shrinks) for
+    /// a centered difference. The actual per-call step additionally scales with the operand's own
+    /// magnitude at evaluation time (see <see cref="DeriveUnknownMethodCall"/>).
+    /// </summary>
+    private static readonly T FiniteDifferenceStepBase =
+        T.CreateChecked(Math.Pow(System.Convert.ToDouble(MachineEpsilon), 1.0 / 3.0));
+
+    private static T ComputeMachineEpsilon()
+    {
+        T two = T.One + T.One;
+        T eps = T.One;
+        while (T.One + eps / two != T.One)
+        {
+            eps /= two;
+        }
+        return eps;
+    }
 
     /// <summary>
     /// Gets the name of the parameter that will be considered the differentiation variable.
     /// </summary>
     public string ParameterName { get; }
+
+    /// <summary>
+    /// Gets whether unknown single-argument methods (with no registered symbolic derivative rule) may be
+    /// differentiated through a centered finite-difference approximation (see
+    /// <see cref="DeriveUnknownMethodCall"/>) instead of failing with <see cref="NotSupportedException"/>.
+    /// This is opt-in and defaults to <see langword="false"/>, since the fallback turns an exact symbolic
+    /// derivation into a numerical runtime approximation that evaluates the source method twice per
+    /// derivative evaluation — only enable it for methods known to be pure (no side effects) and
+    /// reasonably smooth near the evaluation point.
+    /// </summary>
+    public bool AllowNumericalFallback { get; }
 
     /// <summary>
     /// The specific <see cref="ParameterExpression"/> instance, resolved once per <see cref="Derivate"/>
@@ -39,7 +77,12 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// Initializes a new instance of the <see cref="ExpressionDerivation{T}"/> class for the specified parameter.
     /// </summary>
     /// <param name="parameterName">Name of the variable with respect to which derivatives are computed.</param>
-    public ExpressionDerivation(string parameterName) : this(parameterName, null!)
+    /// <param name="allowNumericalFallback">
+    /// See <see cref="AllowNumericalFallback"/>. Defaults to <see langword="false"/>: unknown methods
+    /// fail explicitly instead of silently falling back to a numerical approximation.
+    /// </param>
+    public ExpressionDerivation(string parameterName, bool allowNumericalFallback = false)
+        : this(parameterName, null!, allowNumericalFallback)
     {
     }
 
@@ -51,10 +94,12 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// The specific resolved <see cref="ParameterExpression"/> instance, or <see langword="null"/> for
     /// the publicly-constructed instance that has not yet performed a <see cref="Derivate"/> call.
     /// </param>
-    private ExpressionDerivation(string parameterName, ParameterExpression targetParameter)
+    /// <param name="allowNumericalFallback">See <see cref="AllowNumericalFallback"/>.</param>
+    private ExpressionDerivation(string parameterName, ParameterExpression targetParameter, bool allowNumericalFallback)
     {
         this.ParameterName = parameterName;
         this.targetParameter = targetParameter;
+        this.AllowNumericalFallback = allowNumericalFallback;
     }
 
     /// <summary>
@@ -86,7 +131,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
         // A fresh worker instance isolates the resolved target parameter for this call: concurrent or
         // re-entrant calls on the same public ExpressionDerivation<T> instance no longer share mutable
         // state (see TODO-2026-07-11-pass3.md items #31 and #32).
-        var worker = new ExpressionDerivation<T>(ParameterName, candidates[0]);
+        var worker = new ExpressionDerivation<T>(ParameterName, candidates[0], AllowNumericalFallback);
         return Expression.Lambda(worker.Transform(e.Body.Simplify()).Simplify(), e.Parameters);
     }
 
@@ -494,6 +539,11 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// <param name="methodCallExpression">Method call to derive.</param>
     /// <param name="parameters">Prepared arguments for the call.</param>
     /// <returns>The derivative expression using centered finite difference.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when no symbolic derivative rule matches <paramref name="methodCallExpression"/>'s method,
+    /// and either its signature does not match the required single-argument <typeparamref name="T"/>
+    /// shape, or <see cref="AllowNumericalFallback"/> is <see langword="false"/> (the default).
+    /// </exception>
     private Expression DeriveUnknownMethodCall(MethodCallExpression methodCallExpression, Expression[] parameters)
     {
         if (methodCallExpression.Method.ReturnType != typeof(T)
@@ -503,14 +553,30 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
             throw new NotSupportedException($"No derivative rule is registered for '{methodCallExpression.Method}'.");
         }
 
+        if (!AllowNumericalFallback)
+        {
+            throw new NotSupportedException(
+                $"No symbolic derivative rule is registered for '{methodCallExpression.Method}'. " +
+                $"A centered finite-difference approximation is available but must be explicitly enabled " +
+                $"via '{nameof(AllowNumericalFallback)}' (only do so for a pure, reasonably smooth method, " +
+                "since it will be evaluated twice per derivative evaluation).");
+        }
+
         Expression operand = parameters[0];
         if (!ContainsParameter(operand))
         {
             return ExpressionEx.CreateConstant(T.CreateChecked(0d));
         }
 
-        var epsilon = ExpressionEx.CreateConstant(T.CreateChecked(FiniteDifferenceEpsilon));
-        var twoEpsilon = ExpressionEx.CreateConstant(T.CreateChecked(2.0 * FiniteDifferenceEpsilon));
+        // Scale-aware step: FiniteDifferenceStepBase (~MachineEpsilon^(1/3)) scaled by the operand's own
+        // magnitude at evaluation time, so the step neither underflows relative to a large operand nor
+        // overshoots relative to a small one.
+        var stepBase = ExpressionEx.CreateConstant(FiniteDifferenceStepBase);
+        var operandMagnitude = Expression.Call(MathMethodResolver.ResolveBinary<T>(nameof(double.Max)),
+            Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Abs)), operand),
+            ExpressionEx.CreateConstant(T.One));
+        var epsilon = Expression.Multiply(stepBase, operandMagnitude);
+        var twoEpsilon = Expression.Multiply(ExpressionEx.CreateConstant(T.CreateChecked(2d)), epsilon);
         var operandDerivative = Transform(operand);
 
         var plus = Expression.Call(methodCallExpression.Method, Expression.Add(operand, epsilon));
@@ -551,8 +617,9 @@ public class ExpressionDerivation : ExpressionDerivation<double>
     /// Initializes a new instance of the <see cref="ExpressionDerivation"/> class.
     /// </summary>
     /// <param name="parameterName">Name of the variable with respect to which derivatives are computed.</param>
-    public ExpressionDerivation(string parameterName)
-        : base(parameterName)
+    /// <param name="allowNumericalFallback">See <see cref="ExpressionDerivation{T}.AllowNumericalFallback"/>.</param>
+    public ExpressionDerivation(string parameterName, bool allowNumericalFallback = false)
+        : base(parameterName, allowNumericalFallback)
     {
     }
 }

--- a/Utils.Mathematics/Expressions/ExpressionDerivation.cs
+++ b/Utils.Mathematics/Expressions/ExpressionDerivation.cs
@@ -19,12 +19,41 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     public string ParameterName { get; }
 
     /// <summary>
+    /// The specific <see cref="ParameterExpression"/> instance, resolved once per <see cref="Derivate"/>
+    /// call, that identifies the differentiation variable by reference rather than by name. Two distinct
+    /// <see cref="ParameterExpression"/> objects may legally share the same <see cref="ParameterName"/>
+    /// (e.g. an unrelated captured variable); comparing by reference instead of by name avoids treating
+    /// such a foreign parameter as the differentiation variable. Set once, in the private constructor, on
+    /// a fresh per-call worker instance (see <see cref="Derivate"/>).
+    /// </summary>
+    private readonly ParameterExpression targetParameter;
+
+    /// <summary>
+    /// Determines whether <paramref name="candidate"/> is the specific parameter instance resolved as
+    /// the differentiation variable for the current call.
+    /// </summary>
+    private bool IsTargetParameter(ParameterExpression candidate) => ReferenceEquals(candidate, targetParameter);
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ExpressionDerivation{T}"/> class for the specified parameter.
     /// </summary>
     /// <param name="parameterName">Name of the variable with respect to which derivatives are computed.</param>
-    public ExpressionDerivation(string parameterName)
+    public ExpressionDerivation(string parameterName) : this(parameterName, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a per-call worker instance with its target parameter already resolved.
+    /// </summary>
+    /// <param name="parameterName">Name of the variable with respect to which derivatives are computed.</param>
+    /// <param name="targetParameter">
+    /// The specific resolved <see cref="ParameterExpression"/> instance, or <see langword="null"/> for
+    /// the publicly-constructed instance that has not yet performed a <see cref="Derivate"/> call.
+    /// </param>
+    private ExpressionDerivation(string parameterName, ParameterExpression targetParameter)
     {
         this.ParameterName = parameterName;
+        this.targetParameter = targetParameter;
     }
 
     /// <summary>
@@ -32,10 +61,32 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// </summary>
     /// <param name="e">Lambda expression to differentiate.</param>
     /// <returns>The simplified derivative expression.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no parameter named <see cref="ParameterName"/> is found in <paramref name="e"/>, or
+    /// when more than one distinct parameter shares that name (an ambiguous match that cannot be
+    /// resolved by name alone).
+    /// </exception>
     public Expression Derivate(LambdaExpression e)
     {
         ArgumentNullException.ThrowIfNull(e);
-        return Expression.Lambda(Transform(e.Body.Simplify()).Simplify(), e.Parameters);
+
+        var candidates = e.Parameters.Where(p => p.Name == ParameterName).ToList();
+        if (candidates.Count == 0)
+        {
+            throw new InvalidOperationException($"The parameter '{ParameterName}' was not found in the lambda expression.");
+        }
+        if (candidates.Count > 1)
+        {
+            throw new InvalidOperationException(
+                $"The lambda expression declares {candidates.Count} distinct parameters named '{ParameterName}'; " +
+                "the differentiation variable is ambiguous. Use distinct parameter names.");
+        }
+
+        // A fresh worker instance isolates the resolved target parameter for this call: concurrent or
+        // re-entrant calls on the same public ExpressionDerivation<T> instance no longer share mutable
+        // state (see TODO-2026-07-11-pass3.md items #31 and #32).
+        var worker = new ExpressionDerivation<T>(ParameterName, candidates[0]);
+        return Expression.Lambda(worker.Transform(e.Body.Simplify()).Simplify(), e.Parameters);
     }
 
     /// <summary>
@@ -63,7 +114,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
         ParameterExpression e
     )
     {
-        if (e.Name == ParameterName)
+        if (IsTargetParameter(e))
         {
             return ExpressionEx.CreateConstant(T.CreateChecked(1d));
         }
@@ -427,7 +478,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     {
         return expression switch
         {
-            ParameterExpression parameterExpression => parameterExpression.Name == ParameterName,
+            ParameterExpression parameterExpression => IsTargetParameter(parameterExpression),
             UnaryExpression unaryExpression => ContainsParameter(unaryExpression.Operand),
             BinaryExpression binaryExpression => ContainsParameter(binaryExpression.Left) || ContainsParameter(binaryExpression.Right),
             MethodCallExpression methodCallExpression => methodCallExpression.Arguments.Any(ContainsParameter),

--- a/Utils.Mathematics/Expressions/ExpressionDerivation.cs
+++ b/Utils.Mathematics/Expressions/ExpressionDerivation.cs
@@ -321,6 +321,16 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// <param name="left">Base expression.</param>
     /// <param name="right">Exponent expression.</param>
     /// <returns>The derivative computed through logarithmic differentiation.</returns>
+    /// <remarks>
+    /// Logarithmic differentiation of <c>f(x)^g(x)</c> requires <c>f(x) &gt; 0</c>: this is not an
+    /// artificial narrowing introduced by using <c>Log(f)</c> here, since the original expression itself
+    /// is already only real-valued (rather than <see cref="double.NaN"/>) for a negative base when the
+    /// exponent is non-integer, and the exponent is a general (non-constant) expression here. Unlike the
+    /// integration rules for <c>1/x</c> or <c>tan(x)</c> (which use <c>Log(Abs(x))</c> because the
+    /// original expressions they replace remain well-defined for negative inputs), replacing
+    /// <c>Log(f)</c> with <c>Log(Abs(f))</c> here would not extend the domain of a valid symbolic
+    /// derivative — it would just produce a different, unrelated formula.
+    /// </remarks>
     [ExpressionSignature(ExpressionType.Power)]
     protected Expression Power(
         BinaryExpression e,

--- a/Utils.Mathematics/Expressions/ExpressionDerivation.cs
+++ b/Utils.Mathematics/Expressions/ExpressionDerivation.cs
@@ -58,14 +58,23 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     public bool AllowNumericalFallback { get; }
 
     /// <summary>
-    /// The specific <see cref="ParameterExpression"/> instance, resolved once per <see cref="Derivate"/>
+    /// The specific <see cref="ParameterExpression"/> instance, resolved once per <see cref="Derivate(LambdaExpression)"/>
     /// call, that identifies the differentiation variable by reference rather than by name. Two distinct
     /// <see cref="ParameterExpression"/> objects may legally share the same <see cref="ParameterName"/>
     /// (e.g. an unrelated captured variable); comparing by reference instead of by name avoids treating
     /// such a foreign parameter as the differentiation variable. Set once, in the private constructor, on
-    /// a fresh per-call worker instance (see <see cref="Derivate"/>).
+    /// a fresh per-call worker instance (see <see cref="Derivate(LambdaExpression)"/>).
     /// </summary>
     private readonly ParameterExpression targetParameter;
+
+    /// <summary>
+    /// Set when <see cref="DeriveUnknownMethodCall"/> actually builds a finite-difference approximation
+    /// for at least one sub-expression during this worker's single <see cref="Derivate(LambdaExpression)"/>
+    /// call, so that call can report <c>isExact = false</c> (see item #42). Safe as plain mutable state:
+    /// each call uses its own freshly-constructed worker instance (see items #31/#32), never shared or
+    /// reused across calls.
+    /// </summary>
+    private bool usedNumericalFallback;
 
     /// <summary>
     /// Determines whether <paramref name="candidate"/> is the specific parameter instance resolved as
@@ -92,7 +101,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// <param name="parameterName">Name of the variable with respect to which derivatives are computed.</param>
     /// <param name="targetParameter">
     /// The specific resolved <see cref="ParameterExpression"/> instance, or <see langword="null"/> for
-    /// the publicly-constructed instance that has not yet performed a <see cref="Derivate"/> call.
+    /// the publicly-constructed instance that has not yet performed a <see cref="Derivate(LambdaExpression)"/> call.
     /// </param>
     /// <param name="allowNumericalFallback">See <see cref="AllowNumericalFallback"/>.</param>
     private ExpressionDerivation(string parameterName, ParameterExpression targetParameter, bool allowNumericalFallback)
@@ -112,7 +121,27 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// when more than one distinct parameter shares that name (an ambiguous match that cannot be
     /// resolved by name alone).
     /// </exception>
-    public Expression Derivate(LambdaExpression e)
+    public Expression Derivate(LambdaExpression e) => Derivate(e, out _);
+
+    /// <summary>
+    /// Builds the derivative of the provided lambda expression with respect to the configured parameter,
+    /// additionally reporting whether the result is an exact symbolic derivative or includes at least one
+    /// finite-difference approximation.
+    /// </summary>
+    /// <param name="e">Lambda expression to differentiate.</param>
+    /// <param name="isExact">
+    /// <see langword="true"/> when every part of the result was produced by an exact symbolic rule;
+    /// <see langword="false"/> when at least one sub-expression fell back to the numerical
+    /// finite-difference approximation (only possible when <see cref="AllowNumericalFallback"/> is
+    /// <see langword="true"/>, since otherwise an unknown method throws instead of approximating).
+    /// </param>
+    /// <returns>The simplified derivative expression.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no parameter named <see cref="ParameterName"/> is found in <paramref name="e"/>, or
+    /// when more than one distinct parameter shares that name (an ambiguous match that cannot be
+    /// resolved by name alone).
+    /// </exception>
+    public Expression Derivate(LambdaExpression e, out bool isExact)
     {
         ArgumentNullException.ThrowIfNull(e);
 
@@ -130,9 +159,12 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
 
         // A fresh worker instance isolates the resolved target parameter for this call: concurrent or
         // re-entrant calls on the same public ExpressionDerivation<T> instance no longer share mutable
-        // state (see TODO-2026-07-11-pass3.md items #31 and #32).
+        // state (see TODO-2026-07-11-pass3.md items #31 and #32). usedNumericalFallback is likewise
+        // scoped to this single worker instance, never shared across calls (see item #42).
         var worker = new ExpressionDerivation<T>(ParameterName, candidates[0], AllowNumericalFallback);
-        return Expression.Lambda(worker.Transform(e.Body.Simplify()).Simplify(), e.Parameters);
+        var result = Expression.Lambda(worker.Transform(e.Body.Simplify()).Simplify(), e.Parameters);
+        isExact = !worker.usedNumericalFallback;
+        return result;
     }
 
     /// <summary>
@@ -567,6 +599,8 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
         {
             return ExpressionEx.CreateConstant(T.CreateChecked(0d));
         }
+
+        usedNumericalFallback = true;
 
         // Scale-aware step: FiniteDifferenceStepBase (~MachineEpsilon^(1/3)) scaled by the operand's own
         // magnitude at evaluation time, so the step neither underflows relative to a large operand nor

--- a/Utils.Mathematics/Expressions/ExpressionDerivation.cs
+++ b/Utils.Mathematics/Expressions/ExpressionDerivation.cs
@@ -246,7 +246,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
                     Expression.Multiply(
                         left,
                         Expression.Multiply(
-                            Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]), left),
+                            Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), left),
                             Transform(right)
                         )
                     )
@@ -269,7 +269,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
         return
             Expression.Multiply(
                 Transform(operand),
-                Expression.Call(typeof(T).GetMethod(nameof(double.Exp), [typeof(T)]), operand)
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Exp)), operand)
             );
     }
 
@@ -323,7 +323,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     {
         return Expression.Multiply(
             Transform(operand),
-            Expression.Call(typeof(T).GetMethod(nameof(double.Cos), [typeof(T)]), operand));
+            Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), operand));
     }
 
     /// <summary>
@@ -340,7 +340,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
         return Expression.Negate(
             Expression.Multiply(
             Transform(operand),
-            Expression.Call(typeof(T).GetMethod(nameof(double.Sin), [typeof(T)]), operand)));
+            Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Sin)), operand)));
     }
 
     /// <summary>
@@ -359,7 +359,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
         return Expression.Divide(
             Transform(operand),
             Expression.Power(
-                Expression.Call(typeof(T).GetMethod(nameof(double.Cos), [typeof(T)]), operand),
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), operand),
                 ExpressionEx.CreateConstant(T.CreateChecked(2d))
             )
         );

--- a/Utils.Mathematics/Expressions/ExpressionDerivation.cs
+++ b/Utils.Mathematics/Expressions/ExpressionDerivation.cs
@@ -266,7 +266,9 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// <returns><paramref name="transformedOperand"/>, converted back to <c>original.Type</c> if needed.</returns>
     /// <exception cref="NotSupportedException">
     /// Thrown when the types differ and the conversion is either checked (narrowing/overflow-prone) or
-    /// not a recognized numeric-to-numeric widening.
+    /// not a recognized numeric widening (see <see cref="NumberUtils.IsWideningNumericConversion"/>) —
+    /// this notably rejects reducing conversions such as <c>double</c> to <c>float</c> or <c>double</c>
+    /// to <c>int</c>, which have no well-defined symbolic derivative.
     /// </exception>
     private static Expression PreserveConversion(UnaryExpression original, Expression transformedOperand, bool isChecked)
     {
@@ -275,9 +277,7 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
             return transformedOperand;
         }
 
-        if (!isChecked
-            && NumberUtils.IsNativeNumericType(transformedOperand.Type)
-            && NumberUtils.IsNativeNumericType(original.Type))
+        if (!isChecked && NumberUtils.IsWideningNumericConversion(transformedOperand.Type, original.Type))
         {
             return Expression.Convert(transformedOperand, original.Type);
         }
@@ -622,20 +622,43 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
 
     /// <summary>
     /// Determines whether an expression depends on the configured differentiation parameter.
+    /// Walks the entire expression tree (via <see cref="ParameterUsageVisitor"/>) rather than a
+    /// hand-picked subset of node kinds, so dependencies hidden inside e.g. a conditional, a member
+    /// access, a <c>new</c> expression, or an indexer are not mistaken for a constant.
     /// </summary>
     /// <param name="expression">Expression to inspect.</param>
     /// <returns><see langword="true"/> when the expression depends on the target parameter; otherwise <see langword="false"/>.</returns>
     private bool ContainsParameter(Expression expression)
     {
-        return expression switch
+        var visitor = new ParameterUsageVisitor(targetParameter);
+        visitor.Visit(expression);
+        return visitor.Found;
+    }
+
+    /// <summary>
+    /// Visits every node of an expression tree looking for a specific <see cref="ParameterExpression"/>
+    /// instance, matched by reference identity (see <see cref="IsTargetParameter"/>) rather than by name.
+    /// </summary>
+    /// <param name="target">The parameter instance to search for.</param>
+    private sealed class ParameterUsageVisitor(ParameterExpression target) : ExpressionVisitor
+    {
+        /// <summary>
+        /// Gets whether the target parameter was found during the last <see cref="Visit(Expression?)"/> call.
+        /// </summary>
+        public bool Found { get; private set; }
+
+        /// <inheritdoc/>
+        public override Expression? Visit(Expression? node) => Found || node is null ? node : base.Visit(node);
+
+        /// <inheritdoc/>
+        protected override Expression VisitParameter(ParameterExpression node)
         {
-            ParameterExpression parameterExpression => IsTargetParameter(parameterExpression),
-            UnaryExpression unaryExpression => ContainsParameter(unaryExpression.Operand),
-            BinaryExpression binaryExpression => ContainsParameter(binaryExpression.Left) || ContainsParameter(binaryExpression.Right),
-            MethodCallExpression methodCallExpression => methodCallExpression.Arguments.Any(ContainsParameter),
-            InvocationExpression invocationExpression => invocationExpression.Arguments.Any(ContainsParameter),
-            _ => false
-        };
+            if (ReferenceEquals(node, target))
+            {
+                Found = true;
+            }
+            return node;
+        }
     }
 
 }

--- a/Utils.Mathematics/Expressions/ExpressionIntegration.cs
+++ b/Utils.Mathematics/Expressions/ExpressionIntegration.cs
@@ -162,7 +162,9 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     /// <returns><paramref name="transformedOperand"/>, converted back to <c>original.Type</c> if needed.</returns>
     /// <exception cref="NotSupportedException">
     /// Thrown when the types differ and the conversion is either checked (narrowing/overflow-prone) or
-    /// not a recognized numeric-to-numeric widening.
+    /// not a recognized numeric widening (see <see cref="NumberUtils.IsWideningNumericConversion"/>) —
+    /// this notably rejects reducing conversions such as <c>double</c> to <c>float</c> or <c>double</c>
+    /// to <c>int</c>, which have no well-defined symbolic integral.
     /// </exception>
     private static Expression PreserveConversion(UnaryExpression original, Expression transformedOperand, bool isChecked)
     {
@@ -171,9 +173,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return transformedOperand;
         }
 
-        if (!isChecked
-            && NumberUtils.IsNativeNumericType(transformedOperand.Type)
-            && NumberUtils.IsNativeNumericType(original.Type))
+        if (!isChecked && NumberUtils.IsWideningNumericConversion(transformedOperand.Type, original.Type))
         {
             return Expression.Convert(transformedOperand, original.Type);
         }

--- a/Utils.Mathematics/Expressions/ExpressionIntegration.cs
+++ b/Utils.Mathematics/Expressions/ExpressionIntegration.cs
@@ -240,7 +240,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         if (right.Name != ParameterName) return null;
         return Expression.Multiply(
                 left,
-                Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]), right)
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), right)
             );
     }
 
@@ -266,7 +266,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         ConstantExpression numericLeft = Expression.Constant(System.Convert.ToDouble(constant.Value));
         return Expression.Multiply(
             numericLeft,
-            Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]), right)
+            Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), right)
         );
     }
 
@@ -306,7 +306,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         {
             return Expression.Multiply(
                 left,
-                Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]), p)
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), p)
             );
         }
 
@@ -359,7 +359,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             double factor = 2.0 * System.Convert.ToDouble(left.Value);
             return Expression.Multiply(
                 Expression.Constant(factor),
-                Expression.Call(typeof(T).GetMethod(nameof(double.Sqrt), [typeof(T)]), pSqrt)
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Sqrt)), pSqrt)
             );
         }
 
@@ -385,7 +385,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             {
                 return Expression.Multiply(
                     left,
-                    Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]), pPow)
+                    Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), pPow)
                 );
             }
 
@@ -435,7 +435,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         return Expression.Multiply(
                     parameter,
                     Expression.Subtract(
-                        Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]), parameter),
+                        Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), parameter),
                         ExpressionEx.CreateConstant(T.CreateChecked(1d))
                         )
                 );
@@ -457,7 +457,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         var ln10 = ExpressionEx.CreateConstant(T.CreateChecked(double.Log(10.0)));
         return Expression.Subtract(
             Expression.Multiply(p,
-                Expression.Call(typeof(T).GetMethod(nameof(double.Log10), [typeof(T)]), p)),
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log10)), p)),
             Expression.Divide(p, ln10)
         );
     }
@@ -480,7 +480,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         double n = System.Convert.ToDouble(expo.Value);
         if (double.Abs(n + 1.0) < 1e-10)
         {
-            return Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]), p);
+            return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), p);
         }
         return Expression.Divide(
             Expression.Power(p, Expression.Constant(n + 1.0)),
@@ -532,7 +532,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         if (p.Name != ParameterName) return null;
         double n = System.Convert.ToDouble(expo.Value);
         if (double.Abs(n + 1.0) < 1e-10)
-            return Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]), p);
+            return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), p);
         return Expression.Divide(
             Expression.Power(p, Expression.Constant(n + 1.0)),
             Expression.Constant(n + 1.0)
@@ -573,7 +573,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
 )
     {
         if (op.Name != ParameterName) return null;
-        return Expression.Call(typeof(T).GetMethod(nameof(double.Exp), [typeof(T)]), op);
+        return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Exp)), op);
     }
 
     /// <summary>
@@ -595,7 +595,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return null;
         }
         return Expression.Divide(
-                Expression.Call(typeof(T).GetMethod(nameof(double.Exp), [typeof(T)]), be),
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Exp)), be),
                 c
             );
     }
@@ -614,7 +614,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (op.Name != ParameterName) return null;
         return Expression.Negate(
-                Expression.Call(typeof(T).GetMethod(nameof(double.Cos), [typeof(T)]), op)
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), op)
             );
     }
 
@@ -637,7 +637,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return null;
         }
         return Expression.Divide(
-                Expression.Negate(Expression.Call(typeof(T).GetMethod(nameof(double.Cos), [typeof(T)]), be)),
+                Expression.Negate(Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), be)),
                 c
             );
     }
@@ -655,7 +655,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
 )
     {
         if (op.Name != ParameterName) return null;
-        return Expression.Call(typeof(T).GetMethod(nameof(double.Sin), [typeof(T)]), op);
+        return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Sin)), op);
     }
 
     /// <summary>
@@ -677,7 +677,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return null;
         }
         return Expression.Divide(
-                Expression.Call(typeof(T).GetMethod(nameof(double.Sin), [typeof(T)]), be),
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Sin)), be),
                 c
             );
     }
@@ -698,8 +698,8 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         if (op.Name != ParameterName) return null;
 
         return Expression.Negate(
-                Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]),
-                    Expression.Call(typeof(T).GetMethod(nameof(double.Cos), [typeof(T)]), op))
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)),
+                    Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), op))
             );
     }
 
@@ -722,8 +722,8 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return null;
         }
         return Expression.Divide(
-                Expression.Negate(Expression.Call(typeof(T).GetMethod(nameof(double.Log), [typeof(T)]),
-                    Expression.Call(typeof(T).GetMethod(nameof(double.Cos), [typeof(T)]), be))),
+                Expression.Negate(Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)),
+                    Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), be))),
                 c
             );
     }
@@ -744,7 +744,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         {
             return null;
         }
-        return Expression.Call(typeof(T).GetMethod(nameof(double.Cosh), [typeof(T)]), op);
+        return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cosh)), op);
     }
 
     /// <summary>
@@ -766,7 +766,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return null;
         }
         return Expression.Divide(
-                Expression.Call(typeof(T).GetMethod(nameof(double.Cosh), [typeof(T)]), be),
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cosh)), be),
                 c
             );
     }
@@ -785,7 +785,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (op.Name != ParameterName) return null;
 
-        return Expression.Call(typeof(T).GetMethod(nameof(double.Sinh), [typeof(T)]), op);
+        return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Sinh)), op);
     }
 
     /// <summary>
@@ -807,7 +807,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return null;
         }
         return Expression.Divide(
-                Expression.Call(typeof(T).GetMethod(nameof(double.Sinh), [typeof(T)]), be),
+                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Sinh)), be),
                 c
             );
     }
@@ -827,8 +827,8 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         if (op.Name != ParameterName) return null;
 
         return Expression.Call(
-            typeof(T).GetMethod(nameof(double.Log), [typeof(T)]),
-            Expression.Call(typeof(T).GetMethod(nameof(double.Cosh), [typeof(T)]), op)
+            MathMethodResolver.Resolve<T>(nameof(double.Log)),
+            Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cosh)), op)
         );
     }
 
@@ -852,8 +852,8 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         }
         return Expression.Divide(
                 Expression.Call(
-                    typeof(T).GetMethod(nameof(double.Log), [typeof(T)]),
-                    Expression.Call(typeof(T).GetMethod(nameof(double.Cosh), [typeof(T)]), be)
+                    MathMethodResolver.Resolve<T>(nameof(double.Log)),
+                    Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cosh)), be)
                 ),
                 c
             );

--- a/Utils.Mathematics/Expressions/ExpressionIntegration.cs
+++ b/Utils.Mathematics/Expressions/ExpressionIntegration.cs
@@ -92,33 +92,73 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
 
 
     /// <summary>
-    /// Ignores conversion wrappers by integrating the wrapped operand.
+    /// Integrates the wrapped operand and re-applies the conversion's declared result type when the
+    /// integral's type does not already match it, so the result expression stays type-consistent with
+    /// the original conversion node.
     /// </summary>
     /// <param name="e">The conversion expression.</param>
     /// <param name="operand">The wrapped operand.</param>
-    /// <returns>The integral of the wrapped operand.</returns>
+    /// <returns>The integral of the wrapped operand, converted back to <c>e.Type</c> if needed.</returns>
     [ExpressionSignature(ExpressionType.Convert)]
     public Expression Convert(
         UnaryExpression e,
         Expression operand
     )
     {
-        return Transform(operand);
+        return PreserveConversion(e, Transform(operand), isChecked: false);
     }
 
     /// <summary>
-    /// Ignores checked conversion wrappers by integrating the wrapped operand.
+    /// Integrates the wrapped operand through a checked conversion. Checked conversions exist
+    /// specifically to guard against narrowing/overflow, which has no well-defined symbolic integral;
+    /// only a trivial same-type checked conversion is passed through, anything else is rejected instead
+    /// of silently stripped.
     /// </summary>
     /// <param name="e">The checked conversion expression.</param>
     /// <param name="operand">The wrapped operand.</param>
-    /// <returns>The integral of the wrapped operand.</returns>
+    /// <returns>The integral of the wrapped operand when the checked conversion is a same-type no-op.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the checked conversion actually changes the type (a narrowing or otherwise
+    /// non-trivial conversion), since integrating through it is not well-defined.
+    /// </exception>
     [ExpressionSignature(ExpressionType.ConvertChecked)]
     public Expression ConvertChecked(
         UnaryExpression e,
         Expression operand
     )
     {
-        return Transform(operand);
+        return PreserveConversion(e, Transform(operand), isChecked: true);
+    }
+
+    /// <summary>
+    /// Reconciles the type of a transformed integral with the declared result type of the original
+    /// conversion node it replaces.
+    /// </summary>
+    /// <param name="original">The original <c>Convert</c>/<c>ConvertChecked</c> expression being replaced.</param>
+    /// <param name="transformedOperand">The already-integrated operand.</param>
+    /// <param name="isChecked"><see langword="true"/> for <c>ConvertChecked</c>; <see langword="false"/> for <c>Convert</c>.</param>
+    /// <returns><paramref name="transformedOperand"/>, converted back to <c>original.Type</c> if needed.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the types differ and the conversion is either checked (narrowing/overflow-prone) or
+    /// not a recognized numeric-to-numeric widening.
+    /// </exception>
+    private static Expression PreserveConversion(UnaryExpression original, Expression transformedOperand, bool isChecked)
+    {
+        if (transformedOperand.Type == original.Type)
+        {
+            return transformedOperand;
+        }
+
+        if (!isChecked
+            && NumberUtils.IsNativeNumericType(transformedOperand.Type)
+            && NumberUtils.IsNativeNumericType(original.Type))
+        {
+            return Expression.Convert(transformedOperand, original.Type);
+        }
+
+        throw new NotSupportedException(
+            $"Cannot preserve the {(isChecked ? "checked " : string.Empty)}conversion from '{transformedOperand.Type}' " +
+            $"to '{original.Type}': only same-type conversions and unchecked numeric widenings are supported.");
     }
     /// <summary>
     /// Integrates a numeric constant by multiplying it with the integration parameter.

--- a/Utils.Mathematics/Expressions/ExpressionIntegration.cs
+++ b/Utils.Mathematics/Expressions/ExpressionIntegration.cs
@@ -35,6 +35,16 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     private bool IsTargetParameter(ParameterExpression candidate) => ReferenceEquals(candidate, parameter);
 
     /// <summary>
+    /// Creates a <typeparamref name="T"/>-typed constant from a <see cref="double"/> value computed
+    /// during rule evaluation (e.g. an exponent shifted by one). Rules must use this instead of
+    /// <c>Expression.Constant(value)</c> (which creates a raw <see cref="double"/> constant regardless
+    /// of <typeparamref name="T"/>), since combining a <see cref="double"/> constant with a
+    /// <typeparamref name="T"/>-typed expression fails to construct for any <typeparamref name="T"/>
+    /// other than <see cref="double"/> itself.
+    /// </summary>
+    private static ConstantExpression NumericConstant(double value) => ExpressionEx.CreateConstant(T.CreateChecked(value));
+
+    /// <summary>
     /// Integrates a lambda expression with respect to the configured parameter.
     /// </summary>
     /// <param name="e">The lambda expression to integrate.</param>
@@ -202,9 +212,10 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (IsTargetParameter(e))
         {
+            ConstantExpression two = ExpressionEx.CreateConstant(T.CreateChecked(2d));
             return Expression.Divide(
-                Expression.Power(e, ExpressionEx.CreateConstant(T.CreateChecked(2d))),
-                ExpressionEx.CreateConstant(T.CreateChecked(2d))
+                Expression.Call(MathMethodResolver.ResolveBinary<T>(nameof(double.Pow)), e, two),
+                two
             );
         }
         else
@@ -346,7 +357,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         if (left.NodeType != ExpressionType.Convert && left.NodeType != ExpressionType.ConvertChecked) return null;
         if (left.Operand is not ConstantExpression constant || !NumberUtils.IsNumeric(constant.Value)) return null;
 
-        ConstantExpression numericLeft = Expression.Constant(System.Convert.ToDouble(constant.Value));
+        ConstantExpression numericLeft = NumericConstant(System.Convert.ToDouble(constant.Value));
         return Expression.Multiply(
             numericLeft,
             Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), right)
@@ -394,9 +405,10 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         }
 
         double newExpo = 1.0 - n;
+        ConstantExpression newExpoConstant = NumericConstant(newExpo);
         return Expression.Divide(
-            Expression.Multiply(left, Expression.Power(p, Expression.Constant(newExpo))),
-            Expression.Constant(newExpo)
+            Expression.Multiply(left, Expression.Call(MathMethodResolver.ResolveBinary<T>(nameof(double.Pow)), p, newExpoConstant)),
+            newExpoConstant
         );
     }
 
@@ -416,7 +428,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (left.NodeType != ExpressionType.Convert && left.NodeType != ExpressionType.ConvertChecked) return null;
         if (left.Operand is not ConstantExpression constant || !NumberUtils.IsNumeric(constant.Value)) return null;
-        ConstantExpression numericLeft = Expression.Constant(System.Convert.ToDouble(constant.Value));
+        ConstantExpression numericLeft = NumericConstant(System.Convert.ToDouble(constant.Value));
         return Divide(e, numericLeft, right);
     }
 
@@ -441,7 +453,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         {
             double factor = 2.0 * System.Convert.ToDouble(left.Value);
             return Expression.Multiply(
-                Expression.Constant(factor),
+                NumericConstant(factor),
                 Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Sqrt)), pSqrt)
             );
         }
@@ -473,9 +485,10 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             }
 
             double newExpo = 1.0 - n;
+            ConstantExpression newExpoConstant = NumericConstant(newExpo);
             return Expression.Divide(
-                Expression.Multiply(left, Expression.Power(pPow, Expression.Constant(newExpo))),
-                Expression.Constant(newExpo)
+                Expression.Multiply(left, Expression.Call(MathMethodResolver.ResolveBinary<T>(nameof(double.Pow)), pPow, newExpoConstant)),
+                newExpoConstant
             );
         }
 
@@ -498,7 +511,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (left.NodeType != ExpressionType.Convert && left.NodeType != ExpressionType.ConvertChecked) return null;
         if (left.Operand is not ConstantExpression constant || !NumberUtils.IsNumeric(constant.Value)) return null;
-        ConstantExpression numericLeft = Expression.Constant(System.Convert.ToDouble(constant.Value));
+        ConstantExpression numericLeft = NumericConstant(System.Convert.ToDouble(constant.Value));
         return Divide(e, numericLeft, right);
     }
 
@@ -565,9 +578,10 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         {
             return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), p);
         }
+        ConstantExpression shiftedExpo = NumericConstant(n + 1.0);
         return Expression.Divide(
-            Expression.Power(p, Expression.Constant(n + 1.0)),
-            Expression.Constant(n + 1.0)
+            Expression.Call(MathMethodResolver.ResolveBinary<T>(nameof(double.Pow)), p, shiftedExpo),
+            shiftedExpo
         );
     }
 
@@ -595,7 +609,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return null;
         }
 
-        return Power(e, p, Expression.Constant(System.Convert.ToDouble(constantExpo.Value)));
+        return Power(e, p, NumericConstant(System.Convert.ToDouble(constantExpo.Value)));
     }
 
     /// <summary>
@@ -616,9 +630,10 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         double n = System.Convert.ToDouble(expo.Value);
         if (double.Abs(n + 1.0) < 1e-10)
             return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), p);
+        ConstantExpression shiftedExpo = NumericConstant(n + 1.0);
         return Expression.Divide(
-            Expression.Power(p, Expression.Constant(n + 1.0)),
-            Expression.Constant(n + 1.0)
+            Expression.Call(MathMethodResolver.ResolveBinary<T>(nameof(double.Pow)), p, shiftedExpo),
+            shiftedExpo
         );
     }
 
@@ -640,7 +655,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return null;
         if (expo.Operand is not ConstantExpression constantExpo || !NumberUtils.IsNumeric(constantExpo.Value))
             return null;
-        return PowerMathCall(e, p, Expression.Constant(System.Convert.ToDouble(constantExpo.Value)));
+        return PowerMathCall(e, p, NumericConstant(System.Convert.ToDouble(constantExpo.Value)));
     }
 
     /// <summary>

--- a/Utils.Mathematics/Expressions/ExpressionIntegration.cs
+++ b/Utils.Mathematics/Expressions/ExpressionIntegration.cs
@@ -45,6 +45,18 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     private static ConstantExpression NumericConstant(double value) => ExpressionEx.CreateConstant(T.CreateChecked(value));
 
     /// <summary>
+    /// Builds <c>Log(Abs(operand))</c> rather than a bare <c>Log(operand)</c>. Unlike the source
+    /// expressions these antiderivatives replace (e.g. <c>1/x</c> or <c>tan(x) = sin(x)/cos(x)</c>,
+    /// both well-defined for negative arguments), a raw <c>Log</c> is only real-valued for a positive
+    /// argument and would return NaN on exactly the negative-domain inputs the original expression
+    /// supported. <c>Abs</c> is always available (it is part of <see cref="INumberBase{TSelf}"/>, which
+    /// every <see cref="IFloatingPoint{TSelf}"/> implements), so this never needs a capability check.
+    /// </summary>
+    private static Expression LogAbs(Expression operand) =>
+        Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)),
+            Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Abs)), operand));
+
+    /// <summary>
     /// Integrates a lambda expression with respect to the configured parameter.
     /// </summary>
     /// <param name="e">The lambda expression to integrate.</param>
@@ -332,10 +344,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
 )
     {
         if (!IsTargetParameter(right)) return null;
-        return Expression.Multiply(
-                left,
-                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), right)
-            );
+        return Expression.Multiply(left, LogAbs(right));
     }
 
     /// <summary>
@@ -358,10 +367,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         if (left.Operand is not ConstantExpression constant || !NumberUtils.IsNumeric(constant.Value)) return null;
 
         ConstantExpression numericLeft = NumericConstant(System.Convert.ToDouble(constant.Value));
-        return Expression.Multiply(
-            numericLeft,
-            Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), right)
-        );
+        return Expression.Multiply(numericLeft, LogAbs(right));
     }
 
     /// <summary>
@@ -398,10 +404,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         double n = System.Convert.ToDouble(expo.Value);
         if (double.Abs(n - 1.0) < 1e-10)
         {
-            return Expression.Multiply(
-                left,
-                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), p)
-            );
+            return Expression.Multiply(left, LogAbs(p));
         }
 
         double newExpo = 1.0 - n;
@@ -478,10 +481,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             double n = System.Convert.ToDouble(exponent.Value);
             if (double.Abs(n - 1.0) < 1e-10)
             {
-                return Expression.Multiply(
-                    left,
-                    Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), pPow)
-                );
+                return Expression.Multiply(left, LogAbs(pPow));
             }
 
             double newExpo = 1.0 - n;
@@ -576,7 +576,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         double n = System.Convert.ToDouble(expo.Value);
         if (double.Abs(n + 1.0) < 1e-10)
         {
-            return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), p);
+            return LogAbs(p);
         }
         ConstantExpression shiftedExpo = NumericConstant(n + 1.0);
         return Expression.Divide(
@@ -629,7 +629,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         if (!IsTargetParameter(p)) return null;
         double n = System.Convert.ToDouble(expo.Value);
         if (double.Abs(n + 1.0) < 1e-10)
-            return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), p);
+            return LogAbs(p);
         ConstantExpression shiftedExpo = NumericConstant(n + 1.0);
         return Expression.Divide(
             Expression.Call(MathMethodResolver.ResolveBinary<T>(nameof(double.Pow)), p, shiftedExpo),
@@ -795,10 +795,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (!IsTargetParameter(op)) return null;
 
-        return Expression.Negate(
-                Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)),
-                    Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), op))
-            );
+        return Expression.Negate(LogAbs(Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), op)));
     }
 
     /// <summary>
@@ -820,8 +817,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             return null;
         }
         return Expression.Divide(
-                Expression.Negate(Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)),
-                    Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), be))),
+                Expression.Negate(LogAbs(Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), be))),
                 c
             );
     }

--- a/Utils.Mathematics/Expressions/ExpressionIntegration.cs
+++ b/Utils.Mathematics/Expressions/ExpressionIntegration.cs
@@ -18,32 +18,75 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     public string ParameterName { get; }
 
     /// <summary>
-    /// Gets or sets the cached parameter expression that matches <see cref="ParameterName"/>.
+    /// The specific <see cref="ParameterExpression"/> instance, resolved once per <see cref="Integrate"/>
+    /// call, that identifies the integration variable by reference rather than by name. Two distinct
+    /// <see cref="ParameterExpression"/> objects may legally share the same <see cref="ParameterName"/>
+    /// (e.g. an unrelated captured variable); comparing by reference instead of by name avoids treating
+    /// such a foreign parameter as the integration variable. This field is set once, in the private
+    /// constructor, on a fresh per-call worker instance (see <see cref="Integrate"/>), so it is never
+    /// mutated after construction and each call gets its own isolated instance.
     /// </summary>
-    private ParameterExpression parameter { get; set; } = null!;
+    private readonly ParameterExpression parameter;
+
+    /// <summary>
+    /// Determines whether <paramref name="candidate"/> is the specific parameter instance resolved as
+    /// the integration variable for the current call.
+    /// </summary>
+    private bool IsTargetParameter(ParameterExpression candidate) => ReferenceEquals(candidate, parameter);
 
     /// <summary>
     /// Integrates a lambda expression with respect to the configured parameter.
     /// </summary>
     /// <param name="e">The lambda expression to integrate.</param>
     /// <returns>The integrated expression tree.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no parameter named <see cref="ParameterName"/> is found in <paramref name="e"/>, or
+    /// when more than one distinct parameter shares that name (an ambiguous match that cannot be
+    /// resolved by name alone).
+    /// </exception>
     public Expression Integrate(LambdaExpression e)
     {
         ArgumentNullException.ThrowIfNull(e);
 
-        parameter = e.Parameters.FirstOrDefault(p => p.Name == ParameterName)
-                ?? throw new InvalidOperationException($"The parameter '{ParameterName}' was not found in the lambda expression.");
+        var candidates = e.Parameters.Where(p => p.Name == ParameterName).ToList();
+        if (candidates.Count == 0)
+        {
+            throw new InvalidOperationException($"The parameter '{ParameterName}' was not found in the lambda expression.");
+        }
+        if (candidates.Count > 1)
+        {
+            throw new InvalidOperationException(
+                $"The lambda expression declares {candidates.Count} distinct parameters named '{ParameterName}'; " +
+                "the integration variable is ambiguous. Use distinct parameter names.");
+        }
 
-        return Expression.Lambda(Transform(e.Body), e.Parameters);
+        // A fresh worker instance isolates the resolved target parameter for this call: concurrent or
+        // re-entrant calls on the same public ExpressionIntegration<T> instance no longer share mutable
+        // state (see TODO-2026-07-11-pass3.md item #32).
+        var worker = new ExpressionIntegration<T>(ParameterName, candidates[0]);
+        return Expression.Lambda(worker.Transform(e.Body), e.Parameters);
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ExpressionIntegration{T}"/> class.
     /// </summary>
     /// <param name="parameterName">The name of the parameter serving as the integration variable.</param>
-    public ExpressionIntegration(string parameterName)
+    public ExpressionIntegration(string parameterName) : this(parameterName, null!)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a per-call worker instance with its target parameter already resolved.
+    /// </summary>
+    /// <param name="parameterName">The name of the parameter serving as the integration variable.</param>
+    /// <param name="parameter">
+    /// The specific resolved <see cref="ParameterExpression"/> instance, or <see langword="null"/> for
+    /// the publicly-constructed instance that has not yet performed an <see cref="Integrate"/> call.
+    /// </param>
+    private ExpressionIntegration(string parameterName, ParameterExpression parameter)
     {
         this.ParameterName = parameterName;
+        this.parameter = parameter;
     }
 
 
@@ -117,7 +160,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         ParameterExpression e
     )
     {
-        if (e.Name == ParameterName)
+        if (IsTargetParameter(e))
         {
             return Expression.Divide(
                 Expression.Power(e, ExpressionEx.CreateConstant(T.CreateChecked(2d))),
@@ -237,7 +280,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             ParameterExpression right
 )
     {
-        if (right.Name != ParameterName) return null;
+        if (!IsTargetParameter(right)) return null;
         return Expression.Multiply(
                 left,
                 Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), right)
@@ -259,7 +302,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         ParameterExpression right
     )
     {
-        if (right.Name != ParameterName) return null;
+        if (!IsTargetParameter(right)) return null;
         if (left.NodeType != ExpressionType.Convert && left.NodeType != ExpressionType.ConvertChecked) return null;
         if (left.Operand is not ConstantExpression constant || !NumberUtils.IsNumeric(constant.Value)) return null;
 
@@ -284,7 +327,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     [ExpressionSignature(ExpressionType.Power)] BinaryExpression right
 )
     {
-        if (right.Left is not ParameterExpression p || p.Name != ParameterName)
+        if (right.Left is not ParameterExpression p || !IsTargetParameter(p))
         {
             return null;
         }
@@ -354,7 +397,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         if (right.Method.Name == nameof(double.Sqrt) &&
             right.Arguments.Count == 1 &&
             right.Arguments[0] is ParameterExpression pSqrt &&
-            pSqrt.Name == ParameterName)
+            IsTargetParameter(pSqrt))
         {
             double factor = 2.0 * System.Convert.ToDouble(left.Value);
             return Expression.Multiply(
@@ -366,7 +409,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         if (right.Method.Name == nameof(double.Pow) &&
             right.Arguments.Count == 2 &&
             right.Arguments[0] is ParameterExpression pPow &&
-            pPow.Name == ParameterName)
+            IsTargetParameter(pPow))
         {
             ConstantExpression? exponent = right.Arguments[1] as ConstantExpression;
             if (exponent is null && right.Arguments[1] is UnaryExpression unaryExponent &&
@@ -431,7 +474,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             ParameterExpression p
     )
     {
-        if (p.Name != ParameterName) return null;
+        if (!IsTargetParameter(p)) return null;
         return Expression.Multiply(
                     parameter,
                     Expression.Subtract(
@@ -453,7 +496,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             ParameterExpression p
     )
     {
-        if (p.Name != ParameterName) return null;
+        if (!IsTargetParameter(p)) return null;
         var ln10 = ExpressionEx.CreateConstant(T.CreateChecked(double.Log(10.0)));
         return Expression.Subtract(
             Expression.Multiply(p,
@@ -476,7 +519,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     [ConstantNumeric] ConstantExpression expo
 )
     {
-        if (p.Name != ParameterName) return null;
+        if (!IsTargetParameter(p)) return null;
         double n = System.Convert.ToDouble(expo.Value);
         if (double.Abs(n + 1.0) < 1e-10)
         {
@@ -529,7 +572,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
         [ConstantNumeric] ConstantExpression expo
     )
     {
-        if (p.Name != ParameterName) return null;
+        if (!IsTargetParameter(p)) return null;
         double n = System.Convert.ToDouble(expo.Value);
         if (double.Abs(n + 1.0) < 1e-10)
             return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)), p);
@@ -572,7 +615,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     ParameterExpression op
 )
     {
-        if (op.Name != ParameterName) return null;
+        if (!IsTargetParameter(op)) return null;
         return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Exp)), op);
     }
 
@@ -590,7 +633,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (be.NodeType != ExpressionType.Multiply ||
             be.Left is not ConstantExpression c || !NumberUtils.IsNumeric(c.Value) ||
-            be.Right is not ParameterExpression p2 || p2.Name != ParameterName)
+            be.Right is not ParameterExpression p2 || !IsTargetParameter(p2))
         {
             return null;
         }
@@ -612,7 +655,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     ParameterExpression op
 )
     {
-        if (op.Name != ParameterName) return null;
+        if (!IsTargetParameter(op)) return null;
         return Expression.Negate(
                 Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Cos)), op)
             );
@@ -632,7 +675,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (be.NodeType != ExpressionType.Multiply ||
             be.Left is not ConstantExpression c || !NumberUtils.IsNumeric(c.Value) ||
-            be.Right is not ParameterExpression p2 || p2.Name != ParameterName)
+            be.Right is not ParameterExpression p2 || !IsTargetParameter(p2))
         {
             return null;
         }
@@ -654,7 +697,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     ParameterExpression op
 )
     {
-        if (op.Name != ParameterName) return null;
+        if (!IsTargetParameter(op)) return null;
         return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Sin)), op);
     }
 
@@ -672,7 +715,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (be.NodeType != ExpressionType.Multiply ||
             be.Left is not ConstantExpression c || !NumberUtils.IsNumeric(c.Value) ||
-            be.Right is not ParameterExpression p2 || p2.Name != ParameterName)
+            be.Right is not ParameterExpression p2 || !IsTargetParameter(p2))
         {
             return null;
         }
@@ -695,7 +738,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     ParameterExpression op
 )
     {
-        if (op.Name != ParameterName) return null;
+        if (!IsTargetParameter(op)) return null;
 
         return Expression.Negate(
                 Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Log)),
@@ -717,7 +760,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (be.NodeType != ExpressionType.Multiply ||
             be.Left is not ConstantExpression c || !NumberUtils.IsNumeric(c.Value) ||
-            be.Right is not ParameterExpression p2 || p2.Name != ParameterName)
+            be.Right is not ParameterExpression p2 || !IsTargetParameter(p2))
         {
             return null;
         }
@@ -740,7 +783,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     ParameterExpression op
 )
     {
-        if (op.Name != ParameterName)
+        if (!IsTargetParameter(op))
         {
             return null;
         }
@@ -761,7 +804,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (be.NodeType != ExpressionType.Multiply ||
             be.Left is not ConstantExpression c || !NumberUtils.IsNumeric(c.Value) ||
-            be.Right is not ParameterExpression p2 || p2.Name != ParameterName)
+            be.Right is not ParameterExpression p2 || !IsTargetParameter(p2))
         {
             return null;
         }
@@ -783,7 +826,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             ParameterExpression op
     )
     {
-        if (op.Name != ParameterName) return null;
+        if (!IsTargetParameter(op)) return null;
 
         return Expression.Call(MathMethodResolver.Resolve<T>(nameof(double.Sinh)), op);
     }
@@ -802,7 +845,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (be.NodeType != ExpressionType.Multiply ||
             be.Left is not ConstantExpression c || !NumberUtils.IsNumeric(c.Value) ||
-            be.Right is not ParameterExpression p2 || p2.Name != ParameterName)
+            be.Right is not ParameterExpression p2 || !IsTargetParameter(p2))
         {
             return null;
         }
@@ -824,7 +867,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
             ParameterExpression op
     )
     {
-        if (op.Name != ParameterName) return null;
+        if (!IsTargetParameter(op)) return null;
 
         return Expression.Call(
             MathMethodResolver.Resolve<T>(nameof(double.Log)),
@@ -846,7 +889,7 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     {
         if (be.NodeType != ExpressionType.Multiply ||
             be.Left is not ConstantExpression c || !NumberUtils.IsNumeric(c?.Value) ||
-            be.Right is not ParameterExpression p2 || p2.Name != ParameterName)
+            be.Right is not ParameterExpression p2 || !IsTargetParameter(p2))
         {
             return null;
         }

--- a/Utils.Mathematics/Expressions/MathMethodResolver.cs
+++ b/Utils.Mathematics/Expressions/MathMethodResolver.cs
@@ -1,0 +1,42 @@
+using System.Numerics;
+using System.Reflection;
+
+namespace Utils.Mathematics.Expressions;
+
+/// <summary>
+/// Resolves the single-argument static math method (e.g. <c>Log</c>, <c>Sin</c>, <c>Exp</c>) that a
+/// scalar type <c>T</c> exposes, for use when building symbolic derivative/integral expression trees.
+/// </summary>
+/// <remarks>
+/// <see cref="IFloatingPoint{TSelf}"/> is intentionally broad: it does not guarantee <c>Log</c>,
+/// <c>Sin</c>, <c>Exp</c>, or similar transcendental functions exist for every conforming type (e.g.
+/// <see cref="decimal"/> has none of them). A raw <c>typeof(T).GetMethod(...)</c> call silently
+/// returns <see langword="null"/> for an unsupported type, which then surfaces as an incidental
+/// <see cref="ArgumentNullException"/> deep inside <see cref="System.Linq.Expressions.Expression.Call(MethodInfo?, System.Linq.Expressions.Expression[])"/>
+/// instead of a clear diagnostic. Every call site that needs one of these methods should resolve it
+/// through <see cref="Resolve{T}"/> instead of calling <c>GetMethod</c> directly, so an unsupported
+/// operation fails with a message naming both the operation and the type.
+/// </remarks>
+internal static class MathMethodResolver
+{
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(Type Type, string Name), MethodInfo?> cache = new();
+
+    /// <summary>
+    /// Resolves the single-argument static method named <paramref name="methodName"/> on
+    /// <typeparamref name="T"/> (matching the shape of <c>static T Method(T value)</c>, as declared by
+    /// <see cref="double"/>'s own math methods). Results (including failures) are cached per
+    /// <c>(T, methodName)</c> pair.
+    /// </summary>
+    /// <typeparam name="T">Scalar type the expression tree is being built for.</typeparam>
+    /// <param name="methodName">Name of the method, e.g. <c>nameof(double.Log)</c>.</param>
+    /// <returns>The resolved <see cref="MethodInfo"/>.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <typeparamref name="T"/> does not declare a matching <paramref name="methodName"/> method.
+    /// </exception>
+    public static MethodInfo Resolve<T>(string methodName) where T : IFloatingPoint<T>
+    {
+        MethodInfo? method = cache.GetOrAdd((typeof(T), methodName), key => key.Type.GetMethod(key.Name, [key.Type]));
+        return method ?? throw new NotSupportedException(
+            $"The '{methodName}' operation is not supported for type '{typeof(T)}'.");
+    }
+}

--- a/Utils.Mathematics/Expressions/MathMethodResolver.cs
+++ b/Utils.Mathematics/Expressions/MathMethodResolver.cs
@@ -20,6 +20,7 @@ namespace Utils.Mathematics.Expressions;
 internal static class MathMethodResolver
 {
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<(Type Type, string Name), MethodInfo?> cache = new();
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(Type Type, string Name), MethodInfo?> binaryCache = new();
 
     /// <summary>
     /// Resolves the single-argument static method named <paramref name="methodName"/> on
@@ -36,6 +37,29 @@ internal static class MathMethodResolver
     public static MethodInfo Resolve<T>(string methodName) where T : IFloatingPoint<T>
     {
         MethodInfo? method = cache.GetOrAdd((typeof(T), methodName), key => key.Type.GetMethod(key.Name, [key.Type]));
+        return method ?? throw new NotSupportedException(
+            $"The '{methodName}' operation is not supported for type '{typeof(T)}'.");
+    }
+
+    /// <summary>
+    /// Resolves the two-argument static method named <paramref name="methodName"/> on
+    /// <typeparamref name="T"/> (matching the shape of <c>static T Method(T x, T y)</c>, as declared by
+    /// <see cref="double.Pow(double, double)"/>). Unlike <see cref="System.Linq.Expressions.Expression.Power(System.Linq.Expressions.Expression, System.Linq.Expressions.Expression)"/>,
+    /// which only works when both operands are literally <see cref="double"/>, this resolves a
+    /// type-appropriate method (e.g. <see cref="float.Pow(float, float)"/>) so the resulting call works
+    /// for any <typeparamref name="T"/> that declares it. Results (including failures) are cached per
+    /// <c>(T, methodName)</c> pair.
+    /// </summary>
+    /// <typeparam name="T">Scalar type the expression tree is being built for.</typeparam>
+    /// <param name="methodName">Name of the method, e.g. <c>nameof(double.Pow)</c>.</param>
+    /// <returns>The resolved <see cref="MethodInfo"/>.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <typeparamref name="T"/> does not declare a matching two-argument
+    /// <paramref name="methodName"/> method.
+    /// </exception>
+    public static MethodInfo ResolveBinary<T>(string methodName) where T : IFloatingPoint<T>
+    {
+        MethodInfo? method = binaryCache.GetOrAdd((typeof(T), methodName), key => key.Type.GetMethod(key.Name, [key.Type, key.Type]));
         return method ?? throw new NotSupportedException(
             $"The '{methodName}' operation is not supported for type '{typeof(T)}'.");
     }

--- a/Utils.Mathematics/LinearAlgebra/Line.cs
+++ b/Utils.Mathematics/LinearAlgebra/Line.cs
@@ -94,6 +94,13 @@ public class Line<T> : IFormattable, IEquatable<Line<T>>, ICloneable
     /// </summary>
     /// <param name="other">Line to compare.</param>
     /// <returns><see langword="true"/> if equal; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This compares the exact stored representation (<see cref="Point"/> and <see cref="Direction"/>),
+    /// not geometric equivalence: two lines that describe the same infinite line but were built from a
+    /// different anchor point, or a direction scaled by a nonzero factor (including a negative one),
+    /// compare unequal here. Use <see cref="IsGeometricallyEquivalentTo"/> for a tolerance-aware
+    /// comparison of the geometric object instead.
+    /// </remarks>
     public bool Equals(Line<T>? other)
         => other is not null && Point.Equals(other.Point) && Direction.Equals(other.Direction);
 
@@ -106,7 +113,44 @@ public class Line<T> : IFormattable, IEquatable<Line<T>>, ICloneable
         };
 
     /// <inheritdoc/>
+    /// <remarks>Consistent with the exact representation equality of <see cref="Equals(Line{T})"/>.</remarks>
     public override int GetHashCode() => HashCode.Combine(Point, Direction);
+
+    /// <summary>
+    /// Determines whether this line and <paramref name="other"/> describe the same geometric line,
+    /// independently of which point was used as the anchor or how the direction vector was scaled
+    /// (including a negative scale, i.e. the opposite direction).
+    /// </summary>
+    /// <param name="other">Line to compare against.</param>
+    /// <param name="tolerance">
+    /// Tolerance applied to both the direction-parallelism check and the point-on-line distance check.
+    /// Must be finite and non-negative; there is no implicit default, since an appropriate tolerance
+    /// depends on the caller's own scale and precision requirements.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when both lines have the same dimension, parallel directions (within
+    /// <paramref name="tolerance"/>), and <paramref name="other"/>'s anchor point lies on this line
+    /// (within <paramref name="tolerance"/>); otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is not finite or is negative.</exception>
+    public bool IsGeometricallyEquivalentTo(Line<T> other, T tolerance)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        if (!T.IsFinite(tolerance) || tolerance < T.Zero)
+            throw new ArgumentOutOfRangeException(nameof(tolerance), tolerance, "Tolerance must be finite and non-negative.");
+
+        if (Dimension != other.Dimension) return false;
+
+        // Two directions are parallel (collinear, either same or opposite sense) exactly when the
+        // magnitude of the dot product of their unit vectors is 1.
+        var thisUnit = Direction.Normalize();
+        var otherUnit = other.Direction.Normalize();
+        T absCosine = T.Abs(thisUnit * otherUnit);
+        if (T.Abs(absCosine - T.One) > tolerance) return false;
+
+        return DistanceTo(other.Point) <= tolerance;
+    }
 
     /// <summary>
     /// Returns a string representation of the line.

--- a/Utils.Mathematics/LinearAlgebra/Line.cs
+++ b/Utils.Mathematics/LinearAlgebra/Line.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Numerics;
 
 namespace Utils.Mathematics.LinearAlgebra;
@@ -155,10 +156,20 @@ public class Line<T> : IFormattable, IEquatable<Line<T>>, ICloneable
     /// <summary>
     /// Returns a string representation of the line.
     /// </summary>
-    /// <param name="format">Format string.</param>
-    /// <param name="formatProvider">Format provider.</param>
+    /// <param name="format">
+    /// Numeric format string forwarded to each coordinate's own <see cref="IFormattable.ToString(string?, IFormatProvider?)"/>
+    /// (e.g. <c>"F2"</c>), or <see langword="null"/> for the default numeric format.
+    /// </param>
+    /// <param name="formatProvider">Format provider forwarded to each coordinate.</param>
     /// <returns>A string representation of the line.</returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
-        => $"Point: {Point}, Direction: {Direction}";
+        => $"Point: {FormatVector(Point, format, formatProvider)}, Direction: {FormatVector(Direction, format, formatProvider)}";
+
+    /// <summary>
+    /// Formats a vector's components individually with <paramref name="format"/>/<paramref name="formatProvider"/>,
+    /// since <see cref="Vector{T}"/> itself does not implement <see cref="IFormattable"/>.
+    /// </summary>
+    private static string FormatVector(Vector<T> vector, string? format, IFormatProvider? formatProvider)
+        => "(" + string.Join(", ", vector.Select(component => component.ToString(format, formatProvider))) + ")";
 }
 

--- a/Utils.Mathematics/LinearAlgebra/Line.cs
+++ b/Utils.Mathematics/LinearAlgebra/Line.cs
@@ -30,11 +30,28 @@ public class Line<T> : IFormattable, IEquatable<Line<T>>, ICloneable
     /// </summary>
     /// <param name="point">A point on the line.</param>
     /// <param name="direction">Direction vector of the line.</param>
-    /// <exception cref="ArgumentException">Thrown when vectors do not share the same dimension.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when vectors do not share the same dimension, or when <paramref name="direction"/> is zero
+    /// or numerically negligible (a line has no well-defined direction in that case, and
+    /// <see cref="DistanceTo"/> would divide by zero).
+    /// </exception>
     public Line(Vector<T> point, Vector<T> direction)
     {
         if (point.Dimension != direction.Dimension)
             throw new ArgumentException("Point and direction must be of the same dimension.");
+
+        // Reuses Vector<T>.Normalize's scale-aware zero/near-zero tolerance policy (see its
+        // DefaultNormTolerance) instead of an independent threshold, per the "same numerical policy"
+        // guidance in TODO-2026-07-11-pass3.md. The normalized copy itself is discarded: Direction keeps
+        // its original (non-unit) scale, only used here to validate it is non-negligible.
+        try
+        {
+            direction.Normalize();
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new ArgumentException("Line direction cannot be zero or numerically negligible.", nameof(direction), ex);
+        }
 
         Point = point;
         Direction = direction;

--- a/Utils.Mathematics/LinearAlgebra/Vector.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.cs
@@ -110,17 +110,42 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     /// <summary>
     /// Gets the length of the vector.
     /// </summary>
+    /// <remarks>
+    /// Computed via a scaled sum-of-squares accumulation (the same running-scale technique as BLAS
+    /// <c>nrm2</c>/<c>hypot</c>), rather than summing <c>component * component</c> directly. A direct sum
+    /// can overflow to infinity for large-but-representable components (whose square individually
+    /// overflows even though the true norm does not), or underflow to zero for small-but-representable
+    /// components (whose square underflows to zero even though it contributes to a representable norm).
+    /// Tracking the largest component seen so far as a running scale and accumulating only the *ratio*
+    /// of each component to that scale keeps every intermediate value within a representable range.
+    /// </remarks>
     public T Norm
     {
         get
         {
             if (norm is not null) return norm.Value;
-            T temp = T.Zero;
+
+            T scale = T.Zero;
+            T sumOfSquaredRatios = T.One;
             for (int i = 0; i < this.components.Length; i++)
             {
-                temp += this.components[i] * this.components[i];
+                T absValue = T.Abs(this.components[i]);
+                if (absValue == T.Zero) continue;
+
+                if (scale < absValue)
+                {
+                    T ratio = scale / absValue;
+                    sumOfSquaredRatios = T.One + sumOfSquaredRatios * ratio * ratio;
+                    scale = absValue;
+                }
+                else
+                {
+                    T ratio = absValue / scale;
+                    sumOfSquaredRatios += ratio * ratio;
+                }
             }
-            norm = T.Sqrt(temp);
+
+            norm = scale == T.Zero ? T.Zero : scale * T.Sqrt(sumOfSquaredRatios);
             return norm.Value;
         }
     }

--- a/Utils.Mathematics/LinearAlgebra/Vector.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.cs
@@ -269,6 +269,14 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     /// <param name="vectors">Vectors of dimension n.</param>
     /// <returns>A vector perpendicular to all input vectors.</returns>
     /// <exception cref="ArgumentException">Thrown if vectors are not all of dimension n.</exception>
+    /// <remarks>
+    /// Each component <c>result[i]</c> is <c>(-1)^i</c> times the determinant of the <c>(n-1)x(n-1)</c>
+    /// minor formed by the input vectors' components, excluding column <c>i</c> (the standard Laplace
+    /// expansion of the cross product along a virtual first row of basis vectors). Each minor's
+    /// determinant is computed via <see cref="Matrix{T}.Determinant"/>, which uses Gaussian elimination
+    /// (<c>O(n^3)</c>), rather than the previous direct recursive cofactor expansion (<c>O(n!)</c>) that
+    /// also re-filtered the remaining-columns sequence at every recursion level.
+    /// </remarks>
     public static Vector<T> CrossProduct(params Vector<T>[] vectors)
     {
         int dimensions = vectors.Length + 1;
@@ -281,12 +289,10 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
         }
 
         T[] result = new T[dimensions];
-        var columns = Enumerable.Range(0, dimensions);
         T sign = T.One;
-        foreach (var column in columns)
+        for (int excludedColumn = 0; excludedColumn < dimensions; excludedColumn++)
         {
-            var nextColumns = columns.Where(c => c != column);
-            result[column] = sign * ComputeProduct(1, nextColumns, vectors);
+            result[excludedColumn] = sign * MinorDeterminant(vectors, excludedColumn);
             sign = -sign;
         }
 
@@ -297,33 +303,27 @@ public sealed partial class Vector<T> : IEquatable<Vector<T>>, IEquatable<T[]>, 
     public static Vector<T> Product(params Vector<T>[] vectors) => CrossProduct(vectors);
 
     /// <summary>
-    /// Recursive computation of the cross product of n-1 vectors in an n-dimensional space.
+    /// Computes the determinant of the square matrix formed by using each of <paramref name="vectors"/>
+    /// as a row, dropping the component at <paramref name="excludedColumn"/> from every row.
     /// </summary>
-    /// <param name="recurrence">The current recursion step.</param>
-    /// <param name="columns">The columns to process for computation.</param>
-    /// <param name="vectors">The vectors to compute the product.</param>
-    /// <returns>The computed product.</returns>
-    private static T ComputeProduct(int recurrence, IEnumerable<int> columns, Vector<T>[] vectors)
+    /// <param name="vectors">The <c>n-1</c> input vectors of dimension <c>n</c>.</param>
+    /// <param name="excludedColumn">Index of the component to drop from every row.</param>
+    /// <returns>The determinant of the resulting <c>(n-1)x(n-1)</c> minor.</returns>
+    private static T MinorDeterminant(Vector<T>[] vectors, int excludedColumn)
     {
-        T result = T.Zero;
-        T sign = T.One;
-        foreach (int column in columns)
+        int n = vectors.Length;
+        T[,] minor = new T[n, n];
+        for (int row = 0; row < n; row++)
         {
-            T temp = sign;
-            if (recurrence > 0)
+            int col = 0;
+            for (int component = 0; component < n + 1; component++)
             {
-                temp *= vectors[recurrence - 1].components[column];
-
-                var nextColumns = columns.Where(c => c != column);
-                if (temp != T.Zero && nextColumns.Any())
-                {
-                    temp *= ComputeProduct(recurrence + 1, nextColumns, vectors);
-                }
+                if (component == excludedColumn) continue;
+                minor[row, col] = vectors[row].components[component];
+                col++;
             }
-            result += temp;
-            sign = -sign;
         }
-        return result;
+        return new Matrix<T>(minor).Determinant;
     }
 
     /// <summary>

--- a/Utils.Mathematics/Properties/AssemblyInfo.cs
+++ b/Utils.Mathematics/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UtilsTest.Unit")]

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -37,6 +37,16 @@ Arithmetic-only expressions (`+`, `-`, `*`, `/` without transcendental calls) re
 
 **Priority: P1 symbolic correctness.**
 
+**Fixed.** Both `ExpressionDerivation<T>.Derivate` and `ExpressionIntegration<T>.Integrate` now resolve
+the specific target `ParameterExpression` from `e.Parameters` by name once per call, then compare by
+reference identity (`ReferenceEquals`) everywhere inside the transformation rules instead of comparing
+`.Name` strings. If zero or more than one parameter share the configured name, the call throws a clear
+`InvalidOperationException` (ambiguity is rejected rather than silently guessing). Fixed together with
+item #32 below since both required the same "resolve once, use a fresh per-call worker" change. Test:
+`ExpressionDerivationTests.Derivate_TwoDistinctParametersWithSameName_ThrowsAmbiguousException`,
+`ExpressionDerivationTests.Derivate_ParameterNameNotInLambda_ThrowsClearException`,
+`ExpressionIntegrationTests.Integrate_TwoDistinctParametersWithSameName_ThrowsAmbiguousException`.
+
 ### 32. Integration is stateful and not safe for concurrent or re-entrant calls
 
 `ExpressionIntegration<T>` stores the active parameter in a mutable instance field before transforming the expression. Concurrent `Integrate` calls on one instance, or re-entrant transformations, can overwrite this field and build an integral against the wrong parameter.
@@ -44,6 +54,14 @@ Arithmetic-only expressions (`+`, `-`, `*`, `/` without transcendental calls) re
 **Fix:** make transformation context local to one call, create a fresh transformer/session per integration, or protect and restore state with a strict single-operation contract.
 
 **Priority: P1 determinism and thread safety.**
+
+**Fixed.** `Integrate`/`Derivate` now delegate the actual transformation to a fresh, private worker
+instance created per call, holding its resolved target parameter in a `readonly` field instead of a
+mutable one shared across calls. `ExpressionTransformer`'s reflection scan of
+`ExpressionSignatureAttribute`-annotated methods (previously repeated per instance construction) is now
+cached per concrete type in a static `ConcurrentDictionary`, so constructing a fresh worker per call is
+cheap. Test: `ExpressionDerivationTests.Derivate_ConcurrentCalls_AreIsolatedPerCall`,
+`ExpressionIntegrationTests.Integrate_ConcurrentCalls_AreIsolatedPerCall`.
 
 ### 33. Conversion nodes are discarded without preserving type semantics
 

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -95,6 +95,29 @@ Several integration rules convert numeric constants/exponents with `Convert.ToDo
 
 **Priority: P1 generic expression correctness.**
 
+**Fixed.** Every raw `Expression.Constant(System.Convert.ToDouble(...))`/`Expression.Constant(n + 1.0)`
+site in `ExpressionIntegration<T>` (the `Sqrt`/`Pow`/converted-constant "Divide" rules) now goes through a
+new `NumericConstant(double)` helper that creates a `T`-typed constant via `T.CreateChecked`, matching
+the pattern `ExpressionDerivation<T>` already used consistently. Separately, several of these same rules
+reconstructed a power sub-expression via the literal `Expression.Power(base, exponent)` operator, which
+only works when both operands are literally `System.Double` regardless of the exponent's own type — "no
+matching operator exists" for any other `T` (including the exponent now being correctly `T`-typed).
+These sites (and the `Parameter` rule's `x²/2` case) now call
+`MathMethodResolver.ResolveBinary<T>(nameof(double.Pow))` — a new two-argument counterpart to the
+existing `Resolve<T>` — to resolve a type-appropriate `Pow(T, T)` method instead. Test:
+`ExpressionIntegrationTests.Integrate_TargetParameter_WorksForFloat`,
+`ExpressionIntegrationTests.Integrate_ConstantDividedByPower_WorksForFloat`,
+`ExpressionIntegrationTests.Integrate_ConstantDividedBySqrt_WorksForFloat`.
+
+*Known related limitation found while fixing this (not fixed here, out of scope for this item):*
+`ExpressionTransformer.CopyExpression` (`Utils/Expressions/ExpressionTranformer.cs`) rebuilds a `Power`
+node via the argument-less `Expression.Power(left, right)` overload, silently dropping the original
+node's custom `Method` (needed for any `Power` node built with an explicit non-`double` method, e.g. via
+`Expression.Power(left, right, floatPowMethod)`). This means a source expression containing a genuine
+`ExpressionType.Power` node for a non-`double` operand type cannot currently survive the base
+transformer's dispatch at all — a separate bug in the shared transformer infrastructure, not specific to
+`ExpressionIntegration`/`ExpressionDerivation`.
+
 ### 35. Symbolic power rules ignore domain restrictions
 
 The general derivative of `f(x)^g(x)` emits a logarithm of the base. Over real numbers this formula requires a positive base for general non-integer exponents. Likewise integration rules use `Log(x)` rather than `Log(Abs(x))` for `1/x`.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -225,6 +225,12 @@ delegate to). Test: `LineTests.ToString_WithFormat_AppliesFormatToCoordinates`,
 
 **Priority: P2 numerical stability.**
 
+**Fixed.** `Norm` now tracks the largest component magnitude seen so far as a running scale and
+accumulates the *ratio* of each component to that scale, rather than each component's raw square (the
+same technique as BLAS `nrm2`/`hypot`). Since every ratio is at most 1, no intermediate value overflows
+or underflows even when the raw squares would. Test: `VectorTests.Norm_VeryLargeComponents_DoesNotOverflow`,
+`VectorTests.Norm_VerySmallComponents_DoesNotUnderflow`, `VectorTests.Norm_OrdinaryComponents_MatchesExpectedValue`.
+
 ### 41. Generalized cross product has factorial complexity and repeated enumeration
 
 `CrossProduct` recursively enumerates filtered column sequences and computes determinant-like minors directly. Complexity grows factorially with dimension and creates many iterator objects.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -274,6 +274,44 @@ reasonably by *type* (`NotSupportedException` for a missing rule/unavailable cap
 `ArgumentException`/`InvalidOperationException` for invalid API usage such as an ambiguous parameter
 name or an unsupported conversion) even without a dedicated result object.
 
+### 43. Code review of PR 448 found two silent-wrong-answer bugs in the numerical fallback and conversion handling
+
+A review of items #40-42 found two functional defects, both since fixed:
+
+1. `ExpressionDerivation<T>.ContainsParameter` only recognized a hand-picked subset of node kinds
+   (`ParameterExpression`, `UnaryExpression`, `BinaryExpression`, `MethodCallExpression`,
+   `InvocationExpression`), defaulting to `false` for everything else — including a `ConditionalExpression`,
+   `MemberExpression`, `NewExpression`, or `IndexExpression`. `DeriveUnknownMethodCall` used that `false`
+   to conclude an operand was constant and return an exact zero derivative, silently wrong whenever such
+   an operand actually depended on the differentiation variable.
+2. `PreserveConversion` (duplicated identically in `ExpressionDerivation<T>` and `ExpressionIntegration<T>`)
+   documented accepting only unchecked numeric *widenings*, but its condition only checked that both
+   endpoints were native numeric types — accepting reducing conversions like `double` to `float`, `double`
+   to `int`, or `long` to `short`. The floating-to-integer case was the most serious: for `x => (int)x`,
+   the code built a constant derivative (`(int)1.0 == 1`) instead of rejecting a conversion with no
+   well-defined symbolic derivative.
+
+**Fixed.** `ContainsParameter` now delegates to a nested `ParameterUsageVisitor : ExpressionVisitor` that
+walks the entire expression tree looking for the target parameter by reference identity, instead of a
+partial `switch`. `PreserveConversion` in both files now calls a new centralized
+`NumberUtils.IsWideningNumericConversion(Type, Type)`, which encodes C#'s implicit numeric conversion
+table (ECMA-334 §10.2.1), extended with `decimal` → `float`/`double` to preserve the already-shipped item
+#33 behavior. Test: `ExpressionDerivationTests.Derivate_FiniteDifferenceFallback_NewAndMemberOperand_DoesNotSilentlyReturnZero`,
+`ExpressionDerivationTests.Derivate_DoubleToFloatConversion_ThrowsClearException`,
+`ExpressionDerivationTests.Derivate_DoubleToIntConversion_ThrowsClearException`,
+`ExpressionDerivationTests.Derivate_FloatToDoubleConversion_PreservesDeclaredResultType`,
+`ExpressionIntegrationTests.Integrate_DoubleToFloatConversion_ThrowsClearException`,
+`ExpressionIntegrationTests.Integrate_DoubleToIntConversion_ThrowsClearException`,
+`ExpressionIntegrationTests.Integrate_FloatToDoubleConversion_PreservesDeclaredResultType`,
+`NumberUtilsTests.IsWideningNumericConversion_MatchesExpectedDirection`.
+
+*Separately noticed while writing the regression test, out of scope for this fix:* passing a lambda whose
+body contains a raw `ConditionalExpression` (e.g. a ternary used as a call argument) through
+`ExpressionExtensions.Simplify()` throws an unrelated `IndexOutOfRangeException` — `Transform`'s base
+dispatch treats `ConditionalExpression` as an opaque leaf (`default` case, no sub-expressions extracted),
+but `ExpressionSimplifier.FinalizeExpression` falls through to `CopyExpression`, whose `Conditional` branch
+unconditionally indexes `parameters[0..2]`.
+
 ## Additional duplicated intent to reduce
 
 - Differentiation and integration should share one typed symbolic context for target parameter identity, per-operation symbol capability lookup, constant creation, and domain diagnostics.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -254,6 +254,26 @@ Unsupported expressions rely on transformer fallback behavior, reflection failur
 
 **Priority: P2 API design.**
 
+**Partially fixed** (exactness only; see below for what remains out of scope). `ExpressionDerivation<T>`
+gains a `Derivate(LambdaExpression, out bool isExact)` overload: `isExact` is `false` when at least one
+sub-expression actually fell back to the finite-difference approximation (see item #36), and `true`
+otherwise — including when an unknown method's argument doesn't depend on the differentiation variable,
+which resolves to an exact `0` without ever invoking the approximation. Test:
+`ExpressionDerivationTests.Derivate_ExactRule_ReportsIsExactTrue`,
+`ExpressionDerivationTests.Derivate_FiniteDifferenceFallback_ReportsIsExactFalse`,
+`ExpressionDerivationTests.Derivate_FiniteDifferenceFallback_ConstantArgument_StillReportsIsExactTrue`.
+
+*Not fixed in this pass:* a fully structured, non-throwing result (also reporting "not
+integrable/differentiable" vs. "internal construction failure" without exceptions, and identifying the
+specific unsupported node) would require reworking how `ExpressionTransformer.Transform` propagates
+failure up through the whole recursive dispatch chain — every rule and the base dispatch loop currently
+communicate failure by throwing, and a rule already returns `null` to mean "try the next candidate rule",
+which is a different, already-used-up signal. That is a substantially larger change than fits this pass
+and was judged out of scope; the existing exception vocabulary already separates the two failure kinds
+reasonably by *type* (`NotSupportedException` for a missing rule/unavailable capability,
+`ArgumentException`/`InvalidOperationException` for invalid API usage such as an ambiguous parameter
+name or an unsupported conversion) even without a dedicated result object.
+
 ## Additional duplicated intent to reduce
 
 - Differentiation and integration should share one typed symbolic context for target parameter identity, per-operation symbol capability lookup, constant creation, and domain diagnostics.
@@ -291,4 +311,16 @@ Unsupported expressions rely on transformer fallback behavior, reflection failur
 
 ## Deployment warning
 
-Until items 30–38 are addressed, symbolic APIs can fail through low-level reflection errors when a specific operation is unavailable for `T`, may differentiate the wrong same-named parameter, can create type-invalid expression trees, and may silently substitute numerical approximations for exact symbolic derivatives. Arithmetic-only expressions should remain supported under the broad `IFloatingPoint<T>` contract; capability failures should be localized to the rules that require unavailable functions. `Line<T>` also permits invalid zero-direction instances and uses representation equality rather than geometric equality.
+Historical warning, kept for context: until items 30–38 were addressed, symbolic APIs could fail through
+low-level reflection errors when a specific operation was unavailable for `T`, could differentiate the
+wrong same-named parameter, could create type-invalid expression trees, and could silently substitute
+numerical approximations for exact symbolic derivatives. `Line<T>` also permitted invalid zero-direction
+instances and used representation equality rather than geometric equality.
+
+## Status
+
+All 13 findings in this file (P1 items 30–38, P2 items 39–42) are fixed as of 2026-07-12 (item #42 only
+partially — see its **Partially fixed** note for what a full structured-result API would additionally
+require and why it was judged out of scope for this pass). See the **Fixed**/**Partially fixed** note
+under each item above for what changed and where the regression tests live. PR reference: items 30–42 in
+PR #448.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -128,6 +128,20 @@ The general derivative of `f(x)^g(x)` emits a logarithm of the base. Over real n
 
 **Priority: P1 mathematical correctness.**
 
+**Fixed.** In `ExpressionIntegration<T>`, every rule whose antiderivative introduces a `Log` of a
+quantity that is well-defined (real) on a wider domain than a bare `Log` would suggest — `1/x`
+(all its constant/converted-constant/power/sqrt/`Math.Pow` variants) and `tan(x) = sin(x)/cos(x)`
+(direct and scaled forms), both defined for negative arguments — now emits `Log(Abs(...))` through a new
+shared `LogAbs` helper, instead of a bare `Log` that returns NaN on exactly the negative inputs the
+original expression supported. `Tanh`'s `Log(Cosh(x))` is intentionally left unchanged: `Cosh` is always
+&ge; 1, so no domain-narrowing occurs there. In `ExpressionDerivation<T>`, the variable-exponent `Power`
+rule (logarithmic differentiation of `f(x)^g(x)`) is left unchanged but now documents *why*: unlike
+`1/x`, the original `f(x)^g(x)` for a non-constant exponent is itself only real-valued for a positive
+base, so `Log(f)` does not narrow the domain further — replacing it with `Log(Abs(f))` would just produce
+a different, unrelated (and not more correct) formula. Test:
+`ExpressionIntegrationTests.Integrate_ReciprocalX_IsValidOnNegativeDomain`,
+`ExpressionIntegrationTests.Integrate_Tan_IsValidWhenCosineIsNegative`.
+
 ### 36. Finite-difference fallback silently turns unsupported symbolic derivatives into runtime approximations
 
 Unknown single-argument methods may be differentiated through a centered finite-difference approximation. This changes symbolic derivation into a numerical runtime computation, evaluates the source function multiple times, and may duplicate side effects or fail for discontinuous/non-pure methods.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -152,6 +152,19 @@ The epsilon is chosen only from whether `T` is `float`; all other types share a 
 
 **Priority: P1 semantic correctness.**
 
+**Fixed** (opt-in and step selection; see item #42 for exposing exactness). `ExpressionDerivation<T>` gains
+a new `AllowNumericalFallback` constructor parameter, defaulting to `false`: an unknown method now throws
+a `NotSupportedException` explaining that a finite-difference fallback exists but must be explicitly
+enabled, instead of silently approximating. The step size is no longer a hard-coded `1e-4`/`1e-7` special
+case for `float`; it is now computed generically as `MachineEpsilon<T>^(1/3)` (the standard step that
+balances truncation vs. rounding error for a centered difference, so it is correctly derived for any
+`IFloatingPoint<T>`, not just `float`/`double`) and additionally scaled by the operand's own magnitude at
+evaluation time (`stepBase * Max(Abs(operand), 1)`), so the step neither underflows for a large operand
+nor overshoots for a small one. Purity is still the caller's responsibility (documented on
+`AllowNumericalFallback`): no general mechanism can verify an arbitrary `MethodInfo` is pure. Test:
+`ExpressionDerivationTests.Derivate_UnknownDoubleFunction_FallbackDisabledByDefault_ThrowsClearException`
+(the existing fallback-dependent tests were updated to opt in explicitly).
+
 ### 37. `Line<T>` accepts a zero direction vector
 
 The constructor checks only dimensions. `DistanceTo` later divides by `Direction·Direction`; for a zero direction this is division by zero.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -190,6 +190,17 @@ Two equivalent lines compare unequal when their direction vectors differ by a no
 
 **Priority: P1 API semantics.**
 
+**Fixed.** `Equals`/`GetHashCode` are documented as exact representation equality (behavior unchanged), and
+a new `IsGeometricallyEquivalentTo(Line<T> other, T tolerance)` method (an explicit, mandatory tolerance —
+no implicit default) implements the actual geometric equivalence: directions are parallel when the
+magnitude of the dot product of their unit vectors is within `tolerance` of 1 (collinear, either same or
+opposite sense), and `other`'s anchor point must lie on this line within `tolerance`
+(`DistanceTo(other.Point) <= tolerance`). Test:
+`LineTests.IsGeometricallyEquivalentTo_SameLine_DifferentAnchorAndScale_ReturnsTrue`,
+`LineTests.IsGeometricallyEquivalentTo_ParallelButOffsetLine_ReturnsFalse`,
+`LineTests.IsGeometricallyEquivalentTo_NonParallelLine_ReturnsFalse`,
+`LineTests.IsGeometricallyEquivalentTo_InvalidTolerance_Throws`.
+
 ## Medium-priority findings
 
 ### 39. `Line<T>.ToString(format, provider)` ignores both arguments

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -73,6 +73,20 @@ Both differentiation and integration handle `Convert`/`ConvertChecked` by transf
 
 **Priority: P1 expression correctness.**
 
+**Fixed.** Both `ExpressionDerivation<T>.Convert`/`ConvertChecked` and
+`ExpressionIntegration<T>.Convert`/`ConvertChecked` now route through a shared `PreserveConversion`
+helper: if the transformed operand's type already matches the original conversion's declared result
+type, it is returned unchanged; if the types differ but both are native numeric types (`byte` through
+`decimal`) and the original node was an unchecked `Convert`, the result is re-wrapped in
+`Expression.Convert(result, original.Type)` to restore the declared type. Any other mismatch — in
+particular any type-changing `ConvertChecked`, since checked conversions exist specifically to guard
+against narrowing/overflow that has no well-defined symbolic derivative/integral — throws a clear
+`NotSupportedException` instead of silently returning a value of the wrong type. Test:
+`ExpressionDerivationTests.Derivate_WideningConversion_PreservesDeclaredResultType`,
+`ExpressionDerivationTests.Derivate_NarrowingCheckedConversion_ThrowsClearException`,
+`ExpressionIntegrationTests.Integrate_WideningConversion_PreservesDeclaredResultType`,
+`ExpressionIntegrationTests.Integrate_NarrowingCheckedConversion_ThrowsClearException`.
+
 ### 34. Integration introduces `double` constants into generic `T` expression trees
 
 Several integration rules convert numeric constants/exponents with `Convert.ToDouble` and create `Expression.Constant(double)`, then combine those constants with expressions of type `T`. For non-double `T`, binary expression construction can fail because no matching operator exists, or force unintended conversions.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -16,6 +16,17 @@ Optional specialized subclasses/helpers may add stronger constraints for known c
 
 **Priority: P1 generic API correctness.**
 
+**Fixed.** Added `Utils.Mathematics/Expressions/MathMethodResolver.cs`: a centralized, cached
+`Resolve<T>(methodName)` that every derivative/integration rule now calls instead of raw
+`typeof(T).GetMethod(...)`. Successful and failed lookups are cached per `(T, methodName)`; an
+unsupported operation throws `NotSupportedException` naming both the operation and the type, instead
+of a null propagating into `Expression.Call` and failing with an incidental `ArgumentNullException`.
+Arithmetic-only expressions (`+`, `-`, `*`, `/` without transcendental calls) remain supported for
+`decimal`. Test: `UtilsTest/Mathematics/Expressions/MathMethodResolverTests.cs`,
+`UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs`
+(`Derivate_ExpCall_UnsupportedScalarType_ThrowsClearException`,
+`Derivate_ArithmeticOnlyExpression_WorksForDecimal`).
+
 ### 31. Differentiation identifies variables by parameter name rather than parameter identity
 
 `ExpressionDerivation.Parameter` returns one whenever `ParameterExpression.Name == ParameterName`. Two distinct parameter objects may legally share the same name, especially in nested lambdas or manually built trees.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -173,6 +173,13 @@ The constructor checks only dimensions. `DistanceTo` later divides by `Direction
 
 **Priority: P1 geometry correctness.**
 
+**Fixed.** The constructor now calls `direction.Normalize()` purely to validate it (discarding the
+normalized copy; `Direction` keeps its original, non-unit scale), reusing `Vector<T>`'s existing
+scale-aware zero/near-zero tolerance policy instead of introducing an independent threshold, per the
+"same numerical policy" duplication note in this file. A zero or numerically negligible direction now
+throws `ArgumentException` instead of later producing a `DistanceTo` division by zero. Test:
+`LineTests.Constructor_ZeroDirection_Throws`, `LineTests.Constructor_NearZeroDirection_Throws`.
+
 ### 38. Line equality compares representations rather than geometric lines
 
 Two equivalent lines compare unequal when their direction vectors differ by a non-zero scalar, have opposite signs, or when their anchor points differ but lie on the same line.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -211,6 +211,12 @@ The type implements `IFormattable`, but its method interpolates `Point` and `Dir
 
 **Priority: P2 API correctness.**
 
+**Fixed.** `ToString(format, formatProvider)` now formats each coordinate of `Point`/`Direction`
+individually via a new private `FormatVector` helper that calls each `T` component's own
+`IFormattable.ToString(format, formatProvider)` (`Vector<T>` itself has no formattable overload to
+delegate to). Test: `LineTests.ToString_WithFormat_AppliesFormatToCoordinates`,
+`LineTests.ToString_WithCulture_AppliesFormatProviderToCoordinates`.
+
 ### 40. Vector norm calculation can overflow or underflow unnecessarily
 
 `Norm` sums `component * component` directly. Large finite values can overflow before the square root, and very small values can underflow, even when the true norm is representable.

--- a/Utils.Mathematics/TODO-2026-07-11-pass3.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass3.md
@@ -239,6 +239,13 @@ or underflows even when the raw squares would. Test: `VectorTests.Norm_VeryLarge
 
 **Priority: P2 performance.**
 
+**Fixed.** `CrossProduct` now builds each `(n-1)x(n-1)` minor directly into a plain array and computes its
+determinant via `Matrix<T>.Determinant` (Gaussian elimination, `O(n^3)`), instead of the previous direct
+recursive cofactor expansion (`O(n!)`) that also re-filtered the remaining-columns sequence with `.Where`
+at every recursion level. Overall complexity drops from `O(n!)` to `O(n^4)` (n columns, each an `O(n^3)`
+determinant). Test: `VectorTests.CrossProduct_4D_IsPerpendicularToAllThreeInputs` (existing 3D tests keep
+passing unchanged).
+
 ### 42. Symbolic transformation error behavior is not explicit
 
 Unsupported expressions rely on transformer fallback behavior, reflection failures, null-return conventions, and disabled nullable warnings. Callers cannot reliably distinguish “not integrable/differentiable”, “approximately transformed”, and “internal construction failure”.

--- a/Utils/Expressions/ExpressionTranformer.cs
+++ b/Utils/Expressions/ExpressionTranformer.cs
@@ -29,19 +29,27 @@ public abstract class ExpressionTransformer
     private readonly IReadOnlyList<(MethodInfo Method, ExpressionSignatureAttribute Attribute, ParameterInfo[] Parameters)> _transformMethods;
 
     /// <summary>
+    /// Caches the reflection scan of <see cref="ExpressionSignatureAttribute"/>-annotated methods per
+    /// concrete transformer type, since that scan only depends on the type and never on instance state.
+    /// This lets subclasses cheaply construct a fresh instance per operation (e.g. to isolate per-call
+    /// state instead of mutating a shared field) without repeating <see cref="Type.GetMethods(BindingFlags)"/>
+    /// reflection on every construction.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, IReadOnlyList<(MethodInfo Method, ExpressionSignatureAttribute Attribute, ParameterInfo[] Parameters)>> _transformMethodsCache = new();
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ExpressionTransformer"/> class.
     /// During construction, it gathers all methods marked with <see cref="ExpressionSignatureAttribute"/>
     /// from the derived type.
     /// </summary>
     protected ExpressionTransformer()
     {
-        Type t = GetType();
-        _transformMethods =
+        _transformMethods = _transformMethodsCache.GetOrAdd(GetType(), static t =>
             t.GetMethods(Public | NonPublic | InvokeMethod | Instance)
              .Select(m => (Method: m, Attr: m.GetCustomAttributes<ExpressionSignatureAttribute>().FirstOrDefault()))
              .Where(ma => ma.Attr != null)
              .Select(ma => (ma.Method, ma.Attr, ma.Method.GetParameters()))
-             .ToImmutableList();
+             .ToImmutableList());
     }
 
     /// <summary>

--- a/Utils/Objects/NumberUtils.cs
+++ b/Utils/Objects/NumberUtils.cs
@@ -79,9 +79,13 @@ public static class NumberUtils
     /// <summary>
     /// Checks whether an implicit (widening) numeric conversion exists from <paramref name="from"/> to
     /// <paramref name="to"/>. Unlike checking <see cref="IsNativeNumericType(Type)"/> on both endpoints,
-    /// this rejects conversions that change value or lose precision even between two native numeric
-    /// types, such as <see cref="double"/> to <see cref="float"/>, <see cref="double"/> to <see cref="int"/>,
-    /// or <see cref="long"/> to <see cref="short"/>.
+    /// this rejects conversions that reduce range or truncate, such as <see cref="double"/> to
+    /// <see cref="float"/>, <see cref="double"/> to <see cref="int"/>, or <see cref="long"/> to
+    /// <see cref="short"/>. It does not guarantee the conversion is lossless: some accepted entries —
+    /// matching C#'s own implicit numeric conversions (e.g. <see cref="long"/> to <see cref="float"/>) as
+    /// well as the deliberate <see cref="decimal"/>-to-floating-point extension noted on
+    /// <see cref="WideningNumericConversions"/> — can still lose precision for values near the source
+    /// type's upper range or significant-digit limit.
     /// </summary>
     /// <param name="from">Source CLR numeric type.</param>
     /// <param name="to">Destination CLR numeric type.</param>

--- a/Utils/Objects/NumberUtils.cs
+++ b/Utils/Objects/NumberUtils.cs
@@ -56,6 +56,47 @@ public static class NumberUtils
     }
 
     /// <summary>
+    /// Table of C#'s implicit (widening) numeric conversions (ECMA-334 §10.2.1), keyed by source type,
+    /// extended with <see cref="decimal"/> as a source for <see cref="float"/>/<see cref="double"/> so
+    /// that treating <c>decimal</c> as embeddable into a floating-point type (a deliberate choice of this
+    /// library, even though C# itself only allows that conversion explicitly) stays centralized here
+    /// rather than re-decided at each call site.
+    /// </summary>
+    private static readonly Dictionary<Type, Type[]> WideningNumericConversions = new()
+    {
+        [typeof(sbyte)] = [typeof(short), typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal)],
+        [typeof(byte)] = [typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal)],
+        [typeof(short)] = [typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal)],
+        [typeof(ushort)] = [typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal)],
+        [typeof(int)] = [typeof(long), typeof(float), typeof(double), typeof(decimal)],
+        [typeof(uint)] = [typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal)],
+        [typeof(long)] = [typeof(float), typeof(double), typeof(decimal)],
+        [typeof(ulong)] = [typeof(float), typeof(double), typeof(decimal)],
+        [typeof(float)] = [typeof(double)],
+        [typeof(decimal)] = [typeof(float), typeof(double)],
+    };
+
+    /// <summary>
+    /// Checks whether an implicit (widening) numeric conversion exists from <paramref name="from"/> to
+    /// <paramref name="to"/>. Unlike checking <see cref="IsNativeNumericType(Type)"/> on both endpoints,
+    /// this rejects conversions that change value or lose precision even between two native numeric
+    /// types, such as <see cref="double"/> to <see cref="float"/>, <see cref="double"/> to <see cref="int"/>,
+    /// or <see cref="long"/> to <see cref="short"/>.
+    /// </summary>
+    /// <param name="from">Source CLR numeric type.</param>
+    /// <param name="to">Destination CLR numeric type.</param>
+    /// <returns><c>true</c> when the conversion is the identity or a recognized widening; otherwise <c>false</c>.</returns>
+    public static bool IsWideningNumericConversion(Type from, Type to)
+    {
+        Type effectiveFrom = Nullable.GetUnderlyingType(from) ?? from;
+        Type effectiveTo = Nullable.GetUnderlyingType(to) ?? to;
+
+        if (effectiveFrom == effectiveTo) return true;
+
+        return WideningNumericConversions.TryGetValue(effectiveFrom, out var targets) && Array.IndexOf(targets, effectiveTo) >= 0;
+    }
+
+    /// <summary>
     /// Checks whether the given CLR <paramref name="type"/> is one of the native integral primitives.
     /// This helper intentionally targets built-in integer types and is distinct from
     /// generic math interface checks such as <see cref="IBinaryInteger{TSelf}"/>.

--- a/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
@@ -304,4 +304,45 @@ public class ExpressionDerivationTests
     /// <returns>The cubic value of <paramref name="x"/>.</returns>
     private static float FloatCube(float x) => x * x * x;
 
+    // ── Unsupported scalar-type capability (item 30) ─────────────────────────
+
+    /// <summary>
+    /// <see cref="decimal"/> satisfies <see cref="System.Numerics.IFloatingPoint{TSelf}"/> but declares no
+    /// <c>Exp</c> method. Differentiating a <c>double.Exp</c> call node against a decimal-configured
+    /// transformer must fail with a clear <see cref="NotSupportedException"/> instead of an incidental
+    /// reflection null failure deep inside <see cref="Expression.Call(System.Reflection.MethodInfo, Expression[])"/>.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ExpCall_UnsupportedScalarType_ThrowsClearException()
+    {
+        ExpressionDerivation<decimal> decimalDerivation = new("x");
+        var x = Expression.Parameter(typeof(decimal), "x");
+        var expCall = Expression.Call(typeof(double).GetMethod(nameof(double.Exp), [typeof(double)]), Expression.Convert(x, typeof(double)));
+        var f = Expression.Lambda<Func<decimal, double>>(expCall, x);
+
+        // Transformation rules are dispatched through reflection (see ExpressionTransformer.Transform),
+        // so the NotSupportedException surfaces wrapped in a TargetInvocationException.
+        var invocationException = Assert.ThrowsExactly<System.Reflection.TargetInvocationException>(() => decimalDerivation.Derivate(f));
+        Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
+        var ex = (NotSupportedException)invocationException.InnerException!;
+        StringAssert.Contains(ex.Message, "Exp");
+        StringAssert.Contains(ex.Message, "Decimal");
+    }
+
+    /// <summary>
+    /// Arithmetic-only expressions (no transcendental functions) remain differentiable for
+    /// <see cref="decimal"/> even though it lacks Log/Sin/Exp/etc.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ArithmeticOnlyExpression_WorksForDecimal()
+    {
+        ExpressionDerivation<decimal> decimalDerivation = new("x");
+        Expression<Func<decimal, decimal>> f = x => x * x;
+        var result = (Expression<Func<decimal, decimal>>)decimalDerivation.Derivate(f);
+        var derivative = result.Compile();
+
+        foreach (decimal xv in new[] { -2m, -0.5m, 0m, 1.25m, 3m })
+            Assert.AreEqual(2m * xv, derivative(xv), $"d/dx[x*x] for decimal at x={xv}");
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
@@ -457,4 +457,51 @@ public class ExpressionDerivationTests
         Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
     }
 
+    // ── Exactness reporting (item 42) ─────────────────────────────────────────
+
+    /// <summary>
+    /// A purely symbolic derivative (no finite-difference fallback involved) must report
+    /// <c>isExact = true</c>.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ExactRule_ReportsIsExactTrue()
+    {
+        Expression<Func<double, double>> f = x => x * x;
+        derivation.Derivate(f, out bool isExact);
+
+        Assert.IsTrue(isExact);
+    }
+
+    /// <summary>
+    /// When the finite-difference fallback (opted into via <see cref="ExpressionDerivation{T}.AllowNumericalFallback"/>)
+    /// is actually used for an unknown method, the result must report <c>isExact = false</c> so a caller
+    /// can distinguish an exact symbolic derivative from a numerical approximation.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_FiniteDifferenceFallback_ReportsIsExactFalse()
+    {
+        Expression<Func<double, double>> function = x => CustomUnknown(x);
+        derivationWithFallback.Derivate(function, out bool isExact);
+
+        Assert.IsFalse(isExact);
+    }
+
+    /// <summary>
+    /// Even with the fallback enabled, an unknown method call whose argument does not depend on the
+    /// differentiation variable is resolved exactly (its derivative is trivially zero) without invoking
+    /// the numerical approximation at all.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_FiniteDifferenceFallback_ConstantArgument_StillReportsIsExactTrue()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var y = Expression.Parameter(typeof(double), "y");
+        var body = Expression.Call(typeof(ExpressionDerivationTests).GetMethod(nameof(CustomUnknown), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!, y);
+        var f = Expression.Lambda<Func<double, double, double>>(body, x, y);
+
+        derivationWithFallback.Derivate(f, out bool isExact);
+
+        Assert.IsTrue(isExact);
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
@@ -504,4 +504,81 @@ public class ExpressionDerivationTests
         Assert.IsTrue(isExact);
     }
 
+    // ── Parameter-dependency detection in the numerical fallback (PR 448 review) ──
+
+    /// <summary>
+    /// An unknown-method operand that depends on the differentiation variable only through a
+    /// <see cref="NewExpression"/> plus a <see cref="MemberExpression"/> (<c>(x, 0d).Item1</c>) must not
+    /// be mistaken for a constant: previously, <c>ContainsParameter</c> only recognized a hand-picked
+    /// subset of node kinds (via a <c>switch</c> defaulting to <c>false</c>) and would have silently
+    /// returned a zero derivative for these two node kinds instead of ever reaching
+    /// <see cref="Transform"/>. Since differentiating a <see cref="MemberExpression"/> is not itself
+    /// implemented, the correct behavior once the dependency is detected is an explicit failure — not a
+    /// silently wrong zero.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_FiniteDifferenceFallback_NewAndMemberOperand_DoesNotSilentlyReturnZero()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var tupleCtor = typeof(ValueTuple<double, double>).GetConstructor([typeof(double), typeof(double)])!;
+        var tupleOperand = Expression.Field(Expression.New(tupleCtor, x, Expression.Constant(0d)), "Item1");
+        var method = typeof(ExpressionDerivationTests).GetMethod(nameof(CustomUnknown), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var body = Expression.Call(method, tupleOperand);
+        var f = Expression.Lambda<Func<double, double>>(body, x);
+
+        Assert.ThrowsExactly<NotSupportedException>(() => derivationWithFallback.Derivate(f));
+    }
+
+    // ── Widening-only numeric conversions (PR 448 review) ─────────────────────
+
+    /// <summary>
+    /// An unchecked <c>double</c> to <c>float</c> conversion loses precision and is not a recognized
+    /// widening; it must be rejected rather than silently accepted just because both endpoints are
+    /// native numeric types.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_DoubleToFloatConversion_ThrowsClearException()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.Convert(x, typeof(float));
+        var f = Expression.Lambda<Func<double, float>>(body, x);
+
+        var invocationException = Assert.ThrowsExactly<System.Reflection.TargetInvocationException>(() => derivation.Derivate(f));
+        Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
+    }
+
+    /// <summary>
+    /// An unchecked <c>double</c> to <c>int</c> conversion (e.g. <c>x =&gt; (int)x</c>) truncates and has
+    /// no well-defined symbolic derivative; it must be rejected instead of silently producing a constant
+    /// derivative such as <c>(int)1.0 == 1</c>.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_DoubleToIntConversion_ThrowsClearException()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.Convert(x, typeof(int));
+        var f = Expression.Lambda<Func<double, int>>(body, x);
+
+        var invocationException = Assert.ThrowsExactly<System.Reflection.TargetInvocationException>(() => derivation.Derivate(f));
+        Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
+    }
+
+    /// <summary>
+    /// A genuine widening (<c>float</c> to <c>double</c>) must still be preserved after tightening the
+    /// widening check, so the fix does not overcorrect into rejecting legitimate conversions.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_FloatToDoubleConversion_PreservesDeclaredResultType()
+    {
+        ExpressionDerivation<float> floatDerivation = new("x");
+        var x = Expression.Parameter(typeof(float), "x");
+        var body = Expression.Convert(x, typeof(double));
+        var f = Expression.Lambda<Func<float, double>>(body, x);
+
+        var result = (Expression<Func<float, double>>)floatDerivation.Derivate(f);
+        var derivativeFunc = result.Compile();
+
+        Assert.AreEqual(1.0, derivativeFunc(3f), 1e-9);
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
@@ -403,4 +403,41 @@ public class ExpressionDerivationTests
         }
     }
 
+    // ── Conversion type preservation (item 33) ────────────────────────────────
+
+    /// <summary>
+    /// Differentiating a widening numeric conversion (here <c>decimal</c> to <c>double</c>) must
+    /// preserve the conversion's declared result type, so the produced lambda still matches the
+    /// delegate type the caller compiled the source expression against.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_WideningConversion_PreservesDeclaredResultType()
+    {
+        ExpressionDerivation<decimal> decimalDerivation = new("x");
+        var x = Expression.Parameter(typeof(decimal), "x");
+        var body = Expression.Convert(x, typeof(double));
+        var f = Expression.Lambda<Func<decimal, double>>(body, x);
+
+        var result = (Expression<Func<decimal, double>>)decimalDerivation.Derivate(f);
+        var derivative = result.Compile();
+
+        Assert.AreEqual(1.0, derivative(3m), 1e-9);
+    }
+
+    /// <summary>
+    /// A checked conversion that actually changes the type (here <c>double</c> to <c>int</c>) has no
+    /// well-defined symbolic derivative and must be rejected explicitly rather than silently stripped,
+    /// which would otherwise return a value of the wrong type.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_NarrowingCheckedConversion_ThrowsClearException()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.ConvertChecked(x, typeof(int));
+        var f = Expression.Lambda<Func<double, int>>(body, x);
+
+        var invocationException = Assert.ThrowsExactly<System.Reflection.TargetInvocationException>(() => derivation.Derivate(f));
+        Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
@@ -14,6 +14,7 @@ public class ExpressionDerivationTests
 
     CSyntaxExpressionCompiler compiler = new CSyntaxExpressionCompiler();
     ExpressionDerivation<double> derivation = new ExpressionDerivation<double>("x");
+    ExpressionDerivation<double> derivationWithFallback = new ExpressionDerivation<double>("x", allowNumericalFallback: true);
 
     /// <summary>
     /// A sample unknown function used to validate finite-difference fallback derivatives.
@@ -85,7 +86,7 @@ public class ExpressionDerivationTests
     public void Derivate_UnknownDoubleFunction_UsesFiniteDifferenceFallback()
     {
         Expression<Func<double, double>> function = x => CustomUnknown(x);
-        var result = (Expression<Func<double, double>>)derivation.Derivate(function);
+        var result = (Expression<Func<double, double>>)derivationWithFallback.Derivate(function);
         var derivative = result.Compile();
 
         double[] samples = [-2.0, -0.5, 0.25, 1.5];
@@ -104,7 +105,7 @@ public class ExpressionDerivationTests
     public void Derivate_ComposedUnknownDoubleFunction_AppliesChainRule()
     {
         Expression<Func<double, double>> function = x => CustomUnknown(x * x);
-        var result = (Expression<Func<double, double>>)derivation.Derivate(function);
+        var result = (Expression<Func<double, double>>)derivationWithFallback.Derivate(function);
         var derivative = result.Compile();
 
         double[] samples = [-1.5, -0.75, 0.5, 1.25];
@@ -206,7 +207,7 @@ public class ExpressionDerivationTests
     public void Derivate_Sinh_MatchesCosh()
     {
         Expression<Func<double, double>> f = x => double.Sinh(x);
-        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var df = (Expression<Func<double, double>>)derivationWithFallback.Derivate(f);
         var compiled = df.Compile();
 
         foreach (double xv in new[] { -1.0, 0.0, 0.5, 2.0 })
@@ -220,7 +221,7 @@ public class ExpressionDerivationTests
     public void Derivate_Cosh_MatchesSinh()
     {
         Expression<Func<double, double>> f = x => double.Cosh(x);
-        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var df = (Expression<Func<double, double>>)derivationWithFallback.Derivate(f);
         var compiled = df.Compile();
 
         foreach (double xv in new[] { -1.0, 0.0, 0.5, 2.0 })
@@ -234,7 +235,7 @@ public class ExpressionDerivationTests
     public void Derivate_Tanh_MatchesSechSquared()
     {
         Expression<Func<double, double>> f = x => double.Tanh(x);
-        var df = (Expression<Func<double, double>>)derivation.Derivate(f);
+        var df = (Expression<Func<double, double>>)derivationWithFallback.Derivate(f);
         var compiled = df.Compile();
 
         foreach (double xv in new[] { -1.0, 0.0, 0.5, 2.0 })
@@ -288,7 +289,7 @@ public class ExpressionDerivationTests
     [TestMethod]
     public void Derivate_UnknownFloatFunction_UsesFiniteDifferenceFallback()
     {
-        ExpressionDerivation<float> floatDerivation = new("x");
+        ExpressionDerivation<float> floatDerivation = new("x", allowNumericalFallback: true);
         Expression<Func<float, float>> f = x => x * x * x;
         var df = (Expression<Func<float, float>>)floatDerivation.Derivate(f);
         var compiled = df.Compile();
@@ -303,6 +304,22 @@ public class ExpressionDerivationTests
     /// <param name="x">Input value.</param>
     /// <returns>The cubic value of <paramref name="x"/>.</returns>
     private static float FloatCube(float x) => x * x * x;
+
+    // ── Opt-in finite-difference fallback (item 36) ───────────────────────────
+
+    /// <summary>
+    /// By default (<see cref="ExpressionDerivation{T}.AllowNumericalFallback"/> is <see langword="false"/>),
+    /// an unknown method must fail explicitly rather than silently falling back to a numerical
+    /// approximation that evaluates the source method twice per derivative evaluation.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_UnknownDoubleFunction_FallbackDisabledByDefault_ThrowsClearException()
+    {
+        Expression<Func<double, double>> function = x => CustomUnknown(x);
+
+        var ex = Assert.ThrowsExactly<NotSupportedException>(() => derivation.Derivate(function));
+        StringAssert.Contains(ex.Message, nameof(ExpressionDerivation<double>.AllowNumericalFallback));
+    }
 
     // ── Unsupported scalar-type capability (item 30) ─────────────────────────
 

--- a/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
@@ -345,4 +345,62 @@ public class ExpressionDerivationTests
             Assert.AreEqual(2m * xv, derivative(xv), $"d/dx[x*x] for decimal at x={xv}");
     }
 
+    // ── Parameter identity (item 31) and re-entrancy (item 32) ───────────────
+
+    /// <summary>
+    /// Two distinct <see cref="ParameterExpression"/> objects legally sharing the differentiation
+    /// variable's name cannot be resolved unambiguously by name alone; the previous name-based lookup
+    /// would silently differentiate as if both were the target variable. The fix rejects this instead
+    /// of guessing.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_TwoDistinctParametersWithSameName_ThrowsAmbiguousException()
+    {
+        var x1 = Expression.Parameter(typeof(double), "x");
+        var x2 = Expression.Parameter(typeof(double), "x");
+        var f = Expression.Lambda<Func<double, double, double>>(Expression.Add(x1, x2), x1, x2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => derivation.Derivate(f));
+    }
+
+    /// <summary>
+    /// When the configured parameter name is absent from the lambda's own parameter list, the target
+    /// variable cannot be resolved at all and differentiation must fail clearly rather than silently
+    /// matching an unrelated same-named parameter deep in the expression tree.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ParameterNameNotInLambda_ThrowsClearException()
+    {
+        var y = Expression.Parameter(typeof(double), "y");
+        var f = Expression.Lambda<Func<double, double>>(y, y);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => derivation.Derivate(f));
+    }
+
+    /// <summary>
+    /// Each <see cref="ExpressionDerivation{T}.Derivate"/> call resolves its target parameter into a
+    /// fresh, isolated worker instance rather than mutating shared instance state, so concurrent calls
+    /// on one shared transformer instance cannot corrupt each other's result (item 32).
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ConcurrentCalls_AreIsolatedPerCall()
+    {
+        var shared = new ExpressionDerivation<double>("x");
+        var results = new Expression<Func<double, double>>[64];
+
+        System.Threading.Tasks.Parallel.For(0, results.Length, i =>
+        {
+            var x = Expression.Parameter(typeof(double), "x");
+            var f = Expression.Lambda<Func<double, double>>(Expression.Multiply(Expression.Constant((double)(i + 1)), x), x);
+            results[i] = (Expression<Func<double, double>>)shared.Derivate(f);
+        });
+
+        for (int i = 0; i < results.Length; i++)
+        {
+            double expected = i + 1;
+            double actual = results[i].Compile()(2.5);
+            Assert.AreEqual(expected, actual, 1e-9, $"Concurrent derivate #{i}");
+        }
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
@@ -25,7 +25,7 @@ public class ExpressionIntegrationTests
 
         var tests = new (string function, string integral)[]
         {
-            ("1/x", "Log(x)"),
+            ("1/x", "Log(Abs(x))"),
             ("1/(x**2)", "-(1.0/x)"),
             ("1/Sqrt(x)", "2.0*Sqrt(x)"),
             ("Sinh(x)", "Cosh(x)"),
@@ -444,6 +444,48 @@ public class ExpressionIntegrationTests
 
         foreach (float xv in new[] { 0.5f, 1f, 2f, 4f })
             Assert.AreEqual(6f * MathF.Sqrt(xv), integral(xv), 0.05f, $"∫3/√x dx (float) at x={xv}");
+    }
+
+    // ── Domain restrictions (item 35) ─────────────────────────────────────────
+
+    /// <summary>
+    /// ∫1/x dx = ln|x|, which (unlike a bare <c>Log(x)</c>) is defined for negative <c>x</c> too, just
+    /// like the original <c>1/x</c> it replaces.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ReciprocalX_IsValidOnNegativeDomain()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.Divide(Expression.Constant(1.0), x);
+        var f = Expression.Lambda<Func<double, double>>(body, x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        foreach (double xv in new[] { -5.0, -1.0, -0.25 })
+        {
+            double actual = compiled(xv);
+            Assert.IsFalse(double.IsNaN(actual), $"∫1/x dx at x={xv} should not be NaN");
+            Assert.AreEqual(Math.Log(Math.Abs(xv)), actual, 1e-9, $"∫1/x dx at x={xv}");
+        }
+    }
+
+    /// <summary>
+    /// ∫tan(x) dx = -ln|cos(x)|. At <c>x = 2.0</c>, <c>cos(x)</c> is negative
+    /// (<c>cos(2.0) ≈ -0.416</c>), so a bare <c>Log(Cos(x))</c> would return NaN even though
+    /// <c>tan(x)</c> itself is perfectly well-defined there.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_Tan_IsValidWhenCosineIsNegative()
+    {
+        Expression<Func<double, double>> f = x => double.Tan(x);
+        var result = (Expression<Func<double, double>>)integration.Integrate(f);
+        var compiled = result.Compile();
+
+        const double xv = 2.0;
+        Assert.IsTrue(Math.Cos(xv) < 0, "Test premise: cos(2.0) must be negative.");
+        double actual = compiled(xv);
+        Assert.IsFalse(double.IsNaN(actual), $"∫tan(x) dx at x={xv} should not be NaN");
+        Assert.AreEqual(-Math.Log(Math.Abs(Math.Cos(xv))), actual, 1e-9, $"∫tan(x) dx at x={xv}");
     }
 
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
@@ -292,4 +292,49 @@ public class ExpressionIntegrationTests
             Assert.AreEqual(xv * xv / 2.0 - Math.Cos(xv), compiled(xv), 1e-9, $"∫(x+sin(x)) dx at x={xv}");
     }
 
+    // ── Parameter identity (item 31) and re-entrancy (item 32) ───────────────
+
+    /// <summary>
+    /// Two distinct <see cref="ParameterExpression"/> objects legally sharing the integration
+    /// variable's name cannot be resolved unambiguously by name alone. The fix rejects this instead of
+    /// guessing which one is the real integration variable.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_TwoDistinctParametersWithSameName_ThrowsAmbiguousException()
+    {
+        var x1 = Expression.Parameter(typeof(double), "x");
+        var x2 = Expression.Parameter(typeof(double), "x");
+        var f = Expression.Lambda<Func<double, double, double>>(Expression.Add(x1, x2), x1, x2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => integration.Integrate(f));
+    }
+
+    /// <summary>
+    /// Each <see cref="ExpressionIntegration{T}.Integrate"/> call resolves its target parameter into a
+    /// fresh, isolated worker instance instead of mutating the shared instance's cached parameter field,
+    /// so concurrent calls on one shared transformer instance cannot corrupt each other's result
+    /// (item 32).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ConcurrentCalls_AreIsolatedPerCall()
+    {
+        var shared = new ExpressionIntegration<double>("x");
+        var results = new Expression<Func<double, double>>[64];
+
+        System.Threading.Tasks.Parallel.For(0, results.Length, i =>
+        {
+            var x = Expression.Parameter(typeof(double), "x");
+            var f = Expression.Lambda<Func<double, double>>(Expression.Constant((double)(i + 1)), x);
+            results[i] = (Expression<Func<double, double>>)shared.Integrate(f);
+        });
+
+        for (int i = 0; i < results.Length; i++)
+        {
+            double expectedFactor = i + 1;
+            var compiled = results[i].Compile();
+            foreach (double xv in new[] { -2.0, 0.0, 3.5 })
+                Assert.AreEqual(expectedFactor * xv, compiled(xv), 1e-9, $"Concurrent integrate #{i} at x={xv}");
+        }
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
@@ -378,4 +378,72 @@ public class ExpressionIntegrationTests
         Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
     }
 
+    // ── Generic-T constants in Power-rule integration (item 34) ───────────────
+
+    /// <summary>
+    /// Integrating the bare target parameter (∫x dx = x²/2) previously built
+    /// <c>Expression.Power(e, ...)</c> directly; that overload only ever works when the operand is
+    /// literally <see cref="double"/>, so it threw for any other scalar type even though the exponent
+    /// constant itself was already correctly typed. It now resolves a type-appropriate <c>Pow</c> method
+    /// through <see cref="MathMethodResolver"/> instead, so this works for <see cref="float"/> too.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_TargetParameter_WorksForFloat()
+    {
+        ExpressionIntegration<float> floatIntegration = new("x");
+        var x = Expression.Parameter(typeof(float), "x");
+        var f = Expression.Lambda<Func<float, float>>(x, x);
+
+        var result = (Expression<Func<float, float>>)floatIntegration.Integrate(f);
+        var integral = result.Compile();
+
+        foreach (float xv in new[] { -2f, -0.5f, 0f, 1.25f, 3f })
+            Assert.AreEqual(xv * xv / 2f, integral(xv), 1e-3f, $"∫x dx (float) at x={xv}");
+    }
+
+    /// <summary>
+    /// ∫c/x² dx = -c/x for a non-<see cref="double"/> scalar type. The shifted exponent (<c>1-n</c>)
+    /// must be a <typeparamref name="float"/>-typed constant shared between the numerator's power call
+    /// and the denominator, rather than a raw <see cref="double"/> constant combined with
+    /// <typeparamref name="float"/>-typed expressions (which fails to construct).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ConstantDividedByPower_WorksForFloat()
+    {
+        ExpressionIntegration<float> floatIntegration = new("x");
+        var x = Expression.Parameter(typeof(float), "x");
+        var powMethod = typeof(float).GetMethod(nameof(float.Pow), [typeof(float), typeof(float)]);
+        var body = Expression.Divide(
+            Expression.Constant(3f),
+            Expression.Power(x, Expression.Constant(2f), powMethod));
+        var f = Expression.Lambda<Func<float, float>>(body, x);
+
+        var result = (Expression<Func<float, float>>)floatIntegration.Integrate(f);
+        var integral = result.Compile();
+
+        foreach (float xv in new[] { -2f, -1f, 0.5f, 2f })
+            Assert.AreEqual(-3f / xv, integral(xv), 0.05f, $"∫3/x² dx (float) at x={xv}");
+    }
+
+    /// <summary>
+    /// ∫c/√x dx = 2c·√x for a non-<see cref="double"/> scalar type. The doubled-constant factor must be
+    /// <typeparamref name="float"/>-typed rather than a raw <see cref="double"/> constant multiplied
+    /// against the <typeparamref name="float"/>-typed <c>Sqrt</c> call result.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ConstantDividedBySqrt_WorksForFloat()
+    {
+        ExpressionIntegration<float> floatIntegration = new("x");
+        var x = Expression.Parameter(typeof(float), "x");
+        var sqrtMethod = typeof(float).GetMethod(nameof(float.Sqrt), [typeof(float)]);
+        var body = Expression.Divide(Expression.Constant(3f), Expression.Call(sqrtMethod, x));
+        var f = Expression.Lambda<Func<float, float>>(body, x);
+
+        var result = (Expression<Func<float, float>>)floatIntegration.Integrate(f);
+        var integral = result.Compile();
+
+        foreach (float xv in new[] { 0.5f, 1f, 2f, 4f })
+            Assert.AreEqual(6f * MathF.Sqrt(xv), integral(xv), 0.05f, $"∫3/√x dx (float) at x={xv}");
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
@@ -378,6 +378,59 @@ public class ExpressionIntegrationTests
         Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
     }
 
+    // ── Widening-only numeric conversions (PR 448 review) ─────────────────────
+
+    /// <summary>
+    /// An unchecked <c>double</c> to <c>float</c> conversion loses precision and is not a recognized
+    /// widening; it must be rejected rather than silently accepted just because both endpoints are
+    /// native numeric types (the same bug as <c>ExpressionDerivation{T}.PreserveConversion</c>, since
+    /// this method is a duplicate of it).
+    /// </summary>
+    [TestMethod]
+    public void Integrate_DoubleToFloatConversion_ThrowsClearException()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.Convert(x, typeof(float));
+        var f = Expression.Lambda<Func<double, float>>(body, x);
+
+        var invocationException = Assert.ThrowsExactly<System.Reflection.TargetInvocationException>(() => integration.Integrate(f));
+        Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
+    }
+
+    /// <summary>
+    /// An unchecked <c>double</c> to <c>int</c> conversion truncates and has no well-defined symbolic
+    /// integral; it must be rejected instead of silently producing a value of the wrong type.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_DoubleToIntConversion_ThrowsClearException()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.Convert(x, typeof(int));
+        var f = Expression.Lambda<Func<double, int>>(body, x);
+
+        var invocationException = Assert.ThrowsExactly<System.Reflection.TargetInvocationException>(() => integration.Integrate(f));
+        Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
+    }
+
+    /// <summary>
+    /// A genuine widening (<c>float</c> to <c>double</c>) must still be preserved after tightening the
+    /// widening check, so the fix does not overcorrect into rejecting legitimate conversions.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_FloatToDoubleConversion_PreservesDeclaredResultType()
+    {
+        ExpressionIntegration<float> floatIntegration = new("x");
+        var x = Expression.Parameter(typeof(float), "x");
+        var n = Expression.Parameter(typeof(float), "n");
+        var body = Expression.Convert(n, typeof(double));
+        var f = Expression.Lambda<Func<float, float, double>>(body, x, n);
+
+        var result = (Expression<Func<float, float, double>>)floatIntegration.Integrate(f);
+        var integral = result.Compile();
+
+        Assert.AreEqual((double)(5f * 3f), integral(3f, 5f), 1e-4);
+    }
+
     // ── Generic-T constants in Power-rule integration (item 34) ───────────────
 
     /// <summary>

--- a/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
@@ -337,4 +337,45 @@ public class ExpressionIntegrationTests
         }
     }
 
+    // ── Conversion type preservation (item 33) ────────────────────────────────
+
+    /// <summary>
+    /// Integrating a widening numeric conversion (here <c>decimal</c> to <c>double</c>) must preserve
+    /// the conversion's declared result type, so the produced lambda still matches the delegate type
+    /// the caller compiled the source expression against.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_WideningConversion_PreservesDeclaredResultType()
+    {
+        // n is a foreign (non-integration-variable) parameter, so integrating it takes the
+        // "constant factor" branch (n * x) rather than the target-parameter branch (x**2/2, which
+        // relies on Expression.Power and is unsupported for decimal regardless of this fix).
+        ExpressionIntegration<decimal> decimalIntegration = new("x");
+        var x = Expression.Parameter(typeof(decimal), "x");
+        var n = Expression.Parameter(typeof(decimal), "n");
+        var body = Expression.Convert(n, typeof(double));
+        var f = Expression.Lambda<Func<decimal, decimal, double>>(body, x, n);
+
+        var result = (Expression<Func<decimal, decimal, double>>)decimalIntegration.Integrate(f);
+        var integral = result.Compile();
+
+        Assert.AreEqual((double)(5m * 3m), integral(3m, 5m), 1e-9);
+    }
+
+    /// <summary>
+    /// A checked conversion that actually changes the type (here <c>double</c> to <c>int</c>) has no
+    /// well-defined symbolic integral and must be rejected explicitly rather than silently stripped,
+    /// which would otherwise return a value of the wrong type.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_NarrowingCheckedConversion_ThrowsClearException()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var body = Expression.ConvertChecked(x, typeof(int));
+        var f = Expression.Lambda<Func<double, int>>(body, x);
+
+        var invocationException = Assert.ThrowsExactly<System.Reflection.TargetInvocationException>(() => integration.Integrate(f));
+        Assert.IsInstanceOfType(invocationException.InnerException, typeof(NotSupportedException));
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/MathMethodResolverTests.cs
+++ b/UtilsTest/Mathematics/Expressions/MathMethodResolverTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Mathematics.Expressions;
+
+namespace UtilsTest.Mathematics.Expressions;
+
+/// <summary>
+/// Validates that <see cref="MathMethodResolver"/> resolves supported scalar operations and reports
+/// unsupported ones through an explicit diagnostic instead of a raw reflection null.
+/// </summary>
+[TestClass]
+public class MathMethodResolverTests
+{
+    /// <summary>
+    /// A supported single-argument static method (<see cref="double.Log(double)"/>) resolves to a
+    /// callable <see cref="System.Reflection.MethodInfo"/>.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_SupportedDoubleMethod_ReturnsCallableMethod()
+    {
+        var method = MathMethodResolver.Resolve<double>(nameof(double.Log));
+
+        var x = Expression.Parameter(typeof(double), "x");
+        var call = Expression.Lambda<Func<double, double>>(Expression.Call(method, x), x).Compile();
+
+        Assert.AreEqual(Math.Log(2.0), call(2.0), 1e-12);
+    }
+
+    /// <summary>
+    /// <see cref="decimal"/> satisfies <see cref="System.Numerics.IFloatingPoint{TSelf}"/> but declares no
+    /// transcendental functions; resolving one must fail with a diagnostic naming both the operation and
+    /// the type rather than an incidental null-reference failure deep inside <see cref="Expression.Call(System.Reflection.MethodInfo, Expression[])"/>.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_UnsupportedScalarType_ThrowsNotSupportedExceptionWithDiagnostic()
+    {
+        var ex = Assert.ThrowsExactly<NotSupportedException>(() => MathMethodResolver.Resolve<decimal>(nameof(double.Log)));
+
+        StringAssert.Contains(ex.Message, "Log");
+        StringAssert.Contains(ex.Message, "Decimal");
+    }
+
+    /// <summary>
+    /// Failed lookups are cached: a second call for the same unsupported (type, operation) pair still
+    /// throws the same diagnostic instead of erroring differently or crashing on repeated reflection.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_UnsupportedScalarType_IsConsistentAcrossRepeatedCalls()
+    {
+        var first = Assert.ThrowsExactly<NotSupportedException>(() => MathMethodResolver.Resolve<decimal>(nameof(double.Sin)));
+        var second = Assert.ThrowsExactly<NotSupportedException>(() => MathMethodResolver.Resolve<decimal>(nameof(double.Sin)));
+
+        Assert.AreEqual(first.Message, second.Message);
+    }
+}

--- a/UtilsTest/Mathematics/LinearAlgebra/LineTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/LineTests.cs
@@ -133,4 +133,30 @@ public class LineTests
 
         Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.IsGeometricallyEquivalentTo(b, -1.0));
     }
+
+    // ── ToString format/provider propagation (item 39) ────────────────────────
+
+    [TestMethod]
+    public void ToString_WithFormat_AppliesFormatToCoordinates()
+    {
+        var line = new Line<double>(new Vector<double>(1.23456, 2.5), new Vector<double>(1d, 0d));
+
+        string formatted = line.ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
+
+        StringAssert.Contains(formatted, "1.23");
+        StringAssert.Contains(formatted, "2.50");
+        StringAssert.Contains(formatted, "1.00");
+        StringAssert.Contains(formatted, "0.00");
+    }
+
+    [TestMethod]
+    public void ToString_WithCulture_AppliesFormatProviderToCoordinates()
+    {
+        var line = new Line<double>(new Vector<double>(1.5, 0d), new Vector<double>(1d, 0d));
+        var culture = System.Globalization.CultureInfo.GetCultureInfo("fr-FR");
+
+        string formatted = line.ToString("F1", culture);
+
+        StringAssert.Contains(formatted, "1,5");
+    }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/LineTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/LineTests.cs
@@ -92,4 +92,45 @@ public class LineTests
         Assert.ThrowsException<ArgumentException>(() =>
             new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(1e-300, 1e-300)));
     }
+
+    // ── Geometric equality (item 38) ──────────────────────────────────────────
+
+    [TestMethod]
+    public void IsGeometricallyEquivalentTo_SameLine_DifferentAnchorAndScale_ReturnsTrue()
+    {
+        // Same line (the x-axis), described from a different anchor point and with a scaled,
+        // opposite-sense direction vector — Equals() would say these differ.
+        var a = new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(1d, 0d));
+        var b = new Line<double>(new Vector<double>(5d, 0d), new Vector<double>(-2d, 0d));
+
+        Assert.IsFalse(a.Equals(b));
+        Assert.IsTrue(a.IsGeometricallyEquivalentTo(b, 1e-9));
+    }
+
+    [TestMethod]
+    public void IsGeometricallyEquivalentTo_ParallelButOffsetLine_ReturnsFalse()
+    {
+        var a = new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(1d, 0d));
+        var b = new Line<double>(new Vector<double>(0d, 1d), new Vector<double>(1d, 0d));
+
+        Assert.IsFalse(a.IsGeometricallyEquivalentTo(b, 1e-9));
+    }
+
+    [TestMethod]
+    public void IsGeometricallyEquivalentTo_NonParallelLine_ReturnsFalse()
+    {
+        var a = new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(1d, 0d));
+        var b = new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(0d, 1d));
+
+        Assert.IsFalse(a.IsGeometricallyEquivalentTo(b, 1e-9));
+    }
+
+    [TestMethod]
+    public void IsGeometricallyEquivalentTo_InvalidTolerance_Throws()
+    {
+        var a = new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(1d, 0d));
+        var b = new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(1d, 0d));
+
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => a.IsGeometricallyEquivalentTo(b, -1.0));
+    }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/LineTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/LineTests.cs
@@ -76,4 +76,20 @@ public class LineTests
         var b = new Line<double>(new Vector<double>(1d, 0d), new Vector<double>(1d, 0d));
         Assert.IsFalse(a.Equals(b));
     }
+
+    // ── Zero-direction rejection (item 37) ────────────────────────────────────
+
+    [TestMethod]
+    public void Constructor_ZeroDirection_Throws()
+    {
+        Assert.ThrowsException<ArgumentException>(() =>
+            new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(0d, 0d)));
+    }
+
+    [TestMethod]
+    public void Constructor_NearZeroDirection_Throws()
+    {
+        Assert.ThrowsException<ArgumentException>(() =>
+            new Line<double>(new Vector<double>(0d, 0d), new Vector<double>(1e-300, 1e-300)));
+    }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -187,6 +187,29 @@ public class VectorTests
         Assert.ThrowsException<ArgumentException>(() => Vector<double>.CrossProduct(v1, v2));
     }
 
+    /// <summary>
+    /// Item 41: the generalized cross product must remain correct (perpendicular to every input) in
+    /// dimensions higher than 3, where the reimplementation via <see cref="Matrix{T}.Determinant"/>
+    /// cofactors is exercised beyond the trivial 2x2 minors of the 3D case.
+    /// </summary>
+    [TestMethod]
+    public void CrossProduct_4D_IsPerpendicularToAllThreeInputs()
+    {
+        var a = new Vector<double>(1d, 0d, 0d, 0d);
+        var b = new Vector<double>(0d, 1d, 0d, 0d);
+        var c = new Vector<double>(0d, 0d, 1d, 0d);
+
+        var result = Vector<double>.CrossProduct(a, b, c);
+
+        Assert.AreEqual(4, result.Dimension);
+        Assert.AreEqual(0d, a * result, 1e-9, "Result should be perpendicular to a");
+        Assert.AreEqual(0d, b * result, 1e-9, "Result should be perpendicular to b");
+        Assert.AreEqual(0d, c * result, 1e-9, "Result should be perpendicular to c");
+        // The three orthonormal basis inputs span the first three axes, so the result must be
+        // the fourth standard basis vector, up to sign.
+        Assert.AreEqual(1d, Math.Abs(result[3]), 1e-9);
+    }
+
     // ── ToNormalSpace / FromNormalSpace ────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -430,5 +430,53 @@ public class VectorTests
         Assert.IsFalse(left == right);
         Assert.IsTrue(left != right);
     }
+
+    // ── Norm overflow/underflow stability (item 40) ───────────────────────────
+
+    /// <summary>
+    /// Components individually large enough that squaring them directly overflows to
+    /// <see cref="double.PositiveInfinity"/> must still produce a finite, correctly-scaled norm.
+    /// </summary>
+    [TestMethod]
+    public void Norm_VeryLargeComponents_DoesNotOverflow()
+    {
+        const double large = 1e200;
+        var vector = new Vector<double>(large, large);
+
+        double squared = large * large;
+        Assert.IsTrue(double.IsPositiveInfinity(squared + squared), "Test premise: naive sum-of-squares must overflow.");
+
+        double norm = vector.Norm;
+        Assert.IsFalse(double.IsPositiveInfinity(norm), "Norm of large-but-representable components must not overflow.");
+        Assert.AreEqual(large * Math.Sqrt(2), norm, large * 1e-9);
+    }
+
+    /// <summary>
+    /// Components individually small enough that squaring them directly underflows to zero must still
+    /// produce a correctly-scaled, nonzero norm.
+    /// </summary>
+    [TestMethod]
+    public void Norm_VerySmallComponents_DoesNotUnderflow()
+    {
+        const double small = 1e-200;
+        var vector = new Vector<double>(small, small);
+
+        Assert.AreEqual(0.0, small * small, "Test premise: squaring 'small' alone must underflow to zero.");
+
+        double norm = vector.Norm;
+        Assert.AreNotEqual(0.0, norm, "Norm of small-but-representable components must not underflow to zero.");
+        Assert.AreEqual(small * Math.Sqrt(2), norm, small * 1e-9);
+    }
+
+    /// <summary>
+    /// The scaled accumulation must still agree with the naive formula for ordinary, well-scaled
+    /// components (3-4-5 triangle), regardless of component order.
+    /// </summary>
+    [TestMethod]
+    public void Norm_OrdinaryComponents_MatchesExpectedValue()
+    {
+        Assert.AreEqual(5.0, new Vector<double>(3d, 4d).Norm, 1e-12);
+        Assert.AreEqual(5.0, new Vector<double>(4d, 3d).Norm, 1e-12);
+    }
 }
 

--- a/UtilsTest/Objects/NumberUtilsTests.cs
+++ b/UtilsTest/Objects/NumberUtilsTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Objects;
+
+namespace UtilsTest.Objects;
+
+[TestClass]
+public class NumberUtilsTests
+{
+    [TestMethod]
+    [DataRow(typeof(int), typeof(double), true)]
+    [DataRow(typeof(int), typeof(long), true)]
+    [DataRow(typeof(float), typeof(double), true)]
+    [DataRow(typeof(decimal), typeof(double), true)]
+    [DataRow(typeof(decimal), typeof(float), true)]
+    [DataRow(typeof(long), typeof(short), false)]
+    [DataRow(typeof(double), typeof(float), false)]
+    [DataRow(typeof(double), typeof(int), false)]
+    [DataRow(typeof(float), typeof(int), false)]
+    [DataRow(typeof(double), typeof(decimal), false)]
+    [DataRow(typeof(double), typeof(double), true)]
+    public void IsWideningNumericConversion_MatchesExpectedDirection(System.Type from, System.Type to, bool expected)
+    {
+        Assert.AreEqual(expected, NumberUtils.IsWideningNumericConversion(from, to));
+    }
+}


### PR DESCRIPTION
## Summary
- Addresses all 13 findings in `Utils.Mathematics/TODO-2026-07-11-pass3.md` (items 30-42), one item per commit, each with its own regression tests:
  - #30 centralize symbolic-transform method resolution (`MathMethodResolver`)
  - #31/#32 resolve the differentiation/integration parameter by reference identity and isolate state per call
  - #33 preserve `Convert`/`ConvertChecked` type semantics
  - #34 T-typed constants + generic `Pow` resolution in `ExpressionIntegration`
  - #35 `Log(Abs(x))` domain fix for `1/x` and `tan(x)` antiderivatives
  - #36 opt-in, type/scale-aware finite-difference fallback
  - #37 reject zero-direction `Line<T>`
  - #38 `Line<T>` geometric equality comparer
  - #39 `Line<T>.ToString` honors format/provider
  - #40 stabilize `Vector<T>.Norm` (scaled sum-of-squares)
  - #41 `CrossProduct` complexity (`O(n!)` -> `O(n^4)` via `Matrix<T>.Determinant`)
  - #42 report derivative exactness (partial - see TODO file for what's out of scope)
- The TODO file is fully annotated per item with what changed and where tests live; item #34 and #36 note one discovered-but-out-of-scope related limitation each, and item #42 documents why a fully non-throwing structured result wasn't attempted.

## Test plan
- [x] `dotnet test UtilsTest/UtilsTest.Unit.csproj` after every commit - 3728 passed, 3 ignored, 0 failed (baseline was 3698/3/0)
- [x] New/updated tests across `MathMethodResolverTests`, `ExpressionDerivationTests`, `ExpressionIntegrationTests`, `LineTests`, `VectorTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
