### PR TITLE
Factor runtime embedded-code context symbols into a single builder

### DIFF
--- a/Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs
+++ b/Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs
@@ -158,16 +158,8 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
     /// <returns>Symbol expressions resolved by the expression compiler.</returns>
     private static IReadOnlyDictionary<string, Expression> BuildSemanticPredicateSymbols(
         ParameterExpression runtimeContext,
-        IReadOnlySet<EmbeddedCodeContextSymbol> supportedSymbols)
-    {
-        var symbols = new Dictionary<string, Expression>(StringComparer.Ordinal);
-        foreach (var symbol in supportedSymbols)
-        {
-            AddSemanticPredicateSymbol(symbols, symbol, runtimeContext);
-        }
-
-        return symbols;
-    }
+        IReadOnlySet<EmbeddedCodeContextSymbol> supportedSymbols) =>
+        BuildRuntimeContextSymbols(runtimeContext, supportedSymbols);
 
     /// <summary>
     /// Builds symbol expressions that read parser action values from the runtime context parameter.
@@ -177,71 +169,40 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
     /// <returns>Symbol expressions resolved by the expression compiler.</returns>
     private static IReadOnlyDictionary<string, Expression> BuildParserActionSymbols(
         ParameterExpression runtimeContext,
+        IReadOnlySet<EmbeddedCodeContextSymbol> supportedSymbols) =>
+        BuildRuntimeContextSymbols(runtimeContext, supportedSymbols);
+
+    /// <summary>
+    /// Builds symbol expressions that read shared runtime values from a predicate or action context parameter.
+    /// </summary>
+    /// <param name="runtimeContext">Runtime context parameter used by the compiled artifact delegate.</param>
+    /// <param name="supportedSymbols">Contextual symbols that the preparation context allows this compiler invocation to expose.</param>
+    /// <returns>Symbol expressions resolved by the expression compiler.</returns>
+    private static IReadOnlyDictionary<string, Expression> BuildRuntimeContextSymbols(
+        ParameterExpression runtimeContext,
         IReadOnlySet<EmbeddedCodeContextSymbol> supportedSymbols)
     {
         var symbols = new Dictionary<string, Expression>(StringComparer.Ordinal);
         foreach (var symbol in supportedSymbols)
         {
-            AddParserActionSymbol(symbols, symbol, runtimeContext);
+            switch (symbol)
+            {
+                case EmbeddedCodeContextSymbol.RuleName:
+                    symbols["ruleName"] = BuildRuleName(runtimeContext);
+                    break;
+                case EmbeddedCodeContextSymbol.InputPosition:
+                    symbols["inputPosition"] = Expression.Property(runtimeContext, "InputPosition");
+                    break;
+                case EmbeddedCodeContextSymbol.AlternativeIndex:
+                    symbols["alternativeIndex"] = Expression.Property(runtimeContext, "AlternativeIndex");
+                    break;
+                case EmbeddedCodeContextSymbol.ElementIndex:
+                    symbols["elementIndex"] = Expression.Property(runtimeContext, "ElementIndex");
+                    break;
+            }
         }
 
         return symbols;
-    }
-
-    /// <summary>
-    /// Adds a semantic predicate symbol when the preparation context exposes it.
-    /// </summary>
-    /// <param name="symbols">Mutable symbol dictionary to update.</param>
-    /// <param name="symbol">Context symbol selected by the preparation context.</param>
-    /// <param name="runtimeContext">Runtime context parameter used by the compiled predicate delegate.</param>
-    private static void AddSemanticPredicateSymbol(
-        Dictionary<string, Expression> symbols,
-        EmbeddedCodeContextSymbol symbol,
-        ParameterExpression runtimeContext)
-    {
-        switch (symbol)
-        {
-            case EmbeddedCodeContextSymbol.RuleName:
-                symbols["ruleName"] = BuildRuleName(runtimeContext);
-                break;
-            case EmbeddedCodeContextSymbol.InputPosition:
-                symbols["inputPosition"] = Expression.Property(runtimeContext, nameof(SemanticPredicateEvaluationContext.InputPosition));
-                break;
-            case EmbeddedCodeContextSymbol.AlternativeIndex:
-                symbols["alternativeIndex"] = Expression.Property(runtimeContext, nameof(SemanticPredicateEvaluationContext.AlternativeIndex));
-                break;
-            case EmbeddedCodeContextSymbol.ElementIndex:
-                symbols["elementIndex"] = Expression.Property(runtimeContext, nameof(SemanticPredicateEvaluationContext.ElementIndex));
-                break;
-        }
-    }
-
-    /// <summary>
-    /// Adds a parser action symbol when the preparation context exposes it.
-    /// </summary>
-    /// <param name="symbols">Mutable symbol dictionary to update.</param>
-    /// <param name="symbol">Context symbol selected by the preparation context.</param>
-    /// <param name="runtimeContext">Runtime context parameter used by the compiled action delegate.</param>
-    private static void AddParserActionSymbol(
-        Dictionary<string, Expression> symbols,
-        EmbeddedCodeContextSymbol symbol,
-        ParameterExpression runtimeContext)
-    {
-        switch (symbol)
-        {
-            case EmbeddedCodeContextSymbol.RuleName:
-                symbols["ruleName"] = BuildRuleName(runtimeContext);
-                break;
-            case EmbeddedCodeContextSymbol.InputPosition:
-                symbols["inputPosition"] = Expression.Property(runtimeContext, nameof(ParserActionExecutionContext.InputPosition));
-                break;
-            case EmbeddedCodeContextSymbol.AlternativeIndex:
-                symbols["alternativeIndex"] = Expression.Property(runtimeContext, nameof(ParserActionExecutionContext.AlternativeIndex));
-                break;
-            case EmbeddedCodeContextSymbol.ElementIndex:
-                symbols["elementIndex"] = Expression.Property(runtimeContext, nameof(ParserActionExecutionContext.ElementIndex));
-                break;
-        }
     }
 
     /// <summary>

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -161,6 +161,35 @@ Every API-changing PR must include:
 - Avoid wrappers and abstractions unless they remove real ambiguity.
 - Do not introduce architecture layers without a clear invariant-driven reason.
 - Optimize only after behavior is locked down.
