### PR TITLE
Utils.Mathematics: address TODO-pass5.md findings

### DIFF
--- a/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
@@ -206,6 +206,11 @@ public partial class Matrix<T>
             }
         }
 
-        return new Matrix<T>(inverse, false, false, false, null);
+        // Unlike false (a permanently cached, potentially wrong negative answer that disables lazy
+        // recomputation - see TODO-2026-07-11-pass5.md item #61), null defers isIdentity/isTriangular/
+        // isDiagonal to the first access of the corresponding property, which recomputes them from the
+        // actual computed inverse array. This correctly reports e.g. the inverse of a diagonal matrix
+        // as still diagonal, instead of always false regardless of the source's actual structure.
+        return new Matrix<T>(inverse, null, null, null, null);
     }
 }

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
@@ -44,25 +44,46 @@ public partial class Matrix<T>
     }
 
     /// <summary>
-    /// Performs a pivoted LU decomposition of the current square matrix: a lower unitriangular
-    /// matrix L, an upper triangular matrix U, and a permutation matrix P such that P * A = L * U,
-    /// where A is the current matrix.
+    /// Result of <see cref="TryDecomposePivoted"/>: a pivoted Gauss elimination of a square matrix
+    /// <c>A</c> such that <c>P·A = L·U</c>, where <c>P</c> is the permutation matrix implied by
+    /// <see cref="Permutation"/> (row <c>i</c> of <c>P·A</c> is row <see cref="Permutation"/><c>[i]</c>
+    /// of <c>A</c>).
     /// </summary>
-    /// <remarks>
-    /// Uses partial pivoting (largest-magnitude pivot in each column) and stores the elimination
-    /// multipliers directly in L, as required for L to be the actual lower-triangular LU factor
-    /// rather than a by-product of applying the elimination row operations to an identity matrix.
-    /// Operates entirely on local array copies to preserve immutability.
-    /// </remarks>
-    /// <returns>A tuple containing the lower-triangular, upper-triangular, and permutation matrices.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the matrix is not square or is singular.</exception>
-    public (Matrix<T> L, Matrix<T> U, Matrix<T> P) DiagonalizeLU()
-    {
-        if (!IsSquare)
-        {
-            throw new InvalidOperationException("The matrix must be square for LU decomposition.");
-        }
+    /// <param name="L">Lower unitriangular factor (unit diagonal, elimination multipliers below it).</param>
+    /// <param name="U">Upper triangular factor.</param>
+    /// <param name="Permutation">Row permutation applied to <c>A</c> before elimination.</param>
+    /// <param name="Swaps">
+    /// Number of row transpositions actually performed; <c>(-1)^Swaps</c> is the determinant of the
+    /// implied permutation matrix <c>P</c>.
+    /// </param>
+    private readonly record struct PivotedElimination(T[,] L, T[,] U, int[] Permutation, int Swaps);
 
+    /// <summary>
+    /// Performs the pivoted Gauss elimination shared by <see cref="DiagonalizeLU"/>,
+    /// <see cref="ComputeDeterminant"/>, <see cref="Solve"/>, and <see cref="Invert"/>, so pivot
+    /// selection, tolerance policy, and numerical behavior cannot silently drift between these four
+    /// operations the way four independent reimplementations previously could (see
+    /// TODO-2026-07-11-pass5.md item #69). Uses partial pivoting (largest-magnitude pivot in each
+    /// column) and stores the elimination multipliers directly in <c>L</c>, rather than as a
+    /// by-product of applying the elimination row operations to an identity matrix. Operates entirely
+    /// on local array copies to preserve immutability.
+    /// </summary>
+    /// <param name="relativeSingularityTolerance">
+    /// Overrides the default relative-plus-absolute pivot tolerance (see <see cref="DefaultTolerance"/>)
+    /// used to reject a numerically near-singular matrix. When supplied, the effective absolute
+    /// threshold is this value multiplied by the matrix's largest entry (no absolute floor is added,
+    /// unlike the default).
+    /// </param>
+    /// <param name="decomposition">The computed decomposition, or <c>default</c> when this method returns <see langword="false"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> when the matrix could be decomposed; <see langword="false"/> when a pivot
+    /// column's largest available magnitude does not exceed the singularity tolerance (the matrix is
+    /// singular or numerically near-singular). Returning a sentinel rather than throwing lets
+    /// <see cref="ComputeDeterminant"/> report the mathematically well-defined zero determinant for a
+    /// singular matrix without using an exception for ordinary control flow.
+    /// </returns>
+    private bool TryDecomposePivoted(T? relativeSingularityTolerance, out PivotedElimination decomposition)
+    {
         int n = Rows;
         T[,] u = ToArray();
         T[,] l = new T[n, n];
@@ -74,6 +95,11 @@ public partial class Matrix<T>
             permutation[i] = i;
         }
 
+        T pivotTolerance = relativeSingularityTolerance is { } explicitTolerance
+            ? MaxAbsoluteEntry(u) * explicitTolerance
+            : DefaultTolerance(MaxAbsoluteEntry(u), n);
+
+        int swaps = 0;
         for (int k = 0; k < n; k++)
         {
             int pivotRow = k;
@@ -85,9 +111,10 @@ public partial class Matrix<T>
                 }
             }
 
-            if (u[pivotRow, k].Equals(T.Zero))
+            if (T.Abs(u[pivotRow, k]) <= pivotTolerance)
             {
-                throw new InvalidOperationException("The matrix is singular and cannot be decomposed.");
+                decomposition = default;
+                return false;
             }
 
             if (pivotRow != k)
@@ -97,6 +124,7 @@ public partial class Matrix<T>
                 // column k onward is either not yet computed or the identity diagonal being formed.
                 PermuteRows(l, k, pivotRow, k);
                 (permutation[k], permutation[pivotRow]) = (permutation[pivotRow], permutation[k]);
+                swaps++;
             }
 
             for (int row = k + 1; row < n; row++)
@@ -110,16 +138,120 @@ public partial class Matrix<T>
             }
         }
 
+        decomposition = new PivotedElimination(l, u, permutation, swaps);
+        return true;
+    }
+
+    /// <summary>
+    /// Solves <c>L·y = P·b</c> by forward substitution (<c>L</c> has a unit diagonal, so no division is
+    /// needed on the diagonal step) followed by <c>U·x = y</c> by back substitution, reusing an already
+    /// computed <see cref="PivotedElimination"/>. Shared by <see cref="Solve"/> and <see cref="Invert"/>
+    /// (which calls this once per column of the identity matrix).
+    /// </summary>
+    /// <param name="decomposition">A decomposition of the current matrix from <see cref="TryDecomposePivoted"/>.</param>
+    /// <param name="permutedRightHandSide">
+    /// The right-hand side already permuted according to <see cref="PivotedElimination.Permutation"/>,
+    /// i.e. <c>P·b</c> (index <c>i</c> holds <c>b[Permutation[i]]</c>).
+    /// </param>
+    /// <returns>The solution <c>x</c> of <c>A·x = b</c>.</returns>
+    private static T[] SolvePermuted(PivotedElimination decomposition, T[] permutedRightHandSide)
+    {
+        int n = permutedRightHandSide.Length;
+        T[] y = new T[n];
+        for (int i = 0; i < n; i++)
+        {
+            T sum = permutedRightHandSide[i];
+            for (int j = 0; j < i; j++)
+                sum -= decomposition.L[i, j] * y[j];
+            y[i] = sum;
+        }
+
+        T[] x = new T[n];
+        for (int i = n - 1; i >= 0; i--)
+        {
+            T sum = y[i];
+            for (int j = i + 1; j < n; j++)
+                sum -= decomposition.U[i, j] * x[j];
+            x[i] = sum / decomposition.U[i, i];
+        }
+
+        return x;
+    }
+
+    /// <summary>
+    /// Performs a pivoted LU decomposition of the current square matrix: a lower unitriangular
+    /// matrix L, an upper triangular matrix U, and a permutation matrix P such that P * A = L * U,
+    /// where A is the current matrix.
+    /// </summary>
+    /// <param name="relativeSingularityTolerance">
+    /// Overrides the default relative-plus-absolute pivot tolerance (see <see cref="DefaultTolerance"/>)
+    /// used to reject a numerically near-singular matrix; see <see cref="TryDecomposePivoted"/>. Must be
+    /// finite and non-negative when supplied.
+    /// </param>
+    /// <remarks>
+    /// Delegates to the pivoted elimination shared with <see cref="ComputeDeterminant"/>,
+    /// <see cref="Solve"/>, and <see cref="Invert"/> (see TODO-2026-07-11-pass5.md item #69).
+    /// Structural metadata on the returned matrices reflects only what is mathematically guaranteed for
+    /// every input: <c>L</c>'s unit diagonal makes it always triangular with determinant one, and
+    /// <c>U</c> is always triangular; whether <c>L</c>, <c>U</c>, or <c>P</c> also happen to be diagonal
+    /// or the identity (e.g. when no pivoting was needed, or the source was already triangular) is left
+    /// to lazy recomputation rather than hardcoded as false (see item #61/#68). <c>P</c>'s determinant
+    /// (the sign of the permutation) is known directly from the elimination's swap count, so it is
+    /// supplied rather than left for recomputation.
+    /// </remarks>
+    /// <returns>A tuple containing the lower-triangular, upper-triangular, and permutation matrices.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the matrix is not square or is singular.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="relativeSingularityTolerance"/> is supplied but not finite or is negative.</exception>
+    public (Matrix<T> L, Matrix<T> U, Matrix<T> P) DiagonalizeLU(T? relativeSingularityTolerance = null)
+    {
+        if (!IsSquare)
+        {
+            throw new InvalidOperationException("The matrix must be square for LU decomposition.");
+        }
+        if (relativeSingularityTolerance is { } explicitTolerance)
+            ValidateTolerance(explicitTolerance, nameof(relativeSingularityTolerance));
+
+        if (!TryDecomposePivoted(relativeSingularityTolerance, out PivotedElimination decomposition))
+        {
+            throw new InvalidOperationException("The matrix is singular and cannot be decomposed.");
+        }
+
+        int n = Rows;
         T[,] p = new T[n, n];
         for (int i = 0; i < n; i++)
         {
-            p[i, permutation[i]] = T.One;
+            p[i, decomposition.Permutation[i]] = T.One;
         }
 
-        Matrix<T> L = new Matrix<T>(l, false, true, false, T.One);
-        Matrix<T> U = new Matrix<T>(u, false, true, false, null);
-        Matrix<T> P = new Matrix<T>(p, false, false, false, null);
+        T permutationDeterminant = decomposition.Swaps % 2 == 0 ? T.One : -T.One;
+        Matrix<T> L = new Matrix<T>(decomposition.L, null, true, null, T.One);
+        Matrix<T> U = new Matrix<T>(decomposition.U, null, true, null, null);
+        Matrix<T> P = new Matrix<T>(p, null, null, null, permutationDeterminant);
         return (L, U, P);
+    }
+
+    /// <summary>
+    /// Computes the determinant using the shared pivoted elimination (see
+    /// <see cref="TryDecomposePivoted"/> and TODO-2026-07-11-pass5.md item #69), returning the
+    /// mathematically well-defined zero determinant for a singular or numerically near-singular matrix
+    /// instead of throwing - determinant is defined for every square matrix, unlike decomposition/solve/
+    /// inversion, which genuinely have no answer to give in that case.
+    /// </summary>
+    private T ComputeDeterminant()
+    {
+        // A pivot merely close to zero (not exactly zero) would otherwise amplify rounding error into a
+        // huge/infinite/NaN result instead of the mathematically expected near-zero determinant of a
+        // near-singular matrix - see the tolerance rationale on TryDecomposePivoted/DefaultTolerance.
+        if (!TryDecomposePivoted(relativeSingularityTolerance: null, out PivotedElimination decomposition))
+        {
+            return T.Zero;
+        }
+
+        T det = decomposition.Swaps % 2 == 0 ? T.One : -T.One;
+        int n = Rows;
+        for (int i = 0; i < n; i++)
+            det *= decomposition.U[i, i];
+        return det;
     }
 
     /// <summary>
