### PR TITLE
Utils.Mathematics: address TODO-pass4.md findings

### DIFF
--- a/Utils.Mathematics/Expressions/ExpressionDerivation.cs
+++ b/Utils.Mathematics/Expressions/ExpressionDerivation.cs
@@ -68,6 +68,17 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     private readonly ParameterExpression targetParameter;
 
     /// <summary>
+    /// Set only by the <see cref="ExpressionDerivation{T}(ParameterExpression, bool)"/> constructor: the
+    /// exact parameter instance to differentiate against, supplied directly by the caller instead of by
+    /// name. When set, <see cref="Derivate(LambdaExpression, out bool)"/> skips name-based resolution
+    /// entirely and just checks that the lambda being differentiated declares this exact instance — see
+    /// TODO-2026-07-11-pass4.md item #47 (name-based resolution cannot distinguish two distinct
+    /// parameters sharing one name, and fails outright when a parameter's <see cref="ParameterExpression.Name"/>
+    /// is <see langword="null"/>).
+    /// </summary>
+    private readonly ParameterExpression? explicitTargetParameter;
+
+    /// <summary>
     /// Set when <see cref="DeriveUnknownMethodCall"/> actually builds a finite-difference approximation
     /// for at least one sub-expression during this worker's single <see cref="Derivate(LambdaExpression)"/>
     /// call, so that call can report <c>isExact = false</c> (see item #42). Safe as plain mutable state:
@@ -93,6 +104,21 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     public ExpressionDerivation(string parameterName, bool allowNumericalFallback = false)
         : this(parameterName, null!, allowNumericalFallback)
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExpressionDerivation{T}"/> class that differentiates
+    /// with respect to a specific <see cref="ParameterExpression"/> instance rather than a name. Unlike
+    /// the name-based constructor, this identifies the differentiation variable unambiguously even when
+    /// <paramref name="parameter"/>'s <see cref="ParameterExpression.Name"/> is <see langword="null"/> or
+    /// shared by another, unrelated parameter in the same lambda (see TODO-2026-07-11-pass4.md item #47).
+    /// </summary>
+    /// <param name="parameter">The exact parameter instance to differentiate against.</param>
+    /// <param name="allowNumericalFallback">See <see cref="AllowNumericalFallback"/>.</param>
+    public ExpressionDerivation(ParameterExpression parameter, bool allowNumericalFallback = false)
+        : this(parameter is null ? throw new ArgumentNullException(nameof(parameter)) : parameter.Name!, null!, allowNumericalFallback)
+    {
+        explicitTargetParameter = parameter;
     }
 
     /// <summary>
@@ -137,31 +163,47 @@ public class ExpressionDerivation<T> : ExpressionTransformer where T : IFloating
     /// </param>
     /// <returns>The simplified derivative expression.</returns>
     /// <exception cref="InvalidOperationException">
-    /// Thrown when no parameter named <see cref="ParameterName"/> is found in <paramref name="e"/>, or
-    /// when more than one distinct parameter shares that name (an ambiguous match that cannot be
-    /// resolved by name alone).
+    /// Thrown when this instance was constructed with a parameter name and no parameter named
+    /// <see cref="ParameterName"/> is found in <paramref name="e"/>, or more than one distinct parameter
+    /// shares that name (an ambiguous match that cannot be resolved by name alone). When this instance was
+    /// instead constructed with an exact <see cref="ParameterExpression"/> instance, thrown when that
+    /// instance is not one of <paramref name="e"/>'s declared parameters.
     /// </exception>
     public Expression Derivate(LambdaExpression e, out bool isExact)
     {
         ArgumentNullException.ThrowIfNull(e);
 
-        var candidates = e.Parameters.Where(p => p.Name == ParameterName).ToList();
-        if (candidates.Count == 0)
+        ParameterExpression resolvedParameter;
+        if (explicitTargetParameter is not null)
         {
-            throw new InvalidOperationException($"The parameter '{ParameterName}' was not found in the lambda expression.");
+            if (!e.Parameters.Contains(explicitTargetParameter))
+            {
+                throw new InvalidOperationException(
+                    "The specified parameter instance was not declared in the lambda expression being differentiated.");
+            }
+            resolvedParameter = explicitTargetParameter;
         }
-        if (candidates.Count > 1)
+        else
         {
-            throw new InvalidOperationException(
-                $"The lambda expression declares {candidates.Count} distinct parameters named '{ParameterName}'; " +
-                "the differentiation variable is ambiguous. Use distinct parameter names.");
+            var candidates = e.Parameters.Where(p => p.Name == ParameterName).ToList();
+            if (candidates.Count == 0)
+            {
+                throw new InvalidOperationException($"The parameter '{ParameterName}' was not found in the lambda expression.");
+            }
+            if (candidates.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    $"The lambda expression declares {candidates.Count} distinct parameters named '{ParameterName}'; " +
+                    "the differentiation variable is ambiguous. Use distinct parameter names.");
+            }
+            resolvedParameter = candidates[0];
         }
 
         // A fresh worker instance isolates the resolved target parameter for this call: concurrent or
         // re-entrant calls on the same public ExpressionDerivation<T> instance no longer share mutable
         // state (see TODO-2026-07-11-pass3.md items #31 and #32). usedNumericalFallback is likewise
         // scoped to this single worker instance, never shared across calls (see item #42).
-        var worker = new ExpressionDerivation<T>(ParameterName, candidates[0], AllowNumericalFallback);
+        var worker = new ExpressionDerivation<T>(ParameterName, resolvedParameter, AllowNumericalFallback);
         var result = Expression.Lambda(worker.Transform(e.Body.Simplify()).Simplify(), e.Parameters);
         isExact = !worker.usedNumericalFallback;
         return result;

--- a/Utils.Mathematics/Expressions/ExpressionIntegration.cs
+++ b/Utils.Mathematics/Expressions/ExpressionIntegration.cs
@@ -29,6 +29,16 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     private readonly ParameterExpression parameter;
 
     /// <summary>
+    /// Set only by the <see cref="ExpressionIntegration{T}(ParameterExpression)"/> constructor: the exact
+    /// parameter instance to integrate against, supplied directly by the caller instead of by name. When
+    /// set, <see cref="Integrate(LambdaExpression)"/> skips name-based resolution entirely and just checks
+    /// that the lambda being integrated declares this exact instance — see TODO-2026-07-11-pass4.md item
+    /// #47 (name-based resolution cannot distinguish two distinct parameters sharing one name, and fails
+    /// outright when a parameter's <see cref="ParameterExpression.Name"/> is <see langword="null"/>).
+    /// </summary>
+    private readonly ParameterExpression? explicitTargetParameter;
+
+    /// <summary>
     /// Determines whether <paramref name="candidate"/> is the specific parameter instance resolved as
     /// the integration variable for the current call.
     /// </summary>
@@ -62,30 +72,46 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     /// <param name="e">The lambda expression to integrate.</param>
     /// <returns>The integrated expression tree.</returns>
     /// <exception cref="InvalidOperationException">
-    /// Thrown when no parameter named <see cref="ParameterName"/> is found in <paramref name="e"/>, or
-    /// when more than one distinct parameter shares that name (an ambiguous match that cannot be
-    /// resolved by name alone).
+    /// Thrown when this instance was constructed with a parameter name and no parameter named
+    /// <see cref="ParameterName"/> is found in <paramref name="e"/>, or more than one distinct parameter
+    /// shares that name (an ambiguous match that cannot be resolved by name alone). When this instance was
+    /// instead constructed with an exact <see cref="ParameterExpression"/> instance, thrown when that
+    /// instance is not one of <paramref name="e"/>'s declared parameters.
     /// </exception>
     public Expression Integrate(LambdaExpression e)
     {
         ArgumentNullException.ThrowIfNull(e);
 
-        var candidates = e.Parameters.Where(p => p.Name == ParameterName).ToList();
-        if (candidates.Count == 0)
+        ParameterExpression resolvedParameter;
+        if (explicitTargetParameter is not null)
         {
-            throw new InvalidOperationException($"The parameter '{ParameterName}' was not found in the lambda expression.");
+            if (!e.Parameters.Contains(explicitTargetParameter))
+            {
+                throw new InvalidOperationException(
+                    "The specified parameter instance was not declared in the lambda expression being integrated.");
+            }
+            resolvedParameter = explicitTargetParameter;
         }
-        if (candidates.Count > 1)
+        else
         {
-            throw new InvalidOperationException(
-                $"The lambda expression declares {candidates.Count} distinct parameters named '{ParameterName}'; " +
-                "the integration variable is ambiguous. Use distinct parameter names.");
+            var candidates = e.Parameters.Where(p => p.Name == ParameterName).ToList();
+            if (candidates.Count == 0)
+            {
+                throw new InvalidOperationException($"The parameter '{ParameterName}' was not found in the lambda expression.");
+            }
+            if (candidates.Count > 1)
+            {
+                throw new InvalidOperationException(
+                    $"The lambda expression declares {candidates.Count} distinct parameters named '{ParameterName}'; " +
+                    "the integration variable is ambiguous. Use distinct parameter names.");
+            }
+            resolvedParameter = candidates[0];
         }
 
         // A fresh worker instance isolates the resolved target parameter for this call: concurrent or
         // re-entrant calls on the same public ExpressionIntegration<T> instance no longer share mutable
         // state (see TODO-2026-07-11-pass3.md item #32).
-        var worker = new ExpressionIntegration<T>(ParameterName, candidates[0]);
+        var worker = new ExpressionIntegration<T>(ParameterName, resolvedParameter);
         return Expression.Lambda(worker.Transform(e.Body), e.Parameters);
     }
 