+- When parser and lexer paths share a stable algorithm, prefer composition: a common engine owns the invariant algorithm, while a parser- or lexer-specific strategy owns only the true variation points.
+- Use small immutable context values for traversal state instead of large mutable state objects shared across recursive calls.
+- Prefer immutable descriptors when parser/lexer differences are declarative, such as generated names, context types, signatures, success expressions, fallback expressions, or transformation locations.
+- Do not hide parser/lexer differences behind `isLexer` booleans or domain switches spread throughout a common engine.
+- Avoid abstract base classes that require most of the algorithm to be overridden.
+
+## Parser/lexer specialization refactor direction
+
+Several generator paths currently share a similar global algorithm while still carrying real parser/lexer variation points. This direction is validated for future refactorings, but it is not implemented as a single completed architecture yet. The affected areas include embedded-hook collection, runtime dispatcher generation, generated hook-method emission, and other parser/lexer-specific construction or emission paths.
+
+The target model is incremental and composition-based:
+
+1. a common engine owns the stable traversal, ordering, accumulation, validation, and invariant checks;
+2. parser and lexer strategies own only the true variation points;
+3. small immutable traversal context values carry changing state such as alternative and element indexes;
+4. immutable emission descriptors carry declarative generation differences such as generated class names, method names, context type names, implemented interfaces, success expressions, fallback expressions, transformation locations, prefixes, and signatures;
+5. explicit parser and lexer wrappers remain responsible for choosing the appropriate strategy or descriptor.
+
+The refactor must keep the following differences explicit: parser left recursion, alternative priority ordering, lexer modes, quantifier and negation index semantics, generated names, transformation locations, runtime context types, method signatures, success results, and fallback calls. These differences must not be hidden behind a single `isLexer` flag or scattered parser/lexer switches inside a shared engine.
+
+Incremental plan:
+
+- introduce a shared embedded-hook collection engine;
+- add parser and lexer collection strategies;
+- introduce a shared runtime dispatcher emitter where descriptors or targeted strategies can preserve real differences;
+- introduce a shared generated hook-method emitter for genuinely common hook bodies and signatures;
+- add Roslyn architecture guards that prevent duplicated algorithms, hidden parser/lexer switches, accidental public contracts, and behavioral drift.
+
+Each step must preserve generated C# shape, hook order, indexes, transformer invocation count and order, fallback behavior, diagnostics, public API, parser authority, and lexer/runtime semantics. Each step should be delivered as a separate PR or, at minimum, as a separate auditable change.
 
 ## Roadmap phases
 

--- a/Utils.Parser/TODO.md
+++ b/Utils.Parser/TODO.md
@@ -212,68 +212,87 @@ des parcours récursifs, formalisation globale du pipeline, renommage complet de
 documentation de la façade runtime ne sont pas traités par cette correction.
 
 ### 7. Factoriser la construction des symboles d'expressions
-`BuildSemanticPredicateSymbols` et `BuildParserActionSymbols`, ainsi que leurs méthodes `Add...Symbol`,
-répètent la gestion de `RuleName`, `InputPosition`, `AlternativeIndex` et `ElementIndex`.
+**Corrigé.** `ExpressionEmbeddedCodePreparer` conserve les wrappers spécialisés
+`BuildSemanticPredicateSymbols(...)` et `BuildParserActionSymbols(...)`, mais ceux-ci ne portent plus
+aucune logique de classification : ils délèguent directement à la méthode commune privée
+`BuildRuntimeContextSymbols(ParameterExpression runtimeContext, IReadOnlySet<EmbeddedCodeContextSymbol> supportedSymbols)`.
 
-**Fix proposé** : conserver ce chantier comme une factorisation locale et limitée de
-`ExpressionEmbeddedCodePreparer`. Créer un constructeur privé commun de symboles exploitant les
-propriétés partagées par `SemanticPredicateEvaluationContext` et `ParserActionExecutionContext`, avec
-des wrappers spécialisés courts si ceux-ci améliorent la lisibilité.
+La méthode commune crée le dictionnaire avec `StringComparer.Ordinal`, parcourt `supportedSymbols` une
+seule fois et expose les quatre symboles historiques sans changer leurs noms publics :
 