@@ -134,6 +266,12 @@ public partial class Matrix<T>
     /// <returns>A new matrix representing the inverse of the current matrix.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the matrix is not square.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="relativeSingularityTolerance"/> is supplied but not finite or is negative.</exception>
+    /// <remarks>
+    /// Delegates to the pivoted elimination shared with <see cref="DiagonalizeLU"/>,
+    /// <see cref="ComputeDeterminant"/>, and <see cref="Solve"/> (see TODO-2026-07-11-pass5.md item #69):
+    /// column <c>j</c> of the inverse is the solution of <c>A·x = e_j</c> for the <c>j</c>-th standard
+    /// basis vector, computed via the same forward/back substitution as <see cref="Solve"/>.
+    /// </remarks>
     public Matrix<T> Invert(T? relativeSingularityTolerance = null)
     {
         if (!IsSquare)
@@ -148,62 +286,22 @@ public partial class Matrix<T>
             return new Matrix<T>(this);
         }
 
-        int n = Rows;
-        T[,] working = ToArray();
-        T[,] inverse = new T[n, n];
-        T pivotTolerance = relativeSingularityTolerance is { } explicitInvertTolerance
-            ? MaxAbsoluteEntry(working) * explicitInvertTolerance
-            : DefaultTolerance(MaxAbsoluteEntry(working), n);
-
-        for (int i = 0; i < n; i++)
+        if (!TryDecomposePivoted(relativeSingularityTolerance, out PivotedElimination decomposition))
         {
-            inverse[i, i] = T.One;
+            throw new InvalidOperationException("The matrix is singular or numerically near-singular and cannot be reliably inverted.");
         }
 
-        for (int pivotIndex = 0; pivotIndex < n; pivotIndex++)
+        int n = Rows;
+        T[,] inverse = new T[n, n];
+        T[] permutedColumn = new T[n];
+        for (int col = 0; col < n; col++)
         {
-            int pivotRow = pivotIndex;
-            T pivotMagnitude = T.Abs(working[pivotRow, pivotIndex]);
+            for (int i = 0; i < n; i++)
+                permutedColumn[i] = decomposition.Permutation[i] == col ? T.One : T.Zero;
 
-            for (int row = pivotIndex + 1; row < n; row++)
-            {
-                T candidate = T.Abs(working[row, pivotIndex]);
-                if (candidate > pivotMagnitude)
-                {
-                    pivotMagnitude = candidate;
-                    pivotRow = row;
-                }
-            }
-
-            if (pivotMagnitude <= pivotTolerance)
-            {
-                throw new InvalidOperationException("The matrix is singular or numerically near-singular and cannot be reliably inverted.");
-            }
-
-            if (pivotRow != pivotIndex)
-            {
-                PermuteRows(working, pivotIndex, pivotRow);
-                PermuteRows(inverse, pivotIndex, pivotRow);
-            }
-
-            T pivot = working[pivotIndex, pivotIndex];
-            for (int col = 0; col < n; col++)
-            {
-                working[pivotIndex, col] /= pivot;
-                inverse[pivotIndex, col] /= pivot;
-            }
-
+            T[] x = SolvePermuted(decomposition, permutedColumn);
             for (int row = 0; row < n; row++)
-            {
-                if (row == pivotIndex) continue;
-
-                T factor = working[row, pivotIndex];
-                for (int col = 0; col < n; col++)
-                {
-                    working[row, col] -= factor * working[pivotIndex, col];
-                    inverse[row, col] -= factor * inverse[pivotIndex, col];
-                }
-            }
+                inverse[row, col] = x[row];
         }
 
         // Unlike false (a permanently cached, potentially wrong negative answer that disables lazy

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Compute.cs
@@ -61,28 +61,34 @@ public partial class Matrix<T>
     /// <summary>
     /// Performs the pivoted Gauss elimination shared by <see cref="DiagonalizeLU"/>,
     /// <see cref="ComputeDeterminant"/>, <see cref="Solve"/>, and <see cref="Invert"/>, so pivot
-    /// selection, tolerance policy, and numerical behavior cannot silently drift between these four
+    /// selection and the elimination arithmetic itself cannot silently drift between these four
     /// operations the way four independent reimplementations previously could (see
     /// TODO-2026-07-11-pass5.md item #69). Uses partial pivoting (largest-magnitude pivot in each
     /// column) and stores the elimination multipliers directly in <c>L</c>, rather than as a
-    /// by-product of applying the elimination row operations to an identity matrix. Operates entirely
-    /// on local array copies to preserve immutability.
+    /// by-product of applying the elimination row operations to an identity matrix.
     /// </summary>
-    /// <param name="relativeSingularityTolerance">
-    /// Overrides the default relative-plus-absolute pivot tolerance (see <see cref="DefaultTolerance"/>)
-    /// used to reject a numerically near-singular matrix. When supplied, the effective absolute
-    /// threshold is this value multiplied by the matrix's largest entry (no absolute floor is added,
-    /// unlike the default).
+    /// <param name="pivotTolerance">
+    /// The absolute pivot-rejection threshold: a pivot column whose largest available magnitude does
+    /// not exceed this value is treated as singular. Deliberately <b>not</b> resolved internally from a
+    /// single shared policy - <see cref="ComputeDeterminant"/> needs a fundamentally different notion of
+    /// "singular" than <see cref="DiagonalizeLU"/>/<see cref="Solve"/>/<see cref="Invert"/> do (see
+    /// TODO-2026-07-11-pass5.md item #69 PR review): a determinant is the exact product of the pivots
+    /// and is well-defined (and can be legitimately tiny) for any well-conditioned matrix whose entries
+    /// merely happen to be small in absolute value, so it must reject only an exactly-zero pivot
+    /// (pass <c>T.Zero</c>). Solving/inverting, by contrast, divide by the pivot
+    /// to propagate a numerically reliable result, so they need the scale-aware
+    /// relative-plus-absolute-floor policy computed by <see cref="DefaultTolerance"/> (or an explicit
+    /// override) to reject a pivot that is technically nonzero but too small to trust.
     /// </param>
     /// <param name="decomposition">The computed decomposition, or <c>default</c> when this method returns <see langword="false"/>.</param>
     /// <returns>
     /// <see langword="true"/> when the matrix could be decomposed; <see langword="false"/> when a pivot
-    /// column's largest available magnitude does not exceed the singularity tolerance (the matrix is
-    /// singular or numerically near-singular). Returning a sentinel rather than throwing lets
-    /// <see cref="ComputeDeterminant"/> report the mathematically well-defined zero determinant for a
-    /// singular matrix without using an exception for ordinary control flow.
+    /// column's largest available magnitude does not exceed <paramref name="pivotTolerance"/>. Returning
+    /// a sentinel rather than throwing lets <see cref="ComputeDeterminant"/> report the mathematically
+    /// well-defined zero determinant for an exactly singular matrix without using an exception for
+    /// ordinary control flow.
     /// </returns>
-    private bool TryDecomposePivoted(T? relativeSingularityTolerance, out PivotedElimination decomposition)
+    private bool TryDecomposePivoted(T pivotTolerance, out PivotedElimination decomposition)
     {
         int n = Rows;
         T[,] u = ToArray();
@@ -94,10 +100,6 @@ public partial class Matrix<T>
             l[i, i] = T.One;
             permutation[i] = i;
         }
-
-        T pivotTolerance = relativeSingularityTolerance is { } explicitTolerance
-            ? MaxAbsoluteEntry(u) * explicitTolerance
-            : DefaultTolerance(MaxAbsoluteEntry(u), n);
 
         int swaps = 0;
         for (int k = 0; k < n; k++)
@@ -143,6 +145,21 @@ public partial class Matrix<T>
     }
 
     /// <summary>
+    /// Resolves the scale-aware relative-plus-absolute-floor pivot tolerance shared by
+    /// <see cref="DiagonalizeLU"/>, <see cref="Solve"/>, and <see cref="Invert"/> (never
+    /// <see cref="ComputeDeterminant"/>, which needs an exact-zero check instead - see
+    /// <see cref="TryDecomposePivoted"/>): either the default (see <see cref="DefaultTolerance"/>) or,
+    /// when supplied, <paramref name="relativeSingularityTolerance"/> multiplied by the matrix's largest
+    /// entry (no absolute floor is added in that case, unlike the default).
+    /// </summary>
+    private T ResolveDecompositionTolerance(T[,] matrix, T? relativeSingularityTolerance)
+    {
+        return relativeSingularityTolerance is { } explicitTolerance
+            ? MaxAbsoluteEntry(matrix) * explicitTolerance
+            : DefaultTolerance(MaxAbsoluteEntry(matrix), matrix.GetLength(0));
+    }
+
+    /// <summary>
     /// Solves <c>L·y = P·b</c> by forward substitution (<c>L</c> has a unit diagonal, so no division is
     /// needed on the diagonal step) followed by <c>U·x = y</c> by back substitution, reusing an already
     /// computed <see cref="PivotedElimination"/>. Shared by <see cref="Solve"/> and <see cref="Invert"/>
@@ -185,12 +202,15 @@ public partial class Matrix<T>
     /// </summary>
     /// <param name="relativeSingularityTolerance">
     /// Overrides the default relative-plus-absolute pivot tolerance (see <see cref="DefaultTolerance"/>)
-    /// used to reject a numerically near-singular matrix; see <see cref="TryDecomposePivoted"/>. Must be
-    /// finite and non-negative when supplied.
+    /// used to reject a numerically near-singular matrix; see <see cref="ResolveDecompositionTolerance"/>.
+    /// Must be finite and non-negative when supplied.
     /// </param>
     /// <remarks>
     /// Delegates to the pivoted elimination shared with <see cref="ComputeDeterminant"/>,
-    /// <see cref="Solve"/>, and <see cref="Invert"/> (see TODO-2026-07-11-pass5.md item #69).
+    /// <see cref="Solve"/>, and <see cref="Invert"/> (see TODO-2026-07-11-pass5.md item #69). Unlike
+    /// <see cref="ComputeDeterminant"/>, this uses the scale-aware relative-plus-absolute-floor
+    /// tolerance (see <see cref="TryDecomposePivoted"/>'s remarks), since <c>L</c>/<c>U</c> are meant to
+    /// be used for further numerically reliable computation, not just an exact product of pivots.
     /// Structural metadata on the returned matrices reflects only what is mathematically guaranteed for
     /// every input: <c>L</c>'s unit diagonal makes it always triangular with determinant one, and
     /// <c>U</c> is always triangular; whether <c>L</c>, <c>U</c>, or <c>P</c> also happen to be diagonal
@@ -211,7 +231,8 @@ public partial class Matrix<T>
         if (relativeSingularityTolerance is { } explicitTolerance)
             ValidateTolerance(explicitTolerance, nameof(relativeSingularityTolerance));
 
-        if (!TryDecomposePivoted(relativeSingularityTolerance, out PivotedElimination decomposition))
+        T pivotTolerance = ResolveDecompositionTolerance(ToArray(), relativeSingularityTolerance);
+        if (!TryDecomposePivoted(pivotTolerance, out PivotedElimination decomposition))
         {
             throw new InvalidOperationException("The matrix is singular and cannot be decomposed.");
         }
@@ -232,17 +253,20 @@ public partial class Matrix<T>
 
     /// <summary>
     /// Computes the determinant using the shared pivoted elimination (see