@@ -95,6 +121,20 @@ public class ExpressionIntegration<T> : ExpressionTransformer where T : IFloatin
     /// <param name="parameterName">The name of the parameter serving as the integration variable.</param>
     public ExpressionIntegration(string parameterName) : this(parameterName, null!)
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExpressionIntegration{T}"/> class that integrates with
+    /// respect to a specific <see cref="ParameterExpression"/> instance rather than a name. Unlike the
+    /// name-based constructor, this identifies the integration variable unambiguously even when
+    /// <paramref name="parameter"/>'s <see cref="ParameterExpression.Name"/> is <see langword="null"/> or
+    /// shared by another, unrelated parameter in the same lambda (see TODO-2026-07-11-pass4.md item #47).
+    /// </summary>
+    /// <param name="parameter">The exact parameter instance to integrate against.</param>
+    public ExpressionIntegration(ParameterExpression parameter)
+        : this(parameter is null ? throw new ArgumentNullException(nameof(parameter)) : parameter.Name!, null!)
+    {
+        explicitTargetParameter = parameter;
     }
 
     /// <summary>

--- a/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
@@ -67,6 +67,12 @@ public partial class Vector<T> :
     /// <param name="getVector">Function to extract the vector from the point.</param>
     /// <param name="weightedPoints">Collection of weighted points.</param>
     /// <returns>The total weight and the barycenter vector.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a weight is not finite (<see cref="double.NaN"/> or infinite), or when the total
+    /// weight is exactly zero — both make the normalizing division undefined. A total weight that is
+    /// merely small (e.g. through near-cancelling positive/negative weights) is still divided by as
+    /// ordinary IEEE arithmetic; only the exactly-undefined cases are rejected here.
+    /// </exception>
     public static (T weight, Vector<T> point) ComputeBarycenter<TW>(Func<TW, T> getWeight, Func<TW, Vector<T>> getVector, IEnumerable<TW> weightedPoints)
     {
         using var enumerator = weightedPoints.GetEnumerator();
@@ -78,6 +84,7 @@ public partial class Vector<T> :
         T[] temp = new T[dimension];
 
         T weight = getWeight(first);
+        if (!T.IsFinite(weight)) throw new ArgumentException($"Weight must be finite; got '{weight}'.", nameof(weightedPoints));
         T totalWeight = weight;
         for (int i = 0; i < dimension; i++)
         {
@@ -88,6 +95,7 @@ public partial class Vector<T> :
         {
             var weightedPoint = enumerator.Current;
             weight = getWeight(weightedPoint);
+            if (!T.IsFinite(weight)) throw new ArgumentException($"Weight must be finite; got '{weight}'.", nameof(weightedPoints));
             totalWeight += weight;
             Vector<T> point = getVector(weightedPoint);
             if (dimension != point.Dimension) throw new InvalidOperationException("All points must have the same dimension.");
@@ -95,6 +103,13 @@ public partial class Vector<T> :
             {
                 temp[i] += point[i] * weight;
             }
+        }
+
+        if (!T.IsFinite(totalWeight) || totalWeight == T.Zero)
+        {
+            throw new ArgumentException(
+                $"The total weight must be finite and non-zero to compute a barycenter; got '{totalWeight}'.",
+                nameof(weightedPoints));
         }
 
         for (int i = 0; i < dimension; i++)

--- a/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
@@ -67,19 +67,29 @@ public partial class Vector<T> :
     /// <param name="getVector">Function to extract the vector from the point.</param>
     /// <param name="weightedPoints">Collection of weighted points.</param>
     /// <returns>The total weight and the barycenter vector.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="getWeight"/>, <paramref name="getVector"/>, or
+    /// <paramref name="weightedPoints"/> is <see langword="null"/>.
+    /// </exception>
     /// <exception cref="ArgumentException">
-    /// Thrown when a weight is not finite (<see cref="double.NaN"/> or infinite), or when the total
-    /// weight is exactly zero — both make the normalizing division undefined. A total weight that is
-    /// merely small (e.g. through near-cancelling positive/negative weights) is still divided by as
-    /// ordinary IEEE arithmetic; only the exactly-undefined cases are rejected here.
+    /// Thrown when <paramref name="weightedPoints"/> is empty, when <paramref name="getVector"/> selects a
+    /// <see langword="null"/> vector for some element, when selected vectors do not all share the same
+    /// dimension, when a weight is not finite (<see cref="double.NaN"/> or infinite), or when the total
+    /// weight is exactly zero — the latter two make the normalizing division undefined. A total weight
+    /// that is merely small (e.g. through near-cancelling positive/negative weights) is still divided by
+    /// as ordinary IEEE arithmetic; only the exactly-undefined cases are rejected here.
     /// </exception>
     public static (T weight, Vector<T> point) ComputeBarycenter<TW>(Func<TW, T> getWeight, Func<TW, Vector<T>> getVector, IEnumerable<TW> weightedPoints)
     {
+        ArgumentNullException.ThrowIfNull(getWeight);
+        ArgumentNullException.ThrowIfNull(getVector);
+        ArgumentNullException.ThrowIfNull(weightedPoints);
+
         using var enumerator = weightedPoints.GetEnumerator();
         if (!enumerator.MoveNext()) throw new ArgumentException("At least one point is required", nameof(weightedPoints));
 
         TW first = enumerator.Current;
-        Vector<T> firstPoint = getVector(first);
+        Vector<T> firstPoint = getVector(first) ?? throw new ArgumentException("A selected vector must not be null.", nameof(getVector));
         int dimension = firstPoint.Dimension;
         T[] temp = new T[dimension];
 
@@ -97,8 +107,8 @@ public partial class Vector<T> :
             weight = getWeight(weightedPoint);
             if (!T.IsFinite(weight)) throw new ArgumentException($"Weight must be finite; got '{weight}'.", nameof(weightedPoints));
             totalWeight += weight;
-            Vector<T> point = getVector(weightedPoint);
-            if (dimension != point.Dimension) throw new InvalidOperationException("All points must have the same dimension.");
+            Vector<T> point = getVector(weightedPoint) ?? throw new ArgumentException("A selected vector must not be null.", nameof(getVector));
+            if (dimension != point.Dimension) throw new ArgumentException("All selected vectors must have the same dimension.", nameof(weightedPoints));
             for (int i = 0; i < dimension; i++)
             {
                 temp[i] += point[i] * weight;

--- a/Utils.Mathematics/MathExpressionExtensions.cs
+++ b/Utils.Mathematics/MathExpressionExtensions.cs
@@ -1,6 +1,8 @@
 using System.Linq.Expressions;
 using System.Numerics;
+using System.Reflection;
 using Utils.Objects;
+using Utils.Reflection;
 
 namespace Utils.Mathematics.Expressions;
 
@@ -9,8 +11,66 @@ namespace Utils.Mathematics.Expressions;
 /// </summary>
 public static class MathExpressionExtensions
 {
+    private static readonly MethodInfo DerivateGenericMethod = typeof(MathExpressionExtensions)
+        .GetMethods()
+        .Single(m => m.Name == nameof(Derivate) && m.IsGenericMethodDefinition);
+
+    private static readonly MethodInfo GradientGenericMethod = typeof(MathExpressionExtensions)
+        .GetMethods()
+        .Single(m => m.Name == nameof(Gradient) && m.IsGenericMethodDefinition);
+
+    private static readonly MethodInfo IntegrateGenericMethod = typeof(MathExpressionExtensions)
+        .GetMethods()
+        .Single(m => m.Name == nameof(Integrate) && m.IsGenericMethodDefinition);
+
+    /// <summary>
+    /// Infers the scalar type shared by the parameters named in <paramref name="paramNames"/>, for the
+    /// non-generic convenience overloads below, which dispatch to the matching <c>&lt;T&gt;</c> overload
+    /// through reflection instead of hardcoding <see cref="double"/> (see TODO-pass4 item #46). A lambda
+    /// over <see cref="float"/> or <see cref="decimal"/> parameters is thus handled with that same type's
+    /// constants and method resolution, rather than silently mixing in <see cref="double"/> ones.
+    /// </summary>
+    /// <param name="e">Lambda expression whose parameters are inspected.</param>
+    /// <param name="paramNames">Names of the parameters the caller intends to differentiate/integrate against.</param>
+    /// <returns>
+    /// The single <see cref="IFloatingPoint{TSelf}"/>-conforming CLR type shared by the matching
+    /// parameters, or <see cref="double"/> when no parameter matches (letting the downstream call surface
+    /// its own "parameter not found" diagnostic instead of failing here for an unrelated reason).
+    /// </returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the matching parameters do not share a single type, or when that type does not
+    /// implement <see cref="IFloatingPoint{TSelf}"/>.
+    /// </exception>
+    private static Type ResolveScalarType(LambdaExpression e, IReadOnlyList<string> paramNames)
+    {
+        Type[] types = paramNames
+            .SelectMany(name => e.Parameters.Where(p => p.Name == name))
+            .Select(p => p.Type)
+            .Distinct()
+            .ToArray();
+
+        if (types.Length > 1)
+        {
+            throw new NotSupportedException(
+                "Cannot infer a single scalar type for the non-generic derivative/integral overloads: " +
+                $"the targeted parameters have different types ({string.Join(", ", types.Select(t => t.Name))}). " +
+                "Use the explicit generic overload (e.g. Derivate<T>) to select the scalar type.");
+        }
+
+        Type scalarType = types.Length == 1 ? types[0] : typeof(double);
+        if (!scalarType.IsDefinedBy(typeof(IFloatingPoint<>)))
+        {
+            throw new NotSupportedException(
+                $"The parameter type '{scalarType}' does not implement IFloatingPoint<T>, so it cannot be " +
+                "used with the non-generic derivative/integral convenience overloads. Use the explicit " +
+                "generic overload (e.g. Derivate<T>) with a supported scalar type.");
+        }
+        return scalarType;
+    }
+
     /// <summary>
     /// Computes the derivative of a single-parameter lambda expression with respect to its declared parameter.
+    /// The scalar type is inferred from that parameter's CLR type instead of assuming <see cref="double"/>.
     /// </summary>
     /// <param name="e">Lambda expression to differentiate.</param>
     /// <returns>A lambda expression representing the derivative.</returns>
@@ -18,18 +78,24 @@ public static class MathExpressionExtensions
     {
         e.Arg().MustNotBeNull();
         e.Parameters.ArgMustBeOfSize(1);
-        return e.Derivate<double>(e.Parameters[0].Name);
+        return e.Derivate(e.Parameters[0].Name);
     }
 
     /// <summary>
     /// Computes the derivative of a lambda expression with respect to the specified parameter name.
+    /// The scalar type is inferred from that parameter's CLR type instead of assuming <see cref="double"/>.
     /// </summary>
     /// <param name="e">Lambda expression to differentiate.</param>
     /// <param name="paramName">Name of the parameter used as the differentiation variable.</param>
     /// <returns>A lambda expression representing the derivative.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="paramName"/>'s CLR type does not implement <see cref="IFloatingPoint{TSelf}"/>.
+    /// </exception>
     public static LambdaExpression Derivate(this LambdaExpression e, string paramName)
     {
-        return e.Derivate<double>(paramName);
+        e.Arg().MustNotBeNull();
+        Type scalarType = ResolveScalarType(e, [paramName]);
+        return (LambdaExpression)DerivateGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, paramName])!;
     }
 
     /// <summary>
@@ -50,14 +116,21 @@ public static class MathExpressionExtensions
 
     /// <summary>
     /// Computes the gradient of a multi-parameter lambda expression as an array of partial-derivative expressions.
-    /// Each entry i is the partial derivative with respect to the i-th parameter.
+    /// Each entry i is the partial derivative with respect to the i-th parameter. All parameters must share
+    /// the same CLR type, which is inferred instead of assuming <see cref="double"/>.
     /// </summary>
     /// <param name="e">Lambda expression to differentiate.</param>
     /// <returns>Array of lambda expressions representing each partial derivative; shares the same parameter list as <paramref name="e"/>.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="e"/>'s parameters do not share a single CLR type, or that type does not
+    /// implement <see cref="IFloatingPoint{TSelf}"/>.
+    /// </exception>
     public static LambdaExpression[] Gradient(this LambdaExpression e)
     {
         e.Arg().MustNotBeNull();
-        return e.Gradient<double>(e.Parameters.Select(p => p.Name!).ToArray());
+        string[] paramNames = e.Parameters.Select(p => p.Name!).ToArray();
+        Type scalarType = ResolveScalarType(e, paramNames);
+        return (LambdaExpression[])GradientGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, paramNames])!;
     }
 
     /// <summary>
@@ -83,14 +156,20 @@ public static class MathExpressionExtensions
 
     /// <summary>
     /// Computes the integral of a single-parameter lambda expression with respect to its declared parameter.
+    /// The scalar type is inferred from that parameter's CLR type instead of assuming <see cref="double"/>.
     /// </summary>
     /// <param name="e">Lambda expression to integrate.</param>
     /// <returns>A lambda expression representing the integral.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the declared parameter's CLR type does not implement <see cref="IFloatingPoint{TSelf}"/>.
+    /// </exception>
     public static LambdaExpression Integrate(this LambdaExpression e)
     {
         e.Arg().MustNotBeNull();
         e.Parameters.ArgMustBeOfSize(1);
-        return e.Integrate<double>(e.Parameters[0].Name);
+        string paramName = e.Parameters[0].Name;
+        Type scalarType = ResolveScalarType(e, [paramName]);
+        return (LambdaExpression)IntegrateGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, paramName])!;
     }
 
     /// <summary>

