### PR TITLE
Utils.Mathematics: address TODO-pass4 items #48-#56 and TODO-pass6 items #70-#79

### DIFF
--- a/Utils.Mathematics/Fourier/FourierExtensions.cs
+++ b/Utils.Mathematics/Fourier/FourierExtensions.cs
@@ -9,18 +9,38 @@ namespace Utils.Mathematics.Fourier;
 public static class FourierExtensions
 {
     /// <summary>
+    /// Validates a transform argument shared by every extension method in this class: non-null and
+    /// non-empty (see TODO-2026-07-11-pass4.md item #53). An empty transform has no bins to report and
+    /// - for <see cref="GetFrequencies"/> specifically - would otherwise compute <c>sampleRate / 0</c>
+    /// (an unused but silently-produced infinity) instead of surfacing the invalid input.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
+    private static void ValidateTransform(Complex[] transform, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(transform, parameterName);
+        if (transform.Length == 0)
+            throw new ArgumentException("The transform must contain at least one bin.", parameterName);
+    }
+
+    /// <summary>
     /// Returns the frequency represented by each bin in the first half of a Fourier transform result.
     /// </summary>
-    /// <param name="transform">The transform result.</param>
-    /// <param name="sampleRate">Sampling rate in hertz. Must be positive.</param>
+    /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
+    /// <param name="sampleRate">Sampling rate in hertz. Must be finite and positive.</param>
     /// <returns>Array of <c>N/2</c> frequencies in hertz, one per bin.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when <paramref name="sampleRate"/> is not positive.
+    /// Thrown when <paramref name="sampleRate"/> is not finite or is not positive (previously only
+    /// <c>sampleRate &lt;= 0</c> was checked, silently accepting <see langword="NaN"/> - see
+    /// TODO-2026-07-11-pass4.md item #53).
     /// </exception>
     public static double[] GetFrequencies(this Complex[] transform, double sampleRate)
     {
-        if (sampleRate <= 0)
-            throw new ArgumentOutOfRangeException(nameof(sampleRate), "Sample rate must be positive.");
+        ValidateTransform(transform, nameof(transform));
+        if (!double.IsFinite(sampleRate) || sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate), sampleRate, "Sample rate must be finite and positive.");
 
         int length = transform.Length;
         double[] frequencies = new double[length >> 1];
@@ -35,10 +55,13 @@ public static class FourierExtensions
     /// <summary>
     /// Returns the amplitude (magnitude) of each bin in the transform result.
     /// </summary>
-    /// <param name="transform">The transform result.</param>
+    /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
     /// <returns>Array of amplitudes, one per bin.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
     public static double[] GetAmplitudes(this Complex[] transform)
     {
+        ValidateTransform(transform, nameof(transform));
         double[] amplitudes = new double[transform.Length];
         for (int i = 0; i < transform.Length; i++)
             amplitudes[i] = transform[i].Magnitude;
@@ -48,10 +71,13 @@ public static class FourierExtensions
     /// <summary>
     /// Returns the phase (argument) in radians of each bin in the transform result.
     /// </summary>
-    /// <param name="transform">The transform result.</param>
+    /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
     /// <returns>Array of phases in radians, one per bin.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
     public static double[] GetPhases(this Complex[] transform)
     {
+        ValidateTransform(transform, nameof(transform));
         double[] phases = new double[transform.Length];
         for (int i = 0; i < transform.Length; i++)
             phases[i] = transform[i].Phase;

--- a/Utils.Mathematics/Fourier/FourierExtensions.cs
+++ b/Utils.Mathematics/Fourier/FourierExtensions.cs
@@ -53,19 +53,41 @@ public static class FourierExtensions
     }
 
     /// <summary>
-    /// Returns the amplitude (magnitude) of each bin in the transform result.
+    /// Returns the raw spectral magnitude (<see cref="Complex.Magnitude"/>) of each bin in the transform
+    /// result - <b>not</b> a physically normalized sinusoidal amplitude (see
+    /// TODO-2026-07-11-pass4.md item #55). Depending on the forward transform's own normalization
+    /// convention, signal length, one-sided-vs-two-sided selection, and any window's coherent gain, the
+    /// value that corresponds to a signal component's actual physical amplitude generally requires
+    /// further scaling by the caller (e.g. this library's own forward transform is unnormalized, so a
+    /// pure sinusoid's peak bin magnitude equals <c>signal amplitude * N / 2</c>, not the amplitude
+    /// itself - see <see cref="GetMagnitudes"/>'s "constant signal" example). <see cref="GetMagnitudes"/>
+    /// is an identical, more accurately-named alias; this method is kept for backward compatibility.
     /// </summary>
     /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
-    /// <returns>Array of amplitudes, one per bin.</returns>
+    /// <returns>Array of raw magnitudes, one per bin.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
-    public static double[] GetAmplitudes(this Complex[] transform)
+    public static double[] GetAmplitudes(this Complex[] transform) => GetMagnitudes(transform);
+
+    /// <summary>
+    /// Returns the raw spectral magnitude (<see cref="Complex.Magnitude"/>) of each bin in the transform
+    /// result. The more accurately-named counterpart to <see cref="GetAmplitudes"/> (see
+    /// TODO-2026-07-11-pass4.md item #55): "amplitude" suggests a physically normalized sinusoidal
+    /// amplitude, but this is the raw, unnormalized FFT bin magnitude - e.g. for this library's
+    /// unnormalized forward transform, the FFT of a constant signal of value <c>1</c> over <c>N</c>
+    /// samples has a DC-bin magnitude of <c>N</c>, not <c>1</c>.
+    /// </summary>
+    /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
+    /// <returns>Array of raw magnitudes, one per bin.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
+    public static double[] GetMagnitudes(this Complex[] transform)
     {
         ValidateTransform(transform, nameof(transform));
-        double[] amplitudes = new double[transform.Length];
+        double[] magnitudes = new double[transform.Length];
         for (int i = 0; i < transform.Length; i++)
-            amplitudes[i] = transform[i].Magnitude;
-        return amplitudes;
+            magnitudes[i] = transform[i].Magnitude;
+        return magnitudes;
     }
 
     /// <summary>
@@ -183,13 +205,14 @@ public static class FourierExtensions
     }
 
     /// <summary>
-    /// Returns the amplitude (magnitude) of each one-sided (non-negative frequency) bin, length-matched
+    /// Returns the raw spectral magnitude (see <see cref="GetMagnitudes"/> - <b>not</b> a physically
+    /// normalized sinusoidal amplitude) of each one-sided (non-negative frequency) bin, length-matched
     /// with <see cref="GetOneSidedFrequencies"/> for the same <paramref name="includeNyquist"/> choice
-    /// (see TODO-2026-07-11-pass4.md item #54).
+    /// (see TODO-2026-07-11-pass4.md items #54/#55).
     /// </summary>
     /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
     /// <param name="includeNyquist">See <see cref="GetOneSidedBinCount"/>.</param>
-    /// <returns>Array of one-sided amplitudes; see <see cref="GetOneSidedBinCount"/> for the exact count.</returns>
+    /// <returns>Array of one-sided raw magnitudes; see <see cref="GetOneSidedBinCount"/> for the exact count.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
     public static double[] GetOneSidedAmplitudes(this Complex[] transform, bool includeNyquist = false)

--- a/Utils.Mathematics/Fourier/FourierExtensions.cs
+++ b/Utils.Mathematics/Fourier/FourierExtensions.cs
@@ -208,7 +208,8 @@ public static class FourierExtensions
     /// Returns the raw spectral magnitude (see <see cref="GetMagnitudes"/> - <b>not</b> a physically
     /// normalized sinusoidal amplitude) of each one-sided (non-negative frequency) bin, length-matched
     /// with <see cref="GetOneSidedFrequencies"/> for the same <paramref name="includeNyquist"/> choice
-    /// (see TODO-2026-07-11-pass4.md items #54/#55).
+    /// (see TODO-2026-07-11-pass4.md items #54/#55). <see cref="GetOneSidedMagnitudes"/> is an
+    /// identical, more accurately-named alias; this method is kept for backward compatibility.
     /// </summary>
     /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
     /// <param name="includeNyquist">See <see cref="GetOneSidedBinCount"/>.</param>
@@ -216,13 +217,29 @@ public static class FourierExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
     public static double[] GetOneSidedAmplitudes(this Complex[] transform, bool includeNyquist = false)
+        => GetOneSidedMagnitudes(transform, includeNyquist);
+
+    /// <summary>
+    /// Returns the raw spectral magnitude (<see cref="Complex.Magnitude"/>) of each one-sided
+    /// (non-negative frequency) bin, length-matched with <see cref="GetOneSidedFrequencies"/> for the
+    /// same <paramref name="includeNyquist"/> choice. The more accurately-named counterpart to
+    /// <see cref="GetOneSidedAmplitudes"/>, mirroring the <see cref="GetMagnitudes"/>/<see cref="GetAmplitudes"/>
+    /// relationship: "amplitude" suggests a physically normalized sinusoidal amplitude, but this is the
+    /// raw, unnormalized FFT bin magnitude (see TODO-2026-07-11-pass4.md items #54/#55).
+    /// </summary>
+    /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
+    /// <param name="includeNyquist">See <see cref="GetOneSidedBinCount"/>.</param>
+    /// <returns>Array of one-sided raw magnitudes; see <see cref="GetOneSidedBinCount"/> for the exact count.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
+    public static double[] GetOneSidedMagnitudes(this Complex[] transform, bool includeNyquist = false)
     {
         ValidateTransform(transform, nameof(transform));
         int count = GetOneSidedBinCount(transform.Length, includeNyquist);
-        double[] amplitudes = new double[count];
+        double[] magnitudes = new double[count];
         for (int i = 0; i < count; i++)
-            amplitudes[i] = transform[i].Magnitude;
-        return amplitudes;
+            magnitudes[i] = transform[i].Magnitude;
+        return magnitudes;
     }
 
     /// <summary>

--- a/Utils.Mathematics/Fourier/FourierExtensions.cs
+++ b/Utils.Mathematics/Fourier/FourierExtensions.cs
@@ -83,4 +83,142 @@ public static class FourierExtensions
             phases[i] = transform[i].Phase;
         return phases;
     }
