### PR TITLE
Document ExpressionEmbeddedCodePreparer as supported runtime compilation facade

### DIFF
--- a/Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs
+++ b/Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs
@@ -8,7 +8,12 @@ using Utils.Parser.Runtime;
 namespace Utils.Parser.Expressions;
 
 /// <summary>
-/// Prepares runtime-inline embedded parser code by compiling expression-backed artifacts with an explicit expression compiler.
+/// Provides the supported runtime-inline compilation facade for embedded parser semantic predicates and inline actions.
+/// It validates and transforms embedded source through the shared transformation pipeline, builds expressions that read
+/// runtime symbols from the delegate context, delegates expression compilation to <see cref="IExpressionCompiler"/>,
+/// and materializes specialized CLR lambdas in strongly typed prepared artifacts. Preparation does not execute the
+/// embedded code or capture runtime values. This facade does not generate C# source, replace the source generator,
+/// compile lexer hooks, or select the parser's overall execution strategy.
 /// </summary>
 public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction>
 {
@@ -16,10 +21,16 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
     private readonly IParserEmbeddedCodeTransformer _transformer;
 
     /// <summary>
-    /// Initializes a new expression-backed embedded-code preparer.
+    /// Initializes the supported expression-backed runtime preparation facade.
     /// </summary>
-    /// <param name="compiler">Expression compiler selected by the caller.</param>
-    /// <param name="embeddedCodeTransformer">Optional transformer applied before compiler invocation.</param>
+    /// <param name="compiler">
+    /// Required caller-supplied compiler that converts validated transformed text into an expression tree. It is not
+    /// called for unsupported categories or non-runtime targets and is called exactly once for each supported preparation.
+    /// </param>
+    /// <param name="embeddedCodeTransformer">
+    /// Optional transformer run through <see cref="EmbeddedCodeTransformationPipeline"/> before compiler invocation;
+    /// <see cref="NoOpParserEmbeddedCodeTransformer.Instance"/> is used when no transformer is supplied.
+    /// </param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="compiler"/> is <c>null</c>.</exception>
     public ExpressionEmbeddedCodePreparer(IExpressionCompiler compiler, IParserEmbeddedCodeTransformer? embeddedCodeTransformer = null)
     {
@@ -27,7 +38,21 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
         _transformer = embeddedCodeTransformer ?? NoOpParserEmbeddedCodeTransformer.Instance;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Prepares a <see cref="EmbeddedCodeKind.SemanticPredicate"/> for the
+    /// <see cref="EmbeddedCodeTarget.RuntimeInlineExpression"/> target without evaluating it.
+    /// </summary>
+    /// <param name="source">Raw semantic-predicate source and its parser metadata.</param>
+    /// <param name="context">Preparation context that selects the runtime target and allowed contextual symbols.</param>
+    /// <returns>
+    /// <see cref="EmbeddedCodePreparationStatus.Unsupported"/> for another category,
+    /// <see cref="EmbeddedCodePreparationStatus.PreservedNotCompiled"/> for another target,
+    /// <see cref="EmbeddedCodePreparationStatus.CompilationFailed"/> after a transformation or compilation failure, or
+    /// <see cref="EmbeddedCodePreparationStatus.Succeeded"/> with a <see cref="PreparedExpressionSemanticPredicate"/>
+    /// containing a <see cref="Func{T, TResult}"/> over <see cref="SemanticPredicateEvaluationContext"/>.
+    /// The shared pipeline transforms the source before runtime-bound symbol expressions are passed to the compiler;
+    /// the resulting delegate is not invoked during preparation.
+    /// </returns>
     public EmbeddedCodePreparationResult<PreparedExpressionSemanticPredicate> PrepareSemanticPredicate(
         EmbeddedCodeSource source,
         EmbeddedCodePreparationContext context)
@@ -69,7 +94,22 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
         }
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Prepares an <see cref="EmbeddedCodeKind.ParserInlineAction"/> for the
+    /// <see cref="EmbeddedCodeTarget.RuntimeInlineExpression"/> target without executing it.
+    /// </summary>
+    /// <param name="source">Raw inline parser-action source and its parser metadata.</param>
+    /// <param name="context">Preparation context that selects the runtime target and allowed contextual symbols.</param>
+    /// <returns>
+    /// <see cref="EmbeddedCodePreparationStatus.Unsupported"/> for another category,
+    /// <see cref="EmbeddedCodePreparationStatus.PreservedNotCompiled"/> for another target,
+    /// <see cref="EmbeddedCodePreparationStatus.CompilationFailed"/> after a transformation or compilation failure, or
+    /// <see cref="EmbeddedCodePreparationStatus.Succeeded"/> with a <see cref="PreparedExpressionParserAction"/>
+    /// containing an <see cref="Action{T}"/> over <see cref="ParserActionExecutionContext"/>.
+    /// The shared pipeline transforms the source before runtime-bound symbol expressions are passed to the compiler.
+    /// A non-<see cref="Void"/> expression is normalized to an action whose value is ignored, and the resulting delegate
+    /// is not invoked during preparation.
+    /// </returns>
     public EmbeddedCodePreparationResult<PreparedExpressionParserAction> PrepareParserAction(
         EmbeddedCodeSource source,
         EmbeddedCodePreparationContext context)
@@ -108,12 +148,14 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
     }
 
     /// <summary>
-    /// Applies the configured transformer before invoking the expression compiler.
+    /// Adapts the runtime facade to the shared transformation-and-validation pipeline without compiling source.
+    /// It supplies <see cref="ParserEmbeddedCodeTransformationPath.RuntimeCompilation"/> failure metadata and converts
+    /// the common transformation exception to the public Expressions-package compatibility exception.
     /// </summary>
     /// <param name="source">Original embedded-code source.</param>
     /// <param name="context">Runtime preparation context that supplies grammar metadata.</param>
     /// <param name="location">Embedded-code location represented by the source.</param>
-    /// <returns>Transformed source text to pass to the compiler.</returns>
+    /// <returns>Validated transformed source to pass to the compiler.</returns>
     private TransformedEmbeddedCode TransformSource(EmbeddedCodeSource source, EmbeddedCodePreparationContext context, ParserEmbeddedCodeLocation location)
     {
         try
@@ -151,7 +193,8 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
     }
 
     /// <summary>
-    /// Builds symbol expressions that read semantic predicate values from the runtime context parameter.
+    /// Builds symbol expressions that read semantic predicate values from the runtime context parameter at execution
+    /// time rather than capturing values during preparation.
     /// </summary>
     /// <param name="runtimeContext">Runtime context parameter used by the compiled predicate delegate.</param>
     /// <param name="supportedSymbols">Contextual symbols that the preparation context allows this compiler invocation to expose.</param>
@@ -162,7 +205,8 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
         BuildRuntimeContextSymbols(runtimeContext, supportedSymbols);
 
     /// <summary>
-    /// Builds symbol expressions that read parser action values from the runtime context parameter.
+    /// Builds symbol expressions that read parser action values from the runtime context parameter at execution time
+    /// rather than capturing values during preparation.
     /// </summary>
     /// <param name="runtimeContext">Runtime context parameter used by the compiled action delegate.</param>
     /// <param name="supportedSymbols">Contextual symbols that the preparation context allows this compiler invocation to expose.</param>
@@ -173,7 +217,9 @@ public sealed class ExpressionEmbeddedCodePreparer : IEmbeddedCodePreparer<Prepa
         BuildRuntimeContextSymbols(runtimeContext, supportedSymbols);
 
     /// <summary>
-    /// Builds symbol expressions that read shared runtime values from a predicate or action context parameter.
+    /// Builds symbol expressions for <c>ruleName</c>, <c>inputPosition</c>, <c>alternativeIndex</c>, and
+    /// <c>elementIndex</c> that read shared runtime values from a predicate or action context parameter. No runtime value
+    /// is captured while the artifact is prepared.
     /// </summary>
     /// <param name="runtimeContext">Runtime context parameter used by the compiled artifact delegate.</param>
     /// <param name="supportedSymbols">Contextual symbols that the preparation context allows this compiler invocation to expose.</param>

--- a/Utils.Parser.Expressions/README.md
+++ b/Utils.Parser.Expressions/README.md
@@ -23,7 +23,52 @@ Available surfaces:
 - `ExpressionSemanticPredicateEvaluator` remains the current runtime adapter from `IExpressionCompiler` to `ISemanticPredicateEvaluator`.
 - `ExpressionParserActionExecutor` remains the current runtime adapter from `IExpressionCompiler` to `IParserActionExecutor`.
 
-## Preparing artifacts
+## Supported runtime compilation facade
+
+`ExpressionEmbeddedCodePreparer` is the single supported `omy.Utils.Parser.Expressions` entry point for
+transforming, compiling, and materializing executable parser embedded code before runtime execution. It
+implements `IEmbeddedCodePreparer<PreparedExpressionSemanticPredicate, PreparedExpressionParserAction>`,
+coordinates a caller-supplied `IExpressionCompiler`, and optionally coordinates a caller-supplied
+`IParserEmbeddedCodeTransformer` (the no-op transformer is the default). It does not replace the compiler:
+it directs that compiler within the supported preparation pipeline.
+
+The complete preparation path is:
+
+```text
+EmbeddedCodeSource
+→ validation of kind and target
+→ EmbeddedCodeTransformationPipeline
+→ TransformedEmbeddedCode
+→ runtime-bound symbol expressions
+→ IExpressionCompiler
+→ specialized CLR lambda
+→ prepared artifact
+```
+
+| Source | Runtime context | Delegate | Prepared artifact |
+| --- | --- | --- | --- |
+| `SemanticPredicate` | `SemanticPredicateEvaluationContext` | `Func<SemanticPredicateEvaluationContext, bool>` | `PreparedExpressionSemanticPredicate` |
+| `ParserInlineAction` | `ParserActionExecutionContext` | `Action<ParserActionExecutionContext>` | `PreparedExpressionParserAction` |
+
+The facade normalizes outcomes as follows:
+
+| Condition | Preparation status |
+| --- | --- |
+| The method receives the wrong embedded-code category | `Unsupported` |
+| The target is `SourceGeneratorCSharp` rather than `RuntimeInlineExpression` | `PreservedNotCompiled` |
+| Transformation, expression compilation, or delegate materialization fails | `CompilationFailed` |
+| A specialized prepared artifact is produced | `Success` (`EmbeddedCodePreparationStatus.Succeeded`) |
+
+Only parser semantic predicates and inline parser actions are supported. Lexer predicates, lexer actions,
+grammar actions, `@init`, `@after`, non-inline parser actions, and every other category that is not compatible
+with runtime-inline preparation remain unsupported. The facade does not generate C# source, replace the source
+generator, execute embedded code during preparation, capture preparation-time runtime values, or decide the
+parser's global execution strategy. Generated C# remains a separate `Utils.Parser.Generators` path.
+
+### Minimal preparation example
+
+The following uses the real public preparation contracts; `GetExpressionCompiler()` represents the caller's
+selection of an existing `IExpressionCompiler` implementation.
 
 ```csharp
 IExpressionCompiler compiler = GetExpressionCompiler();
@@ -40,7 +85,8 @@ var context = new EmbeddedCodePreparationContext(
     ruleName: "value",
     languageOrCompilerIdentity: "custom-expression-language");
 
-var result = preparer.PrepareSemanticPredicate(source, context);
+EmbeddedCodePreparationResult<PreparedExpressionSemanticPredicate> result =
+    preparer.PrepareSemanticPredicate(source, context);
 ```
 
 The preparer:
@@ -173,3 +219,7 @@ Lexer actions, lexer predicates, grammar members/`@members`, `@init`, `@after`, 
 Parser embedded-code discovery now has a shared metadata model in `Utils.Parser.EmbeddedCode`. `EmbeddedCodeRuntimeDiscovery` walks a `ParserDefinition` and emits `EmbeddedCodeRuntimeEntry` values with the raw source, `EmbeddedCodeKind`, owning rule name, runtime-compatible alternative and element indexes, a runtime key for executable entries, and an explicit `EmbeddedCodeUnsupportedReason` for skipped entries. The metadata mirrors the existing parser runtime indexing rules for priority-ordered alternatives, single-item alternatives, sequences, quantifier inner parsing, negation probes, and direct-left-recursive base/tail alternatives. It is metadata only: it does not compile source, generate C#, execute actions, or change `ParserEngine` behavior.
 
 The expression-backed prepared registry consumes this shared discovery result before invoking its preparer. Unsupported constructs such as grammar actions, `@init`, `@after`, lexer actions/predicates, and non-inline parser actions remain non-executable, but they now carry explicit skip reasons. Invalid C# in a source-generator-supported hook remains a Roslyn compilation error rather than a custom parser diagnostic.