--- a/Utils.Mathematics/MathExpressionExtensions.cs
+++ b/Utils.Mathematics/MathExpressionExtensions.cs
@@ -1,6 +1,7 @@
 using System.Linq.Expressions;
 using System.Numerics;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Utils.Objects;
 using Utils.Reflection;
 
@@ -118,6 +119,33 @@ public static class MathExpressionExtensions
     }
 
     /// <summary>
+    /// Invokes a closed generic form of <paramref name="genericMethodDefinition"/> built for
+    /// <paramref name="scalarType"/>, centralizing the reflection dispatch used by the non-generic
+    /// <c>Derivate</c>/<c>Gradient</c>/<c>Integrate</c> overloads (see TODO-pass4 item #47 review). Plain
+    /// <see cref="MethodInfo.Invoke(object?, object?[]?)"/> always wraps an exception thrown by the invoked
+    /// method in a <see cref="TargetInvocationException"/>; without unwrapping it here, a caller of e.g.
+    /// <c>expression.Derivate("unknown")</c> would see a <see cref="TargetInvocationException"/> instead of
+    /// the documented <see cref="InvalidOperationException"/>, breaking the public exception contract these
+    /// non-generic overloads share with their explicit generic counterparts.
+    /// </summary>
+    /// <param name="genericMethodDefinition">The open generic method to close over <paramref name="scalarType"/>.</param>
+    /// <param name="scalarType">The scalar type argument used to close the generic method.</param>
+    /// <param name="arguments">Arguments passed to the closed method.</param>
+    /// <returns>The closed method's return value.</returns>
+    private static object InvokeGeneric(MethodInfo genericMethodDefinition, Type scalarType, params object?[] arguments)
+    {
+        try
+        {
+            return genericMethodDefinition.MakeGenericMethod(scalarType).Invoke(null, arguments)!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw; // unreachable: the line above always throws.
+        }
+    }
+
+    /// <summary>
     /// Computes the derivative of a single-parameter lambda expression with respect to its declared parameter.
     /// The scalar type is inferred from that parameter's CLR type instead of assuming <see cref="double"/>.
     /// </summary>
@@ -144,7 +172,7 @@ public static class MathExpressionExtensions
     {
         e.Arg().MustNotBeNull();
         Type scalarType = ResolveScalarType(e, [paramName]);
-        return (LambdaExpression)DerivateGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, paramName])!;
+        return (LambdaExpression)InvokeGeneric(DerivateGenericMethod, scalarType, e, paramName);
     }
 
     /// <summary>
@@ -181,7 +209,7 @@ public static class MathExpressionExtensions
         e.Arg().MustNotBeNull();
         parameter.Arg().MustNotBeNull();
         Type scalarType = ResolveScalarType([parameter]);
-        return (LambdaExpression)DerivateByParameterGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, parameter])!;
+        return (LambdaExpression)InvokeGeneric(DerivateByParameterGenericMethod, scalarType, e, parameter);
     }
 
     /// <summary>
@@ -217,7 +245,7 @@ public static class MathExpressionExtensions
         e.Arg().MustNotBeNull();
         ParameterExpression[] parameters = e.Parameters.ToArray();
         Type scalarType = ResolveScalarType(parameters);
