### PR TITLE
Close embedded-code architecture audit and update docs (AGENTS, ROADMAP, DONE-2026-07-17)

### DIFF
--- a/Utils.Parser/AGENTS.md
+++ b/Utils.Parser/AGENTS.md
@@ -114,7 +114,7 @@ Dynamic embedded code must be transformed before being passed to the existing co
 ## Embedded-code documentation rule
 
 This is an ongoing maintenance rule, not a completed one-time audit task. Every future change to
-embedded-code behavior or architectural boundaries must update:
+embedded-code behavior or architectural boundaries must review and assess:
 
 - `Utils.Parser/ROADMAP.md`
 - `docs/parser/ANTLRCompatibility.md`
@@ -123,8 +123,8 @@ embedded-code behavior or architectural boundaries must update:
 - `docs/parser/Antlr4CompatibilityMatrix.md`
 - `Utils.Parser.Generators/README.md`
 
-Each affected PR must explicitly identify the documentation files it updated or justify why each
-listed document did not require a change.
+Each affected PR must update the documents impacted by the change, explicitly identify those
+updates, and justify why each other reviewed document did not require modification.
 
 ## Runtime safety rules
 

--- a/Utils.Parser/AGENTS.md
+++ b/Utils.Parser/AGENTS.md
@@ -113,13 +113,18 @@ Dynamic embedded code must be transformed before being passed to the existing co
 
 ## Embedded-code documentation rule
 
-When changing embedded-code behavior, update:
+This is an ongoing maintenance rule, not a completed one-time audit task. Every future change to
+embedded-code behavior or architectural boundaries must update:
 
+- `Utils.Parser/ROADMAP.md`
+- `docs/parser/ANTLRCompatibility.md`
 - `docs/parser/EmbeddedCodeExecutionModel.md`
 - `docs/parser/EmbeddedCodeTransactionalState.md`
 - `docs/parser/Antlr4CompatibilityMatrix.md`
 - `Utils.Parser.Generators/README.md`
-- `Utils.Parser/ROADMAP.md`
+
+Each affected PR must explicitly identify the documentation files it updated or justify why each
+listed document did not require a change.
 
 ## Runtime safety rules
 

--- a/Utils.Parser/DONE-2026-07-17.md
+++ b/Utils.Parser/DONE-2026-07-17.md
@@ -3,11 +3,25 @@
 Audit of the `Utils.Parser` scope and its associated projects, with a focus on duplications of
 code or intent, and on transformation, C# injection, and expression-compilation paths.
 
-**Status (2026-07-10):** The identified execution paths currently pass through
-`IParserEmbeddedCodeTransformer`. The dynamic compilation of expressions then goes through
-`IExpressionCompiler`. However, C# code injection remains distributed across `GrammarEmitter` and
-is not isolated behind a dedicated injection class. The items below are suggestions
-not yet addressed unless otherwise noted.
+**Initial status (2026-07-10):** The identified execution paths passed through
+`IParserEmbeddedCodeTransformer`. Dynamic expression compilation then went through
+`IExpressionCompiler`. At the time of the audit, C# code injection was still distributed across
+`GrammarEmitter` and was not isolated behind a dedicated injection class. This paragraph records
+the starting point of the audit; it does not describe the current implementation.
+
+## Global audit status
+
+**Closed.** All technical findings identified by this audit have been addressed:
+
+- items 1–7 are fixed;
+- item 8, including sub-items 8a–8d, is fixed;
+- items 9–13 are fixed;
+- item 14 is an ongoing documentation-maintenance rule rather than an open defect.
+
+The detailed sections below are retained as a historical and architectural record of the
+corrections. Mentions that later items were outside the scope of a correction describe the scope at
+the time of that specific change, not the current status of the audit; those later items have since
+been completed and are documented below.
 
 ## Embedded code architecture (high priority)
 
@@ -166,9 +180,10 @@ Added or strengthened tests:
 - maintaining existing invariants covering the six named `ParserEmbeddedCodeLocation`, the absence of a
   fallback to raw text and exclusive passage by `CSharpEmbeddedCodeInjector`.
 