-    /// <see cref="TryDecomposePivoted"/> and TODO-2026-07-11-pass5.md item #69), returning the
-    /// mathematically well-defined zero determinant for a singular or numerically near-singular matrix
-    /// instead of throwing - determinant is defined for every square matrix, unlike decomposition/solve/
-    /// inversion, which genuinely have no answer to give in that case.
+    /// <see cref="TryDecomposePivoted"/> and TODO-2026-07-11-pass5.md item #69), rejecting only an
+    /// exactly-zero pivot rather than the scale-aware near-singularity tolerance that
+    /// <see cref="DiagonalizeLU"/>/<see cref="Solve"/>/<see cref="Invert"/> use. A determinant is the
+    /// exact product of the pivots (up to sign) and is well-defined - and can be legitimately tiny -
+    /// for any well-conditioned matrix whose entries merely happen to be small in absolute value (e.g.
+    /// <c>diag(1e-20, 2e-20)</c> has an exact, nonzero determinant of <c>2e-40</c>); reusing the other
+    /// three operations' "too small to trust for further arithmetic" tolerance here would incorrectly
+    /// collapse such a determinant to zero (see TODO-2026-07-11-pass5.md item #69 PR review). Only an
+    /// exactly-zero pivot reflects genuine rank deficiency, which is the only case where the
+    /// determinant is actually zero.
     /// </summary>
     private T ComputeDeterminant()
     {
-        // A pivot merely close to zero (not exactly zero) would otherwise amplify rounding error into a
-        // huge/infinite/NaN result instead of the mathematically expected near-zero determinant of a
-        // near-singular matrix - see the tolerance rationale on TryDecomposePivoted/DefaultTolerance.
-        if (!TryDecomposePivoted(relativeSingularityTolerance: null, out PivotedElimination decomposition))
+        if (!TryDecomposePivoted(T.Zero, out PivotedElimination decomposition))
         {
             return T.Zero;
         }
@@ -268,9 +292,11 @@ public partial class Matrix<T>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="relativeSingularityTolerance"/> is supplied but not finite or is negative.</exception>
     /// <remarks>
     /// Delegates to the pivoted elimination shared with <see cref="DiagonalizeLU"/>,
-    /// <see cref="ComputeDeterminant"/>, and <see cref="Solve"/> (see TODO-2026-07-11-pass5.md item #69):
-    /// column <c>j</c> of the inverse is the solution of <c>A·x = e_j</c> for the <c>j</c>-th standard
-    /// basis vector, computed via the same forward/back substitution as <see cref="Solve"/>.
+    /// <see cref="ComputeDeterminant"/>, and <see cref="Solve"/> (see TODO-2026-07-11-pass5.md item #69),
+    /// using the same scale-aware tolerance as <see cref="DiagonalizeLU"/>/<see cref="Solve"/> (not
+    /// <see cref="ComputeDeterminant"/>'s exact-zero check - see <see cref="TryDecomposePivoted"/>'s
+    /// remarks): column <c>j</c> of the inverse is the solution of <c>A·x = e_j</c> for the <c>j</c>-th
+    /// standard basis vector, computed via the same forward/back substitution as <see cref="Solve"/>.
     /// </remarks>
     public Matrix<T> Invert(T? relativeSingularityTolerance = null)
     {
@@ -286,7 +312,9 @@ public partial class Matrix<T>
             return new Matrix<T>(this);
         }
 
-        if (!TryDecomposePivoted(relativeSingularityTolerance, out PivotedElimination decomposition))
+        T[,] working = ToArray();
+        T pivotTolerance = ResolveDecompositionTolerance(working, relativeSingularityTolerance);
+        if (!TryDecomposePivoted(pivotTolerance, out PivotedElimination decomposition))
         {
             throw new InvalidOperationException("The matrix is singular or numerically near-singular and cannot be reliably inverted.");
         }

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Constructors.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Constructors.cs
@@ -30,11 +30,25 @@ public sealed partial class Matrix<T>
     /// Initializes a matrix with a backing array and structural metadata.
     /// </summary>
     /// <param name="array">Backing array containing matrix values.</param>
-    /// <param name="isIdentity">Indicates whether the matrix is an identity matrix.</param>
-    /// <param name="isTriangular">Indicates whether the matrix is triangular (upper or lower).</param>
-    /// <param name="isDiagonal">Indicates whether the matrix is diagonal (all off-diagonal elements are zero).</param>
+    /// <param name="isIdentity">
+    /// Indicates whether the matrix is an identity matrix, or <see langword="null"/> when the caller
+    /// does not have a mathematically guaranteed answer. Unlike <see langword="false"/> - which
+    /// permanently caches a (possibly wrong) negative answer and disables the lazy recomputation
+    /// performed by <see cref="DetermineStructuralFlags"/> - <see langword="null"/> defers the
+    /// determination to the first access of <see cref="IsIdentity"/>, computed from the actual values
+    /// in <paramref name="array"/> (see TODO-2026-07-11-pass5.md item #61).
+    /// </param>
+    /// <param name="isTriangular">
+    /// Indicates whether the matrix is triangular (upper or lower), or <see langword="null"/> per the
+    /// same "unknown defers to lazy recomputation" rule as <paramref name="isIdentity"/>.
+    /// </param>
+    /// <param name="isDiagonal">
+    /// Indicates whether the matrix is diagonal (all off-diagonal elements are zero), or
+    /// <see langword="null"/> per the same "unknown defers to lazy recomputation" rule as
+    /// <paramref name="isIdentity"/>.
+    /// </param>
     /// <param name="determinant">Precomputed determinant, if available.</param>
-    internal Matrix(T[,] array, bool isIdentity, bool isTriangular, bool isDiagonal, T? determinant)
+    internal Matrix(T[,] array, bool? isIdentity, bool? isTriangular, bool? isDiagonal, T? determinant)
     {
         array.Arg().MustNotBeNull();
         this.components = array;

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
@@ -25,7 +25,9 @@ public sealed partial class Matrix<T>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="relativeSingularityTolerance"/> is supplied but not finite or is negative.</exception>
     /// <remarks>
     /// Delegates to the pivoted elimination shared with <see cref="DiagonalizeLU"/>,
-    /// <see cref="Determinant"/>, and <see cref="Invert"/> (see TODO-2026-07-11-pass5.md item #69):
+    /// <see cref="Determinant"/>, and <see cref="Invert"/> (see TODO-2026-07-11-pass5.md item #69),
+    /// using the same scale-aware tolerance as <see cref="DiagonalizeLU"/>/<see cref="Invert"/> (not
+    /// <see cref="Determinant"/>'s exact-zero check - see <c>TryDecomposePivoted</c>'s remarks):
     /// <c>A·x = b</c> becomes <c>L·U·x = P·b</c> (since <c>P·A = L·U</c>), solved by forward
     /// substitution for <c>y</c> in <c>L·y = P·b</c> followed by back substitution for <c>x</c> in
     /// <c>U·x = y</c>.
@@ -39,7 +41,8 @@ public sealed partial class Matrix<T>
         if (relativeSingularityTolerance is { } explicitTolerance)
             ValidateTolerance(explicitTolerance, nameof(relativeSingularityTolerance));
 
-        if (!TryDecomposePivoted(relativeSingularityTolerance, out PivotedElimination decomposition))
+        T pivotTolerance = ResolveDecompositionTolerance(ToArray(), relativeSingularityTolerance);
+        if (!TryDecomposePivoted(pivotTolerance, out PivotedElimination decomposition))
         {
             throw new InvalidOperationException("Matrix is singular or numerically near-singular; the system has no reliable unique solution.");
         }

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Solve.cs
@@ -23,6 +23,13 @@ public sealed partial class Matrix<T>
     /// <exception cref="InvalidOperationException">Thrown when the matrix is not square or is singular.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="b"/> has the wrong dimension.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="relativeSingularityTolerance"/> is supplied but not finite or is negative.</exception>
+    /// <remarks>
+    /// Delegates to the pivoted elimination shared with <see cref="DiagonalizeLU"/>,
+    /// <see cref="Determinant"/>, and <see cref="Invert"/> (see TODO-2026-07-11-pass5.md item #69):
+    /// <c>A·x = b</c> becomes <c>L·U·x = P·b</c> (since <c>P·A = L·U</c>), solved by forward
+    /// substitution for <c>y</c> in <c>L·y = P·b</c> followed by back substitution for <c>x</c> in
+    /// <c>U·x = y</c>.
+    /// </remarks>
     public Vector<T> Solve(Vector<T> b, T? relativeSingularityTolerance = null)
     {
         if (!IsSquare)
@@ -32,49 +39,16 @@ public sealed partial class Matrix<T>
         if (relativeSingularityTolerance is { } explicitTolerance)
             ValidateTolerance(explicitTolerance, nameof(relativeSingularityTolerance));
 
+        if (!TryDecomposePivoted(relativeSingularityTolerance, out PivotedElimination decomposition))
+        {
+            throw new InvalidOperationException("Matrix is singular or numerically near-singular; the system has no reliable unique solution.");
+        }
+
         int n = Rows;
-        T[,] a = ToArray();
-        T[] x = new T[n];
-        for (int i = 0; i < n; i++) x[i] = b[i];
+        T[] permutedRightHandSide = new T[n];
+        for (int i = 0; i < n; i++)
+            permutedRightHandSide[i] = b[decomposition.Permutation[i]];
 
-        T pivotTolerance = relativeSingularityTolerance is { } explicitSolveTolerance
-            ? MaxAbsoluteEntry(a) * explicitSolveTolerance
-            : DefaultTolerance(MaxAbsoluteEntry(a), n);
-
-        // Forward elimination with partial pivoting
-        for (int col = 0; col < n; col++)
-        {
-            int pivotRow = col;
-            for (int row = col + 1; row < n; row++)
-                if (T.Abs(a[row, col]) > T.Abs(a[pivotRow, col]))
-                    pivotRow = row;
-
-            if (T.Abs(a[pivotRow, col]) <= pivotTolerance)
-                throw new InvalidOperationException("Matrix is singular or numerically near-singular; the system has no reliable unique solution.");
-
-            if (pivotRow != col)
-            {
-                for (int j = 0; j < n; j++) (a[col, j], a[pivotRow, j]) = (a[pivotRow, j], a[col, j]);
-                (x[col], x[pivotRow]) = (x[pivotRow], x[col]);
-            }
-
-            for (int row = col + 1; row < n; row++)
-            {
-                T factor = a[row, col] / a[col, col];
-                x[row] -= factor * x[col];
-                for (int j = col; j < n; j++)
-                    a[row, j] -= factor * a[col, j];
-            }
-        }
-
-        // Back substitution
-        for (int i = n - 1; i >= 0; i--)
-        {
-            for (int j = i + 1; j < n; j++)
-                x[i] -= a[i, j] * x[j];
-            x[i] /= a[i, i];
-        }
-
-        return new Vector<T>(x);
+        return new Vector<T>(SolvePermuted(decomposition, permutedRightHandSide));
     }
 }

--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -395,51 +395,6 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
         }
     }
 
-    private T ComputeDeterminant()
-    {
-        int n = Rows;
-        T[,] u = ToArray();
-        int swaps = 0;
-        // Elimination divides by the pivot below, so a pivot that is merely close to zero (not
-        // exactly zero) would otherwise amplify rounding error into a huge/infinite/NaN result
-        // instead of the mathematically expected near-zero determinant of a near-singular matrix.
-        T pivotTolerance = DefaultTolerance(MaxAbsoluteEntry(u), n);
-
-        for (int k = 0; k < n; k++)
-        {
-            int pivotRow = k;
-            for (int i = k + 1; i < n; i++)
-            {
-                if (T.Abs(u[i, k]) > T.Abs(u[pivotRow, k]))
-                    pivotRow = i;
-            }
-
-            if (T.Abs(u[pivotRow, k]) <= pivotTolerance)
-                return T.Zero;
-
-            if (pivotRow != k)
-            {
-                PermuteRows(u, k, pivotRow);
-                swaps++;
-            }
-
-            for (int row = k + 1; row < n; row++)
-            {
-                T factor = u[row, k] / u[k, k];
-                for (int col = k; col < n; col++)
-                    u[row, col] -= factor * u[k, col];
-            }
-        }
-
-        // Each row swap inverts the sign of the determinant.
-        T det = (swaps % 2 == 0) ? T.One : -T.One;
-        for (int i = 0; i < n; i++)
-            det *= u[i, i];
-        return det;
-    }
-
-
-
     /// <summary>
     /// Converts the matrix to an array of vectors.
     /// </summary>