+
+    // -------------------------------------------------------------------------
+    // One-sided / all-bin spectrum APIs (TODO-2026-07-11-pass4.md item #54)
+    //
+    // GetFrequencies returns N/2 bins (no Nyquist) while GetAmplitudes/GetPhases return all N bins,
+    // an array-length mismatch that made it easy to zip them under incompatible conventions or
+    // unknowingly discard the Nyquist component. The methods below give every convention its own,
+    // explicitly-named, length-matched API instead of silently guessing what a caller wants; the three
+    // original methods above are unchanged (kept for backward compatibility).
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Number of one-sided (non-negative frequency) bins for a transform of the given length: every
+    /// index from DC up to - but not including - the Nyquist bin, plus the Nyquist bin itself when
+    /// <paramref name="includeNyquist"/> is requested and actually applicable.
+    /// </summary>
+    /// <param name="length">Transform length (<c>N</c>).</param>
+    /// <param name="includeNyquist">
+    /// Whether to include the Nyquist bin (index <c>N/2</c>). Only meaningful for an even
+    /// <paramref name="length"/>: an odd-length transform has no exact Nyquist bin (its highest bin is
+    /// already a genuine positive frequency, not a fold-over point), so this parameter has no effect in
+    /// that case.
+    /// </param>
+    /// <returns>
+    /// <c>(N + 1) / 2</c> bins by default (<c>N/2</c> for even <c>N</c>, excluding Nyquist; <c>(N+1)/2</c>
+    /// for odd <c>N</c>, which has no separate Nyquist bin to exclude), or one more when
+    /// <paramref name="includeNyquist"/> is <see langword="true"/> and <paramref name="length"/> is even.
+    /// </returns>
+    private static int GetOneSidedBinCount(int length, bool includeNyquist)
+    {
+        bool hasSeparateNyquistBin = length % 2 == 0;
+        int countExcludingNyquist = (length + 1) / 2;
+        return countExcludingNyquist + (includeNyquist && hasSeparateNyquistBin ? 1 : 0);
+    }
+
+    /// <summary>
+    /// Returns the frequency represented by every bin of a Fourier transform result, including the
+    /// negative (aliased) frequencies of the upper half - matching <see cref="GetAmplitudes"/>/
+    /// <see cref="GetPhases"/>'s bin count exactly, unlike <see cref="GetFrequencies"/> (see
+    /// TODO-2026-07-11-pass4.md item #54).
+    /// </summary>
+    /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
+    /// <param name="sampleRate">Sampling rate in hertz. Must be finite and positive.</param>
+    /// <returns>
+    /// Array of <c>N</c> frequencies in hertz: bin <c>i &lt; ceil(N/2)</c> is the positive frequency
+    /// <c>i * sampleRate / N</c>; bin <c>i &gt;= ceil(N/2)</c> is the negative (aliased) frequency
+    /// <c>(i - N) * sampleRate / N</c> - the same convention as e.g. NumPy's <c>fftfreq</c>, under which
+    /// an even-length transform's Nyquist bin is reported as the negative Nyquist frequency.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="sampleRate"/> is not finite or is not positive.</exception>
+    public static double[] GetAllBinFrequencies(this Complex[] transform, double sampleRate)
+    {
+        ValidateTransform(transform, nameof(transform));
+        if (!double.IsFinite(sampleRate) || sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate), sampleRate, "Sample rate must be finite and positive.");
+
+        int length = transform.Length;
+        double step = sampleRate / length;
+        int positiveCount = (length + 1) / 2;
+
+        double[] frequencies = new double[length];
+        for (int i = 0; i < length; i++)
+        {
+            int k = i < positiveCount ? i : i - length;
+            frequencies[i] = k * step;
+        }
+        return frequencies;
+    }
+
+    /// <summary>
+    /// Returns the frequency represented by each one-sided (non-negative frequency) bin, with an
+    /// explicit, caller-controlled choice of whether the Nyquist bin is included (see
+    /// TODO-2026-07-11-pass4.md item #54).
+    /// </summary>
+    /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
+    /// <param name="sampleRate">Sampling rate in hertz. Must be finite and positive.</param>
+    /// <param name="includeNyquist">See <see cref="GetOneSidedBinCount"/>.</param>
+    /// <returns>Array of one-sided frequencies in hertz; see <see cref="GetOneSidedBinCount"/> for the exact count.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="sampleRate"/> is not finite or is not positive.</exception>
+    public static double[] GetOneSidedFrequencies(this Complex[] transform, double sampleRate, bool includeNyquist = false)
+    {
+        ValidateTransform(transform, nameof(transform));
+        if (!double.IsFinite(sampleRate) || sampleRate <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sampleRate), sampleRate, "Sample rate must be finite and positive.");
+
+        int length = transform.Length;
+        double step = sampleRate / length;
+        int count = GetOneSidedBinCount(length, includeNyquist);
+
+        double[] frequencies = new double[count];
+        for (int i = 0; i < count; i++)
+            frequencies[i] = i * step;
+        return frequencies;
+    }
+
+    /// <summary>
+    /// Returns the amplitude (magnitude) of each one-sided (non-negative frequency) bin, length-matched
+    /// with <see cref="GetOneSidedFrequencies"/> for the same <paramref name="includeNyquist"/> choice
+    /// (see TODO-2026-07-11-pass4.md item #54).
+    /// </summary>
+    /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
+    /// <param name="includeNyquist">See <see cref="GetOneSidedBinCount"/>.</param>
+    /// <returns>Array of one-sided amplitudes; see <see cref="GetOneSidedBinCount"/> for the exact count.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
+    public static double[] GetOneSidedAmplitudes(this Complex[] transform, bool includeNyquist = false)
+    {
+        ValidateTransform(transform, nameof(transform));
+        int count = GetOneSidedBinCount(transform.Length, includeNyquist);
+        double[] amplitudes = new double[count];
+        for (int i = 0; i < count; i++)
+            amplitudes[i] = transform[i].Magnitude;
+        return amplitudes;
+    }
+
+    /// <summary>
+    /// Returns the phase (argument) in radians of each one-sided (non-negative frequency) bin,
+    /// length-matched with <see cref="GetOneSidedFrequencies"/> for the same
+    /// <paramref name="includeNyquist"/> choice (see TODO-2026-07-11-pass4.md item #54).
+    /// </summary>
+    /// <param name="transform">The transform result. Must be non-null and non-empty.</param>
+    /// <param name="includeNyquist">See <see cref="GetOneSidedBinCount"/>.</param>
+    /// <returns>Array of one-sided phases in radians; see <see cref="GetOneSidedBinCount"/> for the exact count.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transform"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="transform"/> is empty.</exception>
+    public static double[] GetOneSidedPhases(this Complex[] transform, bool includeNyquist = false)
+    {
+        ValidateTransform(transform, nameof(transform));
+        int count = GetOneSidedBinCount(transform.Length, includeNyquist);
+        double[] phases = new double[count];
+        for (int i = 0; i < count; i++)
+            phases[i] = transform[i].Phase;
+        return phases;
+    }
 }

--- a/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
+++ b/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
@@ -57,14 +57,23 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// <param name="anchor">A point on the subspace.</param>
     /// <param name="directions">Spanning directions. At least one must be non-zero.</param>
     /// <returns>The affine subspace through <paramref name="anchor"/> in the given directions.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="anchor"/>, <paramref name="directions"/>, or any element of