-Points 6 to 11 remain outside the scope: inline parser/lexer actions, predicates, lifecycle hooks,
-recursive traversals, runtime symbols and compilation/preparation of expressions are not consolidated
-by this change.
+At the time of this specific correction, items 6–11 were outside its scope: inline parser/lexer
+actions, predicates, lifecycle hooks, recursive traversals, runtime symbols and
+compilation/preparation of expressions were not consolidated by that change. Those items were
+subsequently completed and are documented below.
 
 ### 6. Merge `EmbeddedCodeHook` and `LexerEmbeddedCodeHook`
 **Fixed.** Generated parser and lexer hooks are now represented by a single internal type
@@ -201,9 +216,10 @@ Added or strengthened tests:
 - `Antlr4GeneratedEmbeddedCodeTests.Emit_WhenParserAndLexerHooksShareGrammar_PreservesStableCategoriesAndGeneratedBodies`;
 - `EmbeddedCodeTransformerArchitectureTests.GrammarEmitterEmbeddedCodeHooks_UseSingleCommonHookModel`.
 
-Points 7 to 11 remain outside the scope: runtime symbol construction, general consolidation of
-recursive traversals, overall formalization of the pipeline, clarification of the raw/transformed state and
-runtime facade documentation are not addressed by this fix.
+At the time of this specific correction, items 7–11 were outside its scope: runtime symbol
+construction, general consolidation of recursive traversals, overall formalization of the pipeline,
+clarification of the raw/transformed state and runtime facade documentation were not addressed by
+that fix. Those items were subsequently completed and are documented below.
 
 ### 7. Consolidate the construction of expression symbols
 **Fixed.** `ExpressionEmbeddedCodePreparer` retains the specialized wrappers
@@ -242,10 +258,13 @@ Added or strengthened tests:
   `EmbeddedCodeContextSymbol`, that lambdas retain their specialized runtime types and that
   no new public contract has been introduced.
 
-Points 8 to 11 remain outside the scope of the production code of this correction: general parser/lexer consolidation, overall pipeline, raw/transformed state clarification and runtime facade documentation remain separate work items.
+At the time of this specific correction, items 8–11 were outside its production-code scope: general
+parser/lexer consolidation, the overall pipeline, raw/transformed state clarification and runtime
+facade documentation remained separate work items. They were subsequently completed and are
+documented below.
 
 ### 8. Introduce common engines with specialized parser/lexer strategies
-**Partially corrected.**
+**Fixed.** Sub-items 8a–8d are complete.
 
 #### 8a. Collecting hooks — fixed
 
@@ -421,8 +440,9 @@ to the transformer and checks that the core is internal, common to both targets,
 and does not depend on any target details. `CSharpEmbeddedCodeInjectorArchitectureTests` maintains the
 injection boundary. No public API or observable behavior was changed.
 
-Point 10 is corrected below. Point 11 (documented status of the runtime facade) remains
-explicitly open.
+At the time item 9 was completed, item 10 was documented by the next correction and item 11 (the
+documented status of the runtime facade) remained open. Item 11 has since been completed and is
+documented below.
 
 ### 10. Explicitly distinguish between raw and transformed states
 **Fixed.** The single internal model `EmbeddedCodeHook` is now an immutable record that retains
@@ -508,7 +528,11 @@ diagnostics, transformer exceptions, null results and null transformed codes.
 preserve the Expressions project's public API without losing structured metadata. The historical constructor taking only one message is retained for compatibility, but the production
 paths use the structured form.
 
-### 14. Check documentation after each pipeline refactoring
+### 14. Maintain documentation after every embedded-code pipeline change
+
+**Ongoing maintenance rule.** This requirement does not block closure of the technical audit. It
+applies to every future change to embedded-code behavior or boundaries.
+
 Any change to the behavior or boundaries of the embedded code must be reflected in the
 documents imposed by `AGENTS.md`, in particular:
 
@@ -519,5 +543,15 @@ documents imposed by `AGENTS.md`, in particular:
 - `docs/parser/Antlr4CompatibilityMatrix.md`;
 - `Utils.Parser.Generators/README.md`.
 