+
+## API documentation
+
+See the [versioned API documentation for `omy.Utils.Parser.Expressions` 0.1.0](https://warny.github.io/All-purpose-Utilities/v0.1.0/).

--- a/Utils.Parser.Expressions/README.md
+++ b/Utils.Parser.Expressions/README.md
@@ -222,4 +222,4 @@ The expression-backed prepared registry consumes this shared discovery result be
 
 ## API documentation
 
-See the [versioned API documentation for `omy.Utils.Parser.Expressions` 0.1.0](https://warny.github.io/All-purpose-Utilities/v0.1.0/).
+See the [versioned API documentation for `omy.Utils.Parser.Expressions` 0.1.0](https://warny.github.io/All-purpose-Utilities/v0.1.0/api/Utils.Parser.Expressions.html).

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -658,7 +658,21 @@ The runtime currently remains conservative and deterministic. Metadata-rich infr
 
 ## Embedded-code transformation boundary
 
-**Status: in progress.**
+**Status: complete.**
+
+The audit sequence represented by items 8 through 11 is complete. Parser and lexer generated-code
+transformation share the upstream pipeline, and the raw (`RawEmbeddedCode`) and validated transformed
+(`TransformedEmbeddedCode`) phases are explicit. Generated C# and runtime-inline expressions remain
+separate targets after that common boundary: generated code continues through
+`GeneratedEmbeddedCodeBody` and `CSharpEmbeddedCodeInjector`, while
+`ExpressionEmbeddedCodePreparer` is the supported runtime parser embedded-code preparation facade.
+
+`IExpressionCompiler` remains caller-supplied and independently reusable; the facade coordinates it
+only for prepared runtime-inline parser predicates and actions. A semantic Roslyn architecture guard
+prevents another production component from combining the shared transformation pipeline, expression
+compilation, specialized embedded-code lambdas, and prepared parser artifacts. This consolidation is
+documentation and test enforcement only: no public API, diagnostics, generated source, or runtime
+behavior changed.
 
 Parser embedded-code handling is centered on preservation plus an explicit `IParserEmbeddedCodeTransformer` extension point. Embedded grammar text is carried as `RawEmbeddedCode`, transformed through `ParserEmbeddedCodeTransformationService.TransformOrThrow(...)`, and consumed by emitters or expression compilers only as `TransformedEmbeddedCode`. The default transformer is no-op, `$...` rewriting is no longer a core parser/generator responsibility, and dynamic expression-backed preparation transforms code before using the existing compiler/preparer mechanism. Future target-language transformers must remain isolated from parser runtime authority and must not introduce a second compiler abstraction.
 

--- a/Utils.Parser/TODO.md
+++ b/Utils.Parser/TODO.md
@@ -466,12 +466,33 @@ Cette correction est interne au générateur : elle ne modifie ni la source C# g
 comportement runtime, ni les diagnostics, ni les API publiques.
 
 ### 11. Documenter `ExpressionEmbeddedCodePreparer` comme façade unique de compilation runtime
-La classe transforme le texte, appelle `IExpressionCompiler`, construit une lambda CLR puis produit
-l'artefact préparé. Son rôle dépasse donc une simple préparation de métadonnées.
 
-**Fix proposé** : préciser dans sa documentation et dans le README du projet qu'elle constitue la
-façade supportée pour la compilation runtime du code embarqué, afin d'éviter l'introduction future
-d'un pipeline de compilation parallèle.
+**Corrigé.** `ExpressionEmbeddedCodePreparer` est désormais documentée comme l'unique façade supportée
+pour la compilation runtime du code embarqué parser. Cette portée ne signifie pas qu'elle est l'unique
+utilisatrice globale de `IExpressionCompiler` : le compilateur reste un composant générique injecté par
+l'appelant et orienté par la façade pour ce pipeline de préparation précis.
+
+La façade prend en charge uniquement `SemanticPredicate` et `ParserInlineAction` pour la cible
+`RuntimeInlineExpression`. Le chemin complet est explicite : `EmbeddedCodeSource`, validation de la
+catégorie et de la cible, `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)`,
+`TransformedEmbeddedCode`, construction des expressions de symboles liées au contexte runtime, appel
+unique à `IExpressionCompiler.Compile(...)`, puis lambda CLR spécialisée. Les prédicats produisent un
+`Func<SemanticPredicateEvaluationContext, bool>` encapsulé dans
+`PreparedExpressionSemanticPredicate`; les actions produisent un
+`Action<ParserActionExecutionContext>` encapsulé dans `PreparedExpressionParserAction`.
+
+Les résultats restent normalisés en `Unsupported`, `PreservedNotCompiled`, `CompilationFailed` ou
+`Success`. Les hooks lexer, actions de grammaire, `@init`, `@after` et autres catégories hors du chemin
+parser runtime-inline restent non supportés. La façade ne génère pas de C#, ne remplace pas le source
+generator et n'exécute ni ne capture les valeurs runtime pendant la préparation.
+
+Les tests de caractérisation vérifient le texte transformé, les symboles runtime, l'appel unique du
+transformateur et du compilateur, l'absence d'appel de ces dépendances pour les catégories ou cibles
+non supportées, et l'absence d'exécution à la préparation. Un garde-fou sémantique Roslyn verrouille
+l'interface et les membres publics existants, le pipeline partagé, le champ compilateur commun, les
+deux constructions d'artefacts et de lambdas spécialisées, l'indépendance du générateur C# et
+l'absence d'une seconde façade ou d'un pipeline combinant transformation, compilation et artefacts.
+Aucun comportement, diagnostic, artefact préparé ou API publique n'a été ajouté ou modifié.
 
 ## Garde-fous et contrôles (priorité basse)
 

--- a/Utils.Parser/TODO.md
+++ b/Utils.Parser/TODO.md
@@ -1,540 +1,523 @@
-# Utils.Parser — Audit qualité (2026-07-10)
+# Utils.Parser — Quality audit (2026-07-10)
 
-Audit du périmètre `Utils.Parser` et de ses projets associés, avec un focus sur les duplications de
-code ou d'intention et sur les chemins de transformation, d'injection C# et de compilation
-d'expressions.
+Audit of the `Utils.Parser` scope and its associated projects, with a focus on duplications of
+code or intent, and on transformation, C# injection, and expression-compilation paths.
 
-**État (2026-07-10) :** les chemins d'exécution identifiés passent actuellement par
-`IParserEmbeddedCodeTransformer`. La compilation dynamique des expressions passe ensuite par
-`IExpressionCompiler`. En revanche, l'injection du code C# reste répartie dans `GrammarEmitter` et
-n'est pas isolée derrière une classe d'injection dédiée. Les items ci-dessous sont des propositions
-non traitées, sauf mention contraire.
+**Status (2026-07-10):** The identified execution paths currently pass through
+`IParserEmbeddedCodeTransformer`. The dynamic compilation of expressions then goes through
+`IExpressionCompiler`. However, C# code injection remains distributed across `GrammarEmitter` and
+is not isolated behind a dedicated injection class. The items below are suggestions
+not yet addressed unless otherwise noted.
 
-## Architecture du code embarqué (priorité haute)
+## Embedded code architecture (high priority)
 
-### 1. Introduire une représentation typée du code transformé
-**Corrigé.** Le pipeline distingue désormais `RawEmbeddedCode` et `TransformedEmbeddedCode` dans
-`Utils.Parser.Diagnostics.EmbeddedCode`. `EmbeddedCodeSource` expose le texte source sous forme de
-`RawEmbeddedCode`, les hooks générés conservent le code brut dans `RawCode`, et leur `TransformedCode`
-est un `TransformedEmbeddedCode` rempli uniquement après l'appel à `IParserEmbeddedCodeTransformer`.
-`GrammarEmitter.TransformEmbeddedCode` et `ExpressionEmbeddedCodePreparer.TransformSource` passent par
-`ParserEmbeddedCodeTransformationService.TransformOrThrow`, qui exécute le transformer, valide les diagnostics
-puis retourne un code transformé typé. Les chemins d'émission C# ou de compilation via
-`IExpressionCompiler` consomment explicitement ce type avant d'extraire le texte final.
+### 1. Introduce a typed representation of the transformed code
+**Fixed.** The pipeline now distinguishes between `RawEmbeddedCode` and `TransformedEmbeddedCode` in
+`Utils.Parser.Diagnostics.EmbeddedCode`. `EmbeddedCodeSource` exposes the source text as
+`RawEmbeddedCode`, the generated hooks keep the raw code in `RawCode`, and their `TransformedCode`
+is a `TransformedEmbeddedCode` populated only after the call to `IParserEmbeddedCodeTransformer`.
+`GrammarEmitter.TransformEmbeddedCode` and `ExpressionEmbeddedCodePreparer.TransformSource` pass through
+`ParserEmbeddedCodeTransformationService.TransformOrThrow`, which runs the transformer, validates the diagnostics, and then returns typed transformed code. C# emission or compilation paths via
+`IExpressionCompiler` explicitly consume this type before extracting the final text.
 
-Tests ajoutés :
+Tests added:
 
-- `ExpressionEmbeddedCodePreparerTests.EmbeddedCodeSource_WhenCreated_ExposesTypedRawCode` ;
-- `ExpressionEmbeddedCodePreparerTests.PrepareSemanticPredicate_WhenTransformerProvided_CompilerReceivesTransformedCode` ;
-- `ExpressionEmbeddedCodePreparerTests.PrepareParserAction_WhenNoOpTransformerUsed_CompilerReceivesTextuallyIdenticalTransformedCode` ;
-- `ExpressionEmbeddedCodePreparerTests.TransformedEmbeddedCode_DoesNotExposePublicConstructorsOrManualResultConversion` ;
-- `ExpressionEmbeddedCodePreparerTests.ParserEmbeddedCodeTransformationService_WhenRawCodeIsNull_DoesNotInvokeTransformer` ;
-- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesParserPredicateAndAction_RawCodeDoesNotAppearInGeneratedHookBodies` ;
-- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesLexerHook_RawCodeDoesNotAppearInGeneratedHookBodies` ;
-- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_UseTypedRawAndTransformedCodeFields` ;
+- `ExpressionEmbeddedCodePreparerTests.EmbeddedCodeSource_WhenCreated_ExposesTypedRawCode`;
+- `ExpressionEmbeddedCodePreparerTests.PrepareSemanticPredicate_WhenTransformerProvided_CompilerReceivesTransformedCode`;
+- `ExpressionEmbeddedCodePreparerTests.PrepareParserAction_WhenNoOpTransformerUsed_CompilerReceivesTextuallyIdenticalTransformedCode`;
+- `ExpressionEmbeddedCodePreparerTests.TransformedEmbeddedCode_DoesNotExposePublicConstructorsOrManualResultConversion`;
+- `ExpressionEmbeddedCodePreparerTests.ParserEmbeddedCodeTransformationService_WhenRawCodeIsNull_DoesNotInvokeTransformer`;
+- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesParserPredicateAndAction_RawCodeDoesNotAppearInGeneratedHookBodies`;
+- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesLexerHook_RawCodeDoesNotAppearInGeneratedHookBodies`;
+- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_UseTypedRawAndTransformedCodeFields`;
 - `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_WhenUntransformedHookIsEmitted_ThrowsBeforeWritingSource`.
 
-### 2. Centraliser l'appel au transformer et la validation des diagnostics
-**Corrigé.** `ParserEmbeddedCodeTransformationService.TransformOrThrow` est désormais la frontière
-unique de transformation : il reçoit le `RawEmbeddedCode`, impose le texte brut dans le
-`ParserEmbeddedCodeTransformationContext`, appelle `IParserEmbeddedCodeTransformer.Transform(...)` une
-seule fois, valide le résultat, traite une liste de diagnostics nulle comme vide, ignore les entrées
-de diagnostic nulles, bloque le premier diagnostic `Error`, vérifie que le code transformé n'est pas
-nul, et retourne uniquement un `TransformedEmbeddedCode` validé.
+### 2. Centralize the transformer call and diagnostic validation
+**Fixed.** `ParserEmbeddedCodeTransformationService.TransformOrThrow` is now the single
+transformation boundary: it receives the `RawEmbeddedCode`, imposes the raw text in the
+`ParserEmbeddedCodeTransformationContext`, calls `IParserEmbeddedCodeTransformer.Transform(...)`
+exactly once, validates the result, treats a null diagnostic list as empty, ignores null
+diagnostic entries, stops at the first `Error` diagnostic, checks that the transformed code is not
+null, and returns only a validated `TransformedEmbeddedCode`.
 
-Les erreurs de génération C# et de compilation runtime passent par le même modèle structuré
-`ParserEmbeddedCodeTransformationException` du package diagnostics. L'exception expose le chemin
-(génération ou compilation runtime), le code et le message du diagnostic, l'emplacement, le nom de
-grammaire, le nom de règle et le span disponible ;
-`Utils.Parser.Expressions` conserve son type public en l'adaptant depuis cette exception commune sans
-perdre l'exception interne du transformer. Les diagnostics `Info` et `Warning` ne bloquent pas la
-transformation et sont conservés sur `TransformedEmbeddedCode.Diagnostics`.
+C# generation and runtime compilation errors go through the same structured model
+`ParserEmbeddedCodeTransformationException` defined in the diagnostics package. The exception exposes the path
+(generation or runtime compilation), the diagnostic code and message, the location, grammar
+name, rule name and available span;
+`Utils.Parser.Expressions` maintains its public type by adapting it from this common exception without
+losing the inner exception of the transformer. The `Info` and `Warning` diagnostics do not block
+transformation and are retained in `TransformedEmbeddedCode.Diagnostics`.
 
-Tests ajoutés ou consolidés :
+Tests added or consolidated:
 
-- appel unique du transformer et transmission du contexte brut/métadonnées existante via les tests de
-  transformation runtime et générateur ;
-- rejet d'un diagnostic `Error` avant compilation runtime ;
-- rejet d'un diagnostic `Error` avant injection générée existante ;
-- conservation des diagnostics `Warning` ;
-- erreurs déterministes pour résultat nul et code nul ;
-- diagnostics nuls traités comme une collection vide ;
-- conservation de l'exception interne quand le transformer lève ;
-- test architectural fonctionnel, basé sur une analyse syntaxique Roslyn légère, scannant les
-  invocations plutôt que les fichiers complets et interdisant les appels directs de production à
-  `IParserEmbeddedCodeTransformer.Transform(...)` hors de l'appel central exact dans
-  `ParserEmbeddedCodeTransformationService.TransformOrThrow(...)`, avec des tests de régression pour les
-  appels multi-lignes et les appels inattendus dans le fichier du service central ;
-- tests générateur vérifiant qu'une erreur du transformer bloque l'émission C# et que les métadonnées
-  d'erreur restent cohérentes entre génération et compilation runtime.
+- a single transformer call and transmission of the raw context/existing metadata through runtime and
+  generator transformation tests;
+- rejection of an `Error` diagnostic before runtime compilation;
+- rejection of an `Error` diagnostic before the existing generated injection path;
+- preservation of `Warning` diagnostics;
+- deterministic errors for null result and null code;
+- null diagnostics treated as an empty collection;
+- preservation of the inner exception when the transformer throws;
+- functional architectural test, based on light Roslyn syntactic analysis, scanning the
+  invocations rather than full files and prohibiting direct production calls to
+  `IParserEmbeddedCodeTransformer.Transform(...)` outside the exact central call in
+  `ParserEmbeddedCodeTransformationService.TransformOrThrow(...)`, with regression tests for
+  multi-line calls and unexpected calls in the central service file;
+- generator tests checking that a transformer error blocks the C# emission and that the metadata
+  error metadata remains consistent between runtime generation and compilation.
 
-### 3. Créer une classe dédiée à l'injection du code C#
-**Corrigé.** L'injection C# générée est désormais centralisée dans
-`Utils.Parser.Generators.Internal.CSharpEmbeddedCodeInjector`. `GrammarEmitter` conserve la collecte,
-la classification, la création des contextes et l'appel à `TransformEmbeddedCode(...)`, mais transmet
-ensuite uniquement des `TransformedEmbeddedCode` à l'injecteur. L'API d'injection n'accepte ni
-`RawEmbeddedCode`, ni `G4GrammarAction`, ni `G4EmbeddedAction`, ni chaîne de contenu brut ; les chaînes
-restantes sont limitées aux marqueurs/descripteurs internes contrôlés par `CSharpEmbeddedCodeRegion`.
+### 3. Create a class dedicated to injecting C# code
+**Fixed.** Generated C# injection is now centralized in
+`Utils.Parser.Generators.Internal.CSharpEmbeddedCodeInjector`. `GrammarEmitter` retains collection, classification, and transformation-context creation and the call to `TransformEmbeddedCode(...)`, and then passes
+only `TransformedEmbeddedCode` to the injector. The injection API accepts neither
+`RawEmbeddedCode`, `G4GrammarAction`, `G4EmbeddedAction`, nor a raw content string; the remaining strings are limited to internal markers/descriptors controlled by `CSharpEmbeddedCodeRegion`.
 
-Familles migrées :
+Migrated families:
 
-- headers, members et footers parser (`@header`, `@members`, `@footer`, `@parser::*`) ;
-- headers, members et footers lexer (`@lexer::header`, `@lexer::members`, `@lexer::footer`) ;
-- actions inline parser et lexer ;
-- prédicats parser et lexer, avec distinction entre expression retournée et fragment complet ;
-- hooks de cycle de vie parser `@init` et `@after`.
+- parser headers, members, and footers (`@header`, `@members`, `@footer`, `@parser::*`);
+- lexer headers, members, and footers (`@lexer::header`, `@lexer::members`, `@lexer::footer`);
+- inline parser and lexer actions;
+- parser and lexer predicates, with distinction between returned expression and complete fragment;
+- parser lifecycle hooks `@init` and `@after`.
 
-L'injecteur porte la normalisation déterministe des fins de ligne (`\n`, `\r\n`, `\r`), le découpage
-en lignes, l'indentation à quatre espaces par niveau, les marqueurs de régions nommées et l'espacement
-final des régions. Une fin de ligne finale continue de produire une ligne vide finale lorsque le texte
-n'est pas préalablement rogné, afin de préserver le comportement historique des régions verbatim.
+The injector carries deterministic normalization of line endings (`\n`, `\r\n`, `\r`), splitting text
+into lines, four-space indentation per level, named region markers, and final region
+spacing. A trailing newline continues to produce a trailing blank line when the text
+is not previously trimmed, in order to preserve the historical behavior of the verbatim regions.
 
-Tests ajoutés :
+Tests added:
 
-- `CSharpEmbeddedCodeInjectorTests` couvre les lignes simples/multiples, la normalisation des fins de
-  ligne, l'indentation, les corps de méthode, les lignes vides, le texte vide, les marqueurs,
-  l'espacement final, les expressions de prédicat, les blocs d'action et la frontière typée de l'API ;
-- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesNamedActions_UsesTransformedMarkedRegions` ;
-- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesParserHooks_UsesTransformedHookBodies` ;
-- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesLexerHooks_UsesTransformedHookBodies` ;
-- `CSharpEmbeddedCodeInjectorArchitectureTests` ajoute un garde-fou Roslyn fonctionnel qui interdit les
-  append directs de code brut et limite les lectures de texte transformé hors injecteur aux usages de
-  classification non injectants explicitement justifiés.
+- `CSharpEmbeddedCodeInjectorTests` covers single/multiple lines, line-ending
+  normalization, indentation, method bodies, empty lines, empty text, markers,
+  final spacing, predicate expressions, action blocks, and typed boundary;
+- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesNamedActions_UsesTransformedMarkedRegions`;
+- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesParserHooks_UsesTransformedHookBodies`;
+- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenTransformerReplacesLexerHooks_UsesTransformedHookBodies`;
+- `CSharpEmbeddedCodeInjectorArchitectureTests` adds a functional Roslyn guardrail that prohibits
+  direct appends of raw code and limits reads of transformed text outside the injector to uses of
+  non-injecting classification explicitly justified.
 
-### 4. Ajouter des tests d'invariant pour tous les emplacements de code embarqué
-**Corrigé.** La couverture d'invariant est portée par `UtilsTest/Parser/EmbeddedCodeTransformationInvariantTests.cs` avec le transformer espion déterministe `RecordingEmbeddedCodeTransformer`.
+### 4. Add invariant tests for all embedded code locations
+**Fixed.** Invariant coverage is carried by `UtilsTest/Parser/EmbeddedCodeTransformationInvariantTests.cs` with the deterministic spy transformer `RecordingEmbeddedCodeTransformer`.
 
-Emplacements génération C# couverts :
+C# generation locations covered:
 
-- parser `@header`, `@members` et `@footer` (`ParserHeader`, `ParserMembers`, `ParserFooter`) ;
-- lexer `@header`, `@members` et `@footer` (`LexerHeader`, `LexerMembers`, `LexerFooter`) ;
-- prédicat sémantique parser inline (`SemanticPredicate`) ;
-- action parser inline (`InlineAction`) ;
-- hooks de cycle de vie `@init` et `@after` (`RuleInit`, `RuleAfter`) ;
-- prédicat lexer inline (`LexerSemanticPredicate`) ;
-- action lexer inline (`LexerInlineAction`).
+- parser `@header`, `@members` and `@footer` (`ParserHeader`, `ParserMembers`, `ParserFooter`);
+- lexer `@header`, `@members` and `@footer` (`LexerHeader`, `LexerMembers`, `LexerFooter`);
+- semantic inline parser semantic predicate (`SemanticPredicate`);
+- inline parser action (`InlineAction`);
+- lifecycle hooks `@init` and `@after` (`RuleInit`, `RuleAfter`);
+- inline lexer predicate (`LexerSemanticPredicate`);
+- inline lexer action (`LexerInlineAction`).
 
-Emplacements runtime couverts :
+Runtime locations covered:
 
-- prédicat parser préparé par `ExpressionEmbeddedCodePreparer` puis compilé par `IExpressionCompiler` ;
-- action parser préparée par `ExpressionEmbeddedCodePreparer` puis compilée par `IExpressionCompiler`.
+- parser predicate prepared by `ExpressionEmbeddedCodePreparer` then compiled by `IExpressionCompiler`;
+- parser action prepared by `ExpressionEmbeddedCodePreparer` then compiled by `IExpressionCompiler`.
 
-Les invariants vérifiés sont les suivants :
+The invariants checked are as follows:
 
-- chaque fragment brut attendu produit exactement un appel à `IParserEmbeddedCodeTransformer.Transform(...)` ;
-- l'appel contient le `ParserEmbeddedCodeLocation`, le nom de grammaire, le nom de règle et les métadonnées passives disponibles ;
-- les paramètres, retours, locaux et labels parser exposés par l'architecture actuelle sont transmis aux fragments de règle ;
-- les fragments parser ne sont pas classés comme fragments lexer, et inversement ;
-- les marqueurs transformés sont uniques, valides pour leur cible C#, et apparaissent exactement une fois au point d'injection ou de compilation attendu ;
-- le texte brut ne réapparaît pas dans les corps exécutables générés ni dans l'entrée du compilateur runtime ;
-- les prédicats générés couvrent la forme expression et la forme bloc avec `return` ;
-- `@init` et `@after` sur la même règle restent deux appels distincts, ordonnés et non confondus ;
-- un diagnostic `Error`, une exception du transformer, un résultat nul ou un code transformé nul bloque l'injection générée ;
-- un diagnostic `Error`, une exception du transformer, un résultat nul ou un code transformé nul bloque la compilation runtime ;
-- un diagnostic `Warning` runtime conserve un traitement simple : transformation unique et compilation unique.
+- each expected raw fragment produces exactly one call to `IParserEmbeddedCodeTransformer.Transform(...)`;
+- the call contains the `ParserEmbeddedCodeLocation`, the grammar name, the rule name and the available passive metadata;
+- the parser parameters, returns, locals, and labels exposed by the current architecture are transmitted to the rule fragments;
+- parser fragments are not classified as lexer fragments, and vice versa;
+- transformed markers are unique, valid for their C# target, and appear exactly once at the expected injection or compilation point;
+- the raw text does not reappear in the generated executable bodies nor in the runtime compiler input;
+- the generated predicates cover the expression form and the block form with `return`;
+- `@init` and `@after` on the same rule remain two distinct calls, ordered and kept separate;
+- an `Error` diagnostic, a transformer exception, a null result or a null transformed code blocks the generated injection;
+- an `Error` diagnostic, a transformer exception, a null result or a null transformed code blocks runtime compilation;
+- a runtime `Warning` diagnostic maintains simple processing: single transformation and single compilation.
 
-Les garde-fous architecturaux existants restent consolidés par :
+Existing architectural safeguards remain consolidated by:
 
-- `EmbeddedCodeTransformerArchitectureTests`, qui limite les appels directs à `Transform(...)` au service central et vérifie par modèle sémantique Roslyn que les préparateurs de code embarqué ne créent pas de second chemin direct vers `IExpressionCompiler.Compile(...)` ;
-- `CSharpEmbeddedCodeInjectorArchitectureTests`, qui vérifie que les méthodes d'émission ciblées utilisent `CSharpEmbeddedCodeInjector` et que les lectures de `TransformedEmbeddedCode.Text` hors injecteur restent limitées aux classifications non injectantes autorisées ;
-- `CSharpEmbeddedCodeInjectorTests`, qui verrouille l'API d'injection sur `TransformedEmbeddedCode` et interdit les paramètres `RawEmbeddedCode` ou chaînes brutes.
+- `EmbeddedCodeTransformerArchitectureTests`, which limits direct calls to `Transform(...)` to the central service and verifies by Roslyn semantic model that embedded code preparers do not create a second direct path to `IExpressionCompiler.Compile(...)`;
+- `CSharpEmbeddedCodeInjectorArchitectureTests`, which verifies that targeted emission methods use `CSharpEmbeddedCodeInjector` and that readings of `TransformedEmbeddedCode.Text` outside the injector remain limited to allowed non-injecting classifications;
+- `CSharpEmbeddedCodeInjectorTests`, which locks the injection API to `TransformedEmbeddedCode` and disallows `RawEmbeddedCode` parameters or raw strings.
 
-Aucun injecteur espion de production n'a été ajouté : la frontière `CSharpEmbeddedCodeInjector` est vérifiée par les tests architecturaux Roslyn et par les marqueurs générés.
+No production spy injector has been added: the `CSharpEmbeddedCodeInjector` boundary is checked by Roslyn architectural tests and by generated markers.
 
-## Duplications de code (priorité moyenne)
+## Code duplication (medium priority)
 
-### 5. Factoriser les named actions parser et lexer
-**Corrigé.** Les six familles de named actions générées (`parser @header`, `parser @members`,
-`parser @footer`, `lexer @header`, `lexer @members`, `lexer @footer`) passent désormais par un
-descripteur interne immuable `NamedActionInjectionDescriptor` et par la méthode commune
+### 5. Consolidate parser and lexer named actions
+**Fixed.** The six generated named-action families (`parser @header`, `parser @members`,
+`parser @footer`, `lexer @header`, `lexer @members`, `lexer @footer`) now go through an
+immutable internal descriptor `NamedActionInjectionDescriptor` and the common method
 `EmitNamedActionRegion`.
 
-Le descripteur porte uniquement les différences nécessaires entre familles :
+The descriptor only carries the necessary differences between families:
 
-- le `ParserEmbeddedCodeLocation` transmis à la frontière de transformation ;
-- la `CSharpEmbeddedCodeRegion`, qui conserve les marqueurs, l'indentation et l'espacement existants ;
-- le sélecteur basé sur `EmbeddedMembersSupport`, afin de ne pas dupliquer la classification
-  `@header` / `@parser::header` / `@lexer::header` et équivalents.
+- the `ParserEmbeddedCodeLocation` transmitted to the transformation boundary;
+- the `CSharpEmbeddedCodeRegion`, which preserves existing markers, indentation and spacing;
+- the selector based on `EmbeddedMembersSupport`, so as not to duplicate the classification
+  `@header` / `@parser::header` / `@lexer::header` and equivalents.
 
-Les wrappers explicites `EmitParserHeaders`, `EmitParserMembers`, `EmitParserFooters`,
-`EmitLexerHeaders`, `EmitLexerMembers` et `EmitLexerFooters` sont conservés. Ils choisissent
-uniquement le descripteur statique approprié et délèguent à la méthode commune. La source C# générée
-reste inchangée : mêmes positions d'émission, mêmes régions, même indentation, mêmes lignes vides et
-même ordre d'appel au transformer.
+The explicit wrappers `EmitParserHeaders`, `EmitParserMembers`, `EmitParserFooters`,
+`EmitLexerHeaders`, `EmitLexerMembers` and `EmitLexerFooters` are preserved. They choose
+only the appropriate static descriptor and delegate to the common method. The generated C# source
+remains unchanged: same emission positions, same regions, same indentation, same empty lines and
+same transformer invocation order.
 
-Tests ajoutés ou renforcés :
+Added or strengthened tests:
 
-- couverture d'invariant pour l'ordre de plusieurs fragments d'une même catégorie de named action ;
-- garde-fous Roslyn vérifiant que les six wrappers délèguent à `EmitNamedActionRegion` ;
-- garde-fous Roslyn vérifiant que les wrappers ne transforment pas et n'injectent pas directement ;
-- maintien des invariants existants couvrant les six `ParserEmbeddedCodeLocation` nommés, l'absence
-  de fallback vers le texte brut et le passage exclusif par `CSharpEmbeddedCodeInjector`.
+- invariant coverage for the order of several fragments of the same named action category;
+- Roslyn guardrails checking that the six wrappers delegate to `EmitNamedActionRegion`;
+- Roslyn safeguards verifying that wrappers do not transform or inject directly;
+- maintaining existing invariants covering the six named `ParserEmbeddedCodeLocation`, the absence of a
+  fallback to raw text and exclusive passage by `CSharpEmbeddedCodeInjector`.
 
-Les points 6 à 11 restent hors périmètre : actions inline parser/lexer, prédicats, lifecycle hooks,
-parcours récursifs, symboles runtime et compilation/préparation d'expressions ne sont pas factorisés
-par cette correction.
+Points 6 to 11 remain outside the scope: inline parser/lexer actions, predicates, lifecycle hooks,
+recursive traversals, runtime symbols and compilation/preparation of expressions are not consolidated
+by this change.
 
-### 6. Fusionner `EmbeddedCodeHook` et `LexerEmbeddedCodeHook`
-**Corrigé.** Les hooks parser et lexer générés sont désormais représentés par un seul type interne
-`GrammarEmitter.EmbeddedCodeHook`. L'ancien type `LexerEmbeddedCodeHook` a été supprimé. Le type
-commun conserve le code brut dans `RawEmbeddedCode RawCode` et le code transformé prêt à l'émission
-dans `TransformedEmbeddedCode? TransformedCode`, sans remplacer ces frontières typées par des chaînes.
+### 6. Merge `EmbeddedCodeHook` and `LexerEmbeddedCodeHook`
+**Fixed.** Generated parser and lexer hooks are now represented by a single internal type
+`GrammarEmitter.EmbeddedCodeHook`. The old `LexerEmbeddedCodeHook` type has been removed. The common type keeps the raw code in `RawEmbeddedCode RawCode` and the transformed code ready for emission
+in `TransformedEmbeddedCode? TransformedCode`, without replacing these typed boundaries with strings.
 
-La distinction de domaine est explicite grâce à deux discriminants internes :
+The domain distinction is explicit thanks to two internal discriminators:
 
-- `EmbeddedCodeHookOwner` distingue `Parser` et `Lexer` ;
-- `EmbeddedCodeHookKind` distingue `SemanticPredicate` et `InlineAction`.
+- `EmbeddedCodeHookOwner` distinguishes between `Parser` and `Lexer`;
+- `EmbeddedCodeHookKind` distinguishes between `SemanticPredicate` and `InlineAction`.
 
-Les quatre catégories sont donc couvertes sans booléen ambigu comme état principal : prédicat parser,
-action inline parser, prédicat lexer et action inline lexer. La construction passe par les fabriques
-`CreateParser(...)` et `CreateLexer(...)`, qui valident le nom de règle, le code brut, les indices
-acceptés (`-1` comme sentinelle historique ou valeur positive/nulle), le nom de méthode générée et les
-valeurs d'enum. Le résultat transformé reste absent avant la transition immuable, et le point d’accès unique des
-émetteurs rejette explicitement cet état avant toute écriture de source.
+The four categories are therefore covered without an ambiguous boolean as their primary state: parser predicate,
+parser inline action, lexer predicate, and inline lexer action. Construction goes through the factories
+`CreateParser(...)` and `CreateLexer(...)`, which validate rule name, raw code, accepted indices (`-1` as historical sentinel or nonnegative value), the generated method name and the
+enum values. The transformed result remains absent before the immutable transition, and the single emitter access point
+explicitly rejects this state before any source writing.
 
-Les producteurs parser et lexer restent séparés : `CollectEmbeddedCodeHooks(...)` conserve les règles
-d'indexation parser, notamment les traitements de séquences, quantificateurs, négations et récursion
-gauche, tandis que `CollectLexerEmbeddedCodeHooks(...)` conserve le parcours lexer existant. Les
-parcours récursifs ne sont pas mutualisés dans cette correction afin de ne pas masquer les différences
-runtime. Les conventions de nommage restent portées par les producteurs (`__Predicate...`,
-`__Action...`, `__LexerPredicate...`, `__LexerAction...`) et la source C# générée reste inchangée.
+The parser and lexer producers remain separate: `CollectEmbeddedCodeHooks(...)` keeps the parser
+indexing rules, including sequence processing, quantifiers, negations and left
+recursion, while `CollectLexerEmbeddedCodeHooks(...)` keeps the existing lexer path. The
+recursive paths are not shared in this correction so as not to mask the runtime
+differences. The naming conventions remain supported by the producers (`__Predicate...`,
+`__Action...`, `__LexerPredicate...`, `__LexerAction...`) and the generated C# source remains unchanged.
 
-Tests ajoutés ou renforcés :
+Added or strengthened tests:
 
-- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_UseOneTypedHookWithExplicitOwnerAndKind` ;
-- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_WhenCreatedThroughFactories_PreserveFourCategories` ;
-- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_WhenInvalidStateIsCreated_RejectsIt` ;
-- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenParserAndLexerHooksShareGrammar_PreservesStableCategoriesAndGeneratedBodies` ;
+- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_UseOneTypedHookWithExplicitOwnerAndKind`;
+- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_WhenCreatedThroughFactories_PreserveFourCategories`;
+- `Antlr4GeneratedEmbeddedCodeTests.EmbeddedCodeHookTypes_WhenInvalidStateIsCreated_RejectsIt`;
+- `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenParserAndLexerHooksShareGrammar_PreservesStableCategoriesAndGeneratedBodies`;
 - `EmbeddedCodeTransformerArchitectureTests.GrammarEmitterEmbeddedCodeHooks_UseSingleCommonHookModel`.
 
-Les points 7 à 11 restent hors périmètre : construction des symboles runtime, mutualisation générale
-des parcours récursifs, formalisation globale du pipeline, clarification de l’état brut/transformé et
-documentation de la façade runtime ne sont pas traités par cette correction.
+Points 7 to 11 remain outside the scope: runtime symbol construction, general consolidation of
+recursive traversals, overall formalization of the pipeline, clarification of the raw/transformed state and
+runtime facade documentation are not addressed by this fix.
 
-### 7. Factoriser la construction des symboles d'expressions
-**Corrigé.** `ExpressionEmbeddedCodePreparer` conserve les wrappers spécialisés
-`BuildSemanticPredicateSymbols(...)` et `BuildParserActionSymbols(...)`, mais ceux-ci ne portent plus
-aucune logique de classification : ils délèguent directement à la méthode commune privée
+### 7. Consolidate the construction of expression symbols
+**Fixed.** `ExpressionEmbeddedCodePreparer` retains the specialized wrappers
+`BuildSemanticPredicateSymbols(...)` and `BuildParserActionSymbols(...)`, but these no longer carry
+any classification logic: they delegate directly to the private common method
 `BuildRuntimeContextSymbols(ParameterExpression runtimeContext, IReadOnlySet<EmbeddedCodeContextSymbol> supportedSymbols)`.
 
-La méthode commune crée le dictionnaire avec `StringComparer.Ordinal`, parcourt `supportedSymbols` une
-seule fois et expose les quatre symboles historiques sans changer leurs noms publics :
+The common method creates the dictionary with `StringComparer.Ordinal`, iterates over `supportedSymbols`
+exactly once and exposes the four historical symbols without changing their public names:
 
-- `RuleName` -> `ruleName` -> `context.Rule.Name` ;
-- `InputPosition` -> `inputPosition` -> `context.InputPosition` ;
-- `AlternativeIndex` -> `alternativeIndex` -> `context.AlternativeIndex` ;
+- `RuleName` -> `ruleName` -> `context.Rule.Name`;
+- `InputPosition` -> `inputPosition` -> `context.InputPosition`;
+- `AlternativeIndex` -> `alternativeIndex` -> `context.AlternativeIndex`;
 - `ElementIndex` -> `elementIndex` -> `context.ElementIndex`.
 
-Les helpers dupliqués `AddSemanticPredicateSymbol(...)` et `AddParserActionSymbol(...)` ont été
-supprimés. `BuildRuleName(...)` reste isolé, car il documente explicitement la chaîne de lecture
-`Rule.Name` partagée par les deux contextes runtime. Aucune interface ou classe de base publique n'a
-été ajoutée pour les contextes `SemanticPredicateEvaluationContext` et `ParserActionExecutionContext` ;
-le type de lambda de chaque chemin reste spécialisé. Les expressions construites lisent toujours les
-valeurs depuis le contexte fourni au moment de l'exécution, sans capture de valeur à la préparation et
-sans appel supplémentaire à `IExpressionCompiler.Compile(...)`. Les valeurs inconnues de
-`EmbeddedCodeContextSymbol` restent ignorées, comme dans les anciens `switch` sans branche `default`.
+The duplicate helpers `AddSemanticPredicateSymbol(...)` and `AddParserActionSymbol(...)` have been
+deleted. `BuildRuleName(...)` remains isolated, because it explicitly documents the property-access chain
+`Rule.Name` shared by both runtime contexts. No public interface or base class has
+been added for the `SemanticPredicateEvaluationContext` and `ParserActionExecutionContext` contexts;
+the lambda type of each path remains specialized. Constructed expressions always read the
+values from the context provided at run time, without capturing values during preparation and
+without an additional call to `IExpressionCompiler.Compile(...)`. Unknown values of
+`EmbeddedCodeContextSymbol` remain ignored, as in the previous `switch` statements without a `default` branch.
 
-Tests ajoutés ou renforcés :
+Added or strengthened tests:
 
-- matrice unitaire couvrant `PrepareSemanticPredicate` et `PrepareParserAction` pour les quatre
-  symboles, le dictionnaire vide, un symbole unique, un sous-ensemble non ordonné et les valeurs
-  inconnues de l'enum ;
-- inspection des `MemberExpression` pour vérifier les membres runtime ciblés sans dépendre de
-  `Expression.ToString()` ;
-- tests d'exécution réutilisant le même artefact préparé avec deux contextes différents pour prouver
-  la lecture runtime des valeurs ;
-- garde-fou Roslyn fonctionnel vérifiant que les wrappers délèguent à `BuildRuntimeContextSymbols`,
-  que les anciens helpers `Add...Symbol` n'existent plus, qu'une seule méthode classe
-  `EmbeddedCodeContextSymbol`, que les lambdas conservent leurs types runtime spécialisés et qu'aucun
-  nouveau contrat public n'a été introduit.
+- unit matrix covering `PrepareSemanticPredicate` and `PrepareParserAction` for all four
+  symbols, an empty dictionary, a single symbol, an unordered subset, and
+  unknown enum values;
+- inspection of `MemberExpression` to check targeted runtime members without depending on
+  `Expression.ToString()`;
+- execution tests reusing the same artifact prepared with two different contexts to prove
+  runtime reading of values;
+- functional Roslyn guardrail checking that wrappers delegate to `BuildRuntimeContextSymbols`,
+  that the old `Add...Symbol` helpers no longer exist, only one method classifies
+  `EmbeddedCodeContextSymbol`, that lambdas retain their specialized runtime types and that
+  no new public contract has been introduced.
 
-Les points 8 à 11 restent hors périmètre du code de production de cette correction : la mutualisation
-générale parser/lexer, le pipeline global, la clarification de l’état brut/transformé et la documentation de façade
-runtime demeurent des chantiers séparés.
+Points 8 to 11 remain outside the scope of the production code of this correction: general parser/lexer consolidation, overall pipeline, raw/transformed state clarification and runtime facade documentation remain separate work items.
 
-### 8. Introduire des moteurs communs avec stratégies parser/lexer spécialisées
-**Partiellement corrigé.**
+### 8. Introduce common engines with specialized parser/lexer strategies
+**Partially corrected.**
 
-#### 8a. Collecte des hooks — corrigé
+#### 8a. Collecting hooks — fixed
 
-La collecte des hooks embarqués parser et lexer est désormais mutualisée par le moteur commun privé
-`EmbeddedHookCollector`. Ce moteur porte la création de la collection, le parcours récursif stable des
-nœuds `G4Alternation`, `G4Alternative`, `G4Sequence`, `G4Quantifier`, `G4Negation` et
-`G4EmbeddedAction`, l'accumulation des hooks, puis la transformation ordonnée de chaque hook une seule
-fois via `TransformEmbeddedCode(...)`.
+The collection of embedded parser and lexer hooks is now shared by the private common engine
+`EmbeddedHookCollector`. This engine implements the creation of the collection, the stable recursive traversal of
+nodes `G4Alternation`, `G4Alternative`, `G4Sequence`, `G4Quantifier`, `G4Negation` and
+`G4EmbeddedAction`, the accumulation of hooks, and then transforms each hook exactly
+once via `TransformEmbeddedCode(...)`.
 
-Les différences réelles restent concentrées dans deux stratégies privées :
+The real differences remain concentrated in two private strategies:
 
-- `ParserEmbeddedHookCollectionStrategy` énumère les règles parser, applique l'ordre par priorité,
-  prépare les racines de parcours des règles direct-left-recursive en séparant alternatives de base et
-  queues récursives, conserve les sentinelles historiques `-1`, les règles parser d'indexation des
-  alternatives, séquences, quantificateurs et négations, les préfixes `__Predicate` / `__Action`, les
-  localisations `SemanticPredicate` / `InlineAction`, et la fabrique typée `EmbeddedCodeHook.CreateParser(...)` ;
-- `LexerEmbeddedHookCollectionStrategy` énumère les règles lexer de `DEFAULT_MODE` puis les modes
-  supplémentaires, conserve l'ordre source, garde les index lexer historiques pour alternatives,
-  séquences, quantificateurs et négations, les préfixes `__LexerPredicate` / `__LexerAction`, les
-  localisations `LexerSemanticPredicate` / `LexerInlineAction`, et la fabrique typée
+- `ParserEmbeddedHookCollectionStrategy` enumerates the parser rules, applies the order by priority,
+  prepares the traversal roots of direct-left-recursive rules by separating base alternatives and
+  recursive tails, preserves historical sentinels `-1`, parser rules for indexing
+  alternatives, sequences, quantifiers and negations, `__Predicate` / `__Action` prefixes,
+  locations `SemanticPredicate` / `InlineAction`, and the typed factory `EmbeddedCodeHook.CreateParser(...)`;
+- `LexerEmbeddedHookCollectionStrategy` lists the lexer rules of `DEFAULT_MODE` then the additional
+  modes, keeps source order, keeps historical lexer indexes for alternatives,
+  sequences, quantifiers and negations, `__LexerPredicate` / `__LexerAction` prefixes,
+  locations `LexerSemanticPredicate` / `LexerInlineAction`, and the typed factory
   `EmbeddedCodeHook.CreateLexer(...)`.
 
-Le contexte immuable `HookTraversalPosition` transporte explicitement `AlternativeIndex` et
-`ElementIndex`, y compris les sentinelles `-1`, sans collection mutable ni état global. Les racines de
-parcours sont transmises par `HookTraversalRoot`, ce qui laisse la récursion gauche au périmètre parser
-spécialisé et les modes lexer au périmètre lexer spécialisé. Les wrappers lisibles
-`CollectEmbeddedCodeHooks(...)` et `CollectLexerEmbeddedCodeHooks(...)` sont conservés, mais ils ne
-contiennent plus de `switch` sur `G4Content`, de récursion, de création directe de hooks, de
-transformation directe ni de logique d'indexation.
+The immutable context `HookTraversalPosition` explicitly carries `AlternativeIndex` and
+`ElementIndex`, including `-1` sentinels, without mutable collection or global state. Traversal roots are passed by `HookTraversalRoot`, which leaves left recursion within the specialized parser
+scope and the lexer modes at the specialized lexer scope. Readable wrappers
+`CollectEmbeddedCodeHooks(...)` and `CollectLexerEmbeddedCodeHooks(...)` are preserved, but they no longer contain a `switch` on `G4Content`, recursion, direct creation of hooks,
+direct transformation or indexing logic.
 
-Aucun booléen `isLexer`, aucune classe de base extensive et aucune nouvelle API publique n'ont été
-introduits. La source C# générée est préservée par les tests existants de source générée et par les
-tests d'invariants de transformation. Le garde-fou Roslyn
-`GrammarEmitterEmbeddedCodeHookCollection_UsesSharedCollectorAndStrategies` vérifie la délégation des
-wrappers, l'existence du moteur et des stratégies, l'absence de parcours dupliqués, l'absence de
-paramètre `bool isLexer`, la centralisation de la transformation, l'utilisation de `CreateParser(...)`
-et `CreateLexer(...)`, le portage de la récursion gauche par la stratégie parser, le portage des modes
-lexer par la stratégie lexer, et la présence du contexte immuable d'indices.
+No `isLexer` boolean, no extensive base classes, and no new public APIs have been
+introduced. The generated C# source is preserved by existing generated source tests and by
+tests of transformation invariants. The Roslyn guardrail
+`GrammarEmitterEmbeddedCodeHookCollection_UsesSharedCollectorAndStrategies` checks the delegation of
+wrappers, the existence of the engine and strategies, the absence of duplicated paths, the absence of
+a `bool isLexer` parameter, centralization of the transformation, use of `CreateParser(...)`
+and `CreateLexer(...)`, ownership of left recursion by the parser strategy, ownership of lexer
+modes by the lexer strategy, and the presence of the immutable context of indices.
 
-Tests ajoutés ou renforcés :
+Added or strengthened tests:
 
-- `EmbeddedCodeTransformerArchitectureTests.GrammarEmitterEmbeddedCodeHookCollection_UsesSharedCollectorAndStrategies` ;
-- tests existants de caractérisation `Antlr4GeneratedEmbeddedCodeTests` couvrant parser non récursif,
-  parser récursif gauche, lexer, grammaires combinées, noms de méthodes, dispatchers, corps transformés
-  et stabilité de la source générée ;
-- tests existants `EmbeddedCodeTransformationInvariantTests` couvrant ordre, nombre d'appels au
-  transformer, localisations, noms de règles, code brut et absence de double transformation.
+- `EmbeddedCodeTransformerArchitectureTests.GrammarEmitterEmbeddedCodeHookCollection_UsesSharedCollectorAndStrategies`;
+- existing characterization tests `Antlr4GeneratedEmbeddedCodeTests` covering non-recursive parser,
+  left recursive parser, lexer, combined grammars, method names, dispatchers, transformed bodies
+  and stability of the generated source;
+- existing tests `EmbeddedCodeTransformationInvariantTests` covering order, number of calls to
+  transform, locations, rule names, raw code and absence of double transformation.
 
-#### 8b. Dispatchers runtime — corrigé
+#### 8b. Runtime dispatchers — fixed
 
-L'émission des dispatchers runtime parser et lexer est désormais mutualisée par le moteur privé
-`EmbeddedHookDispatcherEmitter`. Ce moteur porte l'algorithme stable : déclaration de la classe
-générée, signature de la méthode de dispatch, boucle ordonnée sur les hooks déjà sélectionnés,
-validation des discriminants `Owner` et `Kind`, comparaisons dans l'ordre historique
-`Rule.Name`, code brut (`PredicateCode` ou `ActionCode`), `AlternativeIndex`, `ElementIndex`, appel de
-la méthode de hook, retour de succès et retour de fallback. Aucun tri supplémentaire n'est introduit ;
-l'ordre reste celui des listes `predicates`, `actions`, `lexerActions` et `lexerPredicates` produites par
-la collecte existante.
+The emission of the runtime parser and lexer dispatchers is now shared by the private engine
+`EmbeddedHookDispatcherEmitter`. This engine implements the stable algorithm: generated class declaration,
+dispatch-method signature, ordered loop on the hooks already selected,
+validation of the `Owner` and `Kind` discriminants, comparisons in historical order
+`Rule.Name`, raw code (`PredicateCode` or `ActionCode`), `AlternativeIndex`, `ElementIndex`, call of
+the hook method, success return and fallback return. No additional sorting is introduced;
+the order remains that of the `predicates`, `actions`, `lexerActions` and `lexerPredicates` lists produced by
+the existing collection.
 
-Les différences déclaratives sont concentrées dans le descripteur immuable privé
-`EmbeddedHookDispatcherDescriptor`, qui expose explicitement les quatre configurations constantes :
+Declarative differences are concentrated in the private immutable descriptor
+`EmbeddedHookDispatcherDescriptor`, which explicitly exposes the four constant configurations:
 
-- `ParserPredicate` pour `GeneratedSemanticPredicateEvaluator` / `ISemanticPredicateEvaluator`,
-  `SemanticPredicateEvaluationContext`, `SemanticPredicateEvaluationOutcome`, succès
-  `Satisfied`/`Rejected` et fallback `_fallback.Evaluate(context)` ;
-- `ParserAction` pour `GeneratedParserActionExecutor` / `IParserActionExecutor`,
-  `ParserActionExecutionContext`, `ParserActionExecutionOutcome.Executed` et fallback
-  `_fallback.Execute(context)` ;
-- `LexerPredicate` pour `GeneratedLexerPredicateEvaluator` / `ILexerPredicateEvaluator`,
-  `LexerPredicateEvaluationContext`, `LexerPredicateEvaluationOutcome.True`/`False` et fallback
-  `_fallback.Evaluate(context)` ;
-- `LexerAction` pour `GeneratedLexerActionExecutor` / `ILexerActionExecutor`,
-  `LexerActionExecutionContext` avec `LexerActionExecutionResult`,
-  `LexerActionExecutionOutcome.Executed` et fallback `_fallback.Execute(context, result)`.
+- `ParserPredicate` for `GeneratedSemanticPredicateEvaluator` / `ISemanticPredicateEvaluator`,
+  `SemanticPredicateEvaluationContext`, `SemanticPredicateEvaluationOutcome`, success
+  `Satisfied`/`Rejected` and fallback `_fallback.Evaluate(context)`;
+- `ParserAction` for `GeneratedParserActionExecutor` / `IParserActionExecutor`,
+  `ParserActionExecutionContext`, `ParserActionExecutionOutcome.Executed` and fallback
+  `_fallback.Execute(context)`;
+- `LexerPredicate` for `GeneratedLexerPredicateEvaluator` / `ILexerPredicateEvaluator`,
+  `LexerPredicateEvaluationContext`, `LexerPredicateEvaluationOutcome.True`/`False` and fallback
+  `_fallback.Evaluate(context)`;
+- `LexerAction` for `GeneratedLexerActionExecutor` / `ILexerActionExecutor`,
+  `LexerActionExecutionContext` with `LexerActionExecutionResult`,
+  `LexerActionExecutionOutcome.Executed` and fallback `_fallback.Execute(context, result)`.
 
-Les wrappers explicites `EmitSemanticPredicateEvaluator(...)`, `EmitParserActionExecutor(...)`,
-`EmitLexerPredicateEvaluator(...)` et `EmitLexerActionExecutor(...)` sont conservés comme points de
-lecture parser/lexer et prédicat/action ; ils sélectionnent seulement le descripteur correspondant et
-délèguent au moteur commun. Aucune stratégie comportementale supplémentaire n'a été nécessaire : les
-différences constatées sont les types, signatures, propriétés de code, expressions de succès, arguments
-d'appel et fallbacks, donc elles restent décrites par données. Aucun paramètre `isLexer` ou
-`isPredicate`, aucun gros `switch` de domaine et aucune nouvelle API publique ne sont introduits.
+The explicit wrappers `EmitSemanticPredicateEvaluator(...)`, `EmitParserActionExecutor(...)`,
+`EmitLexerPredicateEvaluator(...)` and `EmitLexerActionExecutor(...)` are kept as explicit parser/lexer and predicate/action entry points; they only select the corresponding descriptor and
+delegate to the common engine. No additional behavioral strategies were necessary: the
+differences are types, signatures, code properties, success expressions, call
+arguments and fallbacks, so they remain described by data. No `isLexer` parameter or
+`isPredicate`, no big domain `switch` and no new public API are introduced.
 
-La source générée est préservée : noms de classes, interfaces, signatures, conditions, ordre des
-conditions, appels `__Predicate...`, `__Action...`, `__LexerPredicate...`, `__LexerAction...`, retours de
-succès et fallbacks restent identiques. Les méthodes de hooks elles-mêmes ne sont pas mutualisées et
-restent explicitement ouvertes pour 8c.
+The generated source is preserved: class names, interfaces, signatures, conditions, order of
+conditions, calls `__Predicate...`, `__Action...`, `__LexerPredicate...`, `__LexerAction...`, success returns and fallbacks remain the same. The hook methods themselves are not shared and
+remain intentionally separate for item 8c.
 
-Tests ajoutés ou renforcés :
+Added or strengthened tests:
 
 - `Antlr4GeneratedEmbeddedCodeTests.Emit_CombinedEmbeddedCode_GeneratesEquivalentRuntimeDispatchers`
-  caractérise les quatre dispatchers sur une grammaire combinée avec plusieurs hooks parser et lexer ;
+  characterizes the four dispatchers on a grammar combined with several parser and lexer hooks;
 - `EmbeddedCodeTransformerArchitectureTests.GrammarEmitterEmbeddedHookDispatchers_UseSharedEmitterAndImmutableDescriptors`
-  vérifie par Roslyn la délégation des quatre wrappers, l'absence de boucle et de structure complète
-  dans les wrappers, l'émetteur commun unique, le descripteur immuable privé, l'absence de `isLexer` /
-  `isPredicate`, l'absence de branches parser/lexer dispersées dans l'émetteur, la validation des
-  discriminants `Owner` et `Kind`, les quatre configurations explicites, les fallbacks et le maintien des
-  méthodes de hooks séparées pour 8c.
+  uses Roslyn to verify the delegation of the four wrappers, the absence of loops and complete implementations
+  in the wrappers, the single common emitter, private immutable descriptor, absence of `isLexer` /
+  `isPredicate`, the absence of scattered parser/lexer branches in the emitter, validation of the
+  discriminants `Owner` and `Kind`, the four explicit configurations, the fallbacks, and preservation of
+  separate hook methods for 8c.
 
-#### 8c. Méthodes de hooks — corrigé
+#### 8c. Hook methods — fixed
 
-L'émission des quatre familles de méthodes de hooks générées est désormais mutualisée par le moteur
-privé `EmbeddedHookMethodEmitter`. Ce moteur porte l'algorithme stable : validation typée du hook par
-`Owner` et `Kind`, création du `GeneratedEmbeddedCodeBody`, commentaire XML, signature, accolade
-d'ouverture, préambule éventuel de locaux de contexte, appel centralisé à
-`EmitGeneratedEmbeddedCodeBody(...)`, accolade de fermeture et ligne vide finale. La source générée
-reste préservée : mêmes commentaires XML, mêmes signatures, même indentation, mêmes corps injectés et
-même ordre d'émission.
+Emission of the four generated hook-method families is now shared by the private engine `EmbeddedHookMethodEmitter`. This engine implements the stable algorithm: typed validation of the hook by
+`Owner` and `Kind`, creation of `GeneratedEmbeddedCodeBody`, XML documentation comment, signature, brace
+opening, optional preamble of context locals, centralized call to
+`EmitGeneratedEmbeddedCodeBody(...)`, closing brace and final empty line. The generated source
+is retained: same XML documentation comments, same signatures, same indentation, same injected bodies and
+same emission order.
 
-Les différences déclaratives sont concentrées dans le descripteur immuable privé
-`EmbeddedHookMethodDescriptor`, qui expose explicitement les quatre configurations :
+Declarative differences are concentrated in the private immutable descriptor
+`EmbeddedHookMethodDescriptor`, which explicitly exposes the four configurations:
 
-- `ParserPredicate` valide `Parser` / `SemanticPredicate`, émet `private bool`, reçoit
-  `SemanticPredicateEvaluationContext context`, utilise `GeneratedEmbeddedCodeBody.ForPredicate(...)`
-  et conserve les locaux parser predicate (`ruleName`, `inputPosition`, `alternativeIndex`,
-  `elementIndex`, `predicateCode`) ;
-- `ParserAction` valide `Parser` / `InlineAction`, émet `private void`, reçoit
-  `ParserActionExecutionContext context`, utilise `GeneratedEmbeddedCodeBody.ForAction(...)` et
-  conserve les locaux parser action (`ruleName`, `inputPosition`, `alternativeIndex`, `elementIndex`,
-  `actionCode`) ;
-- `LexerPredicate` valide `Lexer` / `SemanticPredicate`, émet `private bool`, reçoit
-  `LexerPredicateEvaluationContext context`, utilise `GeneratedEmbeddedCodeBody.ForPredicate(...)` et
-  ne reçoit aucun local parser ;
-- `LexerAction` valide `Lexer` / `InlineAction`, émet `private void`, reçoit
-  `LexerActionExecutionContext context, LexerActionExecutionResult result`, utilise
-  `GeneratedEmbeddedCodeBody.ForAction(...)`, conserve le paramètre mutable `result` et ne reçoit aucun
-  local parser.
+- `ParserPredicate` validates `Parser` / `SemanticPredicate`, emits `private bool`, receives
+  `SemanticPredicateEvaluationContext context`, uses `GeneratedEmbeddedCodeBody.ForPredicate(...)`
+  and keeps the parser predicate locals (`ruleName`, `inputPosition`, `alternativeIndex`,
+  `elementIndex`, `predicateCode`);
+- `ParserAction` validates `Parser` / `InlineAction`, emits `private void`, receives
+  `ParserActionExecutionContext context`, uses `GeneratedEmbeddedCodeBody.ForAction(...)` and
+  preserves parser action locals (`ruleName`, `inputPosition`, `alternativeIndex`, `elementIndex`,
+  `actionCode`);
+- `LexerPredicate` validates `Lexer` / `SemanticPredicate`, emits `private bool`, receives
+  `LexerPredicateEvaluationContext context`, uses `GeneratedEmbeddedCodeBody.ForPredicate(...)` and
+  receives no parser locals;
+- `LexerAction` validates `Lexer` / `InlineAction`, emits `private void`, receives
+  `LexerActionExecutionContext context, LexerActionExecutionResult result`, uses
+  `GeneratedEmbeddedCodeBody.ForAction(...)`, keeps the mutable parameter `result` and receives no
+  parser locals.
 
-Le profil explicite `EmbeddedHookContextLocalProfile` limite le préambule aux trois cas réels
-(`None`, `ParserPredicate`, `ParserAction`) sans introduire de booléen de domaine. Les wrappers
-`EmitPredicateHook(...)`, `EmitActionHook(...)`, `EmitLexerPredicateHook(...)` et
-`EmitLexerActionHook(...)` restent les points de lecture spécialisés ; ils sélectionnent uniquement le
-descripteur et délèguent au moteur commun. Les hooks lifecycle restent hors périmètre : ils reposent
-sur `LifecycleHook`, une visibilité `internal`, `ParserRuleLifecycleContext`, des locaux et phases
-`@init` / `@after`, sans discriminants `EmbeddedCodeHookOwner` / `EmbeddedCodeHookKind`.
+The explicit profile `EmbeddedHookContextLocalProfile` limits the preamble to the three real cases
+(`None`, `ParserPredicate`, `ParserAction`) without introducing a domain boolean. Wrappers
+`EmitPredicateHook(...)`, `EmitActionHook(...)`, `EmitLexerPredicateHook(...)` and
+`EmitLexerActionHook(...)` remain the specialized entry points; they only select the
+descriptor and delegate to the common engine. Lifecycle hooks remain out of scope: they rely
+on `LifecycleHook`, `internal` visibility, `ParserRuleLifecycleContext`, locals and phases
+`@init` / `@after`, without `EmbeddedCodeHookOwner` / `EmbeddedCodeHookKind` discriminators.
 
-Tests ajoutés ou renforcés :
+Added or strengthened tests:
 
 - `Antlr4GeneratedEmbeddedCodeTests.Emit_CombinedEmbeddedCode_GeneratesStableHookMethodBlocks`
-  caractérise les commentaires, signatures, locaux parser, absence de locaux parser côté lexer,
-  transformation expression/bloc, ordre des familles et conservation du paramètre lexer `result` ;
+  characterizes documentation comments, signatures, parser locals, absence of parser locals on the lexer side,
+  expression/block transformation, family ordering and preservation of the lexer parameter `result`;
 - `EmbeddedCodeTransformerArchitectureTests.GrammarEmitterEmbeddedHookMethods_UseSharedEmitterAndImmutableDescriptors`
-  vérifie par Roslyn l'émetteur commun, le descripteur immuable, les quatre configurations explicites,
-  la délégation des wrappers, l'absence d'appels directs interdits dans les wrappers, la validation
-  typée, l'appel unique à `EmitGeneratedEmbeddedCodeBody(...)`, la distinction typée
-  `ForPredicate(...)` / `ForAction(...)`, les profils de locaux explicites, l'absence de `isLexer` /
-  `isPredicate`, et le maintien des hooks lifecycle hors abstraction.
+  uses Roslyn to verify the common emitter, the immutable descriptor, the four explicit configurations,
+  the delegation of wrappers, the absence of forbidden direct calls in wrappers, typed
+  validation, the single call to `EmitGeneratedEmbeddedCodeBody(...)`, the typed distinction
+  `ForPredicate(...)` / `ForAction(...)`, explicit local profiles, absence of `isLexer` /
+  `isPredicate`, and maintaining lifecycle hooks outside the abstraction.
 
-#### 8d. Garde-fous globaux — corrigé
+#### 8d. Global safeguards — fixed
 
-Les garde-fous architecturaux couvrent maintenant la collecte, les dispatchers runtime et les méthodes
-de hooks. Ils vérifient l'absence de réintroduction d'algorithmes parallèles, l'absence de booléens de
-domaine `isLexer` / `isPredicate`, l'absence de nouvelle API publique, la conservation des wrappers
-explicites, la validation typée et la séparation volontaire des hooks lifecycle.
+Architectural guardrails now cover collection, runtime dispatchers and hook
+methods. They check the absence of reintroduction of parallel algorithms, the absence of domain booleans
+`isLexer` / `isPredicate`, the absence of a new public API, the preservation of explicit
+wrappers, typed validation and intentional separation of lifecycle hooks.
 
-## Duplications d'intention et lisibilité (priorité moyenne)
+## Duplicated intent and readability (medium priority)
 
-### 9. Clarifier la frontière entre préparation, transformation, injection et compilation
-**Corrigé.** Le noyau interne `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)`, placé
-dans l'assembly `netstandard2.0` de diagnostics partagée, reçoit un `RawEmbeddedCode`, un
-`IParserEmbeddedCodeTransformer`, un `ParserEmbeddedCodeTransformationContext` fortement typé et les
-métadonnées d'échec. Il appelle le transformer exactement une fois, centralise les validations des
-arguments, du résultat nul, des diagnostics bloquants et du code transformé nul, puis remet un
-`TransformedEmbeddedCode` validé. L'ancien service public délègue au noyau afin de préserver l'API.
+### 9. Clarify the boundary between preparation, transformation, injection and compilation
+**Fixed.** The internal core `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)`, placed
+in the `netstandard2.0` shared diagnostics assembly, receives a `RawEmbeddedCode`, an
+`IParserEmbeddedCodeTransformer`, a strongly typed `ParserEmbeddedCodeTransformationContext` and the
+failure metadata. It calls the transformer exactly once, centralizes validation of arguments, null results, blocking diagnostics, and null transformed code,
+then returns a validated `TransformedEmbeddedCode`. The existing public service delegates to the core in order to preserve the API.
 
-La frontière s'arrête strictement à cet artefact : elle ne connaît ni `StringBuilder`, ni injection,
-ni expression, ni lambda, ni compilation. Le générateur construit son contexte enrichi (règle,
-déclarations et labels), appelle le noyau, conserve la distinction parser/lexer et predicate/action,
-puis classe le résultat via `GeneratedEmbeddedCodeBody.ForPredicate(...)` ou `ForAction(...)` et
-délègue exclusivement à `CSharpEmbeddedCodeInjector`. Le chemin runtime, limité aux prédicats et
-actions parser, construit son contexte dans `ExpressionEmbeddedCodePreparer`, appelle le même noyau,
-construit ensuite les symboles et la lambda spécialisés, et conserve l'appel à
+The boundary stops strictly at this artifact: it knows nothing about `StringBuilder`, injection, expressions, lambdas, or compilation. The generator constructs its enriched context (rule,
+declarations and labels), calls the core, preserves the parser/lexer and predicate/action distinction,
+then classifies the result via `GeneratedEmbeddedCodeBody.ForPredicate(...)` or `ForAction(...)` and
+delegates exclusively to `CSharpEmbeddedCodeInjector`. The runtime path, limited to predicates and
+parser actions, constructs its context in `ExpressionEmbeddedCodePreparer`, calls the same core,
+then constructs specialized symbols and a specialized lambda, and keeps the call to
 `IExpressionCompiler.Compile(...)`.
 
-Les tests de caractérisation couvrent les quatre catégories générées et les deux catégories runtime,
-les contextes et textes bruts exacts, l'appel unique, les échecs de transformation, la classification,
-l'injection, la compilation unique et la réutilisation d'artefacts avec plusieurs contextes runtime.
-Le garde-fou Roslyn `EmbeddedCodeTransformerArchitectureTests` interdit les appels directs parallèles
-au transformer et vérifie que le noyau est interne, commun aux deux cibles, retourne le type transformé
-et ne dépend d'aucun détail de cible. `CSharpEmbeddedCodeInjectorArchitectureTests` maintient la
-frontière d'injection. Aucune API publique ni aucun comportement observable n'a été modifié.
+The characterization tests cover the four generated categories and the two runtime categories,
+exact contexts and raw texts, single invocation, transformation failures, classification,
+injection, single compilation, and reuse of artifacts with multiple runtime contexts.
+Roslyn guardrail `EmbeddedCodeTransformerArchitectureTests` prohibits parallel direct calls
+to the transformer and checks that the core is internal, common to both targets, returns the transformed type
+and does not depend on any target details. `CSharpEmbeddedCodeInjectorArchitectureTests` maintains the
+injection boundary. No public API or observable behavior was changed.
 
-Le point 10 est corrigé ci-dessous. Le point 11 (statut documenté de la façade runtime) reste
-explicitement ouvert.
+Point 10 is corrected below. Point 11 (documented status of the runtime facade) remains
+explicitly open.
 
-### 10. Distinguer explicitement les états brut et transformé
-**Corrigé.** Le modèle interne unique `EmbeddedCodeHook` est désormais un record immuable qui conserve
-le texte collecté dans `RawEmbeddedCode RawCode` et expose séparément
-`TransformedEmbeddedCode? TransformedCode`. Les fabriques parser et lexer créent uniquement l’état
-brut. Le collecteur effectue ensuite une transition explicite par expression `with`, après l’unique
-appel à `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)`; le code brut n’est ni écrasé
-ni reconstruit.
+### 10. Explicitly distinguish between raw and transformed states
+**Fixed.** The single internal model `EmbeddedCodeHook` is now an immutable record that retains
+the collected text in `RawEmbeddedCode RawCode` and exposes separately
+`TransformedEmbeddedCode? TransformedCode`. The parser and lexer factories create only the raw
+state. The collector then makes an explicit transition with a `with` expression, after the single
+call to `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)`; raw code is neither overwritten
+nor rebuilt.
 
-Les quatre émetteurs parser/lexer délèguent toujours à `EmbeddedHookMethodEmitter`. Avant toute écriture
-dans le `StringBuilder`, cet émetteur obtient le résultat par le point d’accès central
-`RequireTransformedCode(...)`. Un hook encore brut provoque une `InvalidOperationException`
-déterministe mentionnant le nom de méthode concerné : aucun fallback vers `RawCode` et aucune source
-partielle ne sont possibles. `GeneratedEmbeddedCodeBody.ForPredicate(...)` et `ForAction(...)`
-continuent ainsi de recevoir exclusivement un `TransformedEmbeddedCode` validé.
+The four parser/lexer emitters continue to delegate to `EmbeddedHookMethodEmitter`. Before writing anything
+to the `StringBuilder`, this emitter gets the result through the central access point
+`RequireTransformedCode(...)`. A hook that is still raw causes a deterministic `InvalidOperationException` that names the affected
+method: neither fallback to `RawCode` nor partial source output is possible. `GeneratedEmbeddedCodeBody.ForPredicate(...)` and `ForAction(...)`
+thus continue to exclusively receive a validated `TransformedEmbeddedCode`.
 
-Le code brut est volontairement conservé après transformation pour les diagnostics, l’audit du flux
-et les tests d’invariant. `LifecycleHook` n’a pas été modifié : il ne représente qu’un état déjà
-transformé et ne portait donc pas la même ambiguïté. Les tests unitaires caractérisent la collecte
-brute, la conservation du texte et l’échec d’émission avant transformation. Les garde-fous Roslyn
-vérifient les types des deux propriétés, l’absence de noms de remplacement ambigus, la transition par
-le pipeline commun, le point d’accès de phase unique, les entrées typées de
-`GeneratedEmbeddedCodeBody` et l’absence de lecture de `RawCode.Text` par les émetteurs.
+The raw code is intentionally retained after transformation for diagnostics, flow audits
+and invariant tests. `LifecycleHook` has not been modified: it only represents a state already
+transformed and therefore did not carry the same ambiguity. Unit tests characterize the raw
+collection, text preservation and emission failure before transformation. Roslyn guardrails
+check the types of the two properties, the absence of ambiguous replacement names, the transition by
+the common pipeline, the single phase-access point, the typed inputs of
+`GeneratedEmbeddedCodeBody` and the absence of `RawCode.Text` reads by the emitters.
 
-Cette correction est interne au générateur : elle ne modifie ni la source C# générée, ni le
-comportement runtime, ni les diagnostics, ni les API publiques.
+This correction is internal to the generator: it modifies neither the generated C# source nor the
+runtime behavior, diagnostics, or public APIs.
 
-### 11. Documenter `ExpressionEmbeddedCodePreparer` comme façade unique de compilation runtime
+### 11. Document `ExpressionEmbeddedCodePreparer` as the single runtime compilation facade
 
-**Corrigé.** `ExpressionEmbeddedCodePreparer` est désormais documentée comme l'unique façade supportée
-pour la compilation runtime du code embarqué parser. Cette portée ne signifie pas qu'elle est l'unique
-utilisatrice globale de `IExpressionCompiler` : le compilateur reste un composant générique injecté par
-l'appelant et orienté par la façade pour ce pipeline de préparation précis.
+**Fixed.** `ExpressionEmbeddedCodePreparer` is now documented as the only supported facade
+for runtime compilation of embedded parser code. This scope does not mean that it is the only
+global user of `IExpressionCompiler`: the compiler remains a generic component injected by
+the caller and directed by the facade for this specific preparation pipeline.
 
-La façade prend en charge uniquement `SemanticPredicate` et `ParserInlineAction` pour la cible
-`RuntimeInlineExpression`. Le chemin complet est explicite : `EmbeddedCodeSource`, validation de la
-catégorie et de la cible, `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)`,
-`TransformedEmbeddedCode`, construction des expressions de symboles liées au contexte runtime, appel
-unique à `IExpressionCompiler.Compile(...)`, puis lambda CLR spécialisée. Les prédicats produisent un
-`Func<SemanticPredicateEvaluationContext, bool>` encapsulé dans
-`PreparedExpressionSemanticPredicate`; les actions produisent un
-`Action<ParserActionExecutionContext>` encapsulé dans `PreparedExpressionParserAction`.
+The facade supports only `SemanticPredicate` and `ParserInlineAction` for the
+`RuntimeInlineExpression` target. The full path is explicit: `EmbeddedCodeSource`, validation of the
+category and target, `EmbeddedCodeTransformationPipeline.TransformAndValidate(...)`,
+`TransformedEmbeddedCode`, construction of symbol expressions linked to the runtime context, a single call
+to `IExpressionCompiler.Compile(...)`, then specialized CLR lambda. Predicates produce a
+`Func<SemanticPredicateEvaluationContext, bool>` wrapped in
+`PreparedExpressionSemanticPredicate`; actions produce a
+`Action<ParserActionExecutionContext>` wrapped in `PreparedExpressionParserAction`.
 
-Les résultats restent normalisés en `Unsupported`, `PreservedNotCompiled`, `CompilationFailed` ou
-`Success`. Les hooks lexer, actions de grammaire, `@init`, `@after` et autres catégories hors du chemin
-parser runtime-inline restent non supportés. La façade ne génère pas de C#, ne remplace pas le source
-generator et n'exécute ni ne capture les valeurs runtime pendant la préparation.
+The results remain normalized to `Unsupported`, `PreservedNotCompiled`, `CompilationFailed` or
+`Success`. Lexer hooks, grammar actions, `@init`, `@after` and other categories outside the parser
+runtime-inline path remain unsupported. The facade does not generate C#, does not replace the source
+generator and does not execute or capture runtime values during preparation.
 
-Les tests de caractérisation vérifient le texte transformé, les symboles runtime, l'appel unique du
-transformateur et du compilateur, l'absence d'appel de ces dépendances pour les catégories ou cibles
-non supportées, et l'absence d'exécution à la préparation. Un garde-fou sémantique Roslyn verrouille
-l'interface et les membres publics existants, le pipeline partagé, le champ compilateur commun, les
-deux constructions d'artefacts et de lambdas spécialisées, l'indépendance du générateur C# et
-l'absence d'une seconde façade ou d'un pipeline combinant transformation, compilation et artefacts.
-Aucun comportement, diagnostic, artefact préparé ou API publique n'a été ajouté ou modifié.
+The characterization tests check the transformed text, the runtime symbols, the single invocation of the
+transformer and compiler, the absence of calls to these dependencies for categories or targets
+not supported, and the absence of execution during preparation. A semantic Roslyn guardrail locks
+the existing public interface and public members, the shared pipeline, the common compiler field, the
+two artifact constructions and specialized lambdas, the independence of the C# generator and
+the absence of a second facade or a pipeline combining transformation, compilation and artifacts.
+No behavior, diagnostic, prepared artifact, or public API was added or changed.
 
-## Garde-fous et contrôles (priorité basse)
+## Safeguards and controls (low priority)
 
-### 12. Ajouter un contrôle statique contre l'injection directe de code brut
+### 12. Add static check against direct injection of raw code
 
-**Corrigé.** `CSharpEmbeddedCodeInjectorArchitectureTests` utilise une analyse sémantique Roslyn pour
-interdire les écritures directes de `RawEmbeddedCode.Text`, `TransformedEmbeddedCode.Text` et
-`SourceText` vers `Append` ou `AppendLine` hors de `CSharpEmbeddedCodeInjector`.
+**Fixed.** `CSharpEmbeddedCodeInjectorArchitectureTests` uses Roslyn semantic analysis to
+disallow direct writes of `RawEmbeddedCode.Text`, `TransformedEmbeddedCode.Text` and
+`SourceText` to `Append` or `AppendLine` outside `CSharpEmbeddedCodeInjector`.
 
-Le contrôle suit également les affectations dans des variables locales afin d'interdire les
-contournements par alias. La seule lecture de texte transformé autorisée hors de l'injecteur est la
-classification non injectante effectuée dans `GeneratedEmbeddedCodeBody.ForPredicate`.
+The guard also tracks assignments to local variables to prohibit
+alias workarounds. The only read of transformed text allowed outside the injector is the
+non-injecting classification done in `GeneratedEmbeddedCodeBody.ForPredicate`.
 
-Le garde-fou reste volontairement ciblé et audit-friendly. Si les chemins de génération deviennent
-plus indirects, une analyse de flux plus générale pourra être envisagée sans remettre en cause la
-frontière actuelle.
+The safeguard remains deliberately targeted and audit-friendly. If the generation paths become
+more indirect, a more general flow analysis could be considered without compromising the
+current boundary.
 
-### 13. Uniformiser les exceptions de transformation
+### 13. Standardize transformation exceptions
 
-**Corrigé.** Les chemins de génération C# et de compilation runtime reposent sur
+**Fixed.** C# generation and runtime compilation paths rely on
 `Utils.Parser.Diagnostics.EmbeddedCode.ParserEmbeddedCodeTransformationException`.
 
-L'exception commune expose le code et le message du diagnostic, le chemin de transformation, le
-`ParserEmbeddedCodeLocation`, le nom de grammaire, le nom de règle, le span et l'exception interne
-éventuelle. `ParserEmbeddedCodeTransformationService.TransformOrThrow` l'utilise pour les diagnostics
-bloquants, les exceptions du transformer, les résultats nuls et les codes transformés nuls.
+The common exception exposes the diagnostic code and message, the transformation path, the
+`ParserEmbeddedCodeLocation`, grammar name, rule name, span and optional inner
+exception. `ParserEmbeddedCodeTransformationService.TransformOrThrow` uses this for blocking
+diagnostics, transformer exceptions, null results and null transformed codes.
 
-`Utils.Parser.Expressions.ParserEmbeddedCodeTransformationException` dérive du type commun afin de
-préserver l'API publique du projet Expressions sans perdre les métadonnées structurées. Le constructeur
-historique prenant uniquement un message reste conservé pour compatibilité, mais les chemins de
-production utilisent la forme structurée.
+`Utils.Parser.Expressions.ParserEmbeddedCodeTransformationException` derives from the common type to
+preserve the Expressions project's public API without losing structured metadata. The historical constructor taking only one message is retained for compatibility, but the production
+paths use the structured form.
 
-### 14. Vérifier la documentation après chaque refactorisation du pipeline
-Toute modification du comportement ou des frontières du code embarqué doit être répercutée dans les
-documents imposés par `AGENTS.md`, notamment :
+### 14. Check documentation after each pipeline refactoring
+Any change to the behavior or boundaries of the embedded code must be reflected in the
+documents imposed by `AGENTS.md`, in particular:
 
-- `Utils.Parser/ROADMAP.md` ;
-- `docs/parser/ANTLRCompatibility.md` ;
-- `docs/parser/EmbeddedCodeExecutionModel.md` ;
-- `docs/parser/EmbeddedCodeTransactionalState.md` ;
-- `docs/parser/Antlr4CompatibilityMatrix.md` ;
+- `Utils.Parser/ROADMAP.md`;
+- `docs/parser/ANTLRCompatibility.md`;
+- `docs/parser/EmbeddedCodeExecutionModel.md`;
+- `docs/parser/EmbeddedCodeTransactionalState.md`;
+- `docs/parser/Antlr4CompatibilityMatrix.md`;
 - `Utils.Parser.Generators/README.md`.
 
-Pour chaque PR, documenter explicitement les fichiers mis à jour ou la raison pour laquelle aucune
-mise à jour n'était nécessaire.
+For each PR, explicitly document which files were updated or why no
+update was necessary.

--- a/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
+++ b/UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs
@@ -184,6 +184,133 @@ public sealed class EmbeddedCodeTransformerArchitectureTests
         StringAssert.StartsWith(violations[0], "Utils.Parser.Expressions/OtherEmbeddedCodePreparer.cs:10: compiler.Compile(\"raw\")");
     }
 
+    /// <summary>
+    /// Ensures the supported runtime embedded-code facade remains the sole production component that combines the
+    /// shared transformation pipeline, expression compilation, specialized lambdas, and prepared parser artifacts.
+    /// </summary>
+    [TestMethod]
+    public void ExpressionEmbeddedCodePreparer_IsOnlySupportedRuntimeEmbeddedCodeCompilationFacade()
+    {
+        string repositoryRoot = FindRepositoryRoot();
+        IReadOnlyList<SourceScan> scans = CreateProductionParserScans(repositoryRoot);
+        Compilation compilation = scans[0].SemanticModel.Compilation;
+        INamedTypeSymbol preparerType = compilation.GetTypeByMetadataName("Utils.Parser.Expressions.ExpressionEmbeddedCodePreparer")!;
+        INamedTypeSymbol preparerContract = compilation.GetTypeByMetadataName("Utils.Parser.EmbeddedCode.IEmbeddedCodePreparer`2")!;
+        INamedTypeSymbol predicateArtifact = compilation.GetTypeByMetadataName("Utils.Parser.Expressions.PreparedExpressionSemanticPredicate")!;
+        INamedTypeSymbol actionArtifact = compilation.GetTypeByMetadataName("Utils.Parser.Expressions.PreparedExpressionParserAction")!;
+        INamedTypeSymbol compilerContract = compilation.GetTypeByMetadataName("Utils.Expressions.IExpressionCompiler")!;
+        INamedTypeSymbol pipelineType = compilation.GetTypeByMetadataName("Utils.Parser.Diagnostics.EmbeddedCode.EmbeddedCodeTransformationPipeline")!;
+
+        Assert.IsTrue(preparerType.IsSealed);
+        INamedTypeSymbol implementedContract = preparerType.AllInterfaces.Single(candidate =>
+            SymbolEqualityComparer.Default.Equals(candidate.OriginalDefinition, preparerContract));
+        Assert.IsTrue(SymbolEqualityComparer.Default.Equals(implementedContract.TypeArguments[0], predicateArtifact));
+        Assert.IsTrue(SymbolEqualityComparer.Default.Equals(implementedContract.TypeArguments[1], actionArtifact));
+        CollectionAssert.AreEquivalent(
+            new[] { "PrepareParserAction", "PrepareSemanticPredicate" },
+            preparerType.GetMembers().OfType<IMethodSymbol>()
+                .Where(static method => method.DeclaredAccessibility == Accessibility.Public && method.MethodKind == MethodKind.Ordinary)
+                .Select(static method => method.Name)
+                .ToArray());
+        Assert.AreEqual(1, preparerType.InstanceConstructors.Count(static constructor => constructor.DeclaredAccessibility == Accessibility.Public));
+
+        SourceScan facadeScan = scans.Single(scan => scan.RelativePath == "Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs");
+        ClassDeclarationSyntax facadeDeclaration = facadeScan.Tree.GetCompilationUnitRoot().DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .Single(static type => type.Identifier.ValueText == "ExpressionEmbeddedCodePreparer");
+        IFieldSymbol compilerField = preparerType.GetMembers("_compiler").OfType<IFieldSymbol>().Single();
+        MethodDeclarationSyntax transformSource = facadeDeclaration.Members.OfType<MethodDeclarationSyntax>()
+            .Single(static method => method.Identifier.ValueText == "TransformSource");
+        Assert.AreEqual(1, transformSource.DescendantNodes().OfType<InvocationExpressionSyntax>().Count(invocation =>
+            facadeScan.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol method
+            && SymbolEqualityComparer.Default.Equals(method.ContainingType, pipelineType)));
+
+        foreach (string methodName in new[] { "PrepareSemanticPredicate", "PrepareParserAction" })
+        {
+            MethodDeclarationSyntax method = facadeDeclaration.Members.OfType<MethodDeclarationSyntax>()
+                .Single(candidate => candidate.Identifier.ValueText == methodName);
+            Assert.AreEqual(1, method.DescendantNodes().OfType<InvocationExpressionSyntax>().Count(invocation =>
+                facadeScan.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol called
+                && SymbolEqualityComparer.Default.Equals(called.ContainingType, preparerType)
+                && called.Name == "TransformSource"));
+            InvocationExpressionSyntax compilerCall = method.DescendantNodes().OfType<InvocationExpressionSyntax>().Single(invocation =>
+                invocation.Expression is MemberAccessExpressionSyntax access
+                && access.Name.Identifier.ValueText == "Compile"
+                && facadeScan.SemanticModel.GetSymbolInfo(access.Expression).Symbol is IFieldSymbol receiver
+                && SymbolEqualityComparer.Default.Equals(receiver, compilerField));
+            Assert.IsTrue(compilerCall.Expression is MemberAccessExpressionSyntax memberAccess
+                && facadeScan.SemanticModel.GetSymbolInfo(memberAccess.Expression).Symbol is IFieldSymbol receiver
+                && SymbolEqualityComparer.Default.Equals(receiver, compilerField));
+        }
+
+        INamedTypeSymbol[] matchingPreparers = scans.SelectMany(scan => scan.Tree.GetCompilationUnitRoot().DescendantNodes().OfType<ClassDeclarationSyntax>()
+                .Select(type => scan.SemanticModel.GetDeclaredSymbol(type)))
+            .OfType<INamedTypeSymbol>()
+            .Where(type => type.AllInterfaces.Any(candidate => SymbolEqualityComparer.Default.Equals(candidate, implementedContract)))
+            .ToArray();
+        CollectionAssert.AreEqual(new[] { preparerType.ToDisplayString() }, matchingPreparers.Select(static type => type.ToDisplayString()).ToArray());
+
+        foreach (INamedTypeSymbol artifactType in new[] { predicateArtifact, actionArtifact })
+        {
+            string[] constructors = scans.SelectMany(scan => scan.Tree.GetCompilationUnitRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>()
+                    .Where(creation => SymbolEqualityComparer.Default.Equals((facadeScan.SemanticModel.Compilation.GetSemanticModel(scan.Tree).GetSymbolInfo(creation).Symbol as IMethodSymbol)?.ContainingType, artifactType))
+                    .Select(creation => GetEnclosingTypeName(creation)))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            CollectionAssert.AreEqual(new[] { "ExpressionEmbeddedCodePreparer" }, constructors);
+        }
+
+        string[] specializedLambdaOwners = scans.SelectMany(scan => scan.Tree.GetCompilationUnitRoot().DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Where(invocation => invocation.Expression is MemberAccessExpressionSyntax
+                    {
+                        Expression: IdentifierNameSyntax expressionType,
+                        Name: GenericNameSyntax { Identifier.ValueText: "Lambda", TypeArgumentList.Arguments.Count: 1 } lambda
+                    }
+                    && scan.SemanticModel.GetSymbolInfo(expressionType).Symbol is INamedTypeSymbol containingType
+                    && containingType.ToDisplayString() == "System.Linq.Expressions.Expression"
+                    && lambda.TypeArgumentList.Arguments[0].ToString() is
+                        "Func<SemanticPredicateEvaluationContext, bool>" or
+                        "Action<ParserActionExecutionContext>")
+                .Select(GetEnclosingTypeName))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        CollectionAssert.AreEqual(new[] { "ExpressionEmbeddedCodePreparer" }, specializedLambdaOwners);
+
+        foreach (SourceScan scan in scans.Where(static scan => scan.RelativePath.StartsWith("Utils.Parser.Generators/", StringComparison.Ordinal)))
+        {
+            Assert.IsFalse(scan.Tree.GetCompilationUnitRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Any(identifier =>
+                scan.SemanticModel.GetSymbolInfo(identifier).Symbol is INamedTypeSymbol type
+                && (SymbolEqualityComparer.Default.Equals(type, preparerType) || SymbolEqualityComparer.Default.Equals(type, compilerContract))));
+        }
+
+        string[] forbiddenFacadeDependencies = facadeDeclaration.DescendantNodes().OfType<IdentifierNameSyntax>()
+            .Select(identifier => facadeScan.SemanticModel.GetSymbolInfo(identifier).Symbol)
+            .OfType<INamedTypeSymbol>()
+            .Where(static type => type.Name is "StringBuilder" or "GeneratedEmbeddedCodeBody" or "CSharpEmbeddedCodeInjector")
+            .Select(static type => type.ToDisplayString())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        CollectionAssert.AreEqual(Array.Empty<string>(), forbiddenFacadeDependencies);
+
+        string[] parallelPipelines = scans.SelectMany(scan => scan.Tree.GetCompilationUnitRoot().DescendantNodes().OfType<TypeDeclarationSyntax>()
+                .Where(type => scan.SemanticModel.GetDeclaredSymbol(type) is INamedTypeSymbol symbol && !SymbolEqualityComparer.Default.Equals(symbol, preparerType))
+                .Where(type => type.DescendantNodes().OfType<IdentifierNameSyntax>()
+                    .Select(identifier => scan.SemanticModel.GetSymbolInfo(identifier).Symbol)
+                    .OfType<INamedTypeSymbol>()
+                    .Any(type => SymbolEqualityComparer.Default.Equals(type, pipelineType)))
+                .Where(type => type.DescendantNodes().OfType<IdentifierNameSyntax>()
+                    .Select(identifier => scan.SemanticModel.GetSymbolInfo(identifier).Symbol)
+                    .OfType<INamedTypeSymbol>()
+                    .Any(type => SymbolEqualityComparer.Default.Equals(type, compilerContract)))
+                .Where(type => type.DescendantNodes().OfType<IdentifierNameSyntax>()
+                    .Select(identifier => scan.SemanticModel.GetSymbolInfo(identifier).Symbol)
+                    .OfType<INamedTypeSymbol>()
+                    .Any(type => SymbolEqualityComparer.Default.Equals(type, predicateArtifact) || SymbolEqualityComparer.Default.Equals(type, actionArtifact)))
+                .Select(static type => type.Identifier.ValueText))
+            .ToArray();
+        CollectionAssert.AreEqual(Array.Empty<string>(), parallelPipelines);
+    }
+
 
 
     /// <summary>

--- a/UtilsTest/Parser/ExpressionEmbeddedCodePreparerTests.cs
+++ b/UtilsTest/Parser/ExpressionEmbeddedCodePreparerTests.cs
@@ -52,7 +52,8 @@ public class ExpressionEmbeddedCodePreparerTests
     public void PrepareSemanticPredicate_WhenTransformerProvided_CompilerReceivesTransformedCode()
     {
         var compiler = new FakeExpressionCompiler();
-        var preparer = new ExpressionEmbeddedCodePreparer(compiler, new ReplaceRuntimeCodeTransformer());
+        var transformer = new ReplaceRuntimeCodeTransformer();
+        var preparer = new ExpressionEmbeddedCodePreparer(compiler, transformer);
 
         var result = preparer.PrepareSemanticPredicate(
             CreateSource("__TOKEN_PREDICATE__", EmbeddedCodeKind.SemanticPredicate),
@@ -61,6 +62,30 @@ public class ExpressionEmbeddedCodePreparerTests
         Assert.AreEqual(EmbeddedCodePreparationStatus.Succeeded, result.Status);
         Assert.AreEqual("true", compiler.LastContent);
         Assert.AreNotEqual("__TOKEN_PREDICATE__", compiler.LastContent);
+        Assert.AreEqual(1, transformer.Count);
+        Assert.AreEqual(1, compiler.CompileCount);
+        Assert.IsNotNull(compiler.LastSymbols);
+        AssertSymbolSet(compiler.LastSymbols, typeof(SemanticPredicateEvaluationContext));
+    }
+
+    [DataTestMethod]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.ParserInlineAction, EmbeddedCodeTarget.RuntimeInlineExpression)]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareSemanticPredicate), EmbeddedCodeKind.SemanticPredicate, EmbeddedCodeTarget.SourceGeneratorCSharp)]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.SemanticPredicate, EmbeddedCodeTarget.RuntimeInlineExpression)]
+    [DataRow(nameof(ExpressionEmbeddedCodePreparer.PrepareParserAction), EmbeddedCodeKind.ParserInlineAction, EmbeddedCodeTarget.SourceGeneratorCSharp)]
+    public void PrepareRuntimeArtifact_WhenKindOrTargetIsUnsupported_DoesNotInvokeDependencies(
+        string prepareMethodName,
+        EmbeddedCodeKind kind,
+        EmbeddedCodeTarget target)
+    {
+        var compiler = new FakeExpressionCompiler();
+        var transformer = new CountingTransformer();
+        var preparer = new ExpressionEmbeddedCodePreparer(compiler, transformer);
+
+        InvokePrepare(preparer, prepareMethodName, CreateSource("true", kind), CreateContext(target));
+
+        Assert.AreEqual(0, transformer.Count);
+        Assert.AreEqual(0, compiler.CompileCount);
     }
 
     [TestMethod]