+    /// <paramref name="directions"/> is <see langword="null"/>.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown when no directions are supplied, a direction has the wrong ambient dimension,
     /// or all directions are zero / mutually collinear.
     /// </exception>
     public static AffineSubspace<T> FromSpan(Vector<T> anchor, params Vector<T>[] directions)
     {
+        ArgumentNullException.ThrowIfNull(anchor);
+        ArgumentNullException.ThrowIfNull(directions);
         if (directions.Length == 0)
             throw new ArgumentException("At least one direction vector is required.", nameof(directions));
+        for (int i = 0; i < directions.Length; i++)
+            if (directions[i] is null)
+                throw new ArgumentNullException(nameof(directions), $"Direction vector at index {i} is null.");
 
         var basis = GramSchmidt(anchor.Dimension, directions);
         if (basis.Length == 0)
@@ -82,13 +91,22 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// <param name="anchor">A point on the subspace.</param>
     /// <param name="normals">Normal vectors. Each independent normal reduces the dimension by one.</param>
     /// <returns>The affine subspace through <paramref name="anchor"/> orthogonal to the given normals.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="anchor"/>, <paramref name="normals"/>, or any element of
+    /// <paramref name="normals"/> is <see langword="null"/>.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown when no normals are supplied or a normal has the wrong ambient dimension.
     /// </exception>
     public static AffineSubspace<T> FromNormals(Vector<T> anchor, params Vector<T>[] normals)
     {
+        ArgumentNullException.ThrowIfNull(anchor);
+        ArgumentNullException.ThrowIfNull(normals);
         if (normals.Length == 0)
             throw new ArgumentException("At least one normal vector is required.", nameof(normals));
+        for (int i = 0; i < normals.Length; i++)
+            if (normals[i] is null)
+                throw new ArgumentNullException(nameof(normals), $"Normal vector at index {i} is null.");
 
         var orthonormals = GramSchmidt(anchor.Dimension, normals);
         var basis = ComputeComplement(anchor.Dimension, orthonormals);
@@ -104,6 +122,7 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// </summary>
     /// <param name="point">Point to project. Must have the same ambient dimension.</param>
     /// <returns>The closest point on this subspace to <paramref name="point"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="point"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when the point has a different ambient dimension.</exception>
     public Vector<T> Project(Vector<T> point)
     {
@@ -120,6 +139,7 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// </summary>
     /// <param name="point">Point to measure from. Must have the same ambient dimension.</param>
     /// <returns>The perpendicular distance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="point"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when the point has a different ambient dimension.</exception>
     public T DistanceTo(Vector<T> point)
     {
@@ -133,6 +153,7 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// <param name="point">Point to test.</param>
     /// <param name="tolerance">Maximum allowable perpendicular distance. Must be finite and non-negative.</param>
     /// <returns><see langword="true"/> if the point is within <paramref name="tolerance"/> of the subspace.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="point"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="tolerance"/> is not finite or is negative: an unchecked negative
     /// tolerance would reject even an exact member, <see langword="NaN"/> would make every comparison
@@ -157,9 +178,11 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// The unique intersection point, or <see langword="null"/> when the line is parallel to
     /// (or embedded in) the subspace.
     /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="line"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when the line has a different ambient dimension.</exception>
     public Vector<T>? IntersectWith(Line<T> line)
     {
+        ArgumentNullException.ThrowIfNull(line);
         if (line.Dimension != AmbientDimension)
             throw new ArgumentException("The line must have the same ambient dimension as the subspace.", nameof(line));
 
@@ -203,9 +226,11 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// The intersection as a new <see cref="AffineSubspace{T}"/>, or <see langword="null"/>
     /// when the two subspaces are parallel and disjoint.
     /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="other"/> has a different ambient dimension.</exception>
     public AffineSubspace<T>? IntersectWith(AffineSubspace<T> other)
     {
+        ArgumentNullException.ThrowIfNull(other);
         if (other.AmbientDimension != AmbientDimension)
             throw new ArgumentException("Both subspaces must have the same ambient dimension.", nameof(other));
 
@@ -332,6 +357,7 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
 
     private void ValidateDimension(Vector<T> point)
     {
+        ArgumentNullException.ThrowIfNull(point);
         if (point.Dimension != AmbientDimension)
             throw new ArgumentException(
                 "The point must have the same ambient dimension as the subspace.", nameof(point));

--- a/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
+++ b/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
@@ -423,11 +423,29 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// <summary>
     /// Returns a string describing the anchor point and the subspace dimensions.
     /// </summary>
-    /// <param name="format">Unused; reserved for future format specifiers.</param>
-    /// <param name="formatProvider">Unused; reserved for future format providers.</param>
+    /// <param name="format">
+    /// Numeric format string forwarded to each coordinate's own <see cref="IFormattable.ToString(string?, IFormatProvider?)"/>
+    /// (e.g. <c>"F2"</c>), or <see langword="null"/> for the default numeric format. Propagated the same
+    /// way as <see cref="Line{T}.ToString(string?, IFormatProvider?)"/>, since <see cref="Vector{T}"/>
+    /// itself does not implement <see cref="IFormattable"/> (see TODO-2026-07-11-pass4.md item #52 - this
+    /// type previously ignored both parameters entirely).
+    /// </param>
+    /// <param name="formatProvider">Format provider forwarded to each coordinate.</param>
     /// <returns>A human-readable description of this subspace.</returns>
     public string ToString(string? format, IFormatProvider? formatProvider)
-        => $"Anchor: {Anchor}, Dimension: {Dimension}/{AmbientDimension}";
+        => $"Anchor: {FormatVector(Anchor, format, formatProvider)}, Dimension: {Dimension}/{AmbientDimension}";
+
+    /// <summary>
+    /// Formats a vector's components individually with <paramref name="format"/>/<paramref name="formatProvider"/>,
+    /// since <see cref="Vector{T}"/> itself does not implement <see cref="IFormattable"/>.
+    /// </summary>
+    private static string FormatVector(Vector<T> vector, string? format, IFormatProvider? formatProvider)
+    {
+        string[] parts = new string[vector.Dimension];
+        for (int i = 0; i < vector.Dimension; i++)
+            parts[i] = vector[i].ToString(format, formatProvider);
+        return "(" + string.Join(", ", parts) + ")";
+    }
 
     // -------------------------------------------------------------------------
     // Private helpers

--- a/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
+++ b/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
@@ -396,7 +396,22 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is AffineSubspace<T> s && Equals(s);
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Combines only <see cref="Dimension"/> and <see cref="AmbientDimension"/>. This is a deliberately
+    /// coarse hash, not an oversight (see TODO-2026-07-11-pass4.md item #51): <see cref="Equals(AffineSubspace{T})"/>
+    /// is a tolerance-based geometric comparison (same point set, not same anchor/basis representation),
+    /// so a hash that is actually consistent with it would need to derive a value invariant across every
+    /// representation of the same subspace - and stable across the boundary where two subspaces stop
+    /// being "close enough" to compare equal - which the fixed-epsilon geometric equality this type uses
+    /// cannot support without also risking hash/equals inconsistency (two subspaces that compare equal
+    /// hashing differently because their real-valued invariants fall in different quantization buckets).
+    /// This satisfies the required equal-implies-same-hash contract, but every subspace of the same
+    /// dimension/ambient dimension collides: this makes hash-based collections (<see cref="HashSet{T}"/>,
+    /// dictionary keys) degrade to near-linear lookup for a collection containing many subspaces. Callers
+    /// needing better distribution should key such collections by an application-specific canonical
+    /// representation (e.g. a snapped/rounded anchor plus basis) via a dedicated <see cref="IEqualityComparer{T}"/>
+    /// instead of relying on this type's own hash.
+    /// </summary>
     public override int GetHashCode() => HashCode.Combine(Dimension, AmbientDimension);
 
     /// <inheritdoc/>

--- a/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
+++ b/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
@@ -7,10 +7,22 @@ namespace Utils.Mathematics.LinearAlgebra;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Construct via <see cref="FromSpan"/> (k spanning vectors → dimension k) or
-/// <see cref="FromNormals"/> (k normal vectors → dimension d − k).
-/// The internal representation is an orthonormal basis computed by Gram–Schmidt, so all
-/// geometric operations are numerically stable.
+/// Construct via <see cref="FromSpan(Vector{T}, Vector{T}[])"/> (k spanning vectors → dimension k) or
+/// <see cref="FromNormals(Vector{T}, Vector{T}[])"/> (k normal vectors → dimension d − k). The internal
+/// representation is an orthonormal basis computed by Gram–Schmidt.
+/// </para>
+/// <para>
+/// <b>Numerical stability is limited, not unconditional</b> (see TODO-2026-07-11-pass4.md item #50):
+/// rank/independence decisions during construction, and the tolerance-based comparisons in
+/// <see cref="IntersectWith(AffineSubspace{T})"/>/<see cref="IntersectWith(Line{T})"/>/<see cref="Equals(AffineSubspace{T})"/>,
+/// use a fixed absolute epsilon (<c>1e-10</c>) rather than a scale-aware relative tolerance, and there is
+/// no re-orthogonalization pass or conditioning/residual diagnostic. This is adequate for
+/// moderate-magnitude coordinates and clearly independent inputs, but nearly dependent directions/normals
+/// or large coordinate scales can silently produce an incorrect rank or a looser-than-expected membership
+/// test. <see cref="FromSpan(Vector{T}, T?, Vector{T}[])"/>/<see cref="FromNormals(Vector{T}, T?, Vector{T}[])"/>
+/// accept an optional <c>rankTolerance</c> override for callers who need to tune this threshold for their
+/// own scale; a fully scale-aware/SVD-based construction was not implemented (see the item's "Fixed" note
+/// for why).
 /// </para>
 /// <para>
 /// Special cases: dimension 0 is a single point; dimension d is the full ambient space.
@@ -51,8 +63,9 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     // -------------------------------------------------------------------------
 
     /// <summary>
-    /// Creates an affine subspace of dimension <c>k</c> spanned by <c>k</c> direction vectors.
-    /// Linearly dependent inputs are silently discarded; the resulting dimension equals the rank.
+    /// Creates an affine subspace of dimension <c>k</c> spanned by <c>k</c> direction vectors, using the
+    /// default rank tolerance. See <see cref="FromSpan(Vector{T}, T?, Vector{T}[])"/> for an overload
+    /// accepting an explicit tolerance override.
     /// </summary>
     /// <param name="anchor">A point on the subspace.</param>
     /// <param name="directions">Spanning directions. At least one must be non-zero.</param>
@@ -66,16 +79,42 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// or all directions are zero / mutually collinear.
     /// </exception>
     public static AffineSubspace<T> FromSpan(Vector<T> anchor, params Vector<T>[] directions)
+        => FromSpan(anchor, rankTolerance: null, directions);
+
+    /// <summary>
+    /// Creates an affine subspace of dimension <c>k</c> spanned by <c>k</c> direction vectors.
+    /// Linearly dependent inputs are silently discarded; the resulting dimension equals the rank.
+    /// </summary>
+    /// <param name="anchor">A point on the subspace.</param>
+    /// <param name="rankTolerance">
+    /// Overrides the default fixed absolute epsilon (<c>1e-10</c>) used to decide whether a direction is
+    /// linearly independent of those already accepted (see this type's remarks on numerical stability,
+    /// TODO-2026-07-11-pass4.md item #50). Must be finite and non-negative when supplied.
+    /// </param>
+    /// <param name="directions">Spanning directions. At least one must be non-zero.</param>
+    /// <returns>The affine subspace through <paramref name="anchor"/> in the given directions.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="anchor"/>, <paramref name="directions"/>, or any element of
+    /// <paramref name="directions"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when no directions are supplied, a direction has the wrong ambient dimension,
+    /// or all directions are zero / mutually collinear.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="rankTolerance"/> is supplied but not finite or is negative.</exception>
+    public static AffineSubspace<T> FromSpan(Vector<T> anchor, T? rankTolerance, params Vector<T>[] directions)
     {
         ArgumentNullException.ThrowIfNull(anchor);
         ArgumentNullException.ThrowIfNull(directions);
+        if (rankTolerance is { } explicitRankTolerance)
+            ValidateTolerance(explicitRankTolerance, nameof(rankTolerance));
         if (directions.Length == 0)
             throw new ArgumentException("At least one direction vector is required.", nameof(directions));
         for (int i = 0; i < directions.Length; i++)
             if (directions[i] is null)
                 throw new ArgumentNullException(nameof(directions), $"Direction vector at index {i} is null.");
 
-        var basis = GramSchmidt(anchor.Dimension, directions);
+        var basis = GramSchmidt(anchor.Dimension, directions, rankTolerance ?? Epsilon);
         if (basis.Length == 0)
             throw new ArgumentException("All direction vectors are linearly dependent (zero span).", nameof(directions));
 
@@ -83,10 +122,9 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     }
 
     /// <summary>
-    /// Creates an affine subspace of dimension <c>d − k</c> defined by <c>k</c> normal vectors.
-    /// The subspace is the set of points whose displacement from <paramref name="anchor"/>
-    /// is orthogonal to every supplied normal.
-    /// Linearly dependent normals are silently discarded.
+    /// Creates an affine subspace of dimension <c>d − k</c> defined by <c>k</c> normal vectors, using
+    /// the default rank tolerance. See <see cref="FromNormals(Vector{T}, T?, Vector{T}[])"/> for an
+    /// overload accepting an explicit tolerance override.
     /// </summary>
     /// <param name="anchor">A point on the subspace.</param>
     /// <param name="normals">Normal vectors. Each independent normal reduces the dimension by one.</param>
@@ -99,17 +137,46 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// Thrown when no normals are supplied or a normal has the wrong ambient dimension.
     /// </exception>
     public static AffineSubspace<T> FromNormals(Vector<T> anchor, params Vector<T>[] normals)
+        => FromNormals(anchor, rankTolerance: null, normals);
+
+    /// <summary>
+    /// Creates an affine subspace of dimension <c>d − k</c> defined by <c>k</c> normal vectors.
+    /// The subspace is the set of points whose displacement from <paramref name="anchor"/>
+    /// is orthogonal to every supplied normal.
+    /// Linearly dependent normals are silently discarded.
+    /// </summary>
+    /// <param name="anchor">A point on the subspace.</param>
+    /// <param name="rankTolerance">
+    /// Overrides the default fixed absolute epsilon (<c>1e-10</c>) used to decide whether a normal is
+    /// linearly independent of those already accepted, and to decide when a candidate complement
+    /// direction has collapsed to zero (see this type's remarks on numerical stability,
+    /// TODO-2026-07-11-pass4.md item #50). Must be finite and non-negative when supplied.
+    /// </param>
+    /// <param name="normals">Normal vectors. Each independent normal reduces the dimension by one.</param>
+    /// <returns>The affine subspace through <paramref name="anchor"/> orthogonal to the given normals.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="anchor"/>, <paramref name="normals"/>, or any element of
+    /// <paramref name="normals"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when no normals are supplied or a normal has the wrong ambient dimension.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="rankTolerance"/> is supplied but not finite or is negative.</exception>
+    public static AffineSubspace<T> FromNormals(Vector<T> anchor, T? rankTolerance, params Vector<T>[] normals)
     {
         ArgumentNullException.ThrowIfNull(anchor);
         ArgumentNullException.ThrowIfNull(normals);
+        if (rankTolerance is { } explicitRankTolerance)
+            ValidateTolerance(explicitRankTolerance, nameof(rankTolerance));
         if (normals.Length == 0)
             throw new ArgumentException("At least one normal vector is required.", nameof(normals));
         for (int i = 0; i < normals.Length; i++)
             if (normals[i] is null)
                 throw new ArgumentNullException(nameof(normals), $"Normal vector at index {i} is null.");
 
-        var orthonormals = GramSchmidt(anchor.Dimension, normals);
-        var basis = ComputeComplement(anchor.Dimension, orthonormals);
+        T effectiveTolerance = rankTolerance ?? Epsilon;
+        var orthonormals = GramSchmidt(anchor.Dimension, normals, effectiveTolerance);
+        var basis = ComputeComplement(anchor.Dimension, orthonormals, effectiveTolerance);
         return new AffineSubspace<T>(anchor, basis);
     }
 
@@ -288,7 +355,7 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
         }
 
         var intersectionAnchor = new Vector<T>(anchorComponents);
-        var intersectionBasis = ComputeComplement(d, [.. combinedNormals]);
+        var intersectionBasis = ComputeComplement(d, [.. combinedNormals], Epsilon);
         return new AffineSubspace<T>(intersectionAnchor, intersectionBasis);
     }
 
@@ -353,7 +420,7 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
 
     /// <summary>Returns the cached orthonormal normals, computing them on first access.</summary>
     private Vector<T>[] GetOrComputeNormals()
-        => _normals ??= ComputeComplement(AmbientDimension, _basis);
+        => _normals ??= ComputeComplement(AmbientDimension, _basis, Epsilon);
 
     private void ValidateDimension(Vector<T> point)
     {
@@ -398,9 +465,14 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// </summary>
     /// <param name="ambientDimension">Expected dimension of each vector.</param>
     /// <param name="vectors">Input vectors to orthonormalize.</param>
+    /// <param name="rankTolerance">
+    /// Threshold below which a candidate's residual norm (after projecting out the directions already
+    /// accepted) is treated as zero - i.e. linearly dependent on them (see
+    /// TODO-2026-07-11-pass4.md item #50).
+    /// </param>
     /// <returns>An array of mutually orthonormal vectors spanning the same subspace.</returns>
     /// <exception cref="ArgumentException">Thrown when a vector has the wrong ambient dimension.</exception>
-    private static Vector<T>[] GramSchmidt(int ambientDimension, Vector<T>[] vectors)
+    private static Vector<T>[] GramSchmidt(int ambientDimension, Vector<T>[] vectors, T rankTolerance)
     {
         var result = new List<Vector<T>>(vectors.Length);
         foreach (var v in vectors)
@@ -418,7 +490,7 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
             }
 
             T norm = Norm(u);
-            if (norm <= Epsilon) continue;
+            if (norm <= rankTolerance) continue;
 
             for (int i = 0; i < ambientDimension; i++) u[i] /= norm;
             result.Add(new Vector<T>(u));
@@ -432,8 +504,13 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// </summary>
     /// <param name="d">Ambient space dimension.</param>
     /// <param name="orthonormals">Already-orthonormal vectors whose complement is sought.</param>
+    /// <param name="rankTolerance">
+    /// Threshold below which a candidate complement direction's residual norm is treated as zero - i.e.
+    /// already spanned by <paramref name="orthonormals"/> plus the complement directions already accepted
+    /// (see TODO-2026-07-11-pass4.md item #50).
+    /// </param>
     /// <returns>An orthonormal basis of the complement subspace.</returns>
-    private static Vector<T>[] ComputeComplement(int d, Vector<T>[] orthonormals)
+    private static Vector<T>[] ComputeComplement(int d, Vector<T>[] orthonormals, T rankTolerance)
     {
         // Project each standard basis vector out of the given orthonormal directions.
         T[][] candidates = new T[d][];
@@ -458,7 +535,7 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
                 for (int k = 0; k < d; k++) u[k] -= dot * e[k];
             }
             T norm = Norm(u);
-            if (norm <= Epsilon) continue;
+            if (norm <= rankTolerance) continue;
             for (int k = 0; k < d; k++) u[k] /= norm;
             result.Add(new Vector<T>(u));
         }

--- a/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
+++ b/Utils.Mathematics/LinearAlgebra/AffineSubspace.cs
@@ -131,10 +131,19 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
     /// Determines whether <paramref name="point"/> lies on this subspace within the given tolerance.
     /// </summary>
     /// <param name="point">Point to test.</param>
-    /// <param name="tolerance">Maximum allowable perpendicular distance.</param>
+    /// <param name="tolerance">Maximum allowable perpendicular distance. Must be finite and non-negative.</param>
     /// <returns><see langword="true"/> if the point is within <paramref name="tolerance"/> of the subspace.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="tolerance"/> is not finite or is negative: an unchecked negative
+    /// tolerance would reject even an exact member, <see langword="NaN"/> would make every comparison
+    /// false, and positive infinity would silently accept every finite-distance point as a member (see
+    /// TODO-2026-07-11-pass4.md item #48).
+    /// </exception>
     public bool Contains(Vector<T> point, T tolerance)
-        => DistanceTo(point) <= tolerance;
+    {
+        ValidateTolerance(tolerance, nameof(tolerance));
+        return DistanceTo(point) <= tolerance;
+    }
 
     /// <summary>
     /// Computes the intersection of this subspace with a line.
@@ -326,6 +335,19 @@ public sealed class AffineSubspace<T> : IEquatable<AffineSubspace<T>>, ICloneabl
         if (point.Dimension != AmbientDimension)
             throw new ArgumentException(
                 "The point must have the same ambient dimension as the subspace.", nameof(point));
+    }
+
+    /// <summary>
+    /// Validates that a caller-supplied tolerance is usable as a comparison threshold: finite and
+    /// non-negative, mirroring the same policy used elsewhere in this library (e.g.
+    /// <see cref="Vector{T}.Normalize"/>, <see cref="Matrix{T}.Invert"/>) rather than accepting a raw,
+    /// unchecked scalar (see TODO-2026-07-11-pass4.md item #48).
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tolerance"/> is not finite or is negative.</exception>
+    private static void ValidateTolerance(T tolerance, string parameterName)
+    {
+        if (!T.IsFinite(tolerance) || tolerance < T.Zero)
+            throw new ArgumentOutOfRangeException(parameterName, tolerance, "Tolerance must be finite and non-negative.");
     }
 
     /// <summary>Dot product of a raw array against a <see cref="Vector{T}"/>.</summary>

--- a/Utils.Mathematics/LinearAlgebra/Matrix.Operators.cs
+++ b/Utils.Mathematics/LinearAlgebra/Matrix.Operators.cs
@@ -96,7 +96,13 @@ public partial class Matrix<T> :
     public static Matrix<T> operator *(Matrix<T> matrix, T scalar) => scalar * matrix;
 
     /// <summary>
-    /// Divides a matrix by a scalar.
+    /// Divides a matrix by a scalar. Not validated: this raw operator performs plain component-wise IEEE
+    /// division, so a zero, near-zero, <see langword="NaN"/>, or infinite <paramref name="scalar"/>
+    /// propagates the corresponding infinity/NaN entries per <typeparamref name="T"/>'s own IEEE
+    /// semantics rather than throwing (see TODO-2026-07-11-pass4.md item #56). Higher-level members that
+    /// need a numerically reliable result validate their own denominator before reaching this operator -
+    /// e.g. <see cref="Invert"/>/<see cref="Solve"/> reject a numerically near-singular pivot - rather
+    /// than this primitive operator growing an arbitrary, undocumented "near-zero" threshold of its own.
     /// </summary>
     public static Matrix<T> operator /(Matrix<T> matrix, T scalar)
     {

--- a/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
+++ b/Utils.Mathematics/LinearAlgebra/Vector.Operators.cs
@@ -221,7 +221,16 @@ public partial class Vector<T> :
     /// Divides a vector by a scalar.
     /// </summary>
     /// <param name="vector">Vector to divide.</param>
-    /// <param name="number">Scalar value.</param>
+    /// <param name="number">
+    /// Scalar divisor. Not validated: this raw operator performs plain component-wise IEEE division, so
+    /// a zero, near-zero, <see langword="NaN"/>, or infinite divisor propagates the corresponding
+    /// infinity/NaN component per <typeparamref name="T"/>'s own IEEE semantics rather than throwing (see
+    /// TODO-2026-07-11-pass4.md item #56). Higher-level members that need a numerically reliable result
+    /// validate their own denominator before reaching this operator - e.g. <see cref="Normalize"/> rejects
+    /// a near-zero norm, and <see cref="ComputeBarycenter{TW}(Func{TW, T}, Func{TW, Vector{T}}, IEnumerable{TW})"/>
+    /// rejects a zero/non-finite total weight - rather than this primitive operator growing an arbitrary,
+    /// undocumented "near-zero" threshold of its own.
+    /// </param>
     /// <returns>The scaled vector.</returns>
     public static Vector<T> operator /(Vector<T> vector, T number)
     {

--- a/Utils.Mathematics/LinearAlgebra/VectorExtensions.cs
+++ b/Utils.Mathematics/LinearAlgebra/VectorExtensions.cs
@@ -19,15 +19,25 @@ public static class VectorExtensions
     public static T AngleWith<T>(this Vector<T> self, Vector<T> other)
         where T : struct, IFloatingPoint<T>, IRootFunctions<T>, ITrigonometricFunctions<T>
     {
+        ArgumentNullException.ThrowIfNull(self);
+        ArgumentNullException.ThrowIfNull(other);
         if (self.Dimension != other.Dimension)
             throw new ArgumentException("Vectors must have the same dimension.", nameof(other));
 
-        T normProduct = self.Norm * other.Norm;
-        if (normProduct == T.Zero)
-            throw new InvalidOperationException("Cannot compute the angle with a zero vector.");
+        // Normalize both vectors before computing the dot product: avoids norm-product overflow
+        // (two individually finite norms can still overflow when multiplied - see
+        // TODO-2026-07-11-pass6.md item #70) and naturally rejects zero/near-zero vectors via
+        // Normalize()'s scale-aware tolerance policy (item #71).
+        Vector<T> selfUnit = self.Normalize();
+        Vector<T> otherUnit = other.Normalize();
+        T cosAngle = selfUnit * otherUnit;
 
-        T cosAngle = (self * other) / normProduct;
-        // Guard against floating-point drift outside [-1, 1].
+        // A non-finite cosine after normalization means an input component was NaN or infinite;
+        // clamping it would silently return a boundary angle instead of diagnosing the bad input
+        // (see TODO-2026-07-11-pass6.md item #76). Reserve clamping only for small documented
+        // floating-point drift inside [-1, 1].
+        if (!T.IsFinite(cosAngle))
+            throw new InvalidOperationException("The angle computation produced a non-finite cosine; check that all vector components are finite.");
         cosAngle = T.Clamp(cosAngle, -T.One, T.One);
         return T.Acos(cosAngle);
     }

--- a/Utils.Mathematics/README.md
+++ b/Utils.Mathematics/README.md
@@ -146,7 +146,7 @@ float d = (float)df.Compile().DynamicInvoke(3f)!; // 7
 
 ## Vector examples
 
-`Vector<T>` is a generic immutable vector that works with any `IFloatingPoint<T>` type.
+`Vector<T>` is a generic immutable vector. The base constraint is `IFloatingPoint<T>, IRootFunctions<T>` (required for `Norm`/`Normalize`); some operations such as `AngleWith` additionally require `ITrigonometricFunctions<T>`.
 
 ### Construction and basic properties
 
@@ -205,7 +205,7 @@ var (_, weighted) = Vector<double>.ComputeBarycenter(
 
 ## Matrix examples
 
-`Matrix<T>` is a generic immutable matrix. Supports `+`, `-`, `*` (matrix/scalar/vector), `/` (scalar), inversion, LU decomposition, and determinant.
+`Matrix<T>` is a generic immutable matrix with base constraint `IFloatingPoint<T>, IRootFunctions<T>`. Supports `+`, `-`, `*` (matrix/scalar/vector), `/` (scalar), inversion, LU decomposition, and determinant. Transformation factories (`MatrixTransformations`) may additionally require `ITrigonometricFunctions<T>`.
 
 ### Construction
 

--- a/Utils.Mathematics/README.md
+++ b/Utils.Mathematics/README.md
@@ -1,6 +1,6 @@
 # omy.Utils.Mathematics (advanced math)
 
-`omy.Utils.Mathematics` offers FFTs, symbolic math helpers, SI conversions, and generic linear algebra structures used across the utility family.
+`omy.Utils.Mathematics` offers FFTs, symbolic expression transformers, polynomials, and generic linear algebra structures used across the utility family.
 
 ## Install
 ```bash
@@ -12,9 +12,9 @@ dotnet add package omy.Utils.Mathematics
 
 ## Features
 - Symbolic expression derivation and integration, including generic numeric transformers.
-- Fast Fourier Transform implementation.
-- SI unit conversions and number-to-text conversion utilities.
-- Generic vector and matrix structures for linear algebra operations.
+- Fast Fourier Transform with frequency/magnitude/phase extraction helpers.
+- Polynomial arithmetic with canonical form and symbolic calculus.
+- Generic vector and matrix structures for linear algebra (arithmetic, inversion, LU decomposition, affine subspaces, geometric transformations).
 
 ## Quick usage
 ```csharp

--- a/Utils.Mathematics/README.md
+++ b/Utils.Mathematics/README.md
@@ -20,8 +20,7 @@ dotnet add package omy.Utils.Mathematics
 ```csharp
 int[] line = Utils.Mathematics.MathEx.ComputePascalTriangleLine(4); // [1,4,6,4,1]
 Complex[] signal = [1, 1, 0, 0];
-var fft = new Utils.Mathematics.Fourrier.FastFourrierTransform();
-fft.Transform(signal);
+Utils.Mathematics.Fourier.FastFourierTransform.Transform(signal);
 ```
 
 ## MathEx — extended math utilities
@@ -79,17 +78,16 @@ MathEx.Max(3, 1, 4, 1, 5);   // 5
 
 ## FFT examples
 
-`FastFourrierTransform` performs an in-place Cooley-Tukey FFT. The input length must be a power of two.
+`FastFourierTransform` is a static class that performs an in-place Cooley-Tukey FFT. The input length must be a power of two.
 
 ### Forward transform
 
 ```csharp
 using System.Numerics;
-using Utils.Mathematics.Fourrier;
+using Utils.Mathematics.Fourier;
 
 Complex[] signal = [1, 1, 0, 0, 0, 0, 0, 0]; // 8 samples
-var fft = new FastFourrierTransform();
-fft.Transform(signal);
+FastFourierTransform.Transform(signal);
 // signal now contains the frequency-domain representation
 // only signal[0..N/2] carry unique information (Nyquist)
 ```
@@ -105,10 +103,14 @@ for (int i = 0; i < frequencies.Length; i++)
 
 ### Transform a sub-range
 
+There is no built-in sub-range overload. Extract a power-of-two slice, transform it, and copy it back:
+
 ```csharp
 Complex[] buffer = new Complex[16];
 // ... fill buffer ...
-fft.Transform(buffer, start: 4, end: 12); // transform samples [4..12)
+Complex[] subRange = buffer[4..12]; // length 8, a power of two
+FastFourierTransform.Transform(subRange);
+Array.Copy(subRange, 0, buffer, 4, subRange.Length);
 ```
 
 ## Symbolic expression examples
@@ -193,7 +195,7 @@ var a = new Vector<double>(0.0, 0.0);
 var b = new Vector<double>(4.0, 0.0);
 var c = new Vector<double>(0.0, 4.0);
 
-var (_, center) = a.ComputeBarycenter(b, c); // (1.33, 1.33)
+var (_, center) = Vector<double>.ComputeBarycenter(a, b, c); // (1.33, 1.33)
 
 // Weighted barycenter
 var (_, weighted) = Vector<double>.ComputeBarycenter(
@@ -257,7 +259,7 @@ var (L, U, P) = m.DiagonalizeLU();
 Console.WriteLine(m.Rows);          // 2
 Console.WriteLine(m.Columns);       // 2
 Console.WriteLine(m.IsSquare);      // True
-Console.WriteLine(m.IsDiagonalized); // False
+Console.WriteLine(m.IsDiagonal); // False
 ```
 
 ## MatrixTransformations examples

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -158,6 +158,20 @@ relocate, not simplify, this one-line check. Test: `AffineSubspaceTests.Contains
 
 **Priority: P1 API robustness.**
 
+**Fixed.** `FromSpan`/`FromNormals` now validate `anchor`, the `directions`/`normals` array itself, and
+every individual element (`ArgumentNullException` naming the parameter, with the offending index in the
+message for an array element) before any dereference. `Project`/`DistanceTo`/`Contains` share the private
+`ValidateDimension` helper, which now null-checks `point` first (`Contains` inherits this transitively via
+`DistanceTo`). Both `IntersectWith` overloads (`Line<T>` and `AffineSubspace<T>`) null-check their
+argument before dereferencing it. Every case previously failed through an incidental
+`NullReferenceException` deep inside a dereference (e.g. `anchor.Dimension`, `line.Dimension`,
+`other.AmbientDimension`, or `v.Dimension` inside `GramSchmidt`'s loop) instead of a precise, named
+`ArgumentNullException` at the public boundary. Test:
+`AffineSubspaceTests.FromSpan_NullAnchor_Throws`, `FromSpan_NullDirectionsArray_Throws`,
+`FromSpan_NullDirectionElement_Throws`, `FromNormals_NullAnchor_Throws`, `FromNormals_NullNormalsArray_Throws`,
+`FromNormals_NullNormalElement_Throws`, `Project_NullPoint_Throws`, `DistanceTo_NullPoint_Throws`,
+`Contains_NullPoint_Throws`, `IntersectWith_NullLine_Throws`, `IntersectWith_NullAffineSubspace_Throws`.
+
 ### 50. Affine-subspace numerical claims exceed the implemented algorithm
 
 The class remarks state that the Gram–Schmidt representation makes “all geometric operations numerically stable.” The implementation uses a fixed absolute epsilon and classical/modified projection-style operations without scale-aware tolerance, re-orthogonalization, residual reporting, or conditioning diagnostics.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -182,6 +182,24 @@ The class remarks state that the Gram–Schmidt representation makes “all geom
 
 **Priority: P1 contract accuracy.**
 
+**Fixed** (documentation corrected + explicit tolerance option; QR/SVD rewrite not adopted). The
+class-level remarks no longer claim unconditional numerical stability: they now explicitly describe the
+fixed absolute epsilon (`1e-10`) used for rank/independence decisions and tolerance-based comparisons, and
+state the known limitation (no scale-aware tolerance, no re-orthogonalization pass, no
+conditioning/residual diagnostics). `FromSpan`/`FromNormals` each gained an overload taking an explicit
+`T? rankTolerance` (validated finite/non-negative via the same `ValidateTolerance` helper added for item
+#48), threaded through to `GramSchmidt`/`ComputeComplement`'s independence checks, so a caller with
+larger-scale coordinates or intentionally near-dependent inputs can tune the threshold instead of being
+stuck with the fixed default. `IntersectWith`'s own tolerance-based comparisons are unchanged (out of this
+item's scope; item #48 already covers `Contains`'s tolerance specifically). A full QR/SVD-based robust
+rank-decomposition rewrite was **not** adopted: it would replace a well-tested, working Gram-Schmidt
+implementation with a materially different algorithm across every construction/intersection path, for a
+P1-but-not-P0 documentation-accuracy finding - a correctness-risk-for-benefit trade this pass judged not
+worth making outside a dedicated numerical-methods effort. Test:
+`AffineSubspaceTests.FromSpan_ExplicitRankTolerance_StillProducesCorrectSubspace`,
+`FromSpan_LooseRankTolerance_TreatsNearDependentDirectionAsDependent`, `FromSpan_NegativeRankTolerance_Throws`,
+`FromNormals_ExplicitRankTolerance_StillProducesCorrectSubspace`, `FromNormals_NegativeRankTolerance_Throws`.
+
 ## Medium-priority findings
 
 ### 51. Affine-subspace equality is approximate but object hashing is intentionally coarse and undocumented

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -302,6 +302,22 @@ retroactively - doing so would be a breaking change to already-published, tested
 
 **Priority: P2 terminology and correctness.**
 
+**Fixed** (renamed via alias; normalization modes/window-gain correction not adopted). Added
+`GetMagnitudes` (and updated `GetOneSidedAmplitudes`'s doc to cross-reference it) as the accurately-named
+method; `GetAmplitudes` now simply forwards to it and is kept, unchanged in behavior, for backward
+compatibility (an actual rename/removal would break the existing, tested
+`GetAmplitudes_ConstantSignal_DcBinIsN`/`GetAmplitudes_SineWave_PeakAtFrequency1` behavior and any external
+caller). Both methods' XML docs now explicitly state the returned values are raw, unnormalized FFT bin
+magnitudes, not physically normalized sinusoidal amplitudes, with a concrete example (constant signal of
+value 1 over N samples → DC-bin magnitude N, not 1). Explicit normalization modes, one-sided doubling
+rules, and window-gain correction were **not** implemented: each depends on an application-specific
+convention (forward-transform normalization choice, whether DC/Nyquist are doubled, which window function
+if any) that this general-purpose library has no basis to pick a default for, and getting the doubling
+rule subtly wrong would be worse than the current honestly-raw output; a caller with a specific convention
+in mind can already derive it by scaling `GetMagnitudes`'s output themselves. Test:
+`FastFourierTransformTests.GetMagnitudes_MatchesGetAmplitudes`, `GetMagnitudes_ConstantSignal_DcBinIsN`,
+`GetMagnitudes_NullTransform_Throws`.
+
 ### 56. Scalar vector/matrix division has no zero/non-finite policy
 
 Vector and matrix `/ scalar` operators perform direct division without checking zero, near-zero, NaN, or infinity. This is sometimes desirable at the primitive operator level, but higher-level methods inconsistently assume such operations are safe.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -326,6 +326,23 @@ Vector and matrix `/ scalar` operators perform direct division without checking 
 
 **Priority: P2 consistency.**
 
+**Fixed** (documented; no behavior change). Investigated every higher-level member that ultimately divides
+by a scalar (`Vector<T>.Normalize`, `Line<T>`'s direction normalization, `Statistics.Mean`/`Variance`,
+`ComputeBarycenter`) and confirmed each already validates its own denominator before dividing (already
+fixed by earlier items in this pass, or already present) - the only genuinely unguarded division in this
+library is the two raw operators themselves. `Vector<T> operator /` and `Matrix<T> operator /` now have
+XML docs explicitly stating they perform unchecked IEEE division (zero/near-zero/NaN/infinite divisor
+propagates the corresponding infinity/NaN per IEEE 754, not an exception) and pointing to the validated
+higher-level alternatives, matching the fix's first option exactly ("keep raw operators only with
+documented IEEE behavior and ensure higher-level algorithms validate denominators" - the latter half was
+already true, only the former half needed doing). A separate checked-division helper (the fix's
+alternative) was not added: there is no current caller that would use it, and every existing division site
+either already has (or, per items #44/#48/#50 in this same pass, now has) a validation policy suited to
+its own specific context, which a single generic "checked division" helper could not replicate without
+reintroducing the "arbitrary undocumented near-zero threshold" this pass's other items explicitly reject
+elsewhere. Test: `VectorTests.DivisionOperator_ByZero_ProducesInfinityInsteadOfThrowing`,
+`MatrixTests.DivisionOperator_ByZero_ProducesInfinityInsteadOfThrowing`.
+
 ## Additional duplicated intent to reduce
 
 - Equality/null semantics should use shared conventional operator templates across `Vector`, `Matrix`, `Polynomial`, `Line`, and `AffineSubspace`.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -212,6 +212,20 @@ worth making outside a dedicated numerical-methods effort. Test:
 
 **Priority: P2 collection performance and API semantics.**
 
+**Fixed** (documented; no code change). `GetHashCode`'s XML doc now explicitly explains this is a
+deliberate coarse hash, not an oversight: `Equals` is a tolerance-based geometric comparison (same point
+set, not same anchor/basis representation), so a canonically-derived hash consistent with it would need a
+value invariant across every representation of the same subspace *and* stable across the fixed-epsilon
+boundary where two subspaces stop comparing equal - which risks hash/equals inconsistency (equal objects
+hashing differently near a quantization boundary) if attempted naively. Neither fork of the suggested fix
+was adopted as code: switching `Equals` to exact representation-based equality would break the
+already-established, tested geometric-equality semantics (`Equals_SamePlane_DifferentAnchorAndNormal_ReturnsTrue`,
+`Equals_SpanAndNormalEquivalent_ReturnsTrue`); a canonical tolerance-aware hash was judged too easy to get
+subtly wrong for a P2 finding. The doc now also points callers who need better hash distribution at a
+dedicated `IEqualityComparer<T>` keyed by an application-specific canonical representation instead. Test:
+`AffineSubspaceTests.GetHashCode_EqualSubspacesWithDifferentAnchorAndNormalScale_HaveSameHash` (the
+concrete equal-implies-same-hash contract check this finding's risk section calls out).
+
 ### 52. `AffineSubspace<T>.IFormattable` ignores formatting inputs
 
 The format and provider parameters are documented as unused. This repeats the misleading `IFormattable` contract already present on `Line<T>` and matrix formatting inconsistencies.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -271,6 +271,29 @@ is not a meaningful FFT result. Test: `FastFourierTransformTests.GetFrequencies_
 
 **Priority: P2 signal-processing contract.**
 
+**Fixed** (additive; legacy methods unchanged). Added exactly the APIs the fix text names:
+- `GetAllBinFrequencies(transform, sampleRate)` returns `N` frequencies (length-matched with
+  `GetAmplitudes`/`GetPhases`), using the standard (NumPy `fftfreq`-style) convention: positive frequency
+  for bins below `ceil(N/2)`, negative (aliased) frequency for the rest - so an even-length transform's
+  Nyquist bin is reported as the negative Nyquist frequency.
+- `GetOneSidedFrequencies(transform, sampleRate, includeNyquist = false)` / `GetOneSidedAmplitudes(transform, includeNyquist = false)` /
+  `GetOneSidedPhases(transform, includeNyquist = false)` share one private `GetOneSidedBinCount` helper for
+  their bin count, so the three can never drift apart the way `GetFrequencies` vs
+  `GetAmplitudes`/`GetPhases` did. Odd-length behavior is explicitly defined: an odd-length transform has
+  no separate Nyquist bin (its highest one-sided bin is already a genuine positive frequency), so
+  `includeNyquist` has no effect in that case - documented on `GetOneSidedBinCount`.
+
+The original `GetFrequencies`/`GetAmplitudes`/`GetPhases` are unchanged (beyond item #53's validation): they
+remain for backward compatibility, and this pass does not attempt to reconcile their differing bin counts
+retroactively - doing so would be a breaking change to already-published, tested behavior. Test:
+`FastFourierTransformTests.GetAllBinFrequencies_EightBinTransform_MatchesFftfreqConvention`,
+`GetAllBinFrequencies_MatchesAmplitudesAndPhasesBinCount`,
+`GetOneSidedFrequencies_EvenLengthDefault_ExcludesNyquistAndMatchesLegacyGetFrequencies`,
+`GetOneSidedFrequencies_EvenLengthIncludeNyquist_AddsNyquistBin`,
+`GetOneSidedFrequencies_OddLength_IncludeNyquistHasNoEffect`,
+`GetOneSidedAmplitudesAndPhases_MatchOneSidedFrequenciesBinCount`, `GetOneSidedAmplitudes_SineWave_PeakAtFrequency1`,
+`GetAllBinFrequencies_NullTransform_Throws`, `GetOneSidedFrequencies_EmptyTransform_Throws`.
+
 ### 55. “Amplitude” helpers return raw magnitudes without FFT normalization policy
 
 `GetAmplitudes` returns `Complex.Magnitude` directly. Depending on forward-transform normalization, signal length, one-sided conversion, and window coherent gain, these are raw spectral magnitudes rather than physical sinusoidal amplitudes.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -234,6 +234,14 @@ The format and provider parameters are documented as unused. This repeats the mi
 
 **Priority: P2 API quality.**
 
+**Fixed** (implemented propagation). `ToString(format, formatProvider)` now formats `Anchor`'s components
+individually via a new private `FormatVector` helper, mirroring the exact pattern already used - and
+already working correctly - by `Line<T>.ToString(string?, IFormatProvider?)` (`Vector<T>` itself does not
+implement `IFormattable`, so each coordinate's own `ToString(format, formatProvider)` is called directly).
+`IFormattable` was not removed: this fix makes the contract genuinely meaningful instead of a no-op, so
+there is no longer a reason to remove it. Test: `AffineSubspaceTests.ToString_WithFormat_AppliesFormatToAnchorCoordinates`,
+`ToString_WithCulture_UsesCultureSpecificDecimalSeparator`.
+
 ### 53. Fourier metadata extensions do not validate null, empty, or non-finite inputs
 
 All methods dereference `transform` without null guards. `GetFrequencies` accepts `NaN` and positive infinity because only `sampleRate <= 0` is checked. For an empty transform, it computes `sampleRate / 0`; the resulting infinity is unused because the output is empty, silently accepting an invalid transform length.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -139,6 +139,17 @@ target and throw, even though they are trivially identifiable by instance. Test:
 
 **Priority: P1 API correctness.**
 
+**Fixed.** `Contains(point, tolerance)` now validates `tolerance` via a new private `ValidateTolerance`
+helper (finite and non-negative), mirroring the same policy already used elsewhere in this library (e.g.
+`Vector<T>.Normalize`, `Matrix<T>.Invert`), throwing `ArgumentOutOfRangeException` for a negative, `NaN`,
+or positive-infinity tolerance instead of silently rejecting/accepting every point. A dedicated shared
+tolerance/options type (the fix's alternative suggestion) was not introduced: every tolerance parameter in
+this library already follows this exact same "finite and non-negative" contract via a small private
+per-type helper (`Vector<T>`, `Matrix<T>`, and now `AffineSubspace<T>`), so a shared type would only
+relocate, not simplify, this one-line check. Test: `AffineSubspaceTests.Contains_NegativeTolerance_Throws`,
+`Contains_NaNTolerance_Throws`, `Contains_PositiveInfinityTolerance_Throws`,
+`Contains_ZeroToleranceExactMember_ReturnsTrue`.
+
 ### 49. Affine-subspace factories and operations lack null-member validation
 
 `FromSpan`, `FromNormals`, `Project`, `IntersectWith`, and related paths assume non-null anchors, arrays, direction/normal vectors, lines, and subspaces. Null values fail through incidental dereferences, often before the documented dimension validation.

--- a/Utils.Mathematics/TODO-2026-07-11-pass4.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass4.md
@@ -250,6 +250,17 @@ All methods dereference `transform` without null guards. `GetFrequencies` accept
 
 **Priority: P2 API robustness.**
 
+**Fixed.** A shared `ValidateTransform` helper (non-null, non-empty) is now called at the top of
+`GetFrequencies`, `GetAmplitudes`, and `GetPhases`. `GetFrequencies`'s `sampleRate` check now also rejects
+`NaN`/infinity (`!double.IsFinite(sampleRate) || sampleRate <= 0`, instead of just `sampleRate <= 0`,
+which let `NaN` through since `NaN <= 0` is `false`). An empty transform is now explicitly rejected
+(`ArgumentException`) rather than silently computing an unused `sampleRate / 0` infinity and returning an
+empty array - aligning with the fix's "align with FFT requirements" option, since a zero-length transform
+is not a meaningful FFT result. Test: `FastFourierTransformTests.GetFrequencies_NaNSampleRate_Throws`,
+`GetFrequencies_PositiveInfinitySampleRate_Throws`, `GetFrequencies_NullTransform_Throws`,
+`GetFrequencies_EmptyTransform_Throws`, `GetAmplitudes_NullTransform_Throws`, `GetAmplitudes_EmptyTransform_Throws`,
+`GetPhases_NullTransform_Throws`, `GetPhases_EmptyTransform_Throws`.
+
 ### 54. One-sided frequency-bin semantics are incomplete for real signals
 
 `GetFrequencies` returns exactly `N/2` bins. For an even-length real-signal FFT, the conventional non-negative spectrum contains `N/2 + 1` bins including the Nyquist bin. The method omits it while `GetAmplitudes` and `GetPhases` return all `N` bins.

--- a/Utils.Mathematics/TODO-2026-07-11-pass6.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass6.md
@@ -78,6 +78,22 @@ Examples refer to:
 
 **Priority: P1 public documentation correctness.**
 
+**Fixed** (README corrected). All six defects were corrected directly in `README.md`:
+- The quick-usage snippet and the FFT "Forward transform" section now use the correct namespace
+  (`Utils.Mathematics.Fourier`) and call the static method directly
+  (`FastFourierTransform.Transform(signal)`) rather than instantiating with `new`.
+- The "Transform a sub-range" section's `fft.Transform(buffer, start: 4, end: 12)` call
+  (referencing a nonexistent overload) was replaced with an explanation that no built-in
+  sub-range overload exists, and a working copy-extract-copy pattern using the public
+  `Transform(Complex[])` overload.
+- `a.ComputeBarycenter(b, c)` (instance-method call on a static API) was corrected to
+  `Vector<double>.ComputeBarycenter(a, b, c)`.
+- `m.IsDiagonalized` (nonexistent property) was corrected to `m.IsDiagonal`.
+- The intro text "FastFourrierTransform performs…" was updated to "FastFourierTransform is a
+  static class that performs…". The CI/sample-project compilation approach was not adopted:
+  there is no existing CI pipeline or sample project infrastructure in this repository, and
+  setting one up is a dedicated infrastructure effort beyond the scope of a documentation fix.
+
 ### 74. README transformation examples advertise behavior known to be incorrect
 
 The README demonstrates translation and composition with column-vector multiplication, but the current translation factory places coefficients in the wrong row. It also documents a shear example based on the broken `Skew` parameter mapping.

--- a/Utils.Mathematics/TODO-2026-07-11-pass6.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass6.md
@@ -12,6 +12,23 @@ The method computes `self.Norm * other.Norm` before division. Two finite norms c
 
 **Priority: P1 numerical correctness.**
 
+**Fixed** (items #70, #71, #76 addressed together in `VectorExtensions.AngleWith`). The method now
+normalizes both vectors via `Normalize()` before computing the dot product, instead of computing
+`self.Norm * other.Norm` directly: two individually finite norms can overflow when multiplied (a
+vector with norm `double.MaxValue / √2` in each axis makes the product infinity), while the
+normalized unit-vector dot product is always in `[-1, 1]` for finite inputs with no overflow risk.
+`Normalize()` already encodes the shared scale-aware zero/near-zero tolerance policy (see
+`DefaultNormTolerance`), so the exact-zero detection (`normProduct == T.Zero`) is replaced by
+that policy, catching a larger class of negligible vectors. `ArgumentNullException.ThrowIfNull`
+guards are added for both operands (item #71; the previous code would fail with
+`NullReferenceException` on the first member access). The finiteness check before clamping (item
+#76) rejects a `NaN` cosine (e.g. from a `NaN`-component vector that survives `Normalize()` and
+produces a `NaN` dot product) instead of silently clamping it to a boundary angle. A `TryAngleWith`
+variant (the suggestion from item #71) was not added: there are no callers that would consume it,
+and the existing `InvalidOperationException` from `Normalize()` already provides a contextual
+message. Test: `VectorTests.AngleWith_NullSelf_Throws`, `AngleWith_NullOther_Throws`,
+`AngleWith_LargeParallelVectors_ReturnsZero` (the concrete overflow regression), `AngleWith_NaNComponent_Throws`.
+
 ### 71. `AngleWith` has only exact zero-vector detection
 
 A near-zero vector passes `normProduct == 0` and may produce a meaningless angle dominated by rounding. Null operands also fail through incidental dereferences.
@@ -19,6 +36,8 @@ A near-zero vector passes `normProduct == 0` and may produce a meaningless angle
 **Fix:** validate nulls explicitly and use the shared scale-aware zero/tolerance policy. Consider a `TryAngleWith` result for degenerate vectors.
 
 **Priority: P1 API and numerical correctness.**
+
+**Fixed** (see item #70 above — items #70, #71, and #76 were all addressed in the same `AngleWith` rewrite).
 
 ### 72. LU and inverse APIs return matrices with unreliable structural metadata
 
@@ -74,6 +93,8 @@ The guide states `L * U == m`. With partial pivoting, the proper contract normal
 **Fix:** validate finiteness before clamping and reserve clamping for small documented floating-point drift.
 
 **Priority: P2 diagnostics.**
+
+**Fixed** (see item #70 above — items #70, #71, and #76 were all addressed in the same `AngleWith` rewrite).
 
 ### 77. Package metadata advertises SI conversions and number-to-text features not present in this project
 

--- a/Utils.Mathematics/TODO-2026-07-11-pass6.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass6.md
@@ -181,6 +181,14 @@ Many mathematically sensitive examples state expected results only in comments. 
 
 **Priority: P2 test/documentation architecture.**
 
+**Not adopted.** Maintaining README examples as executable tests requires a dedicated sample
+project or a doctest infrastructure neither of which exists in this repository. The existing
+unit-test suite already covers the public API at a fine-grained level (the API-drift defects
+fixed in items #73–#78 were caught by this audit pass, not by missing tests per se). The risk
+this item identifies is real, but the mitigation is an infrastructure investment outside the
+scope of this audit-fix cycle. Left as a known, documented trade-off for a future CI/docs
+engineering effort.
+
 ## Additional duplicated intent to reduce
 
 - Stable vector norm, angle, normalization, projection, and line-distance logic should share one rescaling/degeneracy implementation.

--- a/Utils.Mathematics/TODO-2026-07-11-pass6.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass6.md
@@ -167,6 +167,12 @@ adding a reference there is out of scope for this finding.
 
 **Priority: P2 generic API documentation.**
 
+**Fixed** (README corrected). The Vector and Matrix section headers now state the actual base
+constraint (`IFloatingPoint<T>, IRootFunctions<T>`) and call out that some operations (e.g.
+`AngleWith`, rotation/skew factory methods in `MatrixTransformations`) additionally require
+`ITrigonometricFunctions<T>`. The previous claim “works with any `IFloatingPoint<T>`” was simply
+replaced with the accurate constraint text.
+
 ### 79. README examples rely on comments instead of executable result assertions
 
 Many mathematically sensitive examples state expected results only in comments. This allowed API drift and incorrect transformation/LU claims to remain undetected.

--- a/Utils.Mathematics/TODO-2026-07-11-pass6.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass6.md
@@ -150,6 +150,15 @@ The README and package description mention SI conversions and number-to-text con
 
 **Priority: P2 packaging quality.**
 
+**Fixed** (README corrected). The opening description now reads "FFTs, symbolic expression
+transformers, polynomials, and generic linear algebra structures" (replacing the incorrect "FFTs,
+symbolic math helpers, **SI conversions**, and generic linear algebra structures"). The Features
+list was also rewritten: "SI unit conversions and number-to-text conversion utilities" (which live
+in `omy.Utils.NumberToString`, not this package) was replaced with accurate entries for Fourier
+metadata helpers and polynomial arithmetic. The Related packages section at the bottom was left
+unchanged — it references `omy.Utils.Imaging` and `omy.Utils` but not `omy.Utils.NumberToString`;
+adding a reference there is out of scope for this finding.
+
 ### 78. README says vector/matrix support “any `IFloatingPoint<T>`” while actual constraints are stronger
 
 `Vector<T>` and `Matrix<T>` additionally require `IRootFunctions<T>`, and some APIs require trigonometric or power interfaces. The simplified claim hides capability boundaries that matter for generic consumers.

--- a/Utils.Mathematics/TODO-2026-07-11-pass6.md
+++ b/Utils.Mathematics/TODO-2026-07-11-pass6.md
@@ -49,6 +49,18 @@ Because non-null cached flags suppress recomputation, these are semantic results
 
 **Priority: P1 object-state correctness.**
 
+**Already fixed** by TODO-pass5.md items #61, #68, and #69. `DiagonalizeLU` (`Matrix.Compute.cs`)
+constructs `L` with `isTriangular: true` (mathematically guaranteed — unit lower triangular by
+construction) and `T.One` as determinant, and passes `null` for `isIdentity`/`isDiagonal`/`U`'s
+`isIdentity`/`isDiagonal`/`P`'s `isIdentity`/`isTriangular`/`isDiagonal`, deferring to lazy
+recomputation for all flags that depend on the actual computed values (e.g. `P` is exactly the
+identity when no pivot swaps occurred — hardcoded `false` could never report this). `Invert`
+passes `null` for all four structural parameters (`isIdentity`, `isTriangular`, `isDiagonal`,
+`determinant`), replacing the previously hardcoded `false` values. The test
+`MatrixTests.Invert_DiagonalMatrix_ResultReportsDiagonalAndTriangular` verifies that the inverse
+of a diagonal matrix now correctly reports diagonal and triangular. No production or test code
+changed for this item; verified by re-reading `Matrix.Compute.cs`.
+
 ### 73. The README publishes multiple examples that do not compile against the current API
 
 Examples refer to:
@@ -76,6 +88,15 @@ The README demonstrates translation and composition with column-vector multiplic
 
 **Priority: P1 deployment/documentation safety.**
 
+**Already fixed** (production code). `MatrixTransformations.Translation<T>` stores translation
+values in the last column (`array[i, lastColumn] = valuesArray[i]`) — correct for the
+column-vector multiplication convention used throughout this library (`M * v`). The README
+example showing `combined * inHomogeneous` is consistent with this convention. `Skew<T>` iterates
+all off-diagonal positions of the base block in row-major order (rows 0..d-1, skipping the
+diagonal), which is a well-defined, documented parameter mapping. This finding was presumably
+based on an earlier defective implementation that was corrected by a prior pass. No production or
+test code changed for this item; verified by re-reading `MatrixTransformations.cs`.
+
 ### 75. README LU identity assertion is false for pivoted decompositions and the current implementation
 
 The guide states `L * U == m`. With partial pivoting, the proper contract normally includes a permutation (`P * A = L * U`), and the current implementation does not construct a valid `L` anyway.
@@ -83,6 +104,13 @@ The guide states `L * U == m`. With partial pivoting, the proper contract normal
 **Fix:** replace the tuple API with a decomposition result exposing `P`, `L`, `U`, pivot indices, rank/status, and residual validation. Update examples only after the decomposition is corrected.
 
 **Priority: P1 mathematical contract.**
+
+**Already fixed** (README and API). `DiagonalizeLU()` already returns `(Matrix<T> L, Matrix<T> U, Matrix<T> P)` satisfying `P·A = L·U` (corrected by TODO-pass5.md items #57/#58/#69). The README
+already reflects this: the example shows `var (L, U, P) = m.DiagonalizeLU(); // P * m == L * U`.
+A dedicated decomposition result object (`P`, pivot indices, rank/status, residual validation) was
+not introduced: the current tuple API is publicly established and the fix's recommendation was
+framed in the context of a broken implementation that no longer exists. No production or test code
+changed for this item; verified by re-reading `Matrix.Compute.cs` and `README.md`.
 
 ## Medium-priority findings
 

--- a/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
+++ b/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
@@ -132,6 +132,66 @@ public class FastFourierTransformTests
         Assert.ThrowsException<ArgumentOutOfRangeException>(() => samples.GetFrequencies(0));
     }
 
+    // ── Null/empty/non-finite validation (TODO-pass4 item #53) ─────────────────
+
+    [TestMethod]
+    public void GetFrequencies_NaNSampleRate_Throws()
+    {
+        // Previously only "sampleRate <= 0" was checked, silently accepting NaN (NaN <= 0 is false).
+        Complex[] samples = [1, 1, 1, 1];
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => samples.GetFrequencies(double.NaN));
+    }
+
+    [TestMethod]
+    public void GetFrequencies_PositiveInfinitySampleRate_Throws()
+    {
+        Complex[] samples = [1, 1, 1, 1];
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => samples.GetFrequencies(double.PositiveInfinity));
+    }
+
+    [TestMethod]
+    public void GetFrequencies_NullTransform_Throws()
+    {
+        Complex[] transform = null!;
+        Assert.ThrowsException<ArgumentNullException>(() => transform.GetFrequencies(8));
+    }
+
+    [TestMethod]
+    public void GetFrequencies_EmptyTransform_Throws()
+    {
+        // Previously computed sampleRate / 0 (an unused infinity) and silently returned an empty array.
+        Complex[] transform = [];
+        Assert.ThrowsException<ArgumentException>(() => transform.GetFrequencies(8));
+    }
+
+    [TestMethod]
+    public void GetAmplitudes_NullTransform_Throws()
+    {
+        Complex[] transform = null!;
+        Assert.ThrowsException<ArgumentNullException>(() => transform.GetAmplitudes());
+    }
+
+    [TestMethod]
+    public void GetAmplitudes_EmptyTransform_Throws()
+    {
+        Complex[] transform = [];
+        Assert.ThrowsException<ArgumentException>(() => transform.GetAmplitudes());
+    }
+
+    [TestMethod]
+    public void GetPhases_NullTransform_Throws()
+    {
+        Complex[] transform = null!;
+        Assert.ThrowsException<ArgumentNullException>(() => transform.GetPhases());
+    }
+
+    [TestMethod]
+    public void GetPhases_EmptyTransform_Throws()
+    {
+        Complex[] transform = [];
+        Assert.ThrowsException<ArgumentException>(() => transform.GetPhases());
+    }
+
     [TestMethod]
     public void GetAmplitudes_ConstantSignal_DcBinIsN()
     {

--- a/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
+++ b/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
@@ -192,6 +192,97 @@ public class FastFourierTransformTests
         Assert.ThrowsException<ArgumentException>(() => transform.GetPhases());
     }
 
+    // ── One-sided / all-bin spectrum APIs (TODO-pass4 item #54) ────────────────
+
+    [TestMethod]
+    public void GetAllBinFrequencies_EightBinTransform_MatchesFftfreqConvention()
+    {
+        // N=8, sampleRate=8 → step=1. Positive bins 0..3, negative (aliased) bins -4..-1 for 4..7.
+        Complex[] transform = new Complex[8];
+        double[] frequencies = transform.GetAllBinFrequencies(8);
+        CollectionAssert.AreEqual(new double[] { 0, 1, 2, 3, -4, -3, -2, -1 }, frequencies);
+    }
+
+    [TestMethod]
+    public void GetAllBinFrequencies_MatchesAmplitudesAndPhasesBinCount()
+    {
+        Complex[] transform = new Complex[8];
+        Assert.AreEqual(transform.GetAmplitudes().Length, transform.GetAllBinFrequencies(8).Length);
+        Assert.AreEqual(transform.GetPhases().Length, transform.GetAllBinFrequencies(8).Length);
+    }
+
+    [TestMethod]
+    public void GetOneSidedFrequencies_EvenLengthDefault_ExcludesNyquistAndMatchesLegacyGetFrequencies()
+    {
+        Complex[] transform = new Complex[8];
+        CollectionAssert.AreEqual(transform.GetFrequencies(8), transform.GetOneSidedFrequencies(8));
+    }
+
+    [TestMethod]
+    public void GetOneSidedFrequencies_EvenLengthIncludeNyquist_AddsNyquistBin()
+    {
+        // N=8, sampleRate=8 → Nyquist bin (index 4) is frequency 4.
+        Complex[] transform = new Complex[8];
+        double[] frequencies = transform.GetOneSidedFrequencies(8, includeNyquist: true);
+        CollectionAssert.AreEqual(new double[] { 0, 1, 2, 3, 4 }, frequencies);
+    }
+
+    [TestMethod]
+    public void GetOneSidedFrequencies_OddLength_IncludeNyquistHasNoEffect()
+    {
+        // N=7 has no separate Nyquist bin: both calls return the same 4 bins.
+        Complex[] transform = new Complex[7];
+        double[] withoutNyquist = transform.GetOneSidedFrequencies(7);
+        double[] withNyquist = transform.GetOneSidedFrequencies(7, includeNyquist: true);
+        CollectionAssert.AreEqual(new double[] { 0, 1, 2, 3 }, withoutNyquist);
+        CollectionAssert.AreEqual(withoutNyquist, withNyquist);
+    }
+
+    [TestMethod]
+    public void GetOneSidedAmplitudesAndPhases_MatchOneSidedFrequenciesBinCount()
+    {
+        int n = 8;
+        Complex[] samples = new Complex[n];
+        for (int i = 0; i < n; i++)
+            samples[i] = Math.Sin(2 * Math.PI * i / n);
+        FastFourierTransform.Transform(samples);
+
+        Assert.AreEqual(samples.GetOneSidedFrequencies(n).Length, samples.GetOneSidedAmplitudes().Length);
+        Assert.AreEqual(samples.GetOneSidedFrequencies(n).Length, samples.GetOneSidedPhases().Length);
+        Assert.AreEqual(
+            samples.GetOneSidedFrequencies(n, includeNyquist: true).Length,
+            samples.GetOneSidedAmplitudes(includeNyquist: true).Length);
+    }
+
+    [TestMethod]
+    public void GetOneSidedAmplitudes_SineWave_PeakAtFrequency1()
+    {
+        int n = 8;
+        Complex[] samples = new Complex[n];
+        for (int i = 0; i < n; i++)
+            samples[i] = Math.Sin(2 * Math.PI * i / n);
+        FastFourierTransform.Transform(samples);
+
+        double[] amplitudes = samples.GetOneSidedAmplitudes();
+        Assert.AreEqual(4, amplitudes.Length);
+        Assert.AreEqual(4.0, amplitudes[1], Delta);
+        Assert.AreEqual(0.0, amplitudes[0], Delta);
+    }
+
+    [TestMethod]
+    public void GetAllBinFrequencies_NullTransform_Throws()
+    {
+        Complex[] transform = null!;
+        Assert.ThrowsException<ArgumentNullException>(() => transform.GetAllBinFrequencies(8));
+    }
+
+    [TestMethod]
+    public void GetOneSidedFrequencies_EmptyTransform_Throws()
+    {
+        Complex[] transform = [];
+        Assert.ThrowsException<ArgumentException>(() => transform.GetOneSidedFrequencies(8));
+    }
+
     [TestMethod]
     public void GetAmplitudes_ConstantSignal_DcBinIsN()
     {

--- a/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
+++ b/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
@@ -326,6 +326,39 @@ public class FastFourierTransformTests
             Assert.AreEqual(0.0, amplitudes[k], Delta, $"bin {k}");
     }
 
+    // ── GetMagnitudes (TODO-pass4 item #55) ─────────────────────────────────────
+
+    /// <summary>
+    /// <see cref="FourierExtensions.GetMagnitudes"/> is an identically-behaving, more accurately-named
+    /// alias for <see cref="FourierExtensions.GetAmplitudes"/> ("amplitude" implies a physically
+    /// normalized value; this is the raw FFT bin magnitude).
+    /// </summary>
+    [TestMethod]
+    public void GetMagnitudes_MatchesGetAmplitudes()
+    {
+        Complex[] samples = [1, 1, 1, 1];
+        FastFourierTransform.Transform(samples);
+
+        CollectionAssert.AreEqual(samples.GetAmplitudes(), samples.GetMagnitudes());
+    }
+
+    [TestMethod]
+    public void GetMagnitudes_ConstantSignal_DcBinIsN()
+    {
+        Complex[] samples = [1, 1, 1, 1];
+        FastFourierTransform.Transform(samples);
+
+        double[] magnitudes = samples.GetMagnitudes();
+        Assert.AreEqual(4.0, magnitudes[0], Delta);
+    }
+
+    [TestMethod]
+    public void GetMagnitudes_NullTransform_Throws()
+    {
+        Complex[] transform = null!;
+        Assert.ThrowsException<ArgumentNullException>(() => transform.GetMagnitudes());
+    }
+
     // ── InverseTransform ──────────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
+++ b/UtilsTest/Mathematics/Fourier/FastFourierTransformTests.cs
@@ -359,6 +359,18 @@ public class FastFourierTransformTests
         Assert.ThrowsException<ArgumentNullException>(() => transform.GetMagnitudes());
     }
 
+    [TestMethod]
+    public void GetOneSidedMagnitudes_MatchesGetOneSidedAmplitudes()
+    {
+        Complex[] samples = [1, 1, 1, 1];
+        FastFourierTransform.Transform(samples);
+
+        CollectionAssert.AreEqual(samples.GetOneSidedAmplitudes(), samples.GetOneSidedMagnitudes());
+        CollectionAssert.AreEqual(
+            samples.GetOneSidedAmplitudes(includeNyquist: true),
+            samples.GetOneSidedMagnitudes(includeNyquist: true));
+    }
+
     // ── InverseTransform ──────────────────────────────────────────────────────
 
     [TestMethod]

--- a/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
@@ -186,6 +186,40 @@ public class AffineSubspaceTests
         Assert.IsFalse(plane.Contains(V(0, 0, 0.1), 1e-9));
     }
 
+    // ── Contains tolerance validation (TODO-pass4 item #48) ─────────────────────
+
+    [TestMethod]
+    public void Contains_NegativeTolerance_Throws()
+    {
+        var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => plane.Contains(V(3, 4, 0), -1e-9));
+    }
+
+    [TestMethod]
+    public void Contains_NaNTolerance_Throws()
+    {
+        var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => plane.Contains(V(3, 4, 0), double.NaN));
+    }
+
+    /// <summary>
+    /// Before this fix, positive infinity silently made every finite-distance point a "member" of the
+    /// subspace instead of being rejected like the rest of this library's tolerance parameters.
+    /// </summary>
+    [TestMethod]
+    public void Contains_PositiveInfinityTolerance_Throws()
+    {
+        var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => plane.Contains(V(3, 4, 100), double.PositiveInfinity));
+    }
+
+    [TestMethod]
+    public void Contains_ZeroToleranceExactMember_ReturnsTrue()
+    {
+        var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        Assert.IsTrue(plane.Contains(V(3, 4, 0), 0d));
+    }
+
     // -------------------------------------------------------------------------
     // IntersectWith(Line<T>)
     // -------------------------------------------------------------------------

--- a/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
@@ -480,4 +480,41 @@ public class AffineSubspaceTests
         var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
         Assert.ThrowsException<ArgumentNullException>(() => plane.IntersectWith((AffineSubspace<double>)null!));
     }
+
+    // -------------------------------------------------------------------------
+    // Explicit rank tolerance (TODO-pass4 item #50)
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public void FromSpan_ExplicitRankTolerance_StillProducesCorrectSubspace()
+    {
+        var s = AffineSubspace<double>.FromSpan(V(0, 0, 0), 1e-6, V(1, 0, 0), V(0, 1, 0));
+        Assert.AreEqual(2, s.Dimension);
+    }
+
+    [TestMethod]
+    public void FromSpan_LooseRankTolerance_TreatsNearDependentDirectionAsDependent()
+    {
+        // A direction that is only slightly off collinear with the first one is treated as dependent
+        // when the caller supplies a looser tolerance than the tiny default epsilon.
+        var s = AffineSubspace<double>.FromSpan(V(0, 0, 0), 1e-3, V(1, 0, 0), V(1, 1e-6, 0));
+        Assert.AreEqual(1, s.Dimension);
+    }
+
+    [TestMethod]
+    public void FromSpan_NegativeRankTolerance_Throws()
+        => Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => AffineSubspace<double>.FromSpan(V(0, 0, 0), -1e-9, V(1, 0, 0)));
+
+    [TestMethod]
+    public void FromNormals_ExplicitRankTolerance_StillProducesCorrectSubspace()
+    {
+        var s = AffineSubspace<double>.FromNormals(V(0, 0, 0), 1e-6, V(0, 0, 1));
+        Assert.AreEqual(2, s.Dimension);
+    }
+
+    [TestMethod]
+    public void FromNormals_NegativeRankTolerance_Throws()
+        => Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => AffineSubspace<double>.FromNormals(V(0, 0, 0), -1e-9, V(0, 0, 1)));
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
@@ -534,4 +534,30 @@ public class AffineSubspaceTests
     public void FromNormals_NegativeRankTolerance_Throws()
         => Assert.ThrowsException<ArgumentOutOfRangeException>(
             () => AffineSubspace<double>.FromNormals(V(0, 0, 0), -1e-9, V(0, 0, 1)));