-Ne pas introduire une interface publique uniquement pour ces quatre propriétés. Une petite stratégie
-privée ou interne n'est justifiée que si l'audit révèle de vraies différences de résolution entre
-plusieurs familles de contextes runtime. Ce point ne doit pas servir à anticiper la mutualisation plus
-large parser/lexer décrite au point 8.
+- `RuleName` -> `ruleName` -> `context.Rule.Name` ;
+- `InputPosition` -> `inputPosition` -> `context.InputPosition` ;
+- `AlternativeIndex` -> `alternativeIndex` -> `context.AlternativeIndex` ;
+- `ElementIndex` -> `elementIndex` -> `context.ElementIndex`.
+
+Les helpers dupliqués `AddSemanticPredicateSymbol(...)` et `AddParserActionSymbol(...)` ont été
+supprimés. `BuildRuleName(...)` reste isolé, car il documente explicitement la chaîne de lecture
+`Rule.Name` partagée par les deux contextes runtime. Aucune interface ou classe de base publique n'a
+été ajoutée pour les contextes `SemanticPredicateEvaluationContext` et `ParserActionExecutionContext` ;
+le type de lambda de chaque chemin reste spécialisé. Les expressions construites lisent toujours les
+valeurs depuis le contexte fourni au moment de l'exécution, sans capture de valeur à la préparation et
+sans appel supplémentaire à `IExpressionCompiler.Compile(...)`. Les valeurs inconnues de
+`EmbeddedCodeContextSymbol` restent ignorées, comme dans les anciens `switch` sans branche `default`.
+
+Tests ajoutés ou renforcés :
+
+- matrice unitaire couvrant `PrepareSemanticPredicate` et `PrepareParserAction` pour les quatre
+  symboles, le dictionnaire vide, un symbole unique, un sous-ensemble non ordonné et les valeurs
+  inconnues de l'enum ;
+- inspection des `MemberExpression` pour vérifier les membres runtime ciblés sans dépendre de
+  `Expression.ToString()` ;
+- tests d'exécution réutilisant le même artefact préparé avec deux contextes différents pour prouver
+  la lecture runtime des valeurs ;
+- garde-fou Roslyn fonctionnel vérifiant que les wrappers délèguent à `BuildRuntimeContextSymbols`,
+  que les anciens helpers `Add...Symbol` n'existent plus, qu'une seule méthode classe
+  `EmbeddedCodeContextSymbol`, que les lambdas conservent leurs types runtime spécialisés et qu'aucun
+  nouveau contrat public n'a été introduit.
+
+Les points 8 à 11 restent hors périmètre du code de production de cette correction : la mutualisation
+générale parser/lexer, le pipeline global, le renommage de `EmittedCode` et la documentation de façade
+runtime demeurent des chantiers séparés.
 
 ### 8. Introduire des moteurs communs avec stratégies parser/lexer spécialisées
-Plusieurs zones de `GrammarEmitter` répètent le même algorithme général et ne diffèrent que par les
-règles propres au parser ou au lexer :
+Plusieurs zones de `GrammarEmitter` répètent un algorithme global comparable, notamment la collecte
+des hooks embarqués, la propagation des indices, la sélection des emplacements de transformation, les
+conventions de nommage, la génération des dispatchers runtime et la génération des méthodes de hooks.
 
-- collecte récursive des hooks embarqués ;
-- calcul ou propagation des indices d'alternative et d'élément ;
-- choix des emplacements de transformation ;
-- conventions de nommage des méthodes générées ;
-- génération des dispatchers runtime de prédicats et d'actions ;
-- génération des méthodes de hooks et de leurs signatures.
+**Direction architecturale retenue** : appliquer une composition explicite plutôt qu'une hiérarchie
+abstraite surchargée :
 
-Les différences sont réelles et doivent rester explicites : ordre et priorité des alternatives,
-récursion gauche parser, traitement des quantificateurs et négations, modes lexer, types de contexte,
-signatures, types de résultat et appels de fallback.
+1. un moteur commun porte l'ordre des opérations, le parcours stable, l'accumulation des résultats,
+   les invariants et les validations communes ;
+2. une stratégie parser ou lexer fournit uniquement les différences réelles ;
+3. un petit contexte immuable transporte l'état variable du parcours, par exemple l'index
+   d'alternative et l'index d'élément ;
+4. un descripteur immuable est préféré à une interface comportementale lorsque les différences sont
+   purement déclaratives, par exemple noms générés, signatures, types de contexte, expressions de
+   succès ou fallbacks ;
+5. des wrappers parser et lexer explicites choisissent la stratégie ou le descripteur approprié.
 
-**Direction architecturale retenue** : utiliser la composition sous la forme suivante :
+Les différences à préserver restent visibles : règles parser contre lexer, modes lexer supplémentaires,
+ordre source contre ordre de priorité, récursion gauche parser, alternatives de base et queues
+récursives, indexation des quantificateurs et négations, préfixes de noms générés,
+`ParserEmbeddedCodeLocation`, types de contextes runtime, signatures avec ou sans
+`LexerActionExecutionResult`, types et valeurs de retour, appels de fallback, conventions de nommage,
+ordre des hooks et source C# générée. Le moteur commun ne doit pas contenir un booléen `isLexer` ni
+des `switch` parser/lexer dispersés.
 
-1. un moteur commun porte l'algorithme stable ;
-2. une stratégie spécialisée parser ou lexer fournit uniquement les décisions différentes ;
-3. un petit contexte immuable transporte l'état variable du parcours, par exemple le nom de règle,
-   l'index d'alternative et l'index d'élément ;
-4. des descripteurs immuables sont préférés aux interfaces lorsque les différences sont uniquement des
-   valeurs de génération ;
-5. les wrappers parser et lexer restent explicites et choisissent la stratégie ou le descripteur
-   approprié.
+Découpage proposé, à réaliser dans des PR distinctes ou au minimum dans des changements séparés et
+auditables :
 
-Exemples de rôles envisagés, sans imposer prématurément leurs noms exacts :
+- **8a — moteur commun de collecte des hooks** : extraire uniquement l'algorithme stable de parcours et
+  d'accumulation ;
+- **8b — stratégies parser et lexer de collecte** : isoler les règles parser/lexer réelles sans
+  réimplémenter le parcours complet ;
+- **8c — émission commune des dispatchers** : utiliser des descripteurs immuables ou des stratégies
+  ciblées pour les différences de signature, contexte, résultat et fallback ;
+- **8d — émission commune des méthodes de hooks et garde-fous architecturaux** : factoriser les corps
+  réellement communs et verrouiller l'absence de retour à la duplication avec des tests Roslyn.
 