-        return (LambdaExpression[])GradientByParameterGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, parameters])!;
+        return (LambdaExpression[])InvokeGeneric(GradientByParameterGenericMethod, scalarType, e, parameters);
     }
 
     /// <summary>
@@ -315,7 +343,7 @@ public static class MathExpressionExtensions
         e.Arg().MustNotBeNull();
         parameter.Arg().MustNotBeNull();
         Type scalarType = ResolveScalarType([parameter]);
-        return (LambdaExpression)IntegrateByParameterGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, parameter])!;
+        return (LambdaExpression)InvokeGeneric(IntegrateByParameterGenericMethod, scalarType, e, parameter);
     }
 
     /// <summary>

--- a/Utils.Mathematics/MathExpressionExtensions.cs
+++ b/Utils.Mathematics/MathExpressionExtensions.cs
@@ -13,15 +13,27 @@ public static class MathExpressionExtensions
 {
     private static readonly MethodInfo DerivateGenericMethod = typeof(MathExpressionExtensions)
         .GetMethods()
-        .Single(m => m.Name == nameof(Derivate) && m.IsGenericMethodDefinition);
+        .Single(m => m.Name == nameof(Derivate) && m.IsGenericMethodDefinition && m.GetParameters()[1].ParameterType == typeof(string));
+
+    private static readonly MethodInfo DerivateByParameterGenericMethod = typeof(MathExpressionExtensions)
+        .GetMethods()
+        .Single(m => m.Name == nameof(Derivate) && m.IsGenericMethodDefinition && m.GetParameters()[1].ParameterType == typeof(ParameterExpression));
 
     private static readonly MethodInfo GradientGenericMethod = typeof(MathExpressionExtensions)
         .GetMethods()
-        .Single(m => m.Name == nameof(Gradient) && m.IsGenericMethodDefinition);
+        .Single(m => m.Name == nameof(Gradient) && m.IsGenericMethodDefinition && m.GetParameters()[1].ParameterType == typeof(IEnumerable<string>));
+
+    private static readonly MethodInfo GradientByParameterGenericMethod = typeof(MathExpressionExtensions)
+        .GetMethods()
+        .Single(m => m.Name == nameof(Gradient) && m.IsGenericMethodDefinition && m.GetParameters()[1].ParameterType == typeof(IEnumerable<ParameterExpression>));
 
     private static readonly MethodInfo IntegrateGenericMethod = typeof(MathExpressionExtensions)
         .GetMethods()
-        .Single(m => m.Name == nameof(Integrate) && m.IsGenericMethodDefinition);
+        .Single(m => m.Name == nameof(Integrate) && m.IsGenericMethodDefinition && m.GetParameters()[1].ParameterType == typeof(string));
+
+    private static readonly MethodInfo IntegrateByParameterGenericMethod = typeof(MathExpressionExtensions)
+        .GetMethods()
+        .Single(m => m.Name == nameof(Integrate) && m.IsGenericMethodDefinition && m.GetParameters()[1].ParameterType == typeof(ParameterExpression));
 
     /// <summary>
     /// Infers the scalar type shared by the parameters named in <paramref name="paramNames"/>, for the
@@ -48,16 +60,53 @@ public static class MathExpressionExtensions
             .Select(p => p.Type)
             .Distinct()
             .ToArray();
+        return ResolveScalarType(types);
+    }
 
-        if (types.Length > 1)
+    /// <summary>
+    /// Same as <see cref="ResolveScalarType(LambdaExpression, IReadOnlyList{string})"/>, but for the
+    /// parameter-instance overloads below (see TODO-pass4 item #47): the caller already holds the exact
+    /// <see cref="ParameterExpression"/> instances, so no name-based lookup into <c>e.Parameters</c> is
+    /// needed to obtain their declared types.
+    /// </summary>
+    /// <param name="parameters">The exact parameter instances the caller intends to target.</param>
+    /// <returns>The single shared <see cref="IFloatingPoint{TSelf}"/>-conforming CLR type.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the parameters do not share a single type, or when that type does not implement
+    /// <see cref="IFloatingPoint{TSelf}"/>.
+    /// </exception>
+    private static Type ResolveScalarType(IReadOnlyList<ParameterExpression> parameters)
+    {
+        Type[] types = parameters.Select(p => p.Type).Distinct().ToArray();
+        return ResolveScalarType(types);
+    }
+
+    /// <summary>
+    /// Shared core used by both <see cref="ResolveScalarType(LambdaExpression, IReadOnlyList{string})"/>
+    /// and <see cref="ResolveScalarType(IReadOnlyList{ParameterExpression})"/>: validates that the
+    /// distinct parameter types collapse to exactly one <see cref="IFloatingPoint{TSelf}"/>-conforming type.
+    /// </summary>
+    /// <param name="distinctTypes">The distinct CLR types of the targeted parameters.</param>
+    /// <returns>
+    /// The single shared type, or <see cref="double"/> when <paramref name="distinctTypes"/> is empty
+    /// (letting the downstream call surface its own "parameter not found" diagnostic instead of failing
+    /// here for an unrelated reason).
+    /// </returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="distinctTypes"/> contains more than one type, or when the single
+    /// remaining type does not implement <see cref="IFloatingPoint{TSelf}"/>.
+    /// </exception>
+    private static Type ResolveScalarType(IReadOnlyCollection<Type> distinctTypes)
+    {
+        if (distinctTypes.Count > 1)
         {
             throw new NotSupportedException(
                 "Cannot infer a single scalar type for the non-generic derivative/integral overloads: " +
-                $"the targeted parameters have different types ({string.Join(", ", types.Select(t => t.Name))}). " +
+                $"the targeted parameters have different types ({string.Join(", ", distinctTypes.Select(t => t.Name))}). " +
                 "Use the explicit generic overload (e.g. Derivate<T>) to select the scalar type.");
         }
 
-        Type scalarType = types.Length == 1 ? types[0] : typeof(double);
+        Type scalarType = distinctTypes.Count == 1 ? distinctTypes.Single() : typeof(double);
         if (!scalarType.IsDefinedBy(typeof(IFloatingPoint<>)))
         {
             throw new NotSupportedException(
@@ -78,7 +127,7 @@ public static class MathExpressionExtensions
     {
         e.Arg().MustNotBeNull();
         e.Parameters.ArgMustBeOfSize(1);
-        return e.Derivate(e.Parameters[0].Name);
+        return e.Derivate(e.Parameters[0]);
     }
 
     /// <summary>
@@ -115,6 +164,44 @@ public static class MathExpressionExtensions
     }
 
     /// <summary>
+    /// Computes the derivative of a lambda expression with respect to the exact declared parameter
+    /// instance. Unlike the name-based overload, this resolves the differentiation variable unambiguously
+    /// even when the parameter's <see cref="ParameterExpression.Name"/> is <see langword="null"/> or
+    /// shared with another, unrelated parameter (see TODO-pass4 item #47). The scalar type is inferred
+    /// from <paramref name="parameter"/>'s own CLR type instead of assuming <see cref="double"/>.
+    /// </summary>
+    /// <param name="e">Lambda expression to differentiate.</param>
+    /// <param name="parameter">The exact parameter instance used as the differentiation variable.</param>
+    /// <returns>A lambda expression representing the derivative.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="parameter"/>'s CLR type does not implement <see cref="IFloatingPoint{TSelf}"/>.
+    /// </exception>
+    public static LambdaExpression Derivate(this LambdaExpression e, ParameterExpression parameter)
+    {
+        e.Arg().MustNotBeNull();
+        parameter.Arg().MustNotBeNull();
+        Type scalarType = ResolveScalarType([parameter]);
+        return (LambdaExpression)DerivateByParameterGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, parameter])!;
+    }
+
+    /// <summary>
+    /// Computes the derivative of a lambda expression with respect to the exact declared parameter instance.
+    /// </summary>
+    /// <typeparam name="T">Floating-point type used by derivative rules.</typeparam>
+    /// <param name="e">Lambda expression to differentiate.</param>
+    /// <param name="parameter">The exact parameter instance used as the differentiation variable.</param>
+    /// <returns>A lambda expression representing the derivative.</returns>
+    public static LambdaExpression Derivate<T>(this LambdaExpression e, ParameterExpression parameter) where T : IFloatingPoint<T>
+    {
+        e.Arg().MustNotBeNull();
+        parameter.Arg().MustNotBeNull();
+
+        ExpressionDerivation<T> derivation = new ExpressionDerivation<T>(parameter);
+        var expression = (LambdaExpression)derivation.Derivate(e);
+        return Expression.Lambda(expression.Body.Simplify(), e.Parameters);
+    }
+
+    /// <summary>
     /// Computes the gradient of a multi-parameter lambda expression as an array of partial-derivative expressions.
     /// Each entry i is the partial derivative with respect to the i-th parameter. All parameters must share
     /// the same CLR type, which is inferred instead of assuming <see cref="double"/>.