+
+    // -------------------------------------------------------------------------
+    // ToString format/provider propagation (TODO-pass4 item #52)
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public void ToString_WithFormat_AppliesFormatToAnchorCoordinates()
+    {
+        var s = AffineSubspace<double>.FromNormals(V(1.23456, 2.5, 0), V(0, 0, 1));
+
+        string formatted = s.ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
+
+        StringAssert.Contains(formatted, "1.23");
+        StringAssert.Contains(formatted, "2.50");
+    }
+
+    [TestMethod]
+    public void ToString_WithCulture_UsesCultureSpecificDecimalSeparator()
+    {
+        var s = AffineSubspace<double>.FromNormals(V(1.5, 0, 0), V(0, 0, 1));
+        var culture = new System.Globalization.CultureInfo("fr-FR");
+
+        string formatted = s.ToString("F1", culture);
+
+        StringAssert.Contains(formatted, "1,5");
+    }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
@@ -411,4 +411,73 @@ public class AffineSubspaceTests
         Assert.IsTrue(original.Equals(clone));
         Assert.IsFalse(ReferenceEquals(original, clone));
     }
+
+    // -------------------------------------------------------------------------
+    // Null-member validation (TODO-pass4 item #49)
+    // -------------------------------------------------------------------------
+
+    [TestMethod]
+    public void FromSpan_NullAnchor_Throws()
+        => Assert.ThrowsException<ArgumentNullException>(
+            () => AffineSubspace<double>.FromSpan(null!, V(1, 0, 0)));
+
+    [TestMethod]
+    public void FromSpan_NullDirectionsArray_Throws()
+        => Assert.ThrowsException<ArgumentNullException>(
+            () => AffineSubspace<double>.FromSpan(V(0, 0, 0), (Vector<double>[])null!));
+
+    [TestMethod]
+    public void FromSpan_NullDirectionElement_Throws()
+        => Assert.ThrowsException<ArgumentNullException>(
+            () => AffineSubspace<double>.FromSpan(V(0, 0, 0), V(1, 0, 0), null!));
+
+    [TestMethod]
+    public void FromNormals_NullAnchor_Throws()
+        => Assert.ThrowsException<ArgumentNullException>(
+            () => AffineSubspace<double>.FromNormals(null!, V(0, 0, 1)));
+
+    [TestMethod]
+    public void FromNormals_NullNormalsArray_Throws()
+        => Assert.ThrowsException<ArgumentNullException>(
+            () => AffineSubspace<double>.FromNormals(V(0, 0, 0), (Vector<double>[])null!));
+
+    [TestMethod]
+    public void FromNormals_NullNormalElement_Throws()
+        => Assert.ThrowsException<ArgumentNullException>(
+            () => AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1), null!));
+
+    [TestMethod]
+    public void Project_NullPoint_Throws()
+    {
+        var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        Assert.ThrowsException<ArgumentNullException>(() => plane.Project(null!));
+    }
+
+    [TestMethod]
+    public void DistanceTo_NullPoint_Throws()
+    {
+        var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        Assert.ThrowsException<ArgumentNullException>(() => plane.DistanceTo(null!));
+    }
+
+    [TestMethod]
+    public void Contains_NullPoint_Throws()
+    {
+        var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        Assert.ThrowsException<ArgumentNullException>(() => plane.Contains(null!, 1e-9));
+    }
+
+    [TestMethod]
+    public void IntersectWith_NullLine_Throws()
+    {
+        var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        Assert.ThrowsException<ArgumentNullException>(() => plane.IntersectWith((Line<double>)null!));
+    }
+
+    [TestMethod]
+    public void IntersectWith_NullAffineSubspace_Throws()
+    {
+        var plane = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        Assert.ThrowsException<ArgumentNullException>(() => plane.IntersectWith((AffineSubspace<double>)null!));
+    }
 }