@@ -843,9 +868,13 @@ public class ExpressionEmbeddedCodePreparerTests
     /// </summary>
     private sealed class ReplaceRuntimeCodeTransformer : IParserEmbeddedCodeTransformer
     {
+        /// <summary>Gets the number of transform calls.</summary>
+        public int Count { get; private set; }
+
         /// <inheritdoc />
         public ParserEmbeddedCodeTransformationResult Transform(ParserEmbeddedCodeTransformationContext context)
         {
+            Count++;
             return new ParserEmbeddedCodeTransformationResult { Code = context.Code.Replace("__TOKEN__", "increment").Replace("__TOKEN_PREDICATE__", "true") };
         }
     }


### PR DESCRIPTION
### Motivation

- Make explicit and document that `ExpressionEmbeddedCodePreparer` is the supported, single façade for preparing parser embedded code for runtime expression compilation and to protect that boundary from future parallel compilation pipelines.
- Ensure the preparation path (validation → transformation → symbol binding → `IExpressionCompiler.Compile(...)` → CLR lambda → prepared artifact) is clearly described and constrained.
- Preserve all existing runtime behavior and public APIs while adding documentation, tests and a Roslyn architectural guard to prevent accidental duplication of the pipeline.

### Description

- Expanded the XML documentation on `ExpressionEmbeddedCodePreparer` (class summary, constructor, `PrepareSemanticPredicate`, `PrepareParserAction`, and `TransformSource`) to describe its role as the supported runtime-inline compilation facade, the exact responsibilities, and explicit exclusions (no C# generation, no execution during preparation, no capturing of runtime values). (`Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs`)
- Added a dedicated section to `Utils.Parser.Expressions/README.md` describing the supported runtime compilation facade, the full preparation pipeline, the two supported categories, the produced delegates and artifacts, the four normalized statuses, and a minimal usage example. (`Utils.Parser.Expressions/README.md`)
- Marked TODO item 11 as corrected and updated `Utils.Parser/TODO.md` with the detailed resolution text documenting the façade, supported categories, pipeline and tests. (`Utils.Parser/TODO.md`)
- Updated `Utils.Parser/ROADMAP.md` to mark the embedded-code transformation boundary (items 8–11) complete and to record the façade as the supported runtime path while preserving the separation from generated C#. (`Utils.Parser/ROADMAP.md`)
- Added / strengthened Roslyn architecture checks and functional tests that enforce the façade invariant and that no other production component combines: `EmbeddedCodeTransformationPipeline`, `IExpressionCompiler`, and prepared parser artifacts; the new guard verifies the preparer type, the two preparation methods, the single `_compiler` field usage, the single compile invocation per supported path, that prepared artefacts and lambdas are produced only by the façade, and that the generator does not reference the façade or `IExpressionCompiler`. (`UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs`)
- Strengthened unit tests that characterize the façade behavior (transformer invoked exactly once on supported paths, compiler invoked exactly once with transformed text and runtime-bound symbol dictionary, transform/compiler not invoked for `Unsupported`/`PreservedNotCompiled` paths, delegate lambdas are not executed during preparation). (`UtilsTest/Parser/ExpressionEmbeddedCodePreparerTests.cs`)
- Added a small README API link for the package docs to ensure consumers can find the versioned API docs without inventing APIs. (`Utils.Parser.Expressions/README.md`)
- No public API signatures were added, removed or changed; no behavioral changes were introduced to the preparation logic or to the generated artifacts.

### Testing

- Performed the requested project builds and targeted tests: all builds succeeded (existing repository/source-link warnings were unchanged):
  - `dotnet build Utils.Parser/Utils.Parser.csproj`
  - `dotnet build Utils.Parser.Diagnostics/Utils.Parser.Diagnostics.csproj`
  - `dotnet build Utils.Parser.Expressions/Utils.Parser.Expressions.csproj`
  - `dotnet build Utils.Parser.Generators/Utils.Parser.Generators.csproj`
  - `dotnet build UtilsTest/UtilsTest.Unit.csproj`
  - `dotnet build UtilsTest.Functional/UtilsTest.Functional.csproj`
- Ran the focused unit and functional tests (no changes to test logic, added/strengthened tests where required):
  - `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter "ExpressionEmbeddedCodePreparer|EmbeddedCodeTransformationInvariantTests"` — passed (73/73 targeted tests passed).
  - `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --filter "ExpressionEmbeddedCodePreparerArchitectureTests|ExpressionEmbeddedCodePreparer_IsOnlySupportedRuntimeEmbeddedCodeCompilationFacade|EmbeddedCodeTransformerArchitectureTests"` — passed (13/13 targeted tests passed).
- Ran full test suites as additional validation:
  - Full unit suite: `dotnet test UtilsTest/UtilsTest.Unit.csproj` — completed successfully (4,032 passed, 16 skipped).
  - Full functional suite: `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj` — completed successfully (349 passed, 10 skipped).
- All architecture and invariant checks passed, demonstrating that the façade is documented, enforced by tests, and that no parallel prepared-parser compilation pipeline was introduced.

Files modified (high level): `Utils.Parser.Expressions/ExpressionEmbeddedCodePreparer.cs`, `Utils.Parser.Expressions/README.md`, `Utils.Parser/TODO.md`, `Utils.Parser/ROADMAP.md`, `UtilsTest.Functional/Parser/EmbeddedCodeTransformerArchitectureTests.cs`, `UtilsTest/Parser/ExpressionEmbeddedCodePreparerTests.cs`.

If you want, I can now open a pull request with this change description and the committed branch content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a327185c48326a347155e690acaf0)