--- a/Utils.Mathematics/LinearAlgebra/Matrix.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.cs
@@ -297,13 +297,27 @@ public sealed partial class Matrix<T> : IFormattable, IEquatable<Matrix<T>>, IEq
     }
 
     /// <summary>
-    /// Pads the matrix to the specified new dimensions.
+    /// Resizes the matrix to the specified new dimensions, copying the overlapping top-left prefix and
+    /// zero-filling any newly added rows/columns.
     /// </summary>
-    /// <param name="newRows">The new number of rows.</param>
-    /// <param name="newColumns">The new number of columns.</param>
-    /// <returns>A new matrix with the padded dimensions.</returns>
+    /// <param name="newRows">The new number of rows. Must be positive.</param>
+    /// <param name="newColumns">The new number of columns. Must be positive.</param>
+    /// <returns>A new matrix with the requested dimensions.</returns>
+    /// <remarks>
+    /// Despite its name, this is a resize, not a pure enlargement: whenever <paramref name="newRows"/>
+    /// and/or <paramref name="newColumns"/> is smaller than the corresponding current dimension, the
+    /// returned matrix crops that dimension down (see TODO-2026-07-11-pass5.md item #67) instead of
+    /// throwing or requiring the new dimensions to be at least the current ones. Only the overlapping
+    /// <c>min(current, new)</c> prefix of rows/columns is preserved either way.
+    /// </remarks>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="newRows"/> or <paramref name="newColumns"/> is not positive.
+    /// </exception>
     public Matrix<T> Pad(int newRows, int newColumns)
     {
+        if (newRows <= 0) throw new ArgumentException("Row count must be positive", nameof(newRows));
+        if (newColumns <= 0) throw new ArgumentException("Column count must be positive", nameof(newColumns));
+
         T[,] paddedMatrix = new T[newRows, newColumns];
         int rowCount = MathEx.Min(newRows, Rows);
         int colCount = MathEx.Min(newColumns, Columns);

--- a/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
+++ b/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
@@ -137,12 +137,32 @@ public static class MatrixTransformations
     /// Generates a rotation matrix.
     /// </summary>
     /// <typeparam name="T">Numeric type of the matrix.</typeparam>
-    /// <param name="angles">Angles of rotation.</param>
+    /// <param name="angles">
+    /// Angles of rotation, one per axis pair of the base <c>d × d</c> rotation block: <c>d * (d - 1) / 2</c>
+    /// angles are required for a given base dimension <c>d</c>. Must not be empty: with zero angles, the
+    /// <c>d * (d - 1) / 2 = n</c> formula solves to the degenerate <c>d = 1</c> (a meaningless "1×1
+    /// rotation", since rotation requires at least two axes to rotate between) rather than identifying
+    /// which ambient dimension's identity rotation the caller intended (see
+    /// TODO-2026-07-11-pass5.md item #66). To build an identity matrix of a specific dimension, call
+    /// <see cref="Identity{T}(int)"/> directly instead.
+    /// </param>
     /// <returns>New rotation matrix.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="angles"/> is empty, or its count does not match <c>d * (d - 1) / 2</c>
+    /// for any integer <c>d</c>.
+    /// </exception>
     public static Matrix<T> Rotation<T>(params IEnumerable<T> angles)
         where T : struct, IFloatingPoint<T>, ITrigonometricFunctions<T>, IRootFunctions<T>
     {
         T[] anglesArray = angles.ToArray();
+        if (anglesArray.Length == 0)
+        {
+            throw new ArgumentException(
+                "At least one angle is required: an empty angle list is ambiguous about the intended " +
+                $"ambient dimension (it would always resolve to a degenerate 1x1 base rotation). Use " +
+                $"{nameof(Identity)}<T>(int) to build an identity matrix of a specific dimension instead.",
+                nameof(angles));
+        }
         double baseComputeDimension = (1 + Math.Sqrt(8 * anglesArray.Length + 1)) / 2;
         int dimension = (int)Math.Floor(baseComputeDimension);
         if (baseComputeDimension != dimension)

--- a/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
+++ b/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
@@ -12,21 +12,22 @@ public static class MatrixTransformations
     /// Creates an identity matrix of the specified dimension.
     /// </summary>
     /// <typeparam name="T">Numeric type of the matrix.</typeparam>
-    /// <param name="dimension">Matrix dimension.</param>
+    /// <param name="dimension">Matrix dimension. Must be positive.</param>
     /// <returns>New identity matrix.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="dimension"/> is not positive.</exception>
+    /// <remarks>
+    /// Delegates to <see cref="Matrix{T}.Identity(int)"/>, which is the single implementation of
+    /// identity-matrix construction: an earlier, independent implementation here performed no
+    /// validation at all, so a zero dimension silently built a 0×0 matrix and a negative dimension
+    /// failed through raw array allocation instead of a clean, documented exception — disagreeing
+    /// with <see cref="Matrix{T}.Identity(int)"/>'s domain and exception behavior for the same
+    /// operation (see TODO-2026-07-11-pass5.md item #62). Two independently maintained factories for
+    /// the same construction had already drifted once for <see cref="Diagonal{T}(IEnumerable{T})"/>;
+    /// keeping one implementation avoids a repeat.
+    /// </remarks>
     public static Matrix<T> Identity<T>(int dimension)
         where T : struct, IFloatingPoint<T>, IRootFunctions<T>
-    {
-        var array = new T[dimension, dimension];
-        for (int i = 0; i < dimension; i++)
-        {
-            for (int j = 0; j < dimension; j++)
-            {
-                array[i, j] = i == j ? T.One : T.Zero;
-            }
-        }
-        return new Matrix<T>(array, true, true, true, T.One);
-    }
+        => Matrix<T>.Identity(dimension);
 
     /// <summary>
     /// Creates a diagonal matrix from the provided values.

--- a/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
+++ b/Utils.Mathematics/LinearAlgebra/MatrixTransformations.cs
@@ -130,7 +130,13 @@ public static class MatrixTransformations
             }
         }
 
-        return new Matrix<T>(array, false, false, false, null);
+        // Unlike hardcoded false, null defers isIdentity/isTriangular/isDiagonal to lazy recomputation
+        // (see TODO-2026-07-11-pass5.md item #68): with the degenerate zero-angle/base-dimension-1 input
+        // (no coefficients to place), the loop above leaves the array exactly the identity, which
+        // hardcoded false could never report correctly. For any non-degenerate input, at least one
+        // off-diagonal coefficient is filled on both sides of the diagonal (the loop covers every
+        // off-diagonal base-block position), so recomputation still correctly resolves to false there.
+        return new Matrix<T>(array, null, null, null, null);
     }
 
     /// <summary>
@@ -193,7 +199,12 @@ public static class MatrixTransformations
                 rotationArray[dim1, dim2] = -sin;
                 rotationArray[dim2, dim1] = sin;
 
-                Matrix<T> rotation = new Matrix<T>(rotationArray, false, false, false, null);
+                // isIdentity/isTriangular/isDiagonal depend on the specific angle (e.g. angle = 0 makes
+                // this elementary rotation the identity, which hardcoded false could never report - see
+                // TODO-2026-07-11-pass5.md item #68), so null defers to lazy recomputation. The
+                // determinant of any plane rotation is always cos^2 + sin^2 = 1, regardless of angle, so
+                // it is supplied directly instead of left for recomputation.
+                Matrix<T> rotation = new Matrix<T>(rotationArray, null, null, null, T.One);
                 result *= rotation;
                 angleIndex++;
             }
@@ -223,12 +234,20 @@ public static class MatrixTransformations
         }
 
         int lastColumn = dimension - 1;
+        bool allZero = true;
         for (int i = 0; i < valuesArray.Length; i++)
         {
             array[i, lastColumn] = valuesArray[i];
+            if (valuesArray[i] != T.Zero) allZero = false;
         }
 
-        return new Matrix<T>(array, false, false, false, null);
+        // Every flag below is mathematically guaranteed, not just a lazy default (see
+        // TODO-2026-07-11-pass5.md item #68): the translation entries only ever occupy strictly-upper
+        // positions (row i < lastColumn for every i in range), so the matrix is always upper triangular
+        // regardless of the supplied values; it is diagonal/the identity exactly when every translation
+        // value is zero; and its determinant is always 1 (an upper-triangular matrix with an all-ones
+        // diagonal).
+        return new Matrix<T>(array, isIdentity: allZero, isTriangular: true, isDiagonal: allZero, determinant: T.One);
     }
 
     /// <summary>
@@ -283,6 +302,10 @@ public static class MatrixTransformations
             }
         }
 
-        return new Matrix<T>(array, false, false, false, null);
+        // The linear block is arbitrary caller-supplied data, so none of these flags are provable at
+        // construction time in general (e.g. the caller could still supply exactly the identity
+        // coefficients); null defers to lazy recomputation instead of hardcoding false (see
+        // TODO-2026-07-11-pass5.md item #68).
+        return new Matrix<T>(array, null, null, null, null);
     }
 }

--- a/Utils.Mathematics/Polynomial.cs
+++ b/Utils.Mathematics/Polynomial.cs
@@ -264,17 +264,34 @@ public sealed class Polynomial<T> : IEquatable<Polynomial<T>>
         return hash.ToHashCode();
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Renders the polynomial as e.g. <c>"3x^2 - 2x + 1"</c>: each term's sign is applied as a separator
+    /// between terms (<c>" + "</c>/<c>" - "</c> or a leading <c>"-"</c> for the first term) rather than
+    /// baked into the coefficient's own <see cref="object.ToString"/>, which previously produced
+    /// double-signed sequences such as <c>"2x + -3"</c> whenever a non-leading term was negative. A unit
+    /// coefficient (<c>±1</c>) on a non-constant term omits the redundant magnitude (<c>"x"</c>/<c>"-x"</c>
+    /// rather than <c>"1x"</c>/<c>"-1x"</c>).
+    /// </summary>
     public override string ToString()
     {
         if (Degree == 0) return _coefficients[0].ToString() ?? "0";
         var parts = new List<string>();
         for (int i = Degree; i >= 0; i--)
         {
-            if (T.Abs(_coefficients[i]) <= Epsilon) continue;
-            string coef = _coefficients[i].ToString() ?? "0";
-            parts.Add(i == 0 ? coef : i == 1 ? $"{coef}x" : $"{coef}x^{i}");
+            T coefficient = _coefficients[i];
+            if (T.Abs(coefficient) <= Epsilon) continue;
+
+            bool negative = coefficient < T.Zero;
+            T magnitude = T.Abs(coefficient);
+            bool omitMagnitude = i != 0 && magnitude == T.One;
+            string magnitudeText = omitMagnitude ? string.Empty : magnitude.ToString() ?? "0";
+            string variableText = i == 0 ? string.Empty : i == 1 ? "x" : $"x^{i}";
+            string term = magnitudeText + variableText;
+
+            parts.Add(parts.Count == 0
+                ? (negative ? $"-{term}" : term)
+                : (negative ? $"- {term}" : $"+ {term}"));
         }
-        return parts.Count == 0 ? "0" : string.Join(" + ", parts);
+        return parts.Count == 0 ? "0" : string.Join(" ", parts);
     }
 }

--- a/Utils.Mathematics/TODO-2026-07-11-pass5.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass5.md
@@ -99,6 +99,14 @@ For example, the inverse of `diag(2,3)` is still diagonal and triangular, but re
 
 **Priority: P1 API consistency.**
 