--- a/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/AffineSubspaceTests.cs
@@ -399,6 +399,23 @@ public class AffineSubspaceTests
         Assert.IsTrue(fromSpan.Equals(fromNormals));
     }
 
+    // ── GetHashCode consistency (TODO-pass4 item #51) ───────────────────────────
+
+    /// <summary>
+    /// The required equal-implies-same-hash contract must hold even though <see cref="AffineSubspace{T}.GetHashCode"/>
+    /// is deliberately coarser than <see cref="AffineSubspace{T}.Equals(AffineSubspace{T})"/> (see this
+    /// type's XML doc on <c>GetHashCode</c>): two geometrically identical subspaces built from different
+    /// anchors/normal scales must still hash identically.
+    /// </summary>
+    [TestMethod]
+    public void GetHashCode_EqualSubspacesWithDifferentAnchorAndNormalScale_HaveSameHash()
+    {
+        var a = AffineSubspace<double>.FromNormals(V(0, 0, 0), V(0, 0, 1));
+        var b = AffineSubspace<double>.FromNormals(V(5, -3, 0), V(0, 0, 2));
+        Assert.IsTrue(a.Equals(b));
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
     // -------------------------------------------------------------------------
     // Clone
     // -------------------------------------------------------------------------

--- a/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/MatrixTests.cs
@@ -748,6 +748,24 @@ namespace UtilsTest.Mathematics.LinearAlgebra
             Assert.ThrowsException<ArgumentException>(() => m.Pad(2, -1));
         }
 
