### PR TITLE
Clarify embedded hook raw vs transformed phases (remove ambiguous EmittedCode)

### DIFF
--- a/Utils.Parser.Generators/Internal/GrammarEmitter.EmbeddedHooks.cs
+++ b/Utils.Parser.Generators/Internal/GrammarEmitter.EmbeddedHooks.cs
@@ -107,7 +107,10 @@ internal static partial class GrammarEmitter
                 for (int index = firstHookIndex; index < hooks.Count; index++)
                 {
                     EmbeddedCodeHook hook = hooks[index];
-                    hook.EmittedCode = TransformEmbeddedCode(transformer, hook.RawCode, _strategy.GetLocation(hook.Kind), grammar, _strategy.GetTransformationRule(rule));
+                    hooks[index] = hook with
+                    {
+                        TransformedCode = TransformEmbeddedCode(transformer, hook.RawCode, _strategy.GetLocation(hook.Kind), grammar, _strategy.GetTransformationRule(rule))
+                    };
                 }
             }
 
@@ -550,10 +553,8 @@ internal static partial class GrammarEmitter
     /// <summary>
     /// Metadata for one generated parser or lexer embedded-code hook.
     /// </summary>
-    private sealed class EmbeddedCodeHook
+    private sealed record EmbeddedCodeHook
     {
-        private TransformedEmbeddedCode? _emittedCode;
-
         /// <summary>
         /// Initializes generated embedded-code hook metadata after validating common invariants.
         /// </summary>
@@ -622,12 +623,8 @@ internal static partial class GrammarEmitter
         /// <summary>Gets the raw embedded source code without ANTLR braces.</summary>
         public RawEmbeddedCode RawCode { get; }
 
-        /// <summary>Gets the transformed C# source emitted into the hook method.</summary>
-        public TransformedEmbeddedCode EmittedCode
-        {
-            get => _emittedCode ?? throw new InvalidOperationException("Embedded code has not been transformed yet.");
-            set => _emittedCode = value ?? throw new ArgumentNullException(nameof(value));
-        }
+        /// <summary>Gets the validated transformed C# source, or <c>null</c> before transformation.</summary>
+        public TransformedEmbeddedCode? TransformedCode { get; init; }
 
         /// <summary>Gets a value indicating whether the hook is a semantic predicate.</summary>
         public bool IsPredicate => Kind == EmbeddedCodeHookKind.SemanticPredicate;

--- a/Utils.Parser.Generators/Internal/GrammarEmitter.ExecutionContext.Policy.cs
+++ b/Utils.Parser.Generators/Internal/GrammarEmitter.ExecutionContext.Policy.cs
@@ -477,7 +477,8 @@ internal static partial class GrammarEmitter
         public static void Emit(StringBuilder sb, EmbeddedCodeHook hook, EmbeddedHookMethodDescriptor descriptor)
         {
             ValidateEmbeddedCodeHook(hook, descriptor.Owner, descriptor.Kind);
-            GeneratedEmbeddedCodeBody body = descriptor.CreateBody(hook.EmittedCode);
+            TransformedEmbeddedCode transformedCode = RequireTransformedCode(hook);
+            GeneratedEmbeddedCodeBody body = descriptor.CreateBody(transformedCode);
 
             sb.AppendLine(descriptor.CreateSummary(hook));
             sb.AppendLine($"    private {descriptor.ReturnTypeName} {hook.MethodName}({descriptor.Parameters})");
@@ -486,6 +487,17 @@ internal static partial class GrammarEmitter
             EmitGeneratedEmbeddedCodeBody(sb, body, 2);
             sb.AppendLine("    }");
             sb.AppendLine();
+        }
+
+        /// <summary>
+        /// Gets validated transformed code and rejects collected hooks before any source is written.
+        /// </summary>
+        /// <param name="hook">Hook that must have completed the transformation pipeline.</param>
+        /// <returns>The validated transformed hook body.</returns>
+        private static TransformedEmbeddedCode RequireTransformedCode(EmbeddedCodeHook hook)
+        {
+            return hook.TransformedCode
+                ?? throw new InvalidOperationException($"Embedded code hook '{hook.MethodName}' has not been transformed and cannot be emitted.");
         }
 
         /// <summary>

--- a/Utils.Parser.Generators/IsExternalInit.cs
+++ b/Utils.Parser.Generators/IsExternalInit.cs
@@ -1,0 +1,8 @@
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Provides record initialization support when targeting frameworks that do not define the type.
+/// </summary>
+internal static class IsExternalInit
+{
+}

--- a/Utils.Parser.Generators/README.md
+++ b/Utils.Parser.Generators/README.md
@@ -424,9 +424,7 @@ Generated C# preserves embedded parser code by default through `NoOpParserEmbedd
 
 Generated/source-generator emission applies the embedded-code transformer before emitting parser `@header`, parser `@footer`, rule `@init`, rule `@after`, inline parser actions, and semantic predicates where those locations are supported. The standard source generator uses the no-op transformer; direct emitter APIs can supply a custom transformer for tests or specialized tooling.
 
-Internally, the flow is explicit: collection produces `RawEmbeddedCode`, transformation and validation produce `TransformedEmbeddedCode`, classification produces `GeneratedEmbeddedCodeBody`, and injection is owned by `CSharpEmbeddedCodeInjector`. Raw hook text remains available for diagnostics and auditing but is never consumed by a C# emitter. A hook that has not completed transformation is rejected before any generated source is written.
-
-Internally, raw code and its strongly typed transformation context cross the shared transformation-and-validation boundary exactly once. The resulting `TransformedEmbeddedCode` is then classified as a predicate expression/fragment or action fragment by `GeneratedEmbeddedCodeBody` and written only by `CSharpEmbeddedCodeInjector`. This generator-specific tail does not construct runtime expressions or invoke an expression compiler.
+Internally, collection produces `RawEmbeddedCode`, which crosses the shared transformation-and-validation boundary exactly once with its strongly typed context. The resulting `TransformedEmbeddedCode` is classified as a predicate expression/fragment or action fragment by `GeneratedEmbeddedCodeBody` and written only by `CSharpEmbeddedCodeInjector`. Raw hook text remains available for diagnostics and auditing but is never consumed by a C# emitter, and a hook that has not completed transformation is rejected before any generated source is written. This generator-specific tail does not construct runtime expressions or invoke an expression compiler.
 
 ### Optional C# transformer lexer action attributes
 

--- a/Utils.Parser.Generators/README.md
+++ b/Utils.Parser.Generators/README.md
@@ -424,6 +424,8 @@ Generated C# preserves embedded parser code by default through `NoOpParserEmbedd
 
 Generated/source-generator emission applies the embedded-code transformer before emitting parser `@header`, parser `@footer`, rule `@init`, rule `@after`, inline parser actions, and semantic predicates where those locations are supported. The standard source generator uses the no-op transformer; direct emitter APIs can supply a custom transformer for tests or specialized tooling.
 
+Internally, the flow is explicit: collection produces `RawEmbeddedCode`, transformation and validation produce `TransformedEmbeddedCode`, classification produces `GeneratedEmbeddedCodeBody`, and injection is owned by `CSharpEmbeddedCodeInjector`. Raw hook text remains available for diagnostics and auditing but is never consumed by a C# emitter. A hook that has not completed transformation is rejected before any generated source is written.
+
 Internally, raw code and its strongly typed transformation context cross the shared transformation-and-validation boundary exactly once. The resulting `TransformedEmbeddedCode` is then classified as a predicate expression/fragment or action fragment by `GeneratedEmbeddedCodeBody` and written only by `CSharpEmbeddedCodeInjector`. This generator-specific tail does not construct runtime expressions or invoke an expression compiler.
 
 ### Optional C# transformer lexer action attributes

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -216,9 +216,15 @@ Implemented for the transformation boundary:
 - architecture guards prohibit a parallel direct transformer path and prohibit target dependencies
   in the common pipeline.
 
+Completed for the hook phase model:
+
+- collected parser and lexer hooks retain grammar text as `RawEmbeddedCode`;
+- the shared pipeline produces validated `TransformedEmbeddedCode` through an explicit immutable transition;
+- generated-code targets consume only the transformed phase, and the former ambiguous hook member has been removed.
+
 Still planned:
 
-- keep point 10 open for `EmittedCode` naming and point 11 open for public preparer documentation work.
+- keep point 11 open for public preparer documentation work.
 
 The refactor must continue to keep the following differences explicit: parser left recursion, alternative priority ordering, lexer modes, quantifier and negation index semantics, generated names, transformation locations, runtime context types, method signatures, success results, and fallback calls. These differences must not be hidden behind a single `isLexer` flag or scattered parser/lexer switches inside a shared engine.
 

--- a/Utils.Parser/TODO.md
+++ b/Utils.Parser/TODO.md
@@ -15,7 +15,7 @@ non traitées, sauf mention contraire.
 ### 1. Introduire une représentation typée du code transformé
 **Corrigé.** Le pipeline distingue désormais `RawEmbeddedCode` et `TransformedEmbeddedCode` dans
 `Utils.Parser.Diagnostics.EmbeddedCode`. `EmbeddedCodeSource` expose le texte source sous forme de
-`RawEmbeddedCode`, les hooks générés conservent le code brut dans `RawCode`, et leur `EmittedCode`
+`RawEmbeddedCode`, les hooks générés conservent le code brut dans `RawCode`, et leur `TransformedCode`
 est un `TransformedEmbeddedCode` rempli uniquement après l'appel à `IParserEmbeddedCodeTransformer`.
 `GrammarEmitter.TransformEmbeddedCode` et `ExpressionEmbeddedCodePreparer.TransformSource` passent par
 `ParserEmbeddedCodeTransformationService.TransformOrThrow`, qui exécute le transformer, valide les diagnostics
@@ -32,7 +32,7 @@ Tests ajoutés :
 - `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesParserPredicateAndAction_RawCodeDoesNotAppearInGeneratedHookBodies` ;
 - `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesLexerHook_RawCodeDoesNotAppearInGeneratedHookBodies` ;
 - `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_UseTypedRawAndTransformedCodeFields` ;
-- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_WhenEmittedCodeIsReadBeforeTransformation_Throws`.
+- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_WhenUntransformedHookIsEmitted_ThrowsBeforeWritingSource`.
 
 ### 2. Centraliser l'appel au transformer et la validation des diagnostics
 **Corrigé.** `ParserEmbeddedCodeTransformationService.TransformOrThrow` est désormais la frontière
@@ -178,7 +178,7 @@ par cette correction.
 **Corrigé.** Les hooks parser et lexer générés sont désormais représentés par un seul type interne
 `GrammarEmitter.EmbeddedCodeHook`. L'ancien type `LexerEmbeddedCodeHook` a été supprimé. Le type
 commun conserve le code brut dans `RawEmbeddedCode RawCode` et le code transformé prêt à l'émission
-dans `TransformedEmbeddedCode EmittedCode`, sans remplacer ces frontières typées par des chaînes.
+dans `TransformedEmbeddedCode? TransformedCode`, sans remplacer ces frontières typées par des chaînes.
 
 La distinction de domaine est explicite grâce à deux discriminants internes :
 
@@ -189,8 +189,8 @@ Les quatre catégories sont donc couvertes sans booléen ambigu comme état prin
 action inline parser, prédicat lexer et action inline lexer. La construction passe par les fabriques
 `CreateParser(...)` et `CreateLexer(...)`, qui valident le nom de règle, le code brut, les indices
 acceptés (`-1` comme sentinelle historique ou valeur positive/nulle), le nom de méthode générée et les
-valeurs d'enum. La lecture de `EmittedCode` avant transformation continue d'échouer, et l'affectation
-d'un code transformé nul reste rejetée.
+valeurs d'enum. Le résultat transformé reste absent avant la transition immuable, et le point d’accès unique des
+émetteurs rejette explicitement cet état avant toute écriture de source.
 
 Les producteurs parser et lexer restent séparés : `CollectEmbeddedCodeHooks(...)` conserve les règles
 d'indexation parser, notamment les traitements de séquences, quantificateurs, négations et récursion
@@ -208,7 +208,7 @@ Tests ajoutés ou renforcés :
 - `EmbeddedCodeTransformerArchitectureTests.GrammarEmitterEmbeddedCodeHooks_UseSingleCommonHookModel`.
 
 Les points 7 à 11 restent hors périmètre : construction des symboles runtime, mutualisation générale
-des parcours récursifs, formalisation globale du pipeline, renommage complet de `EmittedCode` et
+des parcours récursifs, formalisation globale du pipeline, clarification de l’état brut/transformé et
 documentation de la façade runtime ne sont pas traités par cette correction.
 
 ### 7. Factoriser la construction des symboles d'expressions
@@ -249,7 +249,7 @@ Tests ajoutés ou renforcés :
   nouveau contrat public n'a été introduit.
 
 Les points 8 à 11 restent hors périmètre du code de production de cette correction : la mutualisation
-générale parser/lexer, le pipeline global, le renommage de `EmittedCode` et la documentation de façade
+générale parser/lexer, le pipeline global, la clarification de l’état brut/transformé et la documentation de façade
 runtime demeurent des chantiers séparés.
 
 ### 8. Introduire des moteurs communs avec stratégies parser/lexer spécialisées
@@ -436,16 +436,34 @@ au transformer et vérifie que le noyau est interne, commun aux deux cibles, ret
 et ne dépend d'aucun détail de cible. `CSharpEmbeddedCodeInjectorArchitectureTests` maintient la
 frontière d'injection. Aucune API publique ni aucun comportement observable n'a été modifié.
 
-Les points 10 (`EmbeddedCodeHook.EmittedCode`) et 11 (statut documenté de la façade runtime) restent
-explicitement ouverts.
+Le point 10 est corrigé ci-dessous. Le point 11 (statut documenté de la façade runtime) reste
+explicitement ouvert.
 
-### 10. Renommer ou supprimer l'état ambigu `EmittedCode`
-`EmittedCode` est initialisé avec le code brut avant d'être remplacé par le code transformé. Son nom
-indique pourtant qu'il est déjà prêt pour l'émission.
+### 10. Distinguer explicitement les états brut et transformé
+**Corrigé.** Le modèle interne unique `EmbeddedCodeHook` est désormais un record immuable qui conserve
+le texte collecté dans `RawEmbeddedCode RawCode` et expose séparément
+`TransformedEmbeddedCode? TransformedCode`. Les fabriques parser et lexer créent uniquement l’état
+brut. Le collecteur effectue ensuite une transition explicite par expression `with`, après l’unique
+appel à `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)`; le code brut n’est ni écrasé
+ni reconstruit.
 
-**Fix proposé** : remplacer ce membre par `RawCode` et `TransformedCode`, ce dernier étant absent tant
-que la transformation n'a pas été effectuée, ou construire directement les hooks dans un état
-transformé valide.
+Les quatre émetteurs parser/lexer délèguent toujours à `EmbeddedHookMethodEmitter`. Avant toute écriture
+dans le `StringBuilder`, cet émetteur obtient le résultat par le point d’accès central
+`RequireTransformedCode(...)`. Un hook encore brut provoque une `InvalidOperationException`
+déterministe mentionnant le nom de méthode concerné : aucun fallback vers `RawCode` et aucune source
+partielle ne sont possibles. `GeneratedEmbeddedCodeBody.ForPredicate(...)` et `ForAction(...)`
+continuent ainsi de recevoir exclusivement un `TransformedEmbeddedCode` validé.
+
+Le code brut est volontairement conservé après transformation pour les diagnostics, l’audit du flux
+et les tests d’invariant. `LifecycleHook` n’a pas été modifié : il ne représente qu’un état déjà
+transformé et ne portait donc pas la même ambiguïté. Les tests unitaires caractérisent la collecte
+brute, la conservation du texte et l’échec d’émission avant transformation. Les garde-fous Roslyn
+vérifient les types des deux propriétés, l’absence de noms de remplacement ambigus, la transition par
+le pipeline commun, le point d’accès de phase unique, les entrées typées de
+`GeneratedEmbeddedCodeBody` et l’absence de lecture de `RawCode.Text` par les émetteurs.
+
+Cette correction est interne au générateur : elle ne modifie ni la source C# générée, ni le
+comportement runtime, ni les diagnostics, ni les API publiques.
 
 ### 11. Documenter `ExpressionEmbeddedCodePreparer` comme façade unique de compilation runtime
 La classe transforme le texte, appelle `IExpressionCompiler`, construit une lambda CLR puis produit

--- a/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
+++ b/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
@@ -285,7 +285,10 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
         string[] expectedKinds = ["SemanticPredicate", "InlineAction"];
         CollectionAssert.AreEquivalent(expectedKinds, kindType.GetMembers().OfType<IFieldSymbol>().Where(static field => field.HasConstantValue).Select(static field => field.Name).ToArray());
         Assert.AreEqual("Utils.Parser.Diagnostics.EmbeddedCode.RawEmbeddedCode", hookType.GetMembers("RawCode").OfType<IPropertySymbol>().Single().Type.ToDisplayString());
-        Assert.AreEqual("Utils.Parser.Diagnostics.EmbeddedCode.TransformedEmbeddedCode", hookType.GetMembers("EmittedCode").OfType<IPropertySymbol>().Single().Type.ToDisplayString());
+        Assert.AreEqual("Utils.Parser.Diagnostics.EmbeddedCode.TransformedEmbeddedCode?", hookType.GetMembers("TransformedCode").OfType<IPropertySymbol>().Single().Type.ToDisplayString());
+        Assert.AreEqual(NullableAnnotation.Annotated, hookType.GetMembers("TransformedCode").OfType<IPropertySymbol>().Single().NullableAnnotation);
+        string[] forbiddenCodeMembers = ["EmittedCode", "ProcessedCode", "FinalCode", "PreparedCode", "ReadyCode"];
+        Assert.IsFalse(hookType.GetMembers().Any(member => forbiddenCodeMembers.Contains(member.Name, StringComparer.Ordinal)));
         Assert.AreEqual(ownerType, hookType.GetMembers("Owner").OfType<IPropertySymbol>().Single().Type, SymbolEqualityComparer.Default);
         Assert.AreEqual(kindType, hookType.GetMembers("Kind").OfType<IPropertySymbol>().Single().Type, SymbolEqualityComparer.Default);
 
@@ -495,6 +498,10 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
 
         MethodDeclarationSyntax sharedEmit = emitter.Members.OfType<MethodDeclarationSyntax>().Single(static method => method.Identifier.ValueText == "Emit");
         Assert.IsTrue(sharedEmit.DescendantNodes().OfType<InvocationExpressionSyntax>().Any(invocation => invocation.ToString().StartsWith("ValidateEmbeddedCodeHook", StringComparison.Ordinal)), "The shared method emitter must keep Owner and Kind validation.");
+        Assert.AreEqual(1, sharedEmit.DescendantNodes().OfType<InvocationExpressionSyntax>().Count(invocation => invocation.ToString().StartsWith("RequireTransformedCode", StringComparison.Ordinal)), "The shared emitter must validate the phase through one central accessor.");
+        MethodDeclarationSyntax phaseGuard = emitter.Members.OfType<MethodDeclarationSyntax>().Single(static method => method.Identifier.ValueText == "RequireTransformedCode");
+        Assert.IsTrue(phaseGuard.DescendantNodes().OfType<MemberAccessExpressionSyntax>().Any(member => member.ToString() == "hook.TransformedCode"));
+        Assert.IsFalse(emitter.DescendantNodes().OfType<MemberAccessExpressionSyntax>().Any(member => member.ToString() == "hook.RawCode.Text"), "Hook emitters must never read raw code text.");
         Assert.AreEqual(1, sharedEmit.DescendantNodes().OfType<InvocationExpressionSyntax>().Count(invocation => invocation.ToString().StartsWith("EmitGeneratedEmbeddedCodeBody", StringComparison.Ordinal)), "The shared method emitter must centralize generated body emission.");
         Assert.IsTrue(sharedEmit.DescendantNodes().OfType<MemberAccessExpressionSyntax>().Any(member => member.ToString() == "descriptor.Owner"));
         Assert.IsTrue(sharedEmit.DescendantNodes().OfType<MemberAccessExpressionSyntax>().Any(member => member.ToString() == "descriptor.Kind"));

--- a/UtilsTest/Parser/Antlr4GeneratedEmbeddedCodeTests.cs
+++ b/UtilsTest/Parser/Antlr4GeneratedEmbeddedCodeTests.cs
@@ -6320,7 +6320,7 @@ public class Antlr4GeneratedEmbeddedCodeTests
 
         Assert.IsNull(emitterType.GetNestedType("LexerEmbeddedCodeHook", BindingFlags.NonPublic));
         Assert.AreEqual(typeof(RawEmbeddedCode), hookType.GetProperty("RawCode", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.PropertyType);
-        Assert.AreEqual(typeof(TransformedEmbeddedCode), hookType.GetProperty("EmittedCode", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.PropertyType);
+        Assert.AreEqual(typeof(TransformedEmbeddedCode), hookType.GetProperty("TransformedCode", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.PropertyType);
         Assert.AreEqual(ownerType, hookType.GetProperty("Owner", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.PropertyType);
         Assert.AreEqual(kindType, hookType.GetProperty("Kind", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.PropertyType);
         string[] expectedOwners = ["Parser", "Lexer"];
@@ -6366,28 +6366,29 @@ public class Antlr4GeneratedEmbeddedCodeTests
     }
 
     /// <summary>
-    /// Ensures transformed hook code cannot be read before the transformation phase assigns it.
+    /// Ensures an untransformed hook fails before the method emitter writes partial source.
     /// </summary>
     [TestMethod]
-    public void EmbeddedCodeHookTypes_WhenEmittedCodeIsReadBeforeTransformation_Throws()
+    public void EmbeddedCodeHookTypes_WhenUntransformedHookIsEmitted_ThrowsBeforeWritingSource()
     {
-        Type hookType = typeof(GrammarEmitter).GetNestedType("EmbeddedCodeHook", BindingFlags.NonPublic)!;
-        Type kindType = typeof(GrammarEmitter).GetNestedType("EmbeddedCodeHookKind", BindingFlags.NonPublic)!;
+        Type emitterType = typeof(GrammarEmitter);
+        Type hookType = emitterType.GetNestedType("EmbeddedCodeHook", BindingFlags.NonPublic)!;
+        Type kindType = emitterType.GetNestedType("EmbeddedCodeHookKind", BindingFlags.NonPublic)!;
+        Type methodEmitterType = emitterType.GetNestedType("EmbeddedHookMethodEmitter", BindingFlags.NonPublic)!;
+        Type descriptorType = emitterType.GetNestedType("EmbeddedHookMethodDescriptor", BindingFlags.NonPublic)!;
         object hook = InvokeHookFactory(hookType, "CreateParser", "start", "RAW_ACTION;", Enum.Parse(kindType, "InlineAction"), 0, 0, "__Action_start_0_0_0");
+        object descriptor = descriptorType.GetProperty("ParserAction", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(null)!;
+        var source = new System.Text.StringBuilder();
 
-        var property = hookType.GetProperty("EmittedCode", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
-        try
-        {
-            _ = property.GetValue(hook);
-            Assert.Fail("Reading untransformed emitted code should fail.");
-        }
-        catch (TargetInvocationException exception)
-        {
-            Assert.IsInstanceOfType(exception.InnerException, typeof(InvalidOperationException));
-        }
-        catch (InvalidOperationException)
-        {
-        }
+        TargetInvocationException exception = Assert.ThrowsException<TargetInvocationException>(() =>
+            methodEmitterType.GetMethod("Emit", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)!.Invoke(null, [source, hook, descriptor]));
+
+        Assert.IsInstanceOfType<InvalidOperationException>(exception.InnerException);
+        StringAssert.Contains(exception.InnerException.Message, "__Action_start_0_0_0");
+        StringAssert.Contains(exception.InnerException.Message, "has not been transformed");
+        Assert.AreEqual(0, source.Length);
+        Assert.AreEqual("RAW_ACTION;", ((RawEmbeddedCode)hookType.GetProperty("RawCode", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(hook)!).Text);
+        Assert.IsNull(hookType.GetProperty("TransformedCode", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(hook));
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- Remove the ambiguous `EmittedCode` state that could hold either raw or transformed code and make the raw/transform phases explicit and impossible to confuse. 
- Ensure generators and emitters cannot accidentally emit raw grammar code and make the transformation transition visible and auditable.

### Description
- Replace the mutable/ambiguous `EmittedCode` member with an immutable model: `EmbeddedCodeHook` is now a private `record` holding `RawCode : RawEmbeddedCode` and `TransformedCode : TransformedEmbeddedCode?` to represent phases explicitly. 
- Apply the transformer exactly once during collection and perform the immutable phase transition via `hook with { TransformedCode = TransformEmbeddedCode(...) }` so the raw text is preserved and the transformed result is stored separately. 
- Add a single phase-guard helper `RequireTransformedCode(EmbeddedCodeHook)` used by `EmbeddedHookMethodEmitter.Emit` to throw a deterministic `InvalidOperationException` when a hook has not been transformed, preventing any partial source emission or fallback to raw code. 
- Update tests and architecture guards to expect `TransformedCode` (nullable) and to ban ambiguous replacements such as `EmittedCode`, `ProcessedCode`, `FinalCode`, `PreparedCode`, and `ReadyCode`; update documentation and roadmap to record the invariant and flow; add an internal `IsExternalInit` shim to support `record` initialization in the generator project targeting `netstandard2.0`.

### Testing
- Built the relevant projects: `dotnet build Utils.Parser/Utils.Parser.csproj`, `Utils.Parser.Diagnostics`, `Utils.Parser.Generators`, `Utils.Parser.Expressions`, `UtilsTest/UtilsTest.Unit.csproj`, and `UtilsTest.Functional/UtilsTest.Functional.csproj`, all successful. 
- Ran unit tests with the focused filters: `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter "Antlr4GeneratedEmbeddedCodeTests|EmbeddedCodeTransformationInvariantTests"` and they passed. 
- Ran functional architecture tests with the focused filters: `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --filter "EmbeddedCodeTransformerArchitectureTests|CSharpEmbeddedCodeInjectorArchitectureTests"` and they passed. 
- Executed wider test runs (no-build/no-restore variants where applicable) and the unit and functional suites covering the changed areas completed successfully; Roslyn-based architecture guards confirm the absence of `EmittedCode` and forbid ambiguous replacements and raw-code reads by emitters.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a21e4bfb083268fa9c98a0de44c43)