-- `EmbeddedHookCollector` pour le parcours commun ;
-- `IEmbeddedHookCollectionStrategy` avec implémentations parser et lexer ;
-- `HookTraversalPosition` comme valeur immuable de récursion ;
-- un descripteur d'émission pour les dispatchers et méthodes de hooks.
-
-Le moteur commun ne doit pas contenir de booléen `isLexer` ni de gros `switch` central sur le domaine.
-Les stratégies ne doivent pas réimplémenter l'algorithme entier : elles répondent uniquement aux
-points de variation demandés par le moteur. Préférer la composition à une classe de base abstraite
-comportant de nombreuses méthodes virtuelles.
-
-La mise en œuvre doit être progressive et découpée en PR vérifiables :
-
-- **8a — collecte** : extraire le parcours commun et les décisions parser/lexer ;
-- **8b — dispatchers** : factoriser la structure commune des évaluateurs/exécuteurs générés ;
-- **8c — méthodes de hooks** : factoriser les signatures et corps communs à l'aide de descripteurs ;
-- **8d — consolidation** : supprimer les helpers devenus redondants et verrouiller l'architecture avec
-  des tests Roslyn.
-
-Chaque étape doit préserver strictement les indices runtime, l'ordre des hooks, les noms générés, les
-appels au transformer, la source C# produite et le comportement des fallbacks. La récursion gauche et
-les particularités lexer restent des stratégies explicites, pas des branches cachées dans le moteur.
+Chaque étape doit préserver strictement la forme du C# généré, l'ordre des hooks, les indices, le
+nombre et l'ordre d'appel au transformer, les diagnostics, les fallbacks, l'API publique, l'autorité du
+parser et la sémantique lexer/runtime.
 
 ## Duplications d'intention et lisibilité (priorité moyenne)
 

--- a/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
+++ b/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
@@ -130,6 +130,57 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
     }
 
 
+
+    /// <summary>
+    /// Ensures runtime expression context symbols are built through one shared implementation.
+    /// </summary>
+    [TestMethod]
+    public void ExpressionEmbeddedCodePreparer_RuntimeContextSymbols_UseSingleSharedBuilder()
+    {
+        string repositoryRoot = FindRepositoryRoot();
+        string relativePath = NormalizePath(Path.Combine("Utils.Parser.Expressions", "ExpressionEmbeddedCodePreparer.cs"));
+        string source = File.ReadAllText(Path.Combine(repositoryRoot, relativePath));
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, path: relativePath);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "Utils.Parser.Expressions.SymbolArchitectureScan",
+            [tree],
+            CreateRuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        SemanticModel semanticModel = compilation.GetSemanticModel(tree);
+        ClassDeclarationSyntax preparer = tree.GetCompilationUnitRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().Single(static type => type.Identifier.ValueText == "ExpressionEmbeddedCodePreparer");
+        MethodDeclarationSyntax[] methods = preparer.Members.OfType<MethodDeclarationSyntax>().ToArray();
+        MethodDeclarationSyntax semanticWrapper = methods.Single(static method => method.Identifier.ValueText == "BuildSemanticPredicateSymbols");
+        MethodDeclarationSyntax actionWrapper = methods.Single(static method => method.Identifier.ValueText == "BuildParserActionSymbols");
+        MethodDeclarationSyntax sharedBuilder = methods.Single(static method => method.Identifier.ValueText == "BuildRuntimeContextSymbols");
+
+        AssertWrapperDelegatesToSharedBuilder(semanticWrapper, semanticModel);
+        AssertWrapperDelegatesToSharedBuilder(actionWrapper, semanticModel);
+        Assert.AreEqual(0, semanticWrapper.DescendantNodes().OfType<SwitchStatementSyntax>().Count());
+        Assert.AreEqual(0, actionWrapper.DescendantNodes().OfType<SwitchStatementSyntax>().Count());
+        Assert.IsFalse(methods.Any(static method => method.Identifier.ValueText == "AddSemanticPredicateSymbol"));
+        Assert.IsFalse(methods.Any(static method => method.Identifier.ValueText == "AddParserActionSymbol"));
+
+        MethodDeclarationSyntax[] symbolClassifiers = methods
+            .Where(static method => method.DescendantNodes().OfType<SwitchStatementSyntax>().Any(@switch => @switch.Expression.ToString() == "symbol"))
+            .ToArray();
+        CollectionAssert.AreEqual(new[] { "BuildRuntimeContextSymbols" }, symbolClassifiers.Select(static method => method.Identifier.ValueText).ToArray());
+        Assert.IsTrue(sharedBuilder.DescendantNodes().OfType<AssignmentExpressionSyntax>().Any(assignment => assignment.Right is InvocationExpressionSyntax invocation && invocation.ToString().Contains("Expression.Property", StringComparison.Ordinal)));
+
+        InvocationExpressionSyntax[] expressionCompilerCalls = preparer.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(static invocation => invocation.ToString().StartsWith("_compiler.Compile", StringComparison.Ordinal))
+            .ToArray();
+        Assert.AreEqual(2, expressionCompilerCalls.Length, "The preparer must keep exactly one IExpressionCompiler.Compile call per runtime artifact path.");
+
+        Assert.IsTrue(preparer.DescendantNodes().OfType<InvocationExpressionSyntax>().Any(invocation => invocation.ToString().StartsWith("Expression.Lambda<Func<SemanticPredicateEvaluationContext, bool>>", StringComparison.Ordinal)));
+        Assert.IsTrue(preparer.DescendantNodes().OfType<InvocationExpressionSyntax>().Any(invocation => invocation.ToString().StartsWith("Expression.Lambda<Action<ParserActionExecutionContext>>", StringComparison.Ordinal)));
+
+        string[] publicContracts = tree.GetCompilationUnitRoot().DescendantNodes().OfType<TypeDeclarationSyntax>()
+            .Where(static type => type.Modifiers.Any(SyntaxKind.PublicKeyword) && type.Identifier.ValueText.Contains("RuntimeContext", StringComparison.Ordinal))
+            .Select(static type => type.Identifier.ValueText)
+            .ToArray();
+        CollectionAssert.AreEqual(Array.Empty<string>(), publicContracts);
+    }
+
     /// <summary>
     /// Ensures generated embedded-code hooks use one typed data model with explicit parser/lexer and predicate/action discriminants.
     /// </summary>