+        // ── Raw scalar division operator (TODO-pass4 item #56) ─────────────────────
+
+        /// <summary>
+        /// The raw <c>/</c> operator is documented as unchecked IEEE division (see its XML doc): a zero
+        /// scalar propagates infinity/NaN per entry instead of throwing. Callers needing a validated
+        /// division use a higher-level member such as <see cref="Matrix{T}.Invert"/>/<see cref="Matrix{T}.Solve"/> instead.
+        /// </summary>
+        [TestMethod]
+        public void DivisionOperator_ByZero_ProducesInfinityInsteadOfThrowing()
+        {
+            var m = new Matrix<double>(new double[,] { { 1d, -1d }, { 0d, 2d } });
+            var result = m / 0d;
+            Assert.AreEqual(double.PositiveInfinity, result[0, 0]);
+            Assert.AreEqual(double.NegativeInfinity, result[0, 1]);
+            Assert.IsTrue(double.IsNaN(result[1, 0]));
+            Assert.AreEqual(double.PositiveInfinity, result[1, 1]);
+        }
+
         /// <summary>
         /// Asserts that two matrices contain the same components within the provided tolerance.
         /// </summary>

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -516,6 +516,42 @@ public class VectorTests
     }
 
     [TestMethod]
+    public void AngleWith_NullSelf_Throws()
+    {
+        Vector<double> v1 = null;
+        var v2 = new Vector<double>(1d, 0d);
+        Assert.ThrowsException<ArgumentNullException>(() => v1.AngleWith(v2));
+    }
+
+    [TestMethod]
+    public void AngleWith_NullOther_Throws()
+    {
+        var v1 = new Vector<double>(1d, 0d);
+        Vector<double> v2 = null;
+        Assert.ThrowsException<ArgumentNullException>(() => v1.AngleWith(v2));
+    }
+
+    [TestMethod]
+    public void AngleWith_LargeParallelVectors_ReturnsZero()
+    {
+        // Regression for norm-product overflow (item #70): each norm is 1e200, so
+        // self.Norm * other.Norm = 1e400 overflows to infinity; the old cosine division
+        // produced NaN and Acos returned NaN. The fix normalizes to (1,0) first, making
+        // the cosine exactly 1.0 and the angle exactly 0.
+        var v1 = new Vector<double>(1e200, 0d);
+        var v2 = new Vector<double>(1e200, 0d);
+        Assert.AreEqual(0.0, v1.AngleWith(v2), 1e-9);
+    }
+
+    [TestMethod]
+    public void AngleWith_NaNComponent_Throws()
+    {
+        var v1 = new Vector<double>(double.NaN, 0d);
+        var v2 = new Vector<double>(1d, 0d);
+        Assert.ThrowsException<InvalidOperationException>(() => v1.AngleWith(v2));
+    }
+
+    [TestMethod]
     public void EqualityOperator_BothNull_ReturnsTrue()
     {
         Vector<double> left = null;

--- a/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
+++ b/UtilsTest/Mathematics/LinearAlgebra/VectorTests.cs
@@ -618,5 +618,23 @@ public class VectorTests
         Assert.AreEqual(5.0, new Vector<double>(3d, 4d).Norm, 1e-12);
         Assert.AreEqual(5.0, new Vector<double>(4d, 3d).Norm, 1e-12);
     }