@@ -128,9 +215,9 @@ public static class MathExpressionExtensions
     public static LambdaExpression[] Gradient(this LambdaExpression e)
     {
         e.Arg().MustNotBeNull();
-        string[] paramNames = e.Parameters.Select(p => p.Name!).ToArray();
-        Type scalarType = ResolveScalarType(e, paramNames);
-        return (LambdaExpression[])GradientGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, paramNames])!;
+        ParameterExpression[] parameters = e.Parameters.ToArray();
+        Type scalarType = ResolveScalarType(parameters);
+        return (LambdaExpression[])GradientByParameterGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, parameters])!;
     }
 
     /// <summary>
@@ -155,6 +242,30 @@ public static class MathExpressionExtensions
     }
 
     /// <summary>
+    /// Computes the partial derivatives of a lambda expression with respect to the specified exact
+    /// parameter instances. Unlike the name-based overload, this resolves each differentiation variable
+    /// unambiguously even when multiple targeted parameters share one name — including <see langword="null"/>
+    /// for unnamed parameters (see TODO-pass4 item #47).
+    /// </summary>
+    /// <typeparam name="T">Floating-point type used by derivative rules.</typeparam>
+    /// <param name="e">Lambda expression to differentiate.</param>
+    /// <param name="parameters">The exact parameter instances to differentiate with respect to.</param>
+    /// <returns>Array of lambda expressions representing each partial derivative; shares the same parameter list as <paramref name="e"/>.</returns>
+    public static LambdaExpression[] Gradient<T>(this LambdaExpression e, params IEnumerable<ParameterExpression> parameters)
+        where T : IFloatingPoint<T>
+    {
+        e.Arg().MustNotBeNull();
+        return parameters
+            .Select(parameter =>
+            {
+                ExpressionDerivation<T> derivation = new ExpressionDerivation<T>(parameter);
+                var derived = (LambdaExpression)derivation.Derivate(e);
+                return Expression.Lambda(derived.Body.Simplify(), e.Parameters);
+            })
+            .ToArray();
+    }
+
+    /// <summary>
     /// Computes the integral of a single-parameter lambda expression with respect to its declared parameter.
     /// The scalar type is inferred from that parameter's CLR type instead of assuming <see cref="double"/>.
     /// </summary>
@@ -167,9 +278,7 @@ public static class MathExpressionExtensions
     {
         e.Arg().MustNotBeNull();
         e.Parameters.ArgMustBeOfSize(1);
-        string paramName = e.Parameters[0].Name;
-        Type scalarType = ResolveScalarType(e, [paramName]);
-        return (LambdaExpression)IntegrateGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, paramName])!;
+        return e.Integrate(e.Parameters[0]);
     }
 
     /// <summary>
@@ -184,6 +293,44 @@ public static class MathExpressionExtensions
         e.Arg().MustNotBeNull();
 
         ExpressionIntegration<T> integration = new ExpressionIntegration<T>(paramName);
+        var expression = (LambdaExpression)integration.Integrate(e);
+        return Expression.Lambda(expression.Body.Simplify(), e.Parameters);
+    }
+
+    /// <summary>
+    /// Computes the integral of a lambda expression with respect to the exact declared parameter instance.
+    /// Unlike the name-based overload, this resolves the integration variable unambiguously even when the
+    /// parameter's <see cref="ParameterExpression.Name"/> is <see langword="null"/> or shared with another,
+    /// unrelated parameter (see TODO-pass4 item #47). The scalar type is inferred from
+    /// <paramref name="parameter"/>'s own CLR type instead of assuming <see cref="double"/>.
+    /// </summary>
+    /// <param name="e">Lambda expression to integrate.</param>
+    /// <param name="parameter">The exact parameter instance used as the integration variable.</param>
+    /// <returns>A lambda expression representing the integral.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="parameter"/>'s CLR type does not implement <see cref="IFloatingPoint{TSelf}"/>.
+    /// </exception>
+    public static LambdaExpression Integrate(this LambdaExpression e, ParameterExpression parameter)
+    {
+        e.Arg().MustNotBeNull();
+        parameter.Arg().MustNotBeNull();
+        Type scalarType = ResolveScalarType([parameter]);
+        return (LambdaExpression)IntegrateByParameterGenericMethod.MakeGenericMethod(scalarType).Invoke(null, [e, parameter])!;
+    }
+
+    /// <summary>
+    /// Computes the integral of a lambda expression with respect to the exact declared parameter instance.
+    /// </summary>
+    /// <typeparam name="T">Floating-point type used by integration rules.</typeparam>
+    /// <param name="e">Lambda expression to integrate.</param>
+    /// <param name="parameter">The exact parameter instance used as the integration variable.</param>
+    /// <returns>A lambda expression representing the integral.</returns>
+    public static LambdaExpression Integrate<T>(this LambdaExpression e, ParameterExpression parameter) where T : IFloatingPoint<T>
+    {
+        e.Arg().MustNotBeNull();
+        parameter.Arg().MustNotBeNull();
+
+        ExpressionIntegration<T> integration = new ExpressionIntegration<T>(parameter);
         var expression = (LambdaExpression)integration.Integrate(e);
         return Expression.Lambda(expression.Body.Simplify(), e.Parameters);
     }

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -46,6 +46,19 @@ suite.
 
 **Priority: P1 mathematical correctness.**
 
