### PR TITLE
Formalize the embedded-code transformation pipeline

### DIFF
--- a/Utils.Parser.Diagnostics/EmbeddedCode/EmbeddedCodeText.cs
+++ b/Utils.Parser.Diagnostics/EmbeddedCode/EmbeddedCodeText.cs
@@ -162,6 +162,31 @@ public static class ParserEmbeddedCodeTransformationService
         RawEmbeddedCode rawCode,
         ParserEmbeddedCodeTransformationContext context,
         ParserEmbeddedCodeTransformationFailureContext failureContext)
+        => EmbeddedCodeTransformationPipeline.TransformAndValidate(transformer, rawCode, context, failureContext);
+}
+
+/// <summary>
+/// Defines the shared transformation boundary between raw embedded code and target-specific handling.
+/// The pipeline starts with a typed raw value and parser transformation context, invokes the transformer
+/// exactly once, validates its result and diagnostics, and stops after producing transformed code. C# body
+/// classification and injection remain generator concerns, while symbol construction, lambda creation, and
+/// compilation remain responsibilities of the expression preparer and its compiler.
+/// </summary>
+internal static class EmbeddedCodeTransformationPipeline
+{
+    /// <summary>
+    /// Transforms one raw fragment and validates that the resulting artifact can be handed to a target.
+    /// </summary>
+    /// <param name="transformer">Transformer selected by the caller.</param>
+    /// <param name="rawCode">Typed raw embedded code that has not yet reached a target.</param>
+    /// <param name="context">Strongly typed parser transformation context.</param>
+    /// <param name="failureContext">Structured metadata used to preserve deterministic failures.</param>
+    /// <returns>Validated transformed code ready for target-specific classification or compilation.</returns>
+    internal static TransformedEmbeddedCode TransformAndValidate(
+        IParserEmbeddedCodeTransformer transformer,
+        RawEmbeddedCode rawCode,
+        ParserEmbeddedCodeTransformationContext context,
+        ParserEmbeddedCodeTransformationFailureContext failureContext)
     {
         if (transformer is null) throw new ArgumentNullException(nameof(transformer));
         if (rawCode is null) throw new ArgumentNullException(nameof(rawCode));

--- a/Utils.Parser.Diagnostics/Utils.Parser.Diagnostics.csproj
+++ b/Utils.Parser.Diagnostics/Utils.Parser.Diagnostics.csproj
@@ -24,4 +24,13 @@
         <ProjectReference Include="..\Utils.Parser.Source\Utils.Parser.Source.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Utils.Parser.Generators</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Utils.Parser.Expressions</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs
+++ b/Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs
@@ -118,7 +118,7 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
     {
         try
         {
-            return ParserEmbeddedCodeTransformationService.TransformOrThrow(
+            return EmbeddedCodeTransformationPipeline.TransformAndValidate(
                 _transformer,
                 source.RawCode,
                 new ParserEmbeddedCodeTransformationContext

--- a/Utils.Parser.Expressions/README.md
+++ b/Utils.Parser.Expressions/README.md
@@ -53,6 +53,8 @@ The preparer:
 - returns `PreservedNotCompiled` for `EmbeddedCodeTarget.SourceGeneratorCSharp`, because C# source-generation hooks belong to `Utils.Parser.Generators`;
 - never executes predicates or actions during preparation.
 
+Internally, preparation first crosses the same transformation-and-validation boundary as generated C# and receives a validated `TransformedEmbeddedCode`. Only then does this package build runtime symbol expressions and the specialized lambda and invoke the supplied `IExpressionCompiler`. Lexer hooks are not supported by this runtime path and are not synthesized by the shared boundary.
+
 Contextual symbols (`ruleName`, `inputPosition`, `alternativeIndex`, `elementIndex`) are filtered through `EmbeddedCodePreparationContext.SupportedSymbols` before compilation. Supported symbols are represented as reads from the runtime context parameter when compiling prepared artifacts, so they are not captured as fixed preparation-time constants. Expressions that reference a symbol excluded from `SupportedSymbols` fail through the configured compiler and are returned as `CompilationFailed` results.
 
 ## Runtime status
@@ -171,4 +173,3 @@ Lexer actions, lexer predicates, grammar members/`@members`, `@init`, `@after`, 
 Parser embedded-code discovery now has a shared metadata model in `Utils.Parser.EmbeddedCode`. `EmbeddedCodeRuntimeDiscovery` walks a `ParserDefinition` and emits `EmbeddedCodeRuntimeEntry` values with the raw source, `EmbeddedCodeKind`, owning rule name, runtime-compatible alternative and element indexes, a runtime key for executable entries, and an explicit `EmbeddedCodeUnsupportedReason` for skipped entries. The metadata mirrors the existing parser runtime indexing rules for priority-ordered alternatives, single-item alternatives, sequences, quantifier inner parsing, negation probes, and direct-left-recursive base/tail alternatives. It is metadata only: it does not compile source, generate C#, execute actions, or change `ParserEngine` behavior.
 
 The expression-backed prepared registry consumes this shared discovery result before invoking its preparer. Unsupported constructs such as grammar actions, `@init`, `@after`, lexer actions/predicates, and non-inline parser actions remain non-executable, but they now carry explicit skip reasons. Invalid C# in a source-generator-supported hook remains a Roslyn compilation error rather than a custom parser diagnostic.
-

--- a/Utils.Parser.Generators/Internal/GrammarEmitter.ExecutionContext.Hooks.cs
+++ b/Utils.Parser.Generators/Internal/GrammarEmitter.ExecutionContext.Hooks.cs
@@ -46,7 +46,7 @@ internal static partial class GrammarEmitter
         G4Grammar grammar,
         G4Rule? rule)
     {
-        return ParserEmbeddedCodeTransformationService.TransformOrThrow(
+        return EmbeddedCodeTransformationPipeline.TransformAndValidate(
             transformer,
             code,
             new ParserEmbeddedCodeTransformationContext

--- a/Utils.Parser.Generators/README.md
+++ b/Utils.Parser.Generators/README.md
@@ -424,6 +424,8 @@ Generated C# preserves embedded parser code by default through `NoOpParserEmbedd
 
 Generated/source-generator emission applies the embedded-code transformer before emitting parser `@header`, parser `@footer`, rule `@init`, rule `@after`, inline parser actions, and semantic predicates where those locations are supported. The standard source generator uses the no-op transformer; direct emitter APIs can supply a custom transformer for tests or specialized tooling.
 
+Internally, raw code and its strongly typed transformation context cross the shared transformation-and-validation boundary exactly once. The resulting `TransformedEmbeddedCode` is then classified as a predicate expression/fragment or action fragment by `GeneratedEmbeddedCodeBody` and written only by `CSharpEmbeddedCodeInjector`. This generator-specific tail does not construct runtime expressions or invoke an expression compiler.
+
 ### Optional C# transformer lexer action attributes
 
 Generated C# can opt into a narrow lexer inline-action attribute rewrite set through `CSharpAntlrStyleParserEmbeddedCodeTransformer`. The default/no-op transformer preserves lexer `$...` syntax unchanged. This rewrite applies only to lexer inline actions, not parser actions, lexer predicates, or runtime-inline execution.

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -204,9 +204,21 @@ Implemented for generated hook-method emission:
 - Explicit wrappers `EmitPredicateHook(...)`, `EmitActionHook(...)`, `EmitLexerPredicateHook(...)`, and `EmitLexerActionHook(...)` remain as the four readable selection points and delegate to the shared emitter.
 - Lifecycle hooks remain separate because they use `LifecycleHook`, `ParserRuleLifecycleContext`, lifecycle phases, `internal` visibility, and lifecycle-specific locals rather than `EmbeddedCodeHookOwner` / `EmbeddedCodeHookKind`.
 
+Implemented for the transformation boundary:
+
+- the internal `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)` owns the common,
+  target-independent raw-code transformation and result validation step;
+- generated C# and runtime expression preparation consume the same validated
+  `TransformedEmbeddedCode` boundary while constructing their specialized contexts explicitly;
+- `GeneratedEmbeddedCodeBody` and `CSharpEmbeddedCodeInjector` remain generator-only, while
+  `ExpressionEmbeddedCodePreparer` and `IExpressionCompiler` retain runtime symbol, lambda, and
+  compilation ownership;
+- architecture guards prohibit a parallel direct transformer path and prohibit target dependencies
+  in the common pipeline.
+
 Still planned:
 
-- keep points 9, 10, and 11 open for the broader embedded-code pipeline, `EmittedCode` naming, and public preparer documentation work.
+- keep point 10 open for `EmittedCode` naming and point 11 open for public preparer documentation work.
 
 The refactor must continue to keep the following differences explicit: parser left recursion, alternative priority ordering, lexer modes, quantifier and negation index semantics, generated names, transformation locations, runtime context types, method signatures, success results, and fallback calls. These differences must not be hidden behind a single `isLexer` flag or scattered parser/lexer switches inside a shared engine.
 

--- a/Utils.Parser/TODO.md
+++ b/Utils.Parser/TODO.md
@@ -412,16 +412,32 @@ explicites, la validation typée et la séparation volontaire des hooks lifecycl
 ## Duplications d'intention et lisibilité (priorité moyenne)
 
 ### 9. Clarifier la frontière entre préparation, transformation, injection et compilation
-Plusieurs composants participent à une même intention sans pipeline central explicite :
-`TransformEmbeddedCode`, `TransformSource`, `GeneratedEmbeddedCodeBody`, les méthodes `Emit...` et
-`ExpressionEmbeddedCodePreparer`.
+**Corrigé.** Le noyau interne `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)`, placé
+dans l'assembly `netstandard2.0` de diagnostics partagée, reçoit un `RawEmbeddedCode`, un
+`IParserEmbeddedCodeTransformer`, un `ParserEmbeddedCodeTransformationContext` fortement typé et les
+métadonnées d'échec. Il appelle le transformer exactement une fois, centralise les validations des
+arguments, du résultat nul, des diagnostics bloquants et du code transformé nul, puis remet un
+`TransformedEmbeddedCode` validé. L'ancien service public délègue au noyau afin de préserver l'API.
 
-**Fix proposé** : formaliser le pipeline suivant :
+La frontière s'arrête strictement à cet artefact : elle ne connaît ni `StringBuilder`, ni injection,
+ni expression, ni lambda, ni compilation. Le générateur construit son contexte enrichi (règle,
+déclarations et labels), appelle le noyau, conserve la distinction parser/lexer et predicate/action,
+puis classe le résultat via `GeneratedEmbeddedCodeBody.ForPredicate(...)` ou `ForAction(...)` et
+délègue exclusivement à `CSharpEmbeddedCodeInjector`. Le chemin runtime, limité aux prédicats et
+actions parser, construit son contexte dans `ExpressionEmbeddedCodePreparer`, appelle le même noyau,
+construit ensuite les symboles et la lambda spécialisés, et conserve l'appel à
+`IExpressionCompiler.Compile(...)`.
 
-1. création du contexte de transformation ;
-2. transformation et validation ;
-3. remise du code transformé à une cible unique ;
-4. injection C# via `CSharpEmbeddedCodeInjector` ou compilation via `IExpressionCompiler`.
+Les tests de caractérisation couvrent les quatre catégories générées et les deux catégories runtime,
+les contextes et textes bruts exacts, l'appel unique, les échecs de transformation, la classification,
+l'injection, la compilation unique et la réutilisation d'artefacts avec plusieurs contextes runtime.
+Le garde-fou Roslyn `EmbeddedCodeTransformerArchitectureTests` interdit les appels directs parallèles
+au transformer et vérifie que le noyau est interne, commun aux deux cibles, retourne le type transformé
+et ne dépend d'aucun détail de cible. `CSharpEmbeddedCodeInjectorArchitectureTests` maintient la
+frontière d'injection. Aucune API publique ni aucun comportement observable n'a été modifié.
+
+Les points 10 (`EmbeddedCodeHook.EmittedCode`) et 11 (statut documenté de la façade runtime) restent
+explicitement ouverts.
 
 ### 10. Renommer ou supprimer l'état ambigu `EmittedCode`
 `EmittedCode` est initialisé avec le code brut avant d'être remplacé par le code transformé. Son nom

--- a/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
+++ b/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
@@ -113,10 +113,35 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
         Assert.IsFalse(pipeline.DescendantNodes().OfType<InvocationExpressionSyntax>().Any(static invocation =>
             invocation.Expression.ToString().Contains("Lambda", StringComparison.Ordinal)));
 
-        string generatorSource = File.ReadAllText(Path.Combine(repositoryRoot, "Utils.Parser.Generators", "Internal", "GrammarEmitter.ExecutionContext.Hooks.cs"));
-        string runtimeSource = File.ReadAllText(Path.Combine(repositoryRoot, "Utils.Parser.Expressions", "ExpressionEmbeddedCodePreparer.cs"));
-        Assert.AreEqual(1, CountPipelineCalls(generatorSource));
-        Assert.AreEqual(1, CountPipelineCalls(runtimeSource));
+        IReadOnlyList<SourceScan> scans = CreateProductionParserScans(repositoryRoot);
+        Assert.AreEqual(1, CountPipelineCalls(scans, "Utils.Parser.Generators/Internal/GrammarEmitter.ExecutionContext.Hooks.cs"));
+        Assert.AreEqual(1, CountPipelineCalls(scans, "Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs"));
+    }
+
+    /// <summary>
+    /// Ensures semantic pipeline-call counting recognizes type aliases and static imports.
+    /// </summary>
+    [TestMethod]
+    public void PipelineCallScan_WhenAliasOrStaticImportIsUsed_CountsBothCalls()
+    {
+        IReadOnlyList<SourceScan> scans = CreateSamplePipelineScans(
+            """
+            using Pipeline = Utils.Parser.Diagnostics.EmbeddedCode.EmbeddedCodeTransformationPipeline;
+            using static Utils.Parser.Diagnostics.EmbeddedCode.EmbeddedCodeTransformationPipeline;
+
+            namespace Sample;
+
+            internal static class Caller
+            {
+                internal static void Execute()
+                {
+                    Pipeline.TransformAndValidate();
+                    TransformAndValidate();
+                }
+            }
+            """);
+
+        Assert.AreEqual(2, CountPipelineCalls(scans, "Caller.cs"));
     }
 
     /// <summary>
@@ -602,6 +627,35 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
     }
 
     /// <summary>
+    /// Creates semantic scans for pipeline calls expressed through aliases or static imports.
+    /// </summary>
+    /// <param name="callerSource">Caller source containing the invocation forms to inspect.</param>
+    /// <returns>Semantic scans containing the pipeline contract and caller.</returns>
+    private static IReadOnlyList<SourceScan> CreateSamplePipelineScans(string callerSource)
+    {
+        SyntaxTree pipelineTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace Utils.Parser.Diagnostics.EmbeddedCode;
+
+            internal static class EmbeddedCodeTransformationPipeline
+            {
+                internal static object TransformAndValidate() => new();
+            }
+            """,
+            path: CentralPipelineRelativePath);
+        SyntaxTree callerTree = CSharpSyntaxTree.ParseText(callerSource, path: "Caller.cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "Utils.Parser.EmbeddedCodeTransformer.SamplePipelineScan",
+            [pipelineTree, callerTree],
+            CreateRuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        return new[] { pipelineTree, callerTree }
+            .Select(tree => new SourceScan(tree.FilePath, tree, compilation.GetSemanticModel(tree)))
+            .ToArray();
+    }
+
+    /// <summary>
     /// Finds forbidden direct <c>IExpressionCompiler.Compile(...)</c> calls inside embedded-code preparer implementations.
     /// </summary>
     /// <param name="scans">Semantic source scans to inspect.</param>
@@ -744,17 +798,25 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
     }
 
     /// <summary>
-    /// Counts calls to the common transformation boundary in one source file.
+    /// Counts calls to the common transformation boundary in one source file using resolved method symbols.
     /// </summary>
-    /// <param name="source">C# source to inspect.</param>
+    /// <param name="scans">Semantic scans containing the pipeline declaration and callers.</param>
+    /// <param name="relativePath">Relative path of the caller to inspect.</param>
     /// <returns>The number of calls to the common boundary.</returns>
-    private static int CountPipelineCalls(string source)
+    private static int CountPipelineCalls(IReadOnlyList<SourceScan> scans, string relativePath)
     {
-        CompilationUnitSyntax root = CSharpSyntaxTree.ParseText(source).GetCompilationUnitRoot();
-        return root.DescendantNodes().OfType<InvocationExpressionSyntax>().Count(static invocation =>
-            invocation.Expression is MemberAccessExpressionSyntax member
-            && member.Expression.ToString() == "EmbeddedCodeTransformationPipeline"
-            && member.Name.Identifier.ValueText == "TransformAndValidate");
+        Compilation compilation = scans[0].SemanticModel.Compilation;
+        INamedTypeSymbol? pipelineType = compilation.GetTypeByMetadataName("Utils.Parser.Diagnostics.EmbeddedCode.EmbeddedCodeTransformationPipeline");
+        IMethodSymbol? pipelineMethod = pipelineType?.GetMembers("TransformAndValidate").OfType<IMethodSymbol>().SingleOrDefault();
+        if (pipelineMethod is null)
+        {
+            Assert.Fail("The embedded-code transformation pipeline entry point was not resolved by the architecture scan.");
+        }
+
+        SourceScan scan = scans.Single(candidate => NormalizePath(candidate.RelativePath) == NormalizePath(relativePath));
+        return scan.Tree.GetCompilationUnitRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Count(invocation =>
+            scan.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol method
+            && SymbolEqualityComparer.Default.Equals(method.OriginalDefinition, pipelineMethod));
     }
 
     /// <summary>

--- a/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
+++ b/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
@@ -11,7 +11,7 @@ namespace UtilsTest.Parser;
 [TestClass]
 public sealed class EmbeddedCodeTransformerArchitectureTests
 {
-    private static readonly string CentralServiceRelativePath = Path.Combine("Utils.Parser.Diagnostics", "EmbeddedCode", "EmbeddedCodeText.cs");
+    private static readonly string CentralPipelineRelativePath = Path.Combine("Utils.Parser.Diagnostics", "EmbeddedCode", "EmbeddedCodeText.cs");
 
     /// <summary>
     /// Ensures production parser code does not bypass the central embedded-code transformation service.
@@ -68,9 +68,9 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
         const string source = """
             namespace Utils.Parser.Diagnostics.EmbeddedCode;
 
-            public static class ParserEmbeddedCodeTransformationService
+            internal static class EmbeddedCodeTransformationPipeline
             {
-                public static void TransformOrThrow(IParserEmbeddedCodeTransformer transformer, ParserEmbeddedCodeTransformationContext context)
+                internal static void TransformAndValidate(IParserEmbeddedCodeTransformer transformer, ParserEmbeddedCodeTransformationContext context)
                 {
                     transformer.Transform(context);
                 }
@@ -82,11 +82,41 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
             }
             """;
 
-        string[] violations = FindForbiddenDirectTransformCalls(CentralServiceRelativePath, source)
+        string[] violations = FindForbiddenDirectTransformCalls(CentralPipelineRelativePath, source)
             .Select(static occurrence => occurrence.ToString())
             .ToArray();
 
-        CollectionAssert.AreEqual(new[] { $"{CentralServiceRelativePath}:12: transformer.Transform(context)" }, violations);
+        CollectionAssert.AreEqual(new[] { $"{CentralPipelineRelativePath}:12: transformer.Transform(context)" }, violations);
+    }
+
+    /// <summary>
+    /// Ensures the common boundary stops at validated transformed code and both targets enter it directly.
+    /// </summary>
+    [TestMethod]
+    public void EmbeddedCodeTransformationPipeline_IsInternalTargetIndependentAndShared()
+    {
+        string repositoryRoot = FindRepositoryRoot();
+        string pipelineSource = File.ReadAllText(Path.Combine(repositoryRoot, CentralPipelineRelativePath));
+        CompilationUnitSyntax pipelineRoot = CSharpSyntaxTree.ParseText(pipelineSource).GetCompilationUnitRoot();
+        ClassDeclarationSyntax pipeline = pipelineRoot.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .Single(static type => type.Identifier.ValueText == "EmbeddedCodeTransformationPipeline");
+        MethodDeclarationSyntax entry = pipeline.Members.OfType<MethodDeclarationSyntax>()
+            .Single(static method => method.Identifier.ValueText == "TransformAndValidate");
+
+        Assert.IsTrue(pipeline.Modifiers.Any(SyntaxKind.InternalKeyword));
+        Assert.AreEqual("TransformedEmbeddedCode", entry.ReturnType.ToString());
+        CollectionAssert.AreEqual(
+            new[] { "IParserEmbeddedCodeTransformer", "RawEmbeddedCode", "ParserEmbeddedCodeTransformationContext", "ParserEmbeddedCodeTransformationFailureContext" },
+            entry.ParameterList.Parameters.Select(static parameter => parameter.Type!.ToString()).ToArray());
+        Assert.IsFalse(pipeline.DescendantNodes().OfType<IdentifierNameSyntax>().Any(static identifier =>
+            identifier.Identifier.ValueText is "StringBuilder" or "CSharpEmbeddedCodeInjector" or "IExpressionCompiler"));
+        Assert.IsFalse(pipeline.DescendantNodes().OfType<InvocationExpressionSyntax>().Any(static invocation =>
+            invocation.Expression.ToString().Contains("Lambda", StringComparison.Ordinal)));
+
+        string generatorSource = File.ReadAllText(Path.Combine(repositoryRoot, "Utils.Parser.Generators", "Internal", "GrammarEmitter.ExecutionContext.Hooks.cs"));
+        string runtimeSource = File.ReadAllText(Path.Combine(repositoryRoot, "Utils.Parser.Expressions", "ExpressionEmbeddedCodePreparer.cs"));
+        Assert.AreEqual(1, CountPipelineCalls(generatorSource));
+        Assert.AreEqual(1, CountPipelineCalls(runtimeSource));
     }
 
     /// <summary>
@@ -669,7 +699,7 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
     private static IEnumerable<SourceOccurrence> FindForbiddenDirectTransformCalls(string relativePath, string source)
     {
         return FindDirectTransformCalls(relativePath, source)
-            .Where(static occurrence => !IsCentralServiceOccurrence(occurrence));
+            .Where(static occurrence => !IsCentralPipelineOccurrence(occurrence));
     }
 
     /// <summary>
@@ -705,12 +735,26 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
     /// </summary>
     /// <param name="occurrence">Source occurrence to classify.</param>
     /// <returns><see langword="true" /> when the occurrence is allowed.</returns>
-    private static bool IsCentralServiceOccurrence(SourceOccurrence occurrence)
+    private static bool IsCentralPipelineOccurrence(SourceOccurrence occurrence)
     {
-        return occurrence.RelativePath == CentralServiceRelativePath
-            && occurrence.EnclosingTypeName == "ParserEmbeddedCodeTransformationService"
-            && occurrence.EnclosingMethodName == "TransformOrThrow"
+        return occurrence.RelativePath == CentralPipelineRelativePath
+            && occurrence.EnclosingTypeName == "EmbeddedCodeTransformationPipeline"
+            && occurrence.EnclosingMethodName == "TransformAndValidate"
             && occurrence.ReceiverExpression == "transformer";
+    }
+
+    /// <summary>
+    /// Counts calls to the common transformation boundary in one source file.
+    /// </summary>
+    /// <param name="source">C# source to inspect.</param>
+    /// <returns>The number of calls to the common boundary.</returns>
+    private static int CountPipelineCalls(string source)
+    {
+        CompilationUnitSyntax root = CSharpSyntaxTree.ParseText(source).GetCompilationUnitRoot();
+        return root.DescendantNodes().OfType<InvocationExpressionSyntax>().Count(static invocation =>
+            invocation.Expression is MemberAccessExpressionSyntax member
+            && member.Expression.ToString() == "EmbeddedCodeTransformationPipeline"
+            && member.Name.Identifier.ValueText == "TransformAndValidate");
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation

- Several components participated in transforming embedded grammar code without an explicit shared boundary, causing a duplication of intent between generator and runtime preparation paths.
- The goal was to create a single internal transformation+validation step consumed by both generated-C# emission and runtime expression preparation while preserving target-specific responsibilities and observable behavior.

### Description

- Introduce an internal pipeline `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)` in `Utils.Parser.Diagnostics` that accepts `IParserEmbeddedCodeTransformer`, `RawEmbeddedCode`, `ParserEmbeddedCodeTransformationContext` and a `ParserEmbeddedCodeTransformationFailureContext`, invokes the transformer exactly once, centralizes argument/result/diagnostic validations, and returns a validated `TransformedEmbeddedCode` artifact.
- Make `ParserEmbeddedCodeTransformationService.TransformOrThrow` delegate to the new internal pipeline for compatibility while keeping the public API unchanged.
- Update consumers to use the shared boundary: `GrammarEmitter.ExecutionContext.Hooks` and `ExpressionEmbeddedCodePreparer.TransformSource` now call the new pipeline instead of calling the transformer directly.
- Add `InternalsVisibleTo` entries to `Utils.Parser.Diagnostics` so the internal pipeline can be used by `Utils.Parser.Generators` and `Utils.Parser.Expressions` without adding a public API.
- Update documentation and TODO/ROADMAP to record the new pipeline, mark TODO point 9 as corrected (points 10 and 11 remain open), and document the responsibilities that remain with `GeneratedEmbeddedCodeBody`, `CSharpEmbeddedCodeInjector`, `ExpressionEmbeddedCodePreparer`, and `IExpressionCompiler`.
- Strengthen the functional Roslyn architecture guard test (`EmbeddedCodeTransformerArchitectureTests`) to assert the pipeline is internal, target-independent, returns `TransformedEmbeddedCode`, and is invoked exactly once from both generator and runtime code.

### Testing

- Built the relevant projects with `dotnet build` and observed successful builds for `Utils.Parser`, `Utils.Parser.Generators`, `Utils.Parser.Expressions`, `Utils.Parser.Diagnostics`, `UtilsTest.Unit` and `UtilsTest.Functional` with only pre-existing repository warnings (no new errors introduced).
- Ran targeted unit tests with `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter "Antlr4GeneratedEmbeddedCodeTests|EmbeddedCodeTransformationInvariantTests|ExpressionEmbeddedCodePreparer"` and the matrix passed (`348` tests passed).
- Ran targeted functional architecture tests with `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --filter "EmbeddedCodeTransformerArchitectureTests|CSharpEmbeddedCodeInjectorArchitectureTests"` and they passed (`15` tests passed).
- Verified via repository-wide scans that the only direct transform invocation is the centralized pipeline and that generator and runtime consumers use `TransformAndValidate` (searches and Roslyn-based architecture tests were executed and succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59e1db1ee483268353741f1515bca0)