@@ -222,6 +273,18 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
             .ToArray();
         string[] expectedRecursiveCollectors = ["CollectEmbeddedCodeHooks", "CollectLexerEmbeddedCodeHooks"];
         CollectionAssert.AreEqual(expectedRecursiveCollectors, recursiveCollectors);
+    }
+
+
+    /// <summary>
+    /// Asserts that a specialized symbol wrapper delegates directly to the shared runtime symbol builder.
+    /// </summary>
+    /// <param name="wrapper">Wrapper method declaration to inspect.</param>
+    /// <param name="semanticModel">Semantic model used to resolve the delegated invocation.</param>
+    private static void AssertWrapperDelegatesToSharedBuilder(MethodDeclarationSyntax wrapper, SemanticModel semanticModel)
+    {
+        InvocationExpressionSyntax invocation = wrapper.DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
+        Assert.AreEqual("BuildRuntimeContextSymbols", (semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol)?.Name);
     }
 
     /// <summary>

--- a/UtilsTest/Parser/ExpressionEmbeddedCodePreparerTests.cs
+++ b/UtilsTest/Parser/ExpressionEmbeddedCodePreparerTests.cs
@@ -430,6 +430,195 @@ public class ExpressionEmbeddedCodePreparerTests
         Assert.IsNotNull(result.Exception);
     }
 