+**Fixed.** `ComputeBarycenter<TW>` now rejects a non-finite (`NaN`/infinite) individual weight as soon as
+it is read, and rejects a total weight that is exactly zero or non-finite before the normalizing
+division — both throw `ArgumentException` naming `weightedPoints`. A total weight that is merely small
+(near-cancelling weights that don't sum to exactly zero) is intentionally left to ordinary IEEE division,
+matching item #56's stance that raw arithmetic should stay IEEE-documented rather than growing an
+arbitrary, undocumented "near-zero" threshold. The "return the unnormalized sum separately" alternative
+was not adopted: it would only help the zero-total case specifically (any non-zero total already lets a
+caller recover the unnormalized sum as `point * totalWeight`), and no current caller needs a zero-total
+affine combination, so this pass rejects that case outright instead of adding an unused return shape.
+Test: `VectorTests.ComputeBarycenter_AllZeroWeights_Throws`,
+`ComputeBarycenter_CancellingWeights_Throws`, `ComputeBarycenter_NaNWeight_Throws`,
+`ComputeBarycenter_InfiniteWeight_Throws`, `ComputeBarycenter_NegativeAndPositiveWeightsSummingNonZero_StillWorks`.
+
 ### 45. Barycenter selector/input validation is incomplete
 
 The generic overload dereferences `weightedPoints`, `getWeight`, `getVector`, and selected vectors without explicit null checks. The first selected point determines the dimension before any null/dimension validation. Later dimension mismatch throws `InvalidOperationException`, while comparable public vector APIs use argument exceptions.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -109,6 +109,28 @@ The convenience methods pass `ParameterExpression.Name` into the transformer. Pa
 
 **Priority: P1 symbolic correctness.**
 
+**Fixed.** `ExpressionDerivation<T>` and `ExpressionIntegration<T>` each gained a constructor overload
+taking the exact `ParameterExpression` instance (`ExpressionDerivation(ParameterExpression, bool)`,
+`ExpressionIntegration(ParameterExpression)`). When constructed this way, `Derivate`/`Integrate` skip
+name-based resolution entirely and instead check by reference that the supplied instance is one of the
+lambda's declared parameters, throwing `InvalidOperationException` with a contextual message if not. The
+pre-existing name-based constructors and their 0/>1-candidate diagnostics are unchanged. `MathExpressionExtensions`
+gained matching `Derivate(e, ParameterExpression)`, `Derivate<T>(e, ParameterExpression)`,
+`Gradient<T>(e, params IEnumerable<ParameterExpression>)`, `Integrate(e, ParameterExpression)`, and
+`Integrate<T>(e, ParameterExpression)` overloads, and the parameterless convenience overloads
+(`Derivate()`, `Gradient()`, `Integrate()`) now route through them using the `ParameterExpression`
+instances already available from `e.Parameters`, instead of pulling out `.Name` (previously `!`-suppressed
+on `Gradient()`) and re-resolving by name. This fixes a concrete bug: two unnamed parameters both have a
+`null` `Name`, so the old name-based `Gradient()` would treat them as two ambiguous "candidates" for either
+target and throw, even though they are trivially identifiable by instance. Test:
+`ExpressionDerivationTests.Derivate_ByParameterInstance_TwoUnnamedParameters_ResolvesEachUnambiguously`,
+`Derivate_ByParameterInstance_DuplicateNamedParameters_ResolvesEachUnambiguously`,
+`Derivate_ByParameterInstance_ParameterNotInLambda_Throws`,
+`ExpressionIntegrationTests.Integrate_ByParameterInstance_UnnamedParameter_Works`,
+`Integrate_ByParameterInstance_ParameterNotInLambda_Throws`,
+`MathExpressionExtensionsTests.Gradient_UnnamedParameters_ResolvesEachUnambiguously`,
+`Derivate_ByParameterInstance_UnnamedParameter_Works`, `Integrate_ByParameterInstance_UnnamedParameter_Works`.
+
 ### 48. `AffineSubspace.Contains` accepts invalid tolerances
 
 `Contains(point, tolerance)` directly compares distance to the supplied value. A negative tolerance makes even an exact member return false; NaN produces false; positive infinity makes every finite-distance point a member.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -67,6 +67,16 @@ The generic overload dereferences `weightedPoints`, `getWeight`, `getVector`, an
 
 **Priority: P1 API robustness.**
 
+**Fixed.** `ComputeBarycenter<TW>` now validates `getWeight`, `getVector`, and `weightedPoints` for
+`null` upfront (`ArgumentNullException`), rejects a `null` selected vector as soon as `getVector` returns
+one (`ArgumentException` naming `getVector`), and the dimension-mismatch check — previously
+`InvalidOperationException` — now throws `ArgumentException` naming `weightedPoints`, consistent with
+other `Vector<T>` APIs (e.g. the constructor's zero-dimension guard, `CrossProduct`'s dimension guard).
+All validation happens during the existing single enumeration pass; no second pass was introduced.
+Test: `VectorTests.ComputeBarycenter_NullWeightSelector_Throws`,
+`ComputeBarycenter_NullVectorSelector_Throws`, `ComputeBarycenter_NullWeightedPoints_Throws`,
+`ComputeBarycenter_NullSelectedVector_Throws`, `ComputeBarycenter_MismatchedDimensions_ThrowsArgumentException`.
+
 ### 46. Non-generic symbolic convenience methods silently force `double`
 
 `Derivate()`, `Derivate(string)`, `Gradient()`, and `Integrate()` route to their generic variants with `T = double`, regardless of the parameter and return types of the supplied lambda.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -87,6 +87,20 @@ A lambda over `float`, `decimal`, or another `IFloatingPoint<T>` can consequentl
 
 **Priority: P1 symbolic API correctness.**
 
+**Fixed** (inferred dispatch). `Derivate()`, `Derivate(string)`, `Gradient()`, and `Integrate()` now infer
+the scalar type from the CLR type of the targeted parameter(s) via a shared `ResolveScalarType` helper,
+then dispatch to the matching `<T>` overload through `MethodInfo.MakeGenericMethod` (cached per generic
+method definition in a `static readonly` field, resolved once). `Gradient()` requires every targeted
+parameter to share one type, since a single `T` is applied uniformly across all partial derivatives — a
+lambda mixing e.g. `float` and `double` parameters is rejected rather than picking one arbitrarily. A
+target type that does not implement `IFloatingPoint<T>` (e.g. `int`) is rejected with a clear
+`NotSupportedException` instead of being silently forced through `double` rules that don't match. The
+explicit generic overloads (`Derivate<T>`, `Gradient<T>`, `Integrate<T>`) are unchanged. Test:
+`MathExpressionExtensionsTests.Derivate_FloatLambda_InfersFloatInsteadOfDouble`,
+`Derivate_DecimalLambda_InfersDecimalInsteadOfDouble`, `Integrate_FloatLambda_InfersFloatInsteadOfDouble`,
+`Gradient_FloatLambda_InfersFloatInsteadOfDouble`, `Derivate_NonFloatingPointParameterType_ThrowsNotSupportedException`,
+`Gradient_MixedParameterTypes_ThrowsNotSupportedException`.
+
 ### 47. Symbolic convenience methods still select variables by nullable names
 
 The convenience methods pass `ParameterExpression.Name` into the transformer. Parameter names are optional in expression trees, and different parameters may share one name. `Gradient()` suppresses nullability with `!` rather than validating identity or ambiguity.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -27,6 +27,17 @@ Add exhaustive null/operator truth-table tests.
 
 **Priority: P0 language/operator correctness.**
 
+**Already fixed.** `Vector<T>.operator ==` (`Vector.Operators.cs`) already uses the conventional
+`ReferenceEquals(vector1, vector2) || (vector1 is not null && vector1.Equals(vector2))` pattern this
+finding recommends — a previous audit pass (`fix numerical-correctness and quality audit findings #442`)
+corrected it before this pass4 review ran, and this file was not updated to reflect that. The full
+truth-table coverage this finding asks for also already exists: `VectorTests.EqualityOperator_BothNull_ReturnsTrue`,
+`EqualityOperator_LeftNullRightNonNull_ReturnsFalse`, `EqualityOperator_LeftNonNullRightNull_ReturnsFalse`
+(the exact regression this finding describes), `EqualityOperator_SameReference_ReturnsTrue`,
+`EqualityOperator_EqualValues_ReturnsTrue`, `EqualityOperator_UnequalValues_ReturnsFalse`. No production
+or test code changed for this item; verified by re-reading `Vector.Operators.cs` and running the existing
+suite.
+
 ### 44. Weighted barycenter divides by zero when total weight is zero
 
 `ComputeBarycenter` accumulates weighted coordinates and then divides every component by `totalWeight` without checking it. Opposite weights, all-zero weights, cancellation through rounding, or non-finite weights can therefore produce infinities/NaNs or a type-specific failure.

--- a/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionDerivationTests.cs
@@ -581,4 +581,65 @@ public class ExpressionDerivationTests
         Assert.AreEqual(1.0, derivativeFunc(3f), 1e-9);
     }
 
+    // ── Parameter-instance resolution (TODO-pass4 item #47) ────────────────────
+
+    /// <summary>
+    /// Two parameters sharing the same declared name (including <see langword="null"/> for unnamed
+    /// parameters) previously made name-based resolution ambiguous even when only one of them was
+    /// intended. Targeting the exact instance sidesteps the name entirely.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ByParameterInstance_TwoUnnamedParameters_ResolvesEachUnambiguously()
+    {
+        var x = Expression.Parameter(typeof(double));
+        var y = Expression.Parameter(typeof(double));
+        var f = Expression.Lambda<Func<double, double, double>>(Expression.Multiply(x, y), x, y);
+
+        ExpressionDerivation<double> derivationByX = new(x);
+        ExpressionDerivation<double> derivationByY = new(y);
+
+        var dfdx = (Expression<Func<double, double, double>>)derivationByX.Derivate(f);
+        var dfdy = (Expression<Func<double, double, double>>)derivationByY.Derivate(f);
+
+        Assert.AreEqual(3.0, dfdx.Compile()(2.0, 3.0), 1e-9);
+        Assert.AreEqual(2.0, dfdy.Compile()(2.0, 3.0), 1e-9);
+    }
+
+    /// <summary>
+    /// Two distinct parameters can legally share one non-null name; resolving by instance still picks
+    /// out exactly the one the caller passed instead of throwing an ambiguity error.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ByParameterInstance_DuplicateNamedParameters_ResolvesEachUnambiguously()
+    {
+        var x1 = Expression.Parameter(typeof(double), "x");
+        var x2 = Expression.Parameter(typeof(double), "x");
+        var f = Expression.Lambda<Func<double, double, double>>(Expression.Add(Expression.Multiply(x1, Expression.Constant(2.0)), x2), x1, x2);
+
+        ExpressionDerivation<double> derivationByX1 = new(x1);
+        ExpressionDerivation<double> derivationByX2 = new(x2);
+
+        var dfdx1 = (Expression<Func<double, double, double>>)derivationByX1.Derivate(f);
+        var dfdx2 = (Expression<Func<double, double, double>>)derivationByX2.Derivate(f);
+
+        Assert.AreEqual(2.0, dfdx1.Compile()(5.0, 7.0), 1e-9);
+        Assert.AreEqual(1.0, dfdx2.Compile()(5.0, 7.0), 1e-9);
+    }
+
+    /// <summary>
+    /// A parameter instance that does not belong to the lambda being differentiated must fail with a
+    /// contextual diagnostic instead of silently matching nothing or the wrong variable.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ByParameterInstance_ParameterNotInLambda_Throws()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var foreign = Expression.Parameter(typeof(double), "x");
+        var f = Expression.Lambda<Func<double, double>>(x, x);
+
+        ExpressionDerivation<double> derivationByForeign = new(foreign);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => derivationByForeign.Derivate(f));
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
+++ b/UtilsTest/Mathematics/Expressions/ExpressionIntegrationTests.cs
@@ -541,4 +541,41 @@ public class ExpressionIntegrationTests
         Assert.AreEqual(-Math.Log(Math.Abs(Math.Cos(xv))), actual, 1e-9, $"∫tan(x) dx at x={xv}");
     }
 