-For each PR, explicitly document which files were updated or why no
-update was necessary.
+For each affected PR, explicitly document which files were updated or justify why no update was
+necessary.
+
+## Audit closure
+
+The technical audit is complete. Items 1–13 are implemented and remain protected by
+characterization tests or architectural guardrails where appropriate. Item 14 remains the ongoing
+documentation rule for future changes to embedded-code behavior or boundaries.
+
+Future parser work should be recorded separately in the roadmap or in a new TODO section rather
+than added to this completed historical audit. A regression that invalidates one of the documented
+conclusions may naturally require the corresponding item to be reopened.

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -222,13 +222,15 @@ Completed for the hook phase model:
 - the shared pipeline produces validated `TransformedEmbeddedCode` through an explicit immutable transition;
 - generated-code targets consume only the transformed phase, and the former ambiguous hook member has been removed.
 
-Still planned:
+The [2026-07 embedded-code architecture audit](./DONE-2026-07-17.md) is complete. All technical
+findings 1–13, including items 8–11 in this refactor sequence, have been addressed. Item 14 remains
+an ongoing documentation maintenance rule for future pipeline changes. Future parser evolution must
+be recorded separately rather than appended to the completed audit unless a regression invalidates
+one of its conclusions.
 
-- keep point 11 open for public preparer documentation work.
+Future work must continue to keep the following differences explicit: parser left recursion, alternative priority ordering, lexer modes, quantifier and negation index semantics, generated names, transformation locations, runtime context types, method signatures, success results, and fallback calls. These differences must not be hidden behind a single `isLexer` flag or scattered parser/lexer switches inside a shared engine.
 
-The refactor must continue to keep the following differences explicit: parser left recursion, alternative priority ordering, lexer modes, quantifier and negation index semantics, generated names, transformation locations, runtime context types, method signatures, success results, and fallback calls. These differences must not be hidden behind a single `isLexer` flag or scattered parser/lexer switches inside a shared engine.
-
-Each remaining step must preserve generated C# shape, hook order, indexes, transformer invocation count and order, fallback behavior, diagnostics, public API, parser authority, and lexer/runtime semantics. Each step should be delivered as a separate PR or, at minimum, as a separate auditable change.
+Any future step must preserve generated C# shape, hook order, indexes, transformer invocation count and order, fallback behavior, diagnostics, public API, parser authority, and lexer/runtime semantics. Each step should be delivered as a separate PR or, at minimum, as a separate auditable change.
 
 ## Roadmap phases
 


### PR DESCRIPTION
### Motivation

- Record the completion of the 2026 embedded-code architecture audit and make the resulting conclusions and ongoing obligations explicit in project documentation.
- Clarify that items 1–13 are closed, while item 14 remains a permanent documentation-maintenance rule for future changes.

### Description

- Rename `Utils.Parser/TODO.md` to `Utils.Parser/DONE-2026-07-17.md` and preserve the full audit history while adding a global closure status, contextualizing historical “out of scope” statements, marking items 1–13 complete, and presenting item 14 as an ongoing rule.
- Update `Utils.Parser/AGENTS.md` so every PR that changes embedded-code behavior or architectural boundaries must review the canonical documentation set, update the affected documents, and explicitly justify any listed document that does not require a change.
- Update `Utils.Parser/ROADMAP.md` to reference the completed audit, record that items 1–13 are implemented, and keep the architectural constraints for future parser work explicit.
- Keep the change strictly documentary: no production code, tests, projects, public APIs, diagnostics, generated output, or runtime behavior are modified.

### Validation

- Reviewed the audit status of items 1–14 against the current implementation and existing architectural guardrails.
- Checked repository references affected by the rename from `TODO.md` to `DONE-2026-07-17.md`.
- Verified that the diff contains only documentation changes in:
  - `Utils.Parser/AGENTS.md`
  - `Utils.Parser/DONE-2026-07-17.md`
  - `Utils.Parser/ROADMAP.md`
- No unit tests, functional tests, Roslyn guardrails, or production sources were added or modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5aa6dfe30083268aa52c1eb7f4c41f)