+
+    [DataTestMethod]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.SemanticPredicate, typeof(SemanticPredicateEvaluationContext))]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.ParserInlineAction, typeof(ParserActionExecutionContext))]
+    public void PrepareRuntimeArtifact_WhenNoSymbolsAreSupported_PassesEmptySymbolDictionary(string prepareMethodName, EmbeddedCodeKind kind, Type runtimeContextType)
+    {
+        var compiler = new FakeExpressionCompiler();
+        var preparer = new ExpressionEmbeddedCodePreparer(compiler);
+
+        InvokePrepare(preparer, prepareMethodName, CreateSource("true", kind), CreateContext(EmbeddedCodeTarget.RuntimeInlineExpression, new HashSet<EmbeddedCodeContextSymbol>()));
+
+        Assert.AreEqual(1, compiler.CompileCount);
+        Assert.IsNotNull(compiler.LastSymbols);
+        Assert.AreEqual(0, compiler.LastSymbols.Count);
+    }
+
+    [DataTestMethod]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.SemanticPredicate, typeof(SemanticPredicateEvaluationContext), EmbeddedCodeContextSymbol.RuleName, "ruleName", typeof(string), "Rule.Name")]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.SemanticPredicate, typeof(SemanticPredicateEvaluationContext), EmbeddedCodeContextSymbol.InputPosition, "inputPosition", typeof(int), "InputPosition")]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.SemanticPredicate, typeof(SemanticPredicateEvaluationContext), EmbeddedCodeContextSymbol.AlternativeIndex, "alternativeIndex", typeof(int), "AlternativeIndex")]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.SemanticPredicate, typeof(SemanticPredicateEvaluationContext), EmbeddedCodeContextSymbol.ElementIndex, "elementIndex", typeof(int), "ElementIndex")]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.ParserInlineAction, typeof(ParserActionExecutionContext), EmbeddedCodeContextSymbol.RuleName, "ruleName", typeof(string), "Rule.Name")]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.ParserInlineAction, typeof(ParserActionExecutionContext), EmbeddedCodeContextSymbol.InputPosition, "inputPosition", typeof(int), "InputPosition")]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.ParserInlineAction, typeof(ParserActionExecutionContext), EmbeddedCodeContextSymbol.AlternativeIndex, "alternativeIndex", typeof(int), "AlternativeIndex")]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.ParserInlineAction, typeof(ParserActionExecutionContext), EmbeddedCodeContextSymbol.ElementIndex, "elementIndex", typeof(int), "ElementIndex")]
+    public void PrepareRuntimeArtifact_WhenSingleSymbolIsSupported_PassesOnlyExpectedRuntimeMember(
+        string prepareMethodName,
+        EmbeddedCodeKind kind,
+        Type runtimeContextType,
+        EmbeddedCodeContextSymbol symbol,
+        string expectedName,
+        Type expectedType,
+        string expectedPath)
+    {
+        var compiler = new FakeExpressionCompiler();
+        var preparer = new ExpressionEmbeddedCodePreparer(compiler);
+
+        InvokePrepare(preparer, prepareMethodName, CreateSource("true", kind), CreateContext(EmbeddedCodeTarget.RuntimeInlineExpression, new HashSet<EmbeddedCodeContextSymbol> { symbol }));
+
+        Assert.IsNotNull(compiler.LastSymbols);
+        Assert.AreEqual(1, compiler.LastSymbols.Count);
+        Assert.IsTrue(compiler.LastSymbols.ContainsKey(expectedName));
+        AssertSymbolExpression(compiler.LastSymbols[expectedName], runtimeContextType, expectedType, expectedPath);
+    }
+
+    [DataTestMethod]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.SemanticPredicate, typeof(SemanticPredicateEvaluationContext))]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.ParserInlineAction, typeof(ParserActionExecutionContext))]
+    public void PrepareRuntimeArtifact_WhenAllSymbolsAreSupported_PassesExpectedRuntimeMembers(string prepareMethodName, EmbeddedCodeKind kind, Type runtimeContextType)
+    {
+        var compiler = new FakeExpressionCompiler();
+        var preparer = new ExpressionEmbeddedCodePreparer(compiler);
+
+        InvokePrepare(preparer, prepareMethodName, CreateSource("true", kind), CreateContext(EmbeddedCodeTarget.RuntimeInlineExpression));
+
+        Assert.IsNotNull(compiler.LastSymbols);
+        AssertSymbolSet(compiler.LastSymbols, runtimeContextType);
+    }
+
+    [DataTestMethod]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.SemanticPredicate, typeof(SemanticPredicateEvaluationContext))]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.ParserInlineAction, typeof(ParserActionExecutionContext))]
+    public void PrepareRuntimeArtifact_WhenSubsetIsUnordered_DoesNotAddExtraSymbols(string prepareMethodName, EmbeddedCodeKind kind, Type runtimeContextType)
+    {
+        var compiler = new FakeExpressionCompiler();
+        var preparer = new ExpressionEmbeddedCodePreparer(compiler);
+        var symbols = new HashSet<EmbeddedCodeContextSymbol>
+        {
+            EmbeddedCodeContextSymbol.ElementIndex,
+            EmbeddedCodeContextSymbol.RuleName
+        };
+
+        InvokePrepare(preparer, prepareMethodName, CreateSource("true", kind), CreateContext(EmbeddedCodeTarget.RuntimeInlineExpression, symbols));
+
+        Assert.IsNotNull(compiler.LastSymbols);
+        CollectionAssert.AreEquivalent(new[] { "elementIndex", "ruleName" }, compiler.LastSymbols.Keys.ToArray());
+        AssertSymbolExpression(compiler.LastSymbols["ruleName"], runtimeContextType, typeof(string), "Rule.Name");
+        AssertSymbolExpression(compiler.LastSymbols["elementIndex"], runtimeContextType, typeof(int), "ElementIndex");
+    }
+
+    [DataTestMethod]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.SemanticPredicate)]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.ParserInlineAction)]
+    public void PrepareRuntimeArtifact_WhenUnknownSymbolIsSupported_IgnoresIt(string prepareMethodName, EmbeddedCodeKind kind)
+    {
+        var compiler = new FakeExpressionCompiler();
+        var preparer = new ExpressionEmbeddedCodePreparer(compiler);
+        var symbols = new HashSet<EmbeddedCodeContextSymbol> { (EmbeddedCodeContextSymbol)999 };
+
+        InvokePrepare(preparer, prepareMethodName, CreateSource("true", kind), CreateContext(EmbeddedCodeTarget.RuntimeInlineExpression, symbols));
+
+        Assert.IsNotNull(compiler.LastSymbols);
+        Assert.AreEqual(0, compiler.LastSymbols.Count);
+    }
+
+    [TestMethod]
+    public void PreparedSemanticPredicate_WhenIndexSymbolsAreUsed_ReadsCurrentRuntimeContext()
+    {
+        var preparer = new ExpressionEmbeddedCodePreparer(new FakeExpressionCompiler());
+
+        var result = preparer.PrepareSemanticPredicate(
+            CreateSource("indexes-match", EmbeddedCodeKind.SemanticPredicate),
+            CreateContext(EmbeddedCodeTarget.RuntimeInlineExpression));
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.Succeeded, result.Status);
+        Assert.IsNotNull(result.Artifact);
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.Satisfied, result.Artifact.Evaluate(CreatePredicateContext("indexes-match", inputPosition: 1, alternativeIndex: 2, elementIndex: 3)).Status);
+        Assert.AreEqual(SemanticPredicateEvaluationStatus.Rejected, result.Artifact.Evaluate(CreatePredicateContext("indexes-match", inputPosition: 4, alternativeIndex: 5, elementIndex: 6)).Status);
+    }
+
+    [TestMethod]
+    public void PreparedParserAction_WhenIndexSymbolsAreUsed_ReadsCurrentRuntimeContext()
+    {
+        var compiler = new FakeExpressionCompiler();
+        var preparer = new ExpressionEmbeddedCodePreparer(compiler);
+
+        var result = preparer.PrepareParserAction(
+            CreateSource("record-indexes", EmbeddedCodeKind.ParserInlineAction),
+            CreateContext(EmbeddedCodeTarget.RuntimeInlineExpression));
+
+        Assert.AreEqual(EmbeddedCodePreparationStatus.Succeeded, result.Status);
+        Assert.IsNotNull(result.Artifact);
+        _ = result.Artifact.Execute(CreateActionContext("record-indexes", inputPosition: 1, alternativeIndex: 2, elementIndex: 3));
+        _ = result.Artifact.Execute(CreateActionContext("record-indexes", inputPosition: 4, alternativeIndex: 5, elementIndex: 6));
+        CollectionAssert.AreEqual(new[] { "1:2:3", "4:5:6" }, compiler.RecordedIndexes);
+    }
+
+
+    /// <summary>
+    /// Invokes a preparation method selected by a data-driven test.
+    /// </summary>
+    /// <param name="preparer">Preparer under test.</param>
+    /// <param name="prepareMethodName">Name of the preparation method to invoke.</param>
+    /// <param name="source">Embedded-code source to prepare.</param>
+    /// <param name="context">Preparation context to pass to the method.</param>
+    private static void InvokePrepare(
+        ExpressionEmbeddedCodePreparer preparer,
+        string prepareMethodName,
+        EmbeddedCodeSource source,
+        EmbeddedCodePreparationContext context)
+    {
+        if (prepareMethodName == nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate))
+        {
+            _ = preparer.PrepareSemanticPredicate(source, context);
+            return;
+        }
+
+        _ = preparer.PrepareParserAction(source, context);
+    }
+
+    /// <summary>
+    /// Asserts that a full symbol dictionary exposes the expected public names and runtime member expressions.
+    /// </summary>
+    /// <param name="symbols">Symbol dictionary passed to the expression compiler.</param>
+    /// <param name="runtimeContextType">Runtime context type expected at the root of each expression.</param>
+    private static void AssertSymbolSet(IReadOnlyDictionary<string, Expression> symbols, Type runtimeContextType)
+    {
+        CollectionAssert.AreEquivalent(new[] { "ruleName", "inputPosition", "alternativeIndex", "elementIndex" }, symbols.Keys.ToArray());
+        AssertSymbolExpression(symbols["ruleName"], runtimeContextType, typeof(string), "Rule.Name");
+        AssertSymbolExpression(symbols["inputPosition"], runtimeContextType, typeof(int), "InputPosition");
+        AssertSymbolExpression(symbols["alternativeIndex"], runtimeContextType, typeof(int), "AlternativeIndex");
+        AssertSymbolExpression(symbols["elementIndex"], runtimeContextType, typeof(int), "ElementIndex");
+    }
+
+    /// <summary>
+    /// Asserts that a symbol expression targets the expected runtime member chain without relying on expression text.
+    /// </summary>
+    /// <param name="expression">Expression to inspect.</param>
+    /// <param name="runtimeContextType">Runtime context type expected at the root of the member chain.</param>
+    /// <param name="expectedType">Expression type expected by the compiler.</param>
+    /// <param name="expectedPath">Dot-separated member path expected from the runtime context.</param>
+    private static void AssertSymbolExpression(Expression expression, Type runtimeContextType, Type expectedType, string expectedPath)
+    {
+        Assert.AreEqual(expectedType, expression.Type);
+        string[] members = expectedPath.Split('.');
+        Expression current = expression;
+
+        for (int index = members.Length - 1; index >= 0; index--)
+        {
+            Assert.IsInstanceOfType(current, typeof(MemberExpression));
+            var memberExpression = (MemberExpression)current;
+            Assert.AreEqual(members[index], memberExpression.Member.Name);
+            current = memberExpression.Expression!;
+        }
+
+        Assert.IsInstanceOfType(current, typeof(ParameterExpression));
+        Assert.AreEqual(runtimeContextType, current.Type);
+    }
+
     /// <summary>
     /// Creates source metadata for a test embedded-code construct.
     /// </summary>