+    // ── Parameter-instance resolution (TODO-pass4 item #47) ────────────────────
+
+    /// <summary>
+    /// Two parameters sharing the same declared name (including <see langword="null"/> for unnamed
+    /// parameters) previously made name-based resolution ambiguous even when only one of them was
+    /// intended. Targeting the exact instance sidesteps the name entirely.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ByParameterInstance_UnnamedParameter_Works()
+    {
+        var x = Expression.Parameter(typeof(double));
+        var body = Expression.Multiply(Expression.Constant(2.0), x);
+        var f = Expression.Lambda<Func<double, double>>(body, x);
+
+        ExpressionIntegration<double> integrationByX = new(x);
+        var result = (Expression<Func<double, double>>)integrationByX.Integrate(f);
+
+        // integral of 2x dx = x^2; at x=4 -> 16
+        Assert.AreEqual(16.0, result.Compile()(4.0), 1e-9);
+    }
+
+    /// <summary>
+    /// A parameter instance that does not belong to the lambda being integrated must fail with a
+    /// contextual diagnostic instead of silently matching nothing or the wrong variable.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ByParameterInstance_ParameterNotInLambda_Throws()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var foreign = Expression.Parameter(typeof(double), "x");
+        var f = Expression.Lambda<Func<double, double>>(x, x);
+
+        ExpressionIntegration<double> integrationByForeign = new(foreign);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => integrationByForeign.Integrate(f));
+    }
+
 }

--- a/UtilsTest/Mathematics/Expressions/MathExpressionExtensionsTests.cs
+++ b/UtilsTest/Mathematics/Expressions/MathExpressionExtensionsTests.cs
@@ -74,4 +74,60 @@ public class MathExpressionExtensionsTests
         Expression<Func<float, double, double>> f = (x, y) => x + y;
         Assert.ThrowsException<NotSupportedException>(() => f.Gradient());
     }
+
+    // ── Parameter-instance resolution (TODO-pass4 item #47) ────────────────────
+
+    /// <summary>
+    /// Before the fix, <c>Gradient()</c> resolved each partial derivative by
+    /// <c>ParameterExpression.Name</c>; two unnamed parameters both have a <see langword="null"/> name, so
+    /// name-based resolution would find two "candidates" for either target and throw an ambiguity error
+    /// even though the parameters are perfectly identifiable by position/instance. Routing through the
+    /// parameter-instance overloads fixes this.
+    /// </summary>
+    [TestMethod]
+    public void Gradient_UnnamedParameters_ResolvesEachUnambiguously()
+    {
+        var x = Expression.Parameter(typeof(double));
+        var y = Expression.Parameter(typeof(double));
+        var f = Expression.Lambda<Func<double, double, double>>(Expression.Multiply(x, y), x, y);
+
+        LambdaExpression[] grad = f.Gradient();
+        Assert.AreEqual(2, grad.Length);
+
+        var dfdx = (Expression<Func<double, double, double>>)grad[0];
+        var dfdy = (Expression<Func<double, double, double>>)grad[1];
+        Assert.AreEqual(3.0, dfdx.Compile()(2.0, 3.0), 1e-9);
+        Assert.AreEqual(2.0, dfdy.Compile()(2.0, 3.0), 1e-9);
+    }
+
+    /// <summary>
+    /// <see cref="MathExpressionExtensions.Derivate(LambdaExpression, ParameterExpression)"/> targets the
+    /// exact parameter instance directly, without going through name-based resolution at all.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ByParameterInstance_UnnamedParameter_Works()
+    {
+        var x = Expression.Parameter(typeof(double));
+        Expression<Func<double, double>> f = Expression.Lambda<Func<double, double>>(Expression.Multiply(x, x), x);
+
+        var df = (Expression<Func<double, double>>)f.Derivate(x);
+
+        Assert.AreEqual(6.0, df.Compile()(3.0), 1e-9);
+    }
+
+    /// <summary>
+    /// <see cref="MathExpressionExtensions.Integrate(LambdaExpression, ParameterExpression)"/> targets the
+    /// exact parameter instance directly, without going through name-based resolution at all.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ByParameterInstance_UnnamedParameter_Works()
+    {
+        var x = Expression.Parameter(typeof(double));
+        Expression<Func<double, double>> f = Expression.Lambda<Func<double, double>>(x, x);
+
+        var intF = (Expression<Func<double, double>>)f.Integrate(x);
+
+        // integral of x dx = x^2/2; at x=4 -> 8
+        Assert.AreEqual(8.0, intF.Compile()(4.0), 1e-9);
+    }
 }

--- a/UtilsTest/Mathematics/Expressions/MathExpressionExtensionsTests.cs
+++ b/UtilsTest/Mathematics/Expressions/MathExpressionExtensionsTests.cs
@@ -1,0 +1,77 @@
+using System.Linq.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Mathematics.Expressions;
+
+namespace UtilsTest.Mathematics.Expressions;
+
+/// <summary>
+/// Regression coverage for TODO-pass4 item #46: the non-generic convenience overloads must infer the
+/// lambda's own scalar type instead of silently forcing <see cref="double"/>.
+/// </summary>
+[TestClass]
+public class MathExpressionExtensionsTests
+{
+    [TestMethod]
+    public void Derivate_FloatLambda_InfersFloatInsteadOfDouble()
+    {
+        Expression<Func<float, float>> f = x => x * x;
+        var df = (Expression<Func<float, float>>)f.Derivate();
+
+        // d/dx x^2 = 2x; at x=3 -> 6
+        Assert.AreEqual(6f, df.Compile()(3f), 1e-4f);
+    }
+
+    [TestMethod]
+    public void Derivate_DecimalLambda_InfersDecimalInsteadOfDouble()
+    {
+        Expression<Func<decimal, decimal>> f = x => x;
+        var df = (Expression<Func<decimal, decimal>>)f.Derivate();
+
+        Assert.AreEqual(1m, df.Compile()(3m));
+    }
+
+    [TestMethod]
+    public void Integrate_FloatLambda_InfersFloatInsteadOfDouble()
+    {
+        Expression<Func<float, float>> f = x => x;
+        var intF = (Expression<Func<float, float>>)f.Integrate();
+        var compiled = intF.Compile();
+
+        // integral of x dx = x^2/2; at x=4 -> 8
+        Assert.AreEqual(8f, compiled(4f), 1e-3f);
+    }
+
+    [TestMethod]
+    public void Gradient_FloatLambda_InfersFloatInsteadOfDouble()
+    {
+        Expression<Func<float, float, float>> f = (x, y) => x * y;
+        LambdaExpression[] grad = f.Gradient();
+        Assert.AreEqual(2, grad.Length);
+
+        var dfdx = (Expression<Func<float, float, float>>)grad[0];
+        Assert.AreEqual(3f, dfdx.Compile()(2f, 3f), 1e-4f);
+    }
+
+    /// <summary>
+    /// <see cref="int"/> does not implement <c>IFloatingPoint&lt;T&gt;</c>, so the non-generic overload
+    /// must fail explicitly instead of forcing the expression through <see cref="double"/> rules that
+    /// don't match the lambda's declared parameter type.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_NonFloatingPointParameterType_ThrowsNotSupportedException()
+    {
+        Expression<Func<int, int>> f = x => x;
+        Assert.ThrowsException<NotSupportedException>(() => f.Derivate());
+    }
+
+    /// <summary>
+    /// A gradient over parameters of two different types has no single scalar type to infer and must be
+    /// rejected explicitly rather than picking one arbitrarily.
+    /// </summary>
+    [TestMethod]
+    public void Gradient_MixedParameterTypes_ThrowsNotSupportedException()
+    {
+        Expression<Func<float, double, double>> f = (x, y) => x + y;
+        Assert.ThrowsException<NotSupportedException>(() => f.Gradient());
+    }
+}

--- a/UtilsTest/Mathematics/Expressions/MathExpressionExtensionsTests.cs
+++ b/UtilsTest/Mathematics/Expressions/MathExpressionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.Mathematics.Expressions;
 
@@ -129,5 +130,50 @@ public class MathExpressionExtensionsTests
 
         // integral of x dx = x^2/2; at x=4 -> 8
         Assert.AreEqual(8.0, intF.Compile()(4.0), 1e-9);