+**Fixed.** `MatrixTransformations.Identity<T>` now delegates to `Matrix<T>.Identity(int)`
+(`=> Matrix<T>.Identity(dimension);`) instead of performing its own unvalidated raw array allocation, the
+same pattern already used by `MatrixTransformations.Diagonal` (see item #63). `dimension <= 0` now throws
+the same `ArgumentException` as `Matrix<T>.Identity` for both zero and negative dimensions, instead of
+silently building a `0×0` matrix or failing through raw array allocation. Test:
+`MatrixTransformationsTests.Identity_ZeroDimension_ThrowsLikeMatrixIdentity`,
+`Identity_NegativeDimension_ThrowsLikeMatrixIdentity`, `Identity_MatchesMatrixIdentityFactory`.
+
 ### 63. Duplicate diagonal factories previously diverged in structural behavior
 
 The module contains both `Matrix<T>.Diagonal(...)` and `MatrixTransformations.Diagonal<T>(...)`. They duplicate allocation, determinant, identity, and metadata logic. The latter contained the zero-diagonal metadata defect identified in the second pass, while the former already encodes the correct invariant.

--- a/Utils.Mathematics/TODO-2026-07-11-pass5.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass5.md
@@ -202,6 +202,19 @@ When requested dimensions are smaller, the method copies the overlapping prefix 
 
 **Priority: P2 API semantics.**
 
+**Fixed** (documented as resize + validated domain). `Pad`'s XML doc now explicitly states it resizes
+(crops or enlarges, keeping the overlapping top-left prefix) rather than only enlarging, with a `<remarks>`
+cross-referencing this item. `newRows`/`newColumns` must now be positive, matching the same
+`ArgumentException` policy already used by `Matrix(int, int)`, `Zero`, `Identity`, and `Diagonal`; a
+negative dimension previously failed through raw array allocation with an undocumented, unrelated
+exception. The method was not renamed to e.g. `Resize`: it has zero callers and zero test coverage
+anywhere in the repository (confirmed by search), so there is no established public usage this would need
+to preserve or migrate, and correcting the misleading documentation addresses the actual defect (the
+`Pad` *name* alone isn't unsafe - a caller reading only the corrected doc comment now gets an accurate
+contract) without touching the public API surface for the sake of it. Test:
+`MatrixTests.Pad_LargerDimensions_CopiesPrefixAndZeroFillsRest`, `Pad_EqualDimensions_ReturnsEquivalentCopy`,
+`Pad_SmallerDimensions_CropsToOverlappingPrefix`, `Pad_ZeroRows_Throws`, `Pad_NegativeColumns_Throws`.
+
 ### 68. Matrix metadata is manually injected across many factories with no invariant checker
 
 Identity, diagonal, scaling, rotation, translation, inversion, LU, and other factories pass structural flags and determinant caches independently. Several confirmed defects arose from incorrect supplied metadata rather than matrix values.

--- a/Utils.Mathematics/TODO-2026-07-11-pass5.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass5.md
@@ -89,6 +89,16 @@ For example, the inverse of `diag(2,3)` is still diagonal and triangular, but re
 
 **Priority: P1 matrix contract correctness.**
 
+**Fixed.** The internal `Matrix(T[,], bool?, bool?, bool?, T?)` constructor's three structural-flag
+parameters were widened from `bool` to `bool?` (a backward-compatible change: every existing `true`/`false`
+call site still compiles unchanged). `Invert()` now passes `null` for `isIdentity`/`isTriangular`/
+`isDiagonal` instead of hardcoded `false`, deferring to the existing lazy `DetermineStructuralFlags()`
+recomputation - which inspects the actual computed inverse array - on first access, instead of
+permanently caching a potentially wrong negative answer. The identity short-circuit at the top of
+`Invert()` (`if (IsIdentity) return new Matrix<T>(this);`) already preserved correct metadata by copying
+the source, so it is unaffected. Test: `MatrixTests.Invert_DiagonalMatrix_ResultReportsDiagonalAndTriangular`,
+`Invert_TriangularMatrix_ResultReportsTriangular`, `Invert_GeneralMatrix_ResultReportsNotTriangularNotDiagonal`.
+
 ### 62. `MatrixTransformations.Identity` and `Matrix<T>.Identity` disagree on valid dimensions
 
 `Matrix<T>.Identity(size)` rejects `size <= 0`. `MatrixTransformations.Identity<T>(dimension)` performs no validation and can construct a `0×0` matrix; negative values fail through raw array allocation.

--- a/Utils.Mathematics/TODO-2026-07-11-pass5.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass5.md
@@ -184,6 +184,16 @@ With zero angles, the dimension formula yields one base dimension and returns a 
 
 **Priority: P2 API clarity.**
 
+**Fixed** (reject the ambiguous case). `Rotation<T>` now throws `ArgumentException` when `angles` is
+empty, pointing callers at `Identity<T>(int)` for an explicit-dimension identity matrix, instead of the
+angle count silently resolving to the degenerate base dimension `d = 1` (rotation is only meaningful
+between two or more axes) and returning an arbitrary 2×2 homogeneous identity regardless of the ambient
+dimension the caller actually wanted. The alternative from the fix text - adding an explicit dimension
+parameter - was not adopted: it would change the public signature/usage for the common non-empty-angle
+case (where the dimension is already unambiguous from the angle count) just to serve the one degenerate
+input that has no sensible interpretation anyway. Test:
+`MatrixTransformationsTests.Rotation_NoAngles_ThrowsAmbiguousDimensionError`.
+
 ### 67. `Matrix.Pad` also crops but its contract only describes padding
 
 When requested dimensions are smaller, the method copies the overlapping prefix and returns a cropped matrix. The name and documentation imply enlargement, while negative/zero sizes rely on raw array behavior.

--- a/Utils.Mathematics/TODO-2026-07-11-pass5.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass5.md
@@ -231,6 +231,39 @@ Determinant, solve, inverse, and LU each implement related pivot search, swappin
 
 **Priority: P2 duplication and numerical consistency.**
 
+**Fixed.** `Matrix.Compute.cs` now has a private `TryDecomposePivoted` method (returning a
+`PivotedElimination` record struct of `L`, `U`, `Permutation`, `Swaps`) that performs the pivoted Gauss
+elimination previously reimplemented four separate times, plus a shared `SolvePermuted` forward/back
+substitution helper. `DiagonalizeLU`, `ComputeDeterminant` (backing `Determinant`), `Solve`, and `Invert`
+all now call these instead of maintaining independent elimination loops:
+- `DiagonalizeLU` builds `L`/`U`/`P` directly from the decomposition.
+- `ComputeDeterminant` multiplies `U`'s diagonal and applies the swap-count sign, returning `T.Zero`
+  (instead of throwing) when the decomposition reports singular - determinant is mathematically defined
+  for every square matrix, so a `bool`-returning `TryDecomposePivoted` was used instead of an
+  exception-based decomposition API, to keep that zero-determinant path free of exception-driven control
+  flow.
+- `Solve` reduces to forming `P·b` and calling `SolvePermuted`.
+- `Invert` calls `SolvePermuted` once per standard basis vector, reusing one decomposition instead of
+  running its own independent Gauss-Jordan reduction.
+
+A real behavioral consequence, not just deduplication: `DiagonalizeLU` previously rejected only an
+*exactly* zero pivot, while `Determinant`/`Solve`/`Invert` already used the shared scale-aware tolerance
+(see `DefaultTolerance`); `DiagonalizeLU` now uses that same tolerance (and gained a matching optional
+`relativeSingularityTolerance` parameter), so a near-singular matrix is now rejected consistently by all
+four instead of only three of them. This also let several of item #61/#68's metadata-correctness fixes
+extend naturally to `L`/`U`/`P`: their `isIdentity`/`isTriangular`/`isDiagonal` flags are now `null`
+(lazily recomputed) wherever not mathematically guaranteed for every input, instead of hardcoded `false`
+regardless of the actual result (e.g. `P` is provably the identity when zero pivot swaps occur, which the
+old hardcoded `false` could never report); `P`'s determinant is supplied directly from the swap count
+(`±1`) rather than left `null`, since it is always known without recomputation. No public API breaks:
+`DiagonalizeLU()`'s new tolerance parameter is optional and defaults to `null` (the previous default
+tolerance policy, modulo the exact-vs-near-singular change above). Test:
+`MatrixTests.DiagonalizeLU_NearSingularMatrix_ThrowsInsteadOfReturningGarbage`,
+`DiagonalizeLU_NoSwapNeeded_PermutationReportsIdentity`, `DiagonalizeLU_WithSwap_PermutationDeterminantReflectsSwapParity`,
+`DiagonalizeLU_AlreadyDiagonalMatrix_UReportsDiagonal`, `SingularMatrix_RejectedConsistentlyAcrossDecompositionConsumers`,
+plus the full pre-existing `Determinant`/`Solve`/`Invert`/`DiagonalizeLU` suites (all still green, confirming
+no numerical regression from routing through the shared primitive).
+
 ## Additional duplicated intent to reduce
 
 - Polynomial construction must have one canonicalization path for public constructors and every operator/calculus result.

--- a/Utils.Mathematics/TODO-2026-07-11-pass5.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass5.md
@@ -163,6 +163,19 @@ It also ignores explicit culture/format options because the type does not implem
 
 **Priority: P2 output quality.**
 
+**Fixed** (sign rendering only). `ToString()` now applies each term's sign as an inter-term separator
+(`" + "`/`" - "`, or a leading `"-"` for the first term) instead of relying on the coefficient's own
+`ToString()` producing a leading `-` that then collided with the fixed `" + "` join, which is what caused
+sequences like `"2x + -3"`. A unit coefficient (`±1`) on a non-constant term now omits the redundant
+magnitude (`"x"`/`"-x"` rather than `"1x"`/`"-1x"`); the constant term keeps its magnitude regardless
+(`"1"`, not `""`). The `IFormattable`/culture-aware half of this finding was not implemented: `Polynomial<T>`
+does not currently implement `IFormattable` at all (unlike `Line<T>`/`AffineSubspace<T>`, which implement
+it but ignore the format/provider arguments - a materially different, already-tracked problem), so there is
+no misleading contract to fix here, and the finding itself frames this half as conditional ("if intended
+for public display") rather than a concrete defect. Test: `PolynomialTests.ToString_NegativeTrailingTerm_UsesSignAwareSeparator`,
+`ToString_NegativeLeadingTerm_StartsWithMinusNoPlus`, `ToString_UnitCoefficient_OmitsMagnitude`,
+`ToString_ConstantTermOfOne_KeepsMagnitude`, `ToString_MultipleNegativeTerms_EachUsesMinusSeparator`.
+
 ### 66. Rotation dimension inference has an ambiguous zero-angle case
 
 With zero angles, the dimension formula yields one base dimension and returns a `2×2` homogeneous identity matrix. There is no way to request the identity rotation for a chosen ambient dimension without supplying a corresponding number of zero angles.

--- a/Utils.Mathematics/TODO-2026-07-11-pass5.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass5.md
@@ -304,6 +304,22 @@ tolerance policy, modulo the exact-vs-near-singular change above). Test:
 plus the full pre-existing `Determinant`/`Solve`/`Invert`/`DiagonalizeLU` suites (all still green, confirming
 no numerical regression from routing through the shared primitive).
 
+**Correction from PR review.** The first version of this fix went one step too far: it made
+`ComputeDeterminant` call the *shared* pivoted elimination using the *same* scale-aware
+relative-plus-absolute-floor tolerance as `Solve`/`Invert` (the tolerance `ComputeDeterminant` itself
+already used *before* this item, unchanged - so this was a pre-existing latent bug, not a new regression
+from sharing the primitive, but sharing it made the fix an obvious, low-risk addition to make while
+already in this code). That tolerance's absolute floor (`DefaultTolerance`'s `+ 1` term) is appropriate
+when a pivot will be divided into to propagate a numerically reliable solved/inverted result, but wrong
+for a determinant: a well-conditioned matrix whose entries are merely small in absolute value (e.g.
+`diag(1e-20, 2e-20)`, determinant exactly `2e-40`) was incorrectly collapsed to a zero determinant. Fixed
+by separating "compute the tolerance policy" (`ResolveDecompositionTolerance`, used by
+`DiagonalizeLU`/`Solve`/`Invert`) from the elimination primitive itself: `TryDecomposePivoted` now takes
+an already-resolved absolute `pivotTolerance` argument instead of resolving its own policy internally, and
+`ComputeDeterminant` passes `T.Zero` (reject only an exactly-zero pivot - genuine rank deficiency is the
+only case where the determinant is actually zero) instead of the scale-aware tolerance. Test:
+`MatrixTests.Determinant_SmallWellConditionedMatrix_DoesNotReturnZero`, `Determinant_ScaledIdentity_PreservesScale`.
+
 ## Additional duplicated intent to reduce
 
 - Polynomial construction must have one canonicalization path for public constructors and every operator/calculus result.