@@ -456,11 +645,15 @@ public class ExpressionEmbeddedCodePreparerTests
     /// <param name="predicateCode">Predicate source code stored in the context.</param>
     /// <param name="ruleName">Rule name exposed to contextual expressions.</param>
     /// <param name="inputPosition">Input position exposed to contextual expressions.</param>
+    /// <param name="alternativeIndex">Alternative index exposed to contextual expressions.</param>
+    /// <param name="elementIndex">Element index exposed to contextual expressions.</param>
     /// <returns>A semantic predicate runtime context.</returns>
     private static SemanticPredicateEvaluationContext CreatePredicateContext(
         string predicateCode,
         string ruleName = "start",
-        int inputPosition = 0)
+        int inputPosition = 0,
+        int alternativeIndex = 0,
+        int elementIndex = 0)
     {
         var rule = CreateRule(ruleName);
         return new SemanticPredicateEvaluationContext(
@@ -468,8 +661,8 @@ public class ExpressionEmbeddedCodePreparerTests
             Predicate: new ValidatingPredicate(predicateCode),
             PredicateCode: predicateCode,
             InputPosition: inputPosition,
-            AlternativeIndex: 0,
-            ElementIndex: 0);
+            AlternativeIndex: alternativeIndex,
+            ElementIndex: elementIndex);
     }
 
     /// <summary>
@@ -478,11 +671,15 @@ public class ExpressionEmbeddedCodePreparerTests
     /// <param name="actionCode">Action source code stored in the context.</param>
     /// <param name="ruleName">Rule name exposed to contextual expressions.</param>
     /// <param name="inputPosition">Input position exposed to contextual expressions.</param>
+    /// <param name="alternativeIndex">Alternative index exposed to contextual expressions.</param>
+    /// <param name="elementIndex">Element index exposed to contextual expressions.</param>
     /// <returns>A parser action runtime context.</returns>
     private static ParserActionExecutionContext CreateActionContext(
         string actionCode,
         string ruleName = "start",
-        int inputPosition = 0)
+        int inputPosition = 0,
+        int alternativeIndex = 0,
+        int elementIndex = 0)
     {
         var rule = CreateRule(ruleName);
         return new ParserActionExecutionContext(
@@ -490,8 +687,8 @@ public class ExpressionEmbeddedCodePreparerTests
             Action: new EmbeddedAction(actionCode, ActionContext.Alternative, ActionPosition.Inline, []),
             ActionCode: actionCode,
             InputPosition: inputPosition,
-            AlternativeIndex: 0,
-            ElementIndex: 0);
+            AlternativeIndex: alternativeIndex,
+            ElementIndex: elementIndex);
     }
 
     /// <summary>