+    }
+
+    // ── Reflection dispatch must not wrap exceptions (PR 450 review) ───────────
+
+    /// <summary>
+    /// The non-generic overloads dispatch to their <c>&lt;T&gt;</c> counterpart through
+    /// <see cref="MethodInfo.Invoke(object?, object?[]?)"/>, which by default wraps any exception thrown by
+    /// the invoked method in a <see cref="TargetInvocationException"/>. That would silently change the
+    /// public exception contract of these convenience overloads (their generic counterparts throw
+    /// <see cref="InvalidOperationException"/> directly); the dispatch helper must unwrap it.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_UnknownParameterName_ThrowsInvalidOperationExceptionDirectly()
+    {
+        Expression<Func<double, double>> f = x => x;
+        Assert.ThrowsExactly<InvalidOperationException>(() => f.Derivate("missing"));
+    }
+
+    /// <summary>
+    /// Same as <see cref="Derivate_UnknownParameterName_ThrowsInvalidOperationExceptionDirectly"/>, but for
+    /// the parameter-instance overload: a parameter that does not belong to the lambda must surface the
+    /// underlying <see cref="InvalidOperationException"/> unwrapped.
+    /// </summary>
+    [TestMethod]
+    public void Derivate_ByParameterInstance_ForeignParameter_ThrowsInvalidOperationExceptionDirectly()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var foreign = Expression.Parameter(typeof(double), "x");
+        Expression<Func<double, double>> f = Expression.Lambda<Func<double, double>>(x, x);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => f.Derivate(foreign));
+    }
+
+    /// <summary>
+    /// Same as <see cref="Derivate_ByParameterInstance_ForeignParameter_ThrowsInvalidOperationExceptionDirectly"/>,
+    /// for the integration side.
+    /// </summary>
+    [TestMethod]
+    public void Integrate_ByParameterInstance_ForeignParameter_ThrowsInvalidOperationExceptionDirectly()
+    {
+        var x = Expression.Parameter(typeof(double), "x");
+        var foreign = Expression.Parameter(typeof(double), "x");
+        Expression<Func<double, double>> f = Expression.Lambda<Func<double, double>>(x, x);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => f.Integrate(foreign));
     }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -36,6 +36,71 @@ public class VectorTests
         Assert.AreEqual(0d, barycenter[1], 1e-9);
     }
 
+    // ── Barycenter zero/non-finite total weight (TODO-pass4 item #44) ─────────
+
+    /// <summary>
+    /// All-zero weights sum to an exactly-zero total weight, which cannot normalize the accumulated
+    /// (also zero) coordinates; this must be rejected instead of silently dividing 0/0.
+    /// </summary>
+    [TestMethod]
+    public void ComputeBarycenter_AllZeroWeights_Throws()
+    {
+        var p1 = new Vector<double>(0d, 0d);
+        var p2 = new Vector<double>(2d, 0d);
+        Assert.ThrowsException<ArgumentException>(() => Vector<double>.ComputeBarycenter((0d, p1), (0d, p2)));
+    }
+
+    /// <summary>
+    /// Opposite weights that sum to exactly zero must be rejected the same way as all-zero weights,
+    /// even though the individual weights are non-zero.
+    /// </summary>
+    [TestMethod]
+    public void ComputeBarycenter_CancellingWeights_Throws()
+    {
+        var p1 = new Vector<double>(0d, 0d);
+        var p2 = new Vector<double>(2d, 0d);
+        Assert.ThrowsException<ArgumentException>(() => Vector<double>.ComputeBarycenter((1d, p1), (-1d, p2)));
+    }
+
+    /// <summary>
+    /// A <see cref="double.NaN"/> weight must be rejected explicitly instead of poisoning the total
+    /// weight and every accumulated coordinate with NaN.
+    /// </summary>
+    [TestMethod]
+    public void ComputeBarycenter_NaNWeight_Throws()
+    {
+        var p1 = new Vector<double>(0d, 0d);
+        var p2 = new Vector<double>(2d, 0d);
+        Assert.ThrowsException<ArgumentException>(() => Vector<double>.ComputeBarycenter((1d, p1), (double.NaN, p2)));
+    }
+
+    /// <summary>
+    /// An infinite weight must be rejected explicitly instead of producing an infinite or NaN
+    /// barycenter.
+    /// </summary>
+    [TestMethod]
+    public void ComputeBarycenter_InfiniteWeight_Throws()
+    {
+        var p1 = new Vector<double>(0d, 0d);
+        var p2 = new Vector<double>(2d, 0d);
+        Assert.ThrowsException<ArgumentException>(() => Vector<double>.ComputeBarycenter((1d, p1), (double.PositiveInfinity, p2)));
+    }
+
+    /// <summary>
+    /// Negative and positive weights that do not cancel out to zero remain a valid, well-defined
+    /// (unequal, "external division") barycenter and must not be rejected by the zero/non-finite guard.
+    /// </summary>
+    [TestMethod]
+    public void ComputeBarycenter_NegativeAndPositiveWeightsSummingNonZero_StillWorks()
+    {
+        var p1 = new Vector<double>(0d, 0d);
+        var p2 = new Vector<double>(2d, 0d);
+        var (weight, barycenter) = Vector<double>.ComputeBarycenter((3d, p1), (-1d, p2));
+        Assert.AreEqual(2d, weight, 1e-9);
+        Assert.AreEqual(-1d, barycenter[0], 1e-9);
+        Assert.AreEqual(0d, barycenter[1], 1e-9);
+    }
+
     /// <summary>
     /// Ensures that vectors copy incoming component arrays to remain immutable.
     /// </summary>

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -101,6 +101,58 @@ public class VectorTests
         Assert.AreEqual(0d, barycenter[1], 1e-9);
     }
 
+    // ── Barycenter selector/input validation (TODO-pass4 item #45) ────────────
+
+    /// <summary>A <see langword="null"/> weight selector must be rejected explicitly.</summary>
+    [TestMethod]
+    public void ComputeBarycenter_NullWeightSelector_Throws()
+    {
+        var p1 = new Vector<double>(0d, 0d);
+        Assert.ThrowsException<ArgumentNullException>(
+            () => Vector<double>.ComputeBarycenter<(double weight, Vector<double> vector)>(null, wp => wp.vector, [(1d, p1)]));
+    }
+
+    /// <summary>A <see langword="null"/> vector selector must be rejected explicitly.</summary>
+    [TestMethod]
+    public void ComputeBarycenter_NullVectorSelector_Throws()
+    {
+        var p1 = new Vector<double>(0d, 0d);
+        Assert.ThrowsException<ArgumentNullException>(
+            () => Vector<double>.ComputeBarycenter<(double weight, Vector<double> vector)>(wp => wp.weight, null, [(1d, p1)]));
+    }
+
+    /// <summary>A <see langword="null"/> source enumerable must be rejected explicitly.</summary>
+    [TestMethod]
+    public void ComputeBarycenter_NullWeightedPoints_Throws()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => Vector<double>.ComputeBarycenter<(double weight, Vector<double> vector)>(wp => wp.weight, wp => wp.vector, null));
+    }
+
+    /// <summary>
+    /// A vector selector that returns <see langword="null"/> for some element must be rejected instead of
+    /// failing later with an incidental <see cref="NullReferenceException"/> when the dimension is read.
+    /// </summary>
+    [TestMethod]
+    public void ComputeBarycenter_NullSelectedVector_Throws()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => Vector<double>.ComputeBarycenter<double>(w => w, w => null, [1d, 2d]));
+    }
+
+    /// <summary>
+    /// Selected vectors of mismatched dimension must be rejected with <see cref="ArgumentException"/>,
+    /// consistent with other public <see cref="Vector{T}"/> APIs, instead of the previous
+    /// <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [TestMethod]
+    public void ComputeBarycenter_MismatchedDimensions_ThrowsArgumentException()
+    {
+        var p1 = new Vector<double>(0d, 0d);
+        var p2 = new Vector<double>(1d, 1d, 1d);
+        Assert.ThrowsException<ArgumentException>(() => Vector<double>.ComputeBarycenter((1d, p1), (1d, p2)));
+    }
+
     /// <summary>
     /// Ensures that vectors copy incoming component arrays to remain immutable.
     /// </summary>


### PR DESCRIPTION
## Summary
- Addresses Utils.Mathematics/TODO-2026-07-11-pass4.md items #43-#47, one item per commit (barycenter zero-weight/validation, symbolic convenience overloads forcing double, name-based parameter resolution). Items #48-#56 (AffineSubspace tolerance/null validation, equality/hashing, Fourier metadata APIs, scalar division policy) are tracked in the same TODO file but not yet addressed; they remain for follow-up PRs.
- Item #43 (Vector<T> == null): already fixed by a prior audit pass; annotated instead of duplicating work.
- Fixed a reflection-dispatch bug found in review: the non-generic Derivate/Gradient/Integrate overloads invoke their <T> counterpart via reflection, which by default wraps any exception in a TargetInvocationException. A shared InvokeGeneric helper now unwraps and rethrows the original exception (e.g. InvalidOperationException for an unknown/foreign parameter) so the public exception contract matches the explicit generic overloads.

## Test plan
- [x] dotnet test UtilsTest/UtilsTest.Unit.csproj after each item
- [x] Full suite green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