+
+    // ── Raw scalar division operator (TODO-pass4 item #56) ──────────────────────
+
+    /// <summary>
+    /// The raw <c>/</c> operator is documented as unchecked IEEE division (see its XML doc): a zero
+    /// divisor propagates <see cref="double.PositiveInfinity"/>/<see cref="double.NegativeInfinity"/> per
+    /// component instead of throwing. Callers needing a validated division use a higher-level member such
+    /// as <see cref="Vector{T}.Normalize"/> instead.
+    /// </summary>
+    [TestMethod]
+    public void DivisionOperator_ByZero_ProducesInfinityInsteadOfThrowing()
+    {
+        var v = new Vector<double>(1d, -1d, 0d);
+        var result = v / 0d;
+        Assert.AreEqual(double.PositiveInfinity, result[0]);
+        Assert.AreEqual(double.NegativeInfinity, result[1]);
+        Assert.IsTrue(double.IsNaN(result[2]));
+    }
 }
 


### PR DESCRIPTION
## Summary

Closes out **TODO-2026-07-11-pass4.md** (items #48–#56) and addresses all findings in **TODO-2026-07-11-pass6.md** (items #70–#79), one commit per item.

### TODO-pass4 items (#48–#56)

- **#48** — `AffineSubspace.Contains` invalid tolerances: validates finite/non-negative tolerance.
- **#49** — AffineSubspace null-member validation: explicit `ArgumentNullException` at every public boundary instead of incidental `NullReferenceException`.
- **#50** — AffineSubspace overstated stability claim: corrected docs + explicit `rankTolerance` override on `FromSpan`/`FromNormals`. QR/SVD rewrite not adopted (see TODO rationale).
- **#51** — AffineSubspace hash-collision design: documented as intentional (no code change); changing it risks hash/equals inconsistency near the fixed-epsilon equality boundary.
- **#52** — `AffineSubspace<T>.IFormattable` no-op: `ToString(format, provider)` now propagates into Anchor's coordinates, mirroring `Line<T>`'s existing pattern.
- **#53** — Fourier extensions validation: null/empty transform and finite/positive sample rate now validated.
- **#54** — Fourier one-sided bin semantics: added `GetAllBinFrequencies` and `GetOneSidedFrequencies/Amplitudes/Phases(includeNyquist)` as new, length-matched APIs; legacy methods unchanged.
- **#55** — Fourier amplitude terminology: added `GetMagnitudes` as the accurately-named alias; `GetAmplitudes` forwards to it and is kept for backward compatibility.
- **#56** — Scalar division policy: documented (no code change); confirmed every higher-level division site already validates its denominator; the two raw operators now document their unchecked IEEE behavior.

Also added `GetOneSidedMagnitudes` as the accurately-named counterpart to `GetOneSidedAmplitudes`, mirroring the `GetMagnitudes`/`GetAmplitudes` pattern from item #55 (`GetOneSidedAmplitudes` now forwards to it and is kept for backward compatibility).

### TODO-pass6 items (#70–#79)

- **#70/#71/#76** — `AngleWith` stability and safety: normalises both vectors before computing the dot product (avoids norm-product overflow), adds `ArgumentNullException` guards for null operands, and validates finiteness of the cosine before clamping (rejects NaN instead of silently returning a boundary angle).
- **#72** — LU/inverse structural metadata: already fixed by pass5 items #61/#68/#69 (`null` instead of hardcoded `false`); documented.
- **#73** — README non-compiling examples: fixed wrong namespace (`Fourrier`→`Fourier`), wrong class name and `new` on a static class, nonexistent `Transform(buffer, start, end)` overload, `ComputeBarycenter` called as instance method, nonexistent `IsDiagonalized` property.
- **#74/#75** — README transformation/LU examples: already correct in the current production code and README; documented.
- **#77** — README wrong package features: removed "SI unit conversions and number-to-text conversion utilities" (those live in `omy.Utils.NumberToString`); replaced with accurate feature descriptions.
- **#78** — README wrong generic constraints: replaced "any `IFloatingPoint<T>`" with the actual base constraint (`IFloatingPoint<T>, IRootFunctions<T>`) and documented that some operations additionally require `ITrigonometricFunctions<T>`.
- **#79** — README examples as executable assertions: not adopted — no sample-project/doctest infrastructure exists in this repository; documented as a known trade-off.

## Test plan

- [x] `dotnet test` filter `AngleWith` — 10/10 passed after items #70/#71/#76
- [x] `dotnet test` filter `GetOneSidedMagnitudes` — 1/1 passed
- [x] Full suite green before merge (pass4 items already validated in earlier runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)