--- a/Utils.Mathematics/TODO-2026-07-11-pass5.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass5.md
@@ -223,6 +223,46 @@ Identity, diagonal, scaling, rotation, translation, inversion, LU, and other fac
 
 **Priority: P2 architecture.**
 
+**Fixed.** Item #69's shared decomposition already corrected `L`/`U`/`P`'s metadata. This item audits and
+corrects the remaining `MatrixTransformations.cs` factories that previously hardcoded unproven `false`:
+- `Skew`: the degenerate zero-angle input (base dimension 1) leaves the array exactly the identity, which
+  hardcoded `false` could never report; now `null` (lazily recomputed).
+- The per-axis-pair elementary rotation matrix built inside `Rotation` (an internal value immediately
+  folded into the accumulated product, never itself returned) is `null` for `isIdentity`/`isTriangular`/
+  `isDiagonal` (angle-dependent - e.g. angle 0 makes it the identity), but its determinant is supplied
+  directly as `T.One`: a plane rotation's determinant is always `cos²+sin² = 1` regardless of angle, a
+  mathematically guaranteed value rather than a lazy default.
+- `Translation`: every flag is now mathematically derived rather than defaulted - `isTriangular: true`
+  always (translation entries only ever occupy strictly-upper positions, by construction, regardless of
+  values), `isIdentity`/`isDiagonal` computed from whether every supplied value is zero, and
+  `determinant: T.One` always (upper triangular with an all-ones diagonal).
+- `Transform` (general affine): the linear block is arbitrary caller-supplied data with no provable
+  structure in general (a caller could still supply exactly the identity coefficients), so `null`.
+
+**"Centralize trusted factory helpers"** was not adopted as a separate abstraction: the actually-reusable
+piece of "trusted" construction logic already exists and is now used everywhere it applies -
+`Matrix<T>.Diagonal`/`Matrix<T>.Identity` remain the single implementation each of their respective
+`MatrixTransformations` counterparts delegates to (items #62/#63), and the shared
+`TryDecomposePivoted`/`SolvePermuted` primitives (item #69) are exactly this kind of centralization for
+the decomposition-based factories. The remaining factories audited here (`Skew`, `Rotation`, `Translation`,
+`Transform`) do not share a common construction shape with each other beyond "build an array, wrap it in
+`new Matrix<T>(...)`", so introducing a shared helper for them would only relocate, not reduce, the
+per-factory reasoning about which flags are provable.
+
+**"Debug/test-time invariant verification"** was implemented at test time (the item explicitly allows
+either): `MatrixTransformationsTests.AssertStructuralMetadataMatchesRecomputation` constructs a second,
+always-lazily-recomputed `Matrix<T>` from the factory output's raw array and asserts every structural flag
+and the determinant agree with the factory-cached values - exactly the check that would have caught every
+hardcoded-`false` defect fixed across items #61/#62/#68/#69. Applied to `Identity`, `Diagonal`, `Scaling`,
+`Rotation`, `Skew`, and `Transform`. A production-code (e.g. `#if DEBUG`) assertion embedded in every
+factory was not adopted: it would add a recomputation cost to every call in debug builds for a class of
+bug that test-time verification already catches without touching the hot construction path. Test:
+`MatrixTransformationsTests.Identity_MetadataMatchesRecomputation`, `Diagonal_MetadataMatchesRecomputation`,
+`Scaling_MetadataMatchesRecomputation`, `Rotation_MetadataMatchesRecomputation`, `Skew_MetadataMatchesRecomputation`,
+`Transform_MetadataMatchesRecomputation`, `Translation_AllZeroValues_ReportsIdentity`,
+`Translation_NonZeroValues_IsTriangularButNotDiagonalOrIdentity`, `Skew_NoAngles_ReportsIdentity`,
+`Transform_IdentityCoefficients_ReportsIdentity`.
+
 ### 69. LU and inverse duplicate pivoted elimination without a shared decomposition primitive
 
 Determinant, solve, inverse, and LU each implement related pivot search, swapping, singularity checks, and elimination. Their behavior and returned metadata have already diverged.

--- a/Utils.Mathematics/TODO-2026-07-11-pass5.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass5.md
@@ -16,6 +16,15 @@ For standard Gaussian elimination, the factors `u[row,k] / u[k,k]` must be store
 
 **Priority: P0 linear-algebra correctness.**
 
+**Already fixed.** `DiagonalizeLU()` (`Matrix.Compute.cs`) already stores the elimination multipliers
+directly in `L` (`l[row, k] = multiplier;`) instead of applying row operations to an identity-initialized
+array — a prior audit pass (`fix pass2 numerical-correctness findings (items 17-29)` / PR #443) rewrote
+this method before this pass5 review ran, and this file was not updated to reflect that. Regression tests
+already exist: `MatrixTests.DiagonalizeLUProducesTriangularFactorsWithoutMutatingSource`,
+`DiagonalizeLUSatisfiesPermutedReconstructionIdentity_NoSwapNeeded/_WithSwap`,
+`DiagonalizeLU3x3SatisfiesPermutedReconstructionIdentity`. No production or test code changed for this
+item; verified by re-reading `Matrix.Compute.cs` and running the existing suite.
+
 ### 58. Pivoted LU omits the permutation matrix from its result contract
 
 `DiagonalizeLU()` performs partial pivoting by swapping rows of `U` and part of `L`, but returns only `(L, U)` and documents `A = L·U`. With row pivoting, the correct relation is generally `P·A = L·U` (or `A = P⁻¹·L·U`).
@@ -25,6 +34,11 @@ For standard Gaussian elimination, the factors `u[row,k] / u[k,k]` must be store
 **Fix:** return a permutation matrix/vector together with `L` and `U`, or provide a decomposition object exposing pivot indices and a precise reconstruction contract.
 
 **Priority: P1 decomposition contract.**
+
+**Already fixed** by the same `DiagonalizeLU()` rewrite as item #57: the method's signature is
+`(Matrix<T> L, Matrix<T> U, Matrix<T> P) DiagonalizeLU()`, satisfying `P·A = L·U` and covered by the same
+regression tests listed under item #57 (in particular the `_WithSwap` and 3×3 cases, which exercise a
+non-trivial `P`).
 
 ### 59. Polynomial operations bypass coefficient canonicalization
 
@@ -46,6 +60,13 @@ Example: subtracting a polynomial from itself can produce a polynomial whose `De
 
 **Priority: P1 polynomial correctness.**
 
+**Already fixed.** `Polynomial<T>` (`Polynomial.cs`) already routes every array-producing path through the
+private `Canonicalize` helper before invoking the private `Polynomial(T[])` constructor:
+`Derive()`, `Integrate()`, `operator +`, `operator -`, `operator *` (polynomial×polynomial and
+scalar×polynomial) all call `new Polynomial<T>(Canonicalize(...))`. The private constructor's XML doc
+documents this as the invariant every call site must uphold. No production or test code changed for this
+item; verified by re-reading `Polynomial.cs`.
+
 ### 60. Scalar multiplication by zero can produce a high-degree zero polynomial
 
 Because scalar multiplication uses the non-normalizing private array constructor, `T.Zero * polynomial` preserves the original coefficient-array length. The result prints as zero but reports the original degree and does not equal a canonically constructed zero polynomial.
@@ -53,6 +74,10 @@ Because scalar multiplication uses the non-normalizing private array constructor
 **Fix:** covered by shared canonicalization, with dedicated zero-polynomial invariants and tests.
 
 **Priority: P1 polynomial correctness.**
+
+**Already fixed** by the same canonicalization described under item #59: `operator *(T, Polynomial<T>)`
+also routes through `Canonicalize`, so `T.Zero * polynomial` trims down to the canonical single-coefficient
+zero polynomial rather than preserving the original array length.
 
 ### 61. `Matrix.Invert()` installs permanently false structural metadata
 
@@ -84,6 +109,14 @@ The module contains both `Matrix<T>.Diagonal(...)` and `MatrixTransformations.Di
 
 **Priority: P1 duplicated intent with demonstrated defect drift.**
 
+**Already fixed.** `MatrixTransformations.Diagonal<T>` (`MatrixTransformations.cs`) already delegates to
+`Matrix<T>.Diagonal(IEnumerable<T>)` (`=> Matrix<T>.Diagonal(values);`), with a remark documenting the
+zero-diagonal metadata defect this avoids repeating — a prior audit pass fixed this before this pass5
+review ran, and this file was not updated to reflect that. Test:
+`MatrixTransformationsTests.Diagonal_MatchesMatrixDiagonalFactory`,
+`Diagonal_WithZeroEntry_IsStillTriangularAndDiagonal`. No production or test code changed for this item;
+verified by re-reading `MatrixTransformations.cs`.
+
 ### 64. `ApplyLinearTransformation` validates the wrong concept through the wrong exception
 
 The helper rejects a zero coefficient at `transformations[targetRow]` with an `ArgumentOutOfRangeException` naming `targetRow`. The row index may be valid; it is the transformation coefficient that violates an internal assumption. The helper also does not validate transformation length against matrix rows.
@@ -93,6 +126,12 @@ The helper rejects a zero coefficient at `transformations[targetRow]` with an `A
 **Fix:** replace this helper as part of standard LU implementation. Otherwise validate array length and throw an exception tied to the coefficient collection/invariant.
 
 **Priority: P1 maintainability and diagnostics.**
+
+**Moot / already fixed.** The `ApplyLinearTransformation` helper this item describes no longer exists in
+the codebase (confirmed by search) — the same `DiagonalizeLU()` rewrite that fixed items #57/#58 replaced
+the old row-operation-based implementation with a direct pivoted-elimination loop (`Matrix.Compute.cs`)
+that never introduced this helper or its misleading `ArgumentOutOfRangeException`. Nothing to fix; verified
+by re-reading `Matrix.Compute.cs` and searching the repository for the helper name.
 
 ## Medium-priority findings
 

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -493,6 +493,32 @@ namespace UtilsTest.Mathematics.LinearAlgebra
             Assert.AreEqual(4d, m.Determinant, 1e-10);
         }
 
+        // ── Determinant vs. Solve/Invert singularity policy (PR 452 review) ────────
+
+        /// <summary>
+        /// Before this fix, <see cref="Matrix{T}.Determinant"/> reused the same scale-aware
+        /// relative-plus-absolute-floor tolerance as <see cref="Matrix{T}.Solve"/>/<see cref="Matrix{T}.Invert"/>
+        /// to decide "singular." That tolerance includes a fixed absolute floor (see
+        /// <c>DefaultTolerance</c>'s <c>+ 1</c> term) that is appropriate when dividing by the pivot to
+        /// propagate a numerically reliable solution, but wrong for a determinant: a well-conditioned
+        /// matrix whose entries are merely small in absolute value (here <c>1e-20</c>) has an exact,
+        /// legitimately tiny nonzero determinant, which the shared tolerance previously collapsed to zero.
+        /// </summary>
+        [TestMethod]
+        public void Determinant_SmallWellConditionedMatrix_DoesNotReturnZero()
+        {
+            var matrix = new Matrix<double>(new double[,] { { 1e-20 } });
+            Assert.AreEqual(1e-20, matrix.Determinant, 1e-35);
+        }
+
+        /// <summary>Same as <see cref="Determinant_SmallWellConditionedMatrix_DoesNotReturnZero"/>, for a multi-entry diagonal matrix.</summary>
+        [TestMethod]
+        public void Determinant_ScaledIdentity_PreservesScale()
+        {
+            var matrix = Matrix<double>.Diagonal(1e-20, 2e-20);
+            Assert.AreEqual(2e-40, matrix.Determinant, 1e-54);
+        }
+
         [TestMethod]
         public void Transpose_NonSquare_SwapsRowsAndColumns()
         {

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -574,6 +574,62 @@ namespace UtilsTest.Mathematics.LinearAlgebra
             Assert.ThrowsException<FormatException>(() => m.ToString("bogus", null));
         }
 
+        // ── Pad (TODO-pass5 item #67) ───────────────────────────────────────────────
+
+        [TestMethod]
+        public void Pad_LargerDimensions_CopiesPrefixAndZeroFillsRest()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d, 2d }, { 3d, 4d } });
+            Matrix<double> padded = m.Pad(3, 3);
+
+            Assert.AreEqual(3, padded.Rows);
+            Assert.AreEqual(3, padded.Columns);
+            Assert.AreEqual(1d, padded[0, 0]);
+            Assert.AreEqual(2d, padded[0, 1]);
+            Assert.AreEqual(3d, padded[1, 0]);
+            Assert.AreEqual(4d, padded[1, 1]);
+            Assert.AreEqual(0d, padded[2, 2]);
+            Assert.AreEqual(0d, padded[0, 2]);
+        }
+
+        [TestMethod]
+        public void Pad_EqualDimensions_ReturnsEquivalentCopy()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d, 2d }, { 3d, 4d } });
+            Matrix<double> padded = m.Pad(2, 2);
+            AssertMatricesAreEqual(m, padded, 1e-12);
+        }
+
+        /// <summary>
+        /// Despite its name, <see cref="Matrix{T}.Pad"/> also crops when the requested dimensions are
+        /// smaller than the current ones (see TODO-pass5 item #67): it keeps only the overlapping
+        /// top-left prefix instead of throwing or requiring the new dimensions to be at least as large.
+        /// </summary>
+        [TestMethod]
+        public void Pad_SmallerDimensions_CropsToOverlappingPrefix()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d, 2d, 3d }, { 4d, 5d, 6d }, { 7d, 8d, 9d } });
+            Matrix<double> cropped = m.Pad(2, 2);
+
+            Assert.AreEqual(2, cropped.Rows);
+            Assert.AreEqual(2, cropped.Columns);
+            AssertMatricesAreEqual(new Matrix<double>(new double[,] { { 1d, 2d }, { 4d, 5d } }), cropped, 1e-12);
+        }
+
+        [TestMethod]
+        public void Pad_ZeroRows_Throws()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d } });
+            Assert.ThrowsException<ArgumentException>(() => m.Pad(0, 2));
+        }
+
+        [TestMethod]
+        public void Pad_NegativeColumns_Throws()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d } });
+            Assert.ThrowsException<ArgumentException>(() => m.Pad(2, -1));
+        }
+
         /// <summary>
         /// Asserts that two matrices contain the same components within the provided tolerance.
         /// </summary>

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -95,6 +95,98 @@ namespace UtilsTest.Mathematics.LinearAlgebra
             AssertMatricesAreEqual(P * matrix, L * U, 1e-9);
         }
 
+        // ── Shared pivoted decomposition (TODO-pass5 item #69) ─────────────────────
+
+        /// <summary>
+        /// Before item #69, <see cref="Matrix{T}.DiagonalizeLU"/> rejected only an exactly-zero pivot,
+        /// unlike <see cref="Matrix{T}.Invert"/>/<see cref="Matrix{T}.Solve"/>/<see cref="Matrix{T}.Determinant"/>,
+        /// which all use the shared scale-aware tolerance. Now that all four share one decomposition,
+        /// a near-singular (but not exactly singular) matrix is rejected consistently everywhere.
+        /// </summary>
+        [TestMethod]
+        public void DiagonalizeLU_NearSingularMatrix_ThrowsInsteadOfReturningGarbage()
+        {
+            var matrix = new Matrix<double>(new double[,] { { 1d, 2d }, { 2d + 2e-13, 4d + 4e-13 } });
+            Assert.ThrowsException<InvalidOperationException>(() => matrix.DiagonalizeLU());
+        }
+
+        /// <summary>
+        /// Before item #69, the permutation matrix returned by <see cref="Matrix{T}.DiagonalizeLU"/> was
+        /// always constructed with hardcoded <c>isIdentity: false</c>, even when zero row swaps occurred
+        /// and <c>P</c> is therefore actually the identity matrix.
+        /// </summary>
+        [TestMethod]
+        public void DiagonalizeLU_NoSwapNeeded_PermutationReportsIdentity()
+        {
+            // |2| is already the largest first-column magnitude, so no pivot swap occurs and P is
+            // literally the identity matrix.
+            Matrix<double> matrix = new Matrix<double>(new double[,]
+            {
+                                { 2d, 1d },
+                                { 1d, 3d },
+            });
+
+            (_, _, Matrix<double> P) = matrix.DiagonalizeLU();
+
+            Assert.IsTrue(P.IsIdentity);
+            Assert.IsTrue(P.IsDiagonal);
+            Assert.IsTrue(P.IsTriangular);
+            Assert.AreEqual(1d, P.Determinant, 1e-12);
+        }
+
+        /// <summary>
+        /// Same as <see cref="DiagonalizeLU_NoSwapNeeded_PermutationReportsIdentity"/>, but for a case
+        /// where a swap does occur: <c>P</c> must report a determinant of <c>-1</c> (an odd number of
+        /// transpositions) and must not be the identity.
+        /// </summary>
+        [TestMethod]
+        public void DiagonalizeLU_WithSwap_PermutationDeterminantReflectsSwapParity()
+        {
+            Matrix<double> matrix = new Matrix<double>(new double[,]
+            {
+                                { 4d, 3d },
+                                { 6d, 3d },
+            });
+
+            (_, _, Matrix<double> P) = matrix.DiagonalizeLU();
+
+            Assert.AreEqual(-1d, P.Determinant, 1e-12);
+            Assert.IsFalse(P.IsIdentity);
+        }
+
+        /// <summary>
+        /// Before item #69, <c>U</c> was always constructed with hardcoded <c>isDiagonal: false</c>, even
+        /// when decomposing an already-diagonal matrix (which needs no elimination and leaves <c>U</c>
+        /// genuinely diagonal).
+        /// </summary>
+        [TestMethod]
+        public void DiagonalizeLU_AlreadyDiagonalMatrix_UReportsDiagonal()
+        {
+            Matrix<double> matrix = Matrix<double>.Diagonal(2d, 3d, 4d);
+
+            (Matrix<double> L, Matrix<double> U, _) = matrix.DiagonalizeLU();
+
+            Assert.IsTrue(U.IsDiagonal);
+            Assert.IsTrue(L.IsIdentity);
+        }
+
+        /// <summary>
+        /// <see cref="Matrix{T}.DiagonalizeLU"/>, <see cref="Matrix{T}.Determinant"/>,
+        /// <see cref="Matrix{T}.Solve"/>, and <see cref="Matrix{T}.Invert"/> now share one pivoted
+        /// elimination, so they must agree on which matrices are singular. A rank-deficient matrix is
+        /// rejected/zeroed by all four instead of only some of them.
+        /// </summary>
+        [TestMethod]
+        public void SingularMatrix_RejectedConsistentlyAcrossDecompositionConsumers()
+        {
+            var matrix = new Matrix<double>(new double[,] { { 1d, 2d }, { 2d, 4d } });
+
+            Assert.AreEqual(0d, matrix.Determinant, 1e-12);
+            Assert.ThrowsException<InvalidOperationException>(() => matrix.DiagonalizeLU());
+            Assert.ThrowsException<InvalidOperationException>(() => matrix.Invert());
+            Assert.ThrowsException<InvalidOperationException>(() => matrix.Solve(new Vector<double>(1d, 1d)));
+        }
+
         /// <summary>
         /// Verifies that inverting a matrix leaves the original unchanged and produces an identity when multiplied.
         /// </summary>

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -139,6 +139,66 @@ namespace UtilsTest.Mathematics.LinearAlgebra
             Assert.ThrowsException<InvalidOperationException>(() => matrix.Invert());
         }
 
+        // ── Structural metadata on the inverse (TODO-pass5 item #61) ───────────────
+
+        /// <summary>
+        /// Before the fix, <see cref="Matrix{T}.Invert"/> always hardcoded <c>isDiagonal: false</c> on the
+        /// returned matrix regardless of its actual structure, permanently disabling lazy recomputation.
+        /// The inverse of a diagonal matrix is itself diagonal (and therefore triangular).
+        /// </summary>
+        [TestMethod]
+        public void Invert_DiagonalMatrix_ResultReportsDiagonalAndTriangular()
+        {
+            Matrix<double> diagonal = Matrix<double>.Diagonal(2d, 4d, 5d);
+            Matrix<double> inverse = diagonal.Invert();
+
+            Assert.IsTrue(inverse.IsDiagonal);
+            Assert.IsTrue(inverse.IsTriangular);
+            Assert.IsFalse(inverse.IsIdentity);
+            AssertMatricesAreEqual(Matrix<double>.Diagonal(0.5d, 0.25d, 0.2d), inverse, 1e-9);
+        }
+
+        /// <summary>
+        /// Same as <see cref="Invert_DiagonalMatrix_ResultReportsDiagonalAndTriangular"/>, but for a
+        /// non-diagonal upper-triangular source: the inverse of an upper-triangular matrix is itself
+        /// upper-triangular, so the recomputed metadata should report it as such.
+        /// </summary>
+        [TestMethod]
+        public void Invert_TriangularMatrix_ResultReportsTriangular()
+        {
+            Matrix<double> upperTriangular = new Matrix<double>(new double[,]
+            {
+                { 2d, 3d },
+                { 0d, 4d },
+            });
+
+            Matrix<double> inverse = upperTriangular.Invert();
+
+            Assert.IsTrue(inverse.IsTriangular);
+            Assert.IsFalse(inverse.IsDiagonal);
+        }
+
+        /// <summary>
+        /// A general (non-triangular, non-diagonal) matrix's inverse is itself generally neither
+        /// triangular nor diagonal; the recomputed metadata (rather than a hardcoded value) must still
+        /// correctly report that.
+        /// </summary>
+        [TestMethod]
+        public void Invert_GeneralMatrix_ResultReportsNotTriangularNotDiagonal()
+        {
+            Matrix<double> matrix = new Matrix<double>(new double[,]
+            {
+                { 4d, 7d },
+                { 2d, 6d },
+            });
+
+            Matrix<double> inverse = matrix.Invert();
+
+            Assert.IsFalse(inverse.IsTriangular);
+            Assert.IsFalse(inverse.IsDiagonal);
+            Assert.IsFalse(inverse.IsIdentity);
+        }
+
         [TestMethod]
         public void Determinant_NearSingularMatrix_ReturnsZeroInsteadOfGarbage()
         {

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
@@ -29,6 +29,40 @@ public class MatrixTransformationsTests
         Assert.AreEqual(1d, m.Determinant, Delta);
     }
 
+    /// <summary>
+    /// Before TODO-pass5.md item #62 was fixed, <see cref="MatrixTransformations.Identity{T}"/> performed
+    /// no dimension validation at all, disagreeing with <see cref="Matrix{T}.Identity(int)"/> (which
+    /// rejects <c>size &lt;= 0</c>): a zero dimension silently built a 0×0 matrix instead of throwing.
+    /// </summary>
+    [TestMethod]
+    public void Identity_ZeroDimension_ThrowsLikeMatrixIdentity()
+        => Assert.ThrowsException<ArgumentException>(() => MatrixTransformations.Identity<double>(0));
+
+    /// <summary>
+    /// Same as <see cref="Identity_ZeroDimension_ThrowsLikeMatrixIdentity"/>, for a negative dimension:
+    /// previously this failed through raw array allocation (an undocumented, unrelated exception) rather
+    /// than the same validated <see cref="ArgumentException"/> as <see cref="Matrix{T}.Identity(int)"/>.
+    /// </summary>
+    [TestMethod]
+    public void Identity_NegativeDimension_ThrowsLikeMatrixIdentity()
+        => Assert.ThrowsException<ArgumentException>(() => MatrixTransformations.Identity<double>(-1));
+
+    [TestMethod]
+    public void Identity_MatchesMatrixIdentityFactory()
+    {
+        var viaTransformations = MatrixTransformations.Identity<double>(3);
+        var viaMatrix = Matrix<double>.Identity(3);
+
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                Assert.AreEqual(viaMatrix[i, j], viaTransformations[i, j], Delta, $"[{i},{j}]");
+
+        Assert.AreEqual(viaMatrix.IsDiagonal, viaTransformations.IsDiagonal);
+        Assert.AreEqual(viaMatrix.IsTriangular, viaTransformations.IsTriangular);
+        Assert.AreEqual(viaMatrix.IsIdentity, viaTransformations.IsIdentity);
+        Assert.AreEqual(viaMatrix.Determinant, viaTransformations.Determinant, Delta);
+    }
+
     // ── Diagonal ─────────────────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
@@ -274,6 +274,15 @@ public class MatrixTransformationsTests
                 Assert.AreEqual(i == j ? 1d : 0d, m[i, j], Delta, $"[{i},{j}]");
     }
 
+    /// <summary>
+    /// Before TODO-pass5.md item #66 was fixed, an empty angle list silently resolved to the degenerate
+    /// base dimension <c>d = 1</c> (a meaningless "1×1 rotation") and returned a 2×2 homogeneous identity
+    /// matrix, with no way to instead request the identity rotation for a chosen ambient dimension.
+    /// </summary>
+    [TestMethod]
+    public void Rotation_NoAngles_ThrowsAmbiguousDimensionError()
+        => Assert.ThrowsException<ArgumentException>(() => MatrixTransformations.Rotation<double>());
+
     // ── Transform ────────────────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTransformationsTests.cs
@@ -343,4 +343,105 @@ public class MatrixTransformationsTests
         // 5 is not d*(d+1) for any integer d (0, 2, 6, 12, ...).
         Assert.ThrowsException<ArgumentException>(() => MatrixTransformations.Transform<double>(1d, 2d, 3d, 4d, 5d));
     }
+
+    // ── Structural metadata invariants (TODO-pass5 item #68) ────────────────────
+
+    /// <summary>
+    /// Asserts that a factory-constructed matrix's cached structural flags/determinant agree with what
+    /// the same values would lazily recompute to from scratch (via the public array constructor, which
+    /// always defers to <c>DetermineStructuralFlags</c>). Before item #68, several factories hardcoded
+    /// <c>false</c> for flags that were not actually mathematically guaranteed for every input, which this
+    /// helper would have caught: a hardcoded <c>false</c> next to a lazily-recomputed <c>true</c> is
+    /// exactly the defect this item describes.
+    /// </summary>
+    private static void AssertStructuralMetadataMatchesRecomputation(Matrix<double> matrix)
+    {
+        var recomputed = new Matrix<double>(matrix.ToArray());
+        Assert.AreEqual(recomputed.IsIdentity, matrix.IsIdentity, "IsIdentity mismatch vs. recomputation.");
+        Assert.AreEqual(recomputed.IsTriangular, matrix.IsTriangular, "IsTriangular mismatch vs. recomputation.");
+        Assert.AreEqual(recomputed.IsDiagonal, matrix.IsDiagonal, "IsDiagonal mismatch vs. recomputation.");
+        Assert.AreEqual(recomputed.Determinant, matrix.Determinant, Delta, "Determinant mismatch vs. recomputation.");
+    }
+
+    [TestMethod]
+    public void Identity_MetadataMatchesRecomputation()
+        => AssertStructuralMetadataMatchesRecomputation(MatrixTransformations.Identity<double>(3));
+
+    [TestMethod]
+    public void Diagonal_MetadataMatchesRecomputation()
+        => AssertStructuralMetadataMatchesRecomputation(MatrixTransformations.Diagonal<double>(2d, 0d, 3d));
+
+    [TestMethod]
+    public void Scaling_MetadataMatchesRecomputation()
+        => AssertStructuralMetadataMatchesRecomputation(MatrixTransformations.Scaling<double>(2d, 3d));
+
+    [TestMethod]
+    public void Rotation_MetadataMatchesRecomputation()
+        => AssertStructuralMetadataMatchesRecomputation(MatrixTransformations.Rotation<double>(Math.PI / 4));
+
+    [TestMethod]
+    public void Skew_MetadataMatchesRecomputation()
+        => AssertStructuralMetadataMatchesRecomputation(MatrixTransformations.Skew<double>(0.5, 0.25));
+
+    [TestMethod]
+    public void Transform_MetadataMatchesRecomputation()
+        => AssertStructuralMetadataMatchesRecomputation(MatrixTransformations.Transform<double>(2d, 3d, 5d, 4d, 6d, 7d));
+
+    /// <summary>
+    /// Before item #68, <see cref="MatrixTransformations.Translation{T}"/> always hardcoded
+    /// <c>isIdentity: false</c>/<c>isDiagonal: false</c>, even though a translation by zero in every
+    /// axis is, by value, exactly the identity matrix.
+    /// </summary>
+    [TestMethod]
+    public void Translation_AllZeroValues_ReportsIdentity()
+    {
+        var m = MatrixTransformations.Translation<double>(0d, 0d);
+        Assert.IsTrue(m.IsIdentity);
+        Assert.IsTrue(m.IsDiagonal);
+        Assert.IsTrue(m.IsTriangular);
+        Assert.AreEqual(1d, m.Determinant, Delta);
+        AssertStructuralMetadataMatchesRecomputation(m);
+    }
+
+    /// <summary>
+    /// A translation matrix is always upper triangular by construction (translation entries only ever
+    /// occupy strictly-upper positions), which was previously hardcoded to the wrong answer (<c>false</c>)
+    /// alongside the correctly-false <see cref="Matrix{T}.IsDiagonal"/>/<see cref="Matrix{T}.IsIdentity"/>.
+    /// </summary>
+    [TestMethod]
+    public void Translation_NonZeroValues_IsTriangularButNotDiagonalOrIdentity()
+    {
+        var m = MatrixTransformations.Translation<double>(5d, 7d);
+        Assert.IsTrue(m.IsTriangular);
+        Assert.IsFalse(m.IsDiagonal);
+        Assert.IsFalse(m.IsIdentity);
+        Assert.AreEqual(1d, m.Determinant, Delta);
+        AssertStructuralMetadataMatchesRecomputation(m);
+    }
+
+    /// <summary>
+    /// With zero angles, <see cref="MatrixTransformations.Skew{T}"/> resolves to the degenerate base
+    /// dimension 1 (no off-diagonal position to fill) and returns a 2×2 identity matrix by value; before
+    /// item #68 this was hardcoded to report <c>isIdentity: false</c>.
+    /// </summary>
+    [TestMethod]
+    public void Skew_NoAngles_ReportsIdentity()
+    {
+        var m = MatrixTransformations.Skew<double>();
+        Assert.IsTrue(m.IsIdentity);
+        AssertStructuralMetadataMatchesRecomputation(m);
+    }
+
+    /// <summary>
+    /// Supplying exactly the identity coefficients to <see cref="MatrixTransformations.Transform{T}"/>
+    /// must report <see cref="Matrix{T}.IsIdentity"/> as <see langword="true"/> now that the factory no
+    /// longer hardcodes <c>false</c>.
+    /// </summary>
+    [TestMethod]
+    public void Transform_IdentityCoefficients_ReportsIdentity()
+    {
+        var m = MatrixTransformations.Transform<double>(1d, 0d, 0d, 0d, 1d, 0d);
+        Assert.IsTrue(m.IsIdentity);
+        AssertStructuralMetadataMatchesRecomputation(m);
+    }
 }

--- a/UtilsTest/Mathematics/PolynomialTests.cs
+++ b/UtilsTest/Mathematics/PolynomialTests.cs
@@ -277,4 +277,49 @@ public class PolynomialTests
     [TestMethod]
     public void NoCoefficients_Throws()
         => Assert.ThrowsException<ArgumentException>(() => new Polynomial<double>(System.Array.Empty<double>()));
+
+    // ── ToString sign rendering (TODO-pass5 item #65) ───────────────────────────
+
+    /// <summary>
+    /// Before the fix, a negative non-leading term rendered as a double-signed sequence such as
+    /// <c>"2x + -3"</c> because each coefficient's own sign was baked into its <see cref="object.ToString"/>
+    /// and every term was joined with a literal <c>" + "</c>.
+    /// </summary>
+    [TestMethod]
+    public void ToString_NegativeTrailingTerm_UsesSignAwareSeparator()
+    {
+        // 2x - 3
+        var p = new Polynomial<double>(-3.0, 2.0);
+        Assert.AreEqual("2x - 3", p.ToString());
+    }
+
+    [TestMethod]
+    public void ToString_NegativeLeadingTerm_StartsWithMinusNoPlus()
+    {
+        // 1 - 2x
+        var p = new Polynomial<double>(1.0, -2.0);
+        Assert.AreEqual("-2x + 1", p.ToString());
+    }
+
+    /// <summary>A unit coefficient on a non-constant term omits the redundant "1"/"-1" magnitude.</summary>
+    [TestMethod]
+    public void ToString_UnitCoefficient_OmitsMagnitude()
+    {
+        Assert.AreEqual("x", new Polynomial<double>(0.0, 1.0).ToString());
+        Assert.AreEqual("-x", new Polynomial<double>(0.0, -1.0).ToString());
+        Assert.AreEqual("x^2 + x", new Polynomial<double>(0.0, 1.0, 1.0).ToString());
+    }
+
+    /// <summary>The constant term's own coefficient of 1 must not be omitted (it is not a variable term).</summary>
+    [TestMethod]
+    public void ToString_ConstantTermOfOne_KeepsMagnitude()
+        => Assert.AreEqual("1", new Polynomial<double>(1.0).ToString());
+
+    [TestMethod]
+    public void ToString_MultipleNegativeTerms_EachUsesMinusSeparator()
+    {
+        // -3x^2 - 2x - 1
+        var p = new Polynomial<double>(-1.0, -2.0, -3.0);
+        Assert.AreEqual("-3x^2 - 2x - 1", p.ToString());
+    }
 }


### PR DESCRIPTION
## Summary
- Addresses all findings in Utils.Mathematics/TODO-2026-07-11-pass5.md (items #57-#69), one item per commit.
- Items #57, #58, #59, #60, #63, #64: already fixed by prior audit passes (mainly the DiagonalizeLU rewrite in PR #443 and Polynomial's Canonicalize routing); annotated instead of duplicating work.
- Item #61 (Invert installs false structural metadata): fixed - the internal Matrix constructor's structural-flag parameters are now bool? so Invert can pass null (unknown, lazily recomputed) instead of hardcoded false.
- Item #62 (Identity factory validation mismatch): fixed - MatrixTransformations.Identity<T> now delegates to Matrix<T>.Identity(int).
- Item #65 (Polynomial ToString sign rendering): fixed - sign-aware term separators instead of double-signed sequences like "2x + -3".
- Item #66 (Rotation zero-angle ambiguity): fixed - an empty angle list now throws instead of silently returning an arbitrary 2x2 identity.
- Item #67 (Matrix.Pad contract): fixed - documented as resize (crop-or-enlarge) and validated to require positive dimensions.
- Item #69 (shared pivoted decomposition): fixed - DiagonalizeLU/Determinant/Solve/Invert now share one TryDecomposePivoted primitive instead of four independently drifted elimination implementations.
- Item #68 (unproven metadata across factories): fixed - corrected the remaining MatrixTransformations factories (Skew/Rotation/Translation/Transform) that hardcoded unproven false flags, plus a test-time invariant helper comparing factory-cached metadata against lazy recomputation.

## Test plan
- [x] dotnet test UtilsTest/UtilsTest.Unit.csproj after each item
- [x] Full suite green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