@@ -536,11 +733,20 @@ public class ExpressionEmbeddedCodePreparerTests
         /// </summary>
         public List<int> RecordedPositions { get; } = [];
 
+        /// <summary>
+        /// Gets index tuples recorded by generated action delegates.
+        /// </summary>
+        public List<string> RecordedIndexes { get; } = [];
+
+        /// <summary>Gets the last symbol dictionary passed to the fake compiler.</summary>
+        public IReadOnlyDictionary<string, Expression>? LastSymbols { get; private set; }
+
         /// <inheritdoc />
         public Expression Compile(string content, IReadOnlyDictionary<string, Expression>? symbols = null)
         {
             CompileCount++;
             LastContent = content;
+            LastSymbols = symbols;
             return content switch
             {
                 "true" => Expression.Constant(true),
@@ -550,6 +756,18 @@ public class ExpressionEmbeddedCodePreparerTests
                 "record-position inputPosition" => Expression.Call(Expression.Constant(this), nameof(RecordPosition), Type.EmptyTypes, symbols!["inputPosition"]),
                 "ruleName == target" => Expression.Equal(symbols!["ruleName"], Expression.Constant("start")),
                 "inputPosition >= 0" => Expression.GreaterThanOrEqual(symbols!["inputPosition"], Expression.Constant(0)),
+                "indexes-match" => Expression.AndAlso(
+                    Expression.Equal(symbols!["inputPosition"], Expression.Constant(1)),
+                    Expression.AndAlso(
+                        Expression.Equal(symbols!["alternativeIndex"], Expression.Constant(2)),
+                        Expression.Equal(symbols!["elementIndex"], Expression.Constant(3)))),
+                "record-indexes" => Expression.Call(
+                    Expression.Constant(this),
+                    nameof(RecordIndexes),
+                    Type.EmptyTypes,
+                    symbols!["inputPosition"],
+                    symbols!["alternativeIndex"],
+                    symbols!["elementIndex"]),
                 "throw-compile" => throw new InvalidOperationException("boom"),
                 _ => Expression.Empty()
             };
@@ -571,6 +789,15 @@ public class ExpressionEmbeddedCodePreparerTests
         /// </summary>
         /// <param name="inputPosition">Input position to record.</param>
         public void RecordPosition(int inputPosition) => RecordedPositions.Add(inputPosition);
+
+        /// <summary>
+        /// Records runtime indexes supplied through runtime context symbols.
+        /// </summary>
+        /// <param name="inputPosition">Runtime input position.</param>
+        /// <param name="alternativeIndex">Runtime alternative index.</param>
+        /// <param name="elementIndex">Runtime element index.</param>
+        public void RecordIndexes(int inputPosition, int alternativeIndex, int elementIndex) =>
+            RecordedIndexes.Add($"{inputPosition}:{alternativeIndex}:{elementIndex}");
     }
 
 


### PR DESCRIPTION
### Motivation
- Remove duplicated symbol-construction logic in `ExpressionEmbeddedCodePreparer` (TODO point 7) while preserving runtime behavior and public symbol names.
- Keep the two preparation wrappers for readability but delegate their work to a single shared implementation.
- Preserve exact runtime semantics: symbol names, `StringComparer.Ordinal`, runtime evaluation timing, lambda types and compiler call count.
- Record the agreed future parser/lexer refactor direction without implementing it prematurely in this PR.

### Description
- Introduced a single private builder, `BuildRuntimeContextSymbols(ParameterExpression runtimeContext, IReadOnlySet<EmbeddedCodeContextSymbol> supportedSymbols)`, that creates the symbol dictionary with `StringComparer.Ordinal`, walks `supportedSymbols` once, and maps the four retained symbols: `ruleName`, `inputPosition`, `alternativeIndex`, and `elementIndex`.
- Converted `BuildSemanticPredicateSymbols(...)` and `BuildParserActionSymbols(...)` into short wrappers that delegate to the shared builder.
- Removed the duplicated helpers `AddSemanticPredicateSymbol(...)` and `AddParserActionSymbol(...)`.
- Kept `BuildRuleName(...)` unchanged so both paths continue to produce the `context.Rule.Name` member chain.
- Added unit coverage for empty, single, full, unordered and unknown symbol sets, plus runtime-read scenarios for both semantic predicates and parser actions.
- Added a Roslyn-based architecture guard verifying that both wrappers delegate to the shared builder, only one symbol-classification switch remains, the old helpers are gone, and the existing compiler call structure is preserved.
- Updated `Utils.Parser/TODO.md` to mark point 7 as corrected and to refine point 8 into the agreed common-engine + specialized-strategy + immutable-context direction.
- Updated `Utils.Parser/ROADMAP.md` to document that future parser/lexer mutualisation should use composition, targeted strategies and immutable descriptors while preserving explicit runtime differences.

### Testing
- Built:
  - `Utils.Parser/Utils.Parser.csproj`
  - `Utils.Parser.Expressions/Utils.Parser.Expressions.csproj`
  - `UtilsTest/UtilsTest.Unit.csproj`
  - `UtilsTest.Functional/UtilsTest.Functional.csproj`
- Ran targeted unit tests for `ExpressionEmbeddedCodePreparerTests` successfully.
- Ran targeted functional tests for `EmbeddedCodeTransformerArchitectureTests` successfully.
- GitHub Actions workflow `Utils` run 2163 completed successfully on the latest commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a565a35c5d08326ac6a81f74dc70595)