### PR TITLE
feat(Utils.Dates): DateFormulaExpression IR with culture-neutral serialisation

### DIFF
--- a/Utils/Dates/DateFormula.cs
+++ b/Utils/Dates/DateFormula.cs
@@ -22,6 +22,9 @@ public static class DateFormula
         return new JsonDateFormulaLanguageProvider(json);
     });
 
+    /// <summary>The default language provider loaded from the bundled configuration file.</summary>
+    internal static IDateFormulaLanguageProvider DefaultProvider => _defaultProvider.Value;
+
     /// <summary>Cache for compiled formulas.</summary>
     private static readonly Dictionary<FormulaCacheKey, Func<DateTime, DateTime>> _cache = [];
 
@@ -73,6 +76,18 @@ public static class DateFormula
     }
 
     /// <summary>
+    /// Builds an expression tree for <paramref name="formula"/>.
+    /// </summary>
+    public static Expression<Func<DateTime, DateTime>> ToExpression(string formula, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+        => DateFormulaExpression.Parse(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture).ToExpression(culture ?? CultureInfo.CurrentCulture, calendarProvider);
+
+    /// <summary>
+    /// Builds an expression tree for <paramref name="formula"/> using a custom provider.
+    /// </summary>
+    public static Expression<Func<DateTime, DateTime>> ToExpression(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+        => DateFormulaExpression.Parse(formula, provider, culture ?? CultureInfo.CurrentCulture).ToExpression(culture ?? CultureInfo.CurrentCulture, calendarProvider);
+
+    /// <summary>
     /// Compiles the provided <paramref name="formula"/> into a delegate.
     /// </summary>
     /// <param name="formula">Formula to compile.</param>
@@ -81,6 +96,19 @@ public static class DateFormula
     /// <returns>A delegate computing the resulting date.</returns>
     public static Func<DateTime, DateTime> Compile(string formula, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
                     => Compile(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture, calendarProvider);
+
+    /// <summary>
+    /// Parses <paramref name="formula"/> into a culture-neutral <see cref="DateFormulaExpression"/>.
+    /// </summary>
+    public static DateFormulaExpression Parse(string formula, CultureInfo culture = null)
+        => DateFormulaExpression.Parse(formula, _defaultProvider.Value, culture ?? CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Parses <paramref name="formula"/> into a culture-neutral <see cref="DateFormulaExpression"/>
+    /// using a custom <paramref name="provider"/>.
+    /// </summary>
+    public static DateFormulaExpression Parse(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null)
+        => DateFormulaExpression.Parse(formula, provider, culture ?? CultureInfo.CurrentCulture);
 
     /// <summary>
     /// Compiles the provided <paramref name="formula"/> using a custom provider.
@@ -93,102 +121,10 @@ public static class DateFormula
     public static Func<DateTime, DateTime> Compile(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
     {
         culture ??= CultureInfo.CurrentCulture;
-        var lang = provider.GetLanguage(culture);
-
-        if (formula.Length < 2)
-            throw new ArgumentException("Formula is too short.", nameof(formula));
-
-        var start = formula[0] == lang.Start;
-        var end = formula[0] == lang.End;
-        if (!start && !end)
-            throw new ArgumentException("Invalid formula start token.", nameof(formula));
-
-        var period = ParsePeriod(formula[1], lang);
-
-        if (start && (period == PeriodTypeEnum.Day || period == PeriodTypeEnum.WorkingDay))
-            throw new ArgumentException("Start of day and start of working day formulas are not supported.", nameof(formula));
-
-        if (end && (period == PeriodTypeEnum.Day || period == PeriodTypeEnum.WorkingDay))
-            throw new ArgumentException("End of day and end of working day formulas are not supported.", nameof(formula));
-
-        var param = Expression.Parameter(typeof(DateTime), "d");
-
-        Expression expr = Expression.Call(
-                typeof(DateUtils).GetMethod(start ? nameof(DateUtils.StartOf) : nameof(DateUtils.EndOf), BindingFlags.Public | BindingFlags.Static, [typeof(DateTime), typeof(PeriodTypeEnum), typeof(CultureInfo)]),
-                param,
-                Expression.Constant(period),
-                Expression.Constant(culture));
-
-        var index = 2;
-        while (index < formula.Length && (formula[index].In('+', '-')))
-        {
-            var sign = formula[index];
-            var pos = index + 1;
-            if (pos < formula.Length && char.IsDigit(formula[pos]))
-            {
-                var startPos = pos;
-                while (pos < formula.Length && char.IsDigit(formula[pos])) pos++;
-                var value = int.Parse(formula[startPos..pos], CultureInfo.InvariantCulture);
-                if (sign == '-') value = -value;
-                if (pos >= formula.Length)
-                    throw new ArgumentException("Missing unit token.", nameof(formula));
-                var unit = ParsePeriod(formula[pos], lang);
-                expr = CreateCalendarCall(culture, expr, unit, value, calendarProvider);
-                index = pos + 1;
-            }
-            else if (pos < formula.Length && formula[pos] == lang.WorkingDay && pos + 1 == formula.Length)
-            {
-                if (calendarProvider is null)
-                    throw new InvalidOperationException("Working day operations require a calendar provider.");
-                var method = sign == '+' ? nameof(DateUtils.NextWorkingDay) : nameof(DateUtils.PreviousWorkingDay);
-                expr = Expression.Call(
-                                typeof(DateUtils).GetMethod(method, BindingFlags.Public | BindingFlags.Static)!,
-                                expr,
-                                Expression.Constant(calendarProvider));
-                index = pos + 1;
-                return Expression.Lambda<Func<DateTime, DateTime>>(Expression.Property(expr, nameof(DateTime.Date)), param).Compile();
-            }
-            else
-            {
-                if (pos + 2 > formula.Length)
-                    throw new ArgumentException("Incomplete day token.", nameof(formula));
-                var day = formula.Substring(pos, 2);
-                expr = Expression.Call(
-                                typeof(DateFormula).GetMethod(nameof(AdjustToDayOfWeek), BindingFlags.NonPublic | BindingFlags.Static)!,
-                                expr,
-                                Expression.Constant(lang.Days[day]),
-                                Expression.Constant(sign == '+'));
-                index = pos + 2;
-                return Expression.Lambda<Func<DateTime, DateTime>>(Expression.Property(expr, nameof(DateTime.Date)), param).Compile();
-            }
-        }
-        if (index < formula.Length)
-        {
-            var token = formula.Substring(index, 2);
-            if (token.Length == 2 && token[1] == lang.WorkingDay && token[0].In('+', '-'))
-            {
-                if (calendarProvider is null)
-                    throw new InvalidOperationException("Working day operations require a calendar provider.");
-                var method = token[0] == '+' ? nameof(DateUtils.NextWorkingDay) : nameof(DateUtils.PreviousWorkingDay);
-                expr = Expression.Call(
-                                typeof(DateUtils).GetMethod(method, BindingFlags.Public | BindingFlags.Static)!,
-                                expr,
-                                Expression.Constant(calendarProvider));
-            }
-            else
-            {
-                expr = Expression.Call(
-                                typeof(DateFormula).GetMethod(nameof(MoveToSameWeekDay), BindingFlags.NonPublic | BindingFlags.Static)!,
-                                expr,
-                                Expression.Constant(lang.Days[token]),
-                                Expression.Constant(culture.DateTimeFormat.FirstDayOfWeek));
-            }
-        }
-        expr = Expression.Property(expr, nameof(DateTime.Date));
-        return Expression.Lambda<Func<DateTime, DateTime>>(expr, param).Compile();
+        return DateFormulaExpression.Parse(formula, provider, culture).Compile(culture, calendarProvider);
     }
 
-    private static Expression CreateCalendarCall(CultureInfo culture, Expression expr, PeriodTypeEnum period, int value, ICalendarProvider? calendarProvider)
+    internal static Expression CreateCalendarCall(CultureInfo culture, Expression expr, PeriodTypeEnum period, int value, ICalendarProvider? calendarProvider)
     {
         if (period == PeriodTypeEnum.WorkingDay)
         {
@@ -221,7 +157,7 @@ public static class DateFormula
                 Expression.Constant(value));
     }
 
-    private static PeriodTypeEnum ParsePeriod(char token, DateFormulaLanguage lang)
+    internal static PeriodTypeEnum ParsePeriod(char token, DateFormulaLanguage lang)
         => token switch
         {
             var t when t == lang.Day => PeriodTypeEnum.Day,

--- a/Utils/Dates/DateFormulaExpression.cs
+++ b/Utils/Dates/DateFormulaExpression.cs
@@ -108,7 +108,7 @@ public sealed class DateFormulaExpression : IFormattable
     {
         IsStart = isStart;
         BasePeriod = basePeriod;
-        Steps = steps;
+        Steps = Array.AsReadOnly(steps.ToArray());
     }
 
     /// <summary>
@@ -178,14 +178,23 @@ public sealed class DateFormulaExpression : IFormattable
                     throw new ArgumentException($"Unknown day token '{dayStr}'.", nameof(formula));
                 steps.Add(DateFormulaStep.ForAdjustToWeekDay(sign == '+' ? 1 : -1, dayOfWeek));
                 index = pos + 2;
+                if (index != formula.Length)
+                    throw new ArgumentException(
+                        $"No token is allowed after a day-of-week adjustment (position {index}).",
+                        nameof(formula));
                 break;
             }
         }
 
         if (index < formula.Length)
         {
-            if (formula.Length - index < 2)
+            var remaining = formula.Length - index;
+            if (remaining < 2)
                 throw new ArgumentException("Trailing token is too short.", nameof(formula));
+            if (remaining > 2)
+                throw new ArgumentException(
+                    $"Unexpected trailing content at position {index + 2}.",
+                    nameof(formula));
             var token = formula.Substring(index, 2);
 
             if ((token[0] == '+' || token[0] == '-') && token[1] == lang.WorkingDay)

--- a/Utils/Dates/DateFormulaExpression.cs
+++ b/Utils/Dates/DateFormulaExpression.cs
@@ -24,7 +24,7 @@ public enum DateFormulaStepKind
 }
 
 /// <summary>Represents a single operation step within a <see cref="DateFormulaExpression"/>.</summary>
-public readonly struct DateFormulaStep
+public readonly struct DateFormulaStep : IEquatable<DateFormulaStep>
 {
     /// <summary>The kind of operation this step performs.</summary>
     public DateFormulaStepKind Kind { get; }
@@ -65,6 +65,25 @@ public readonly struct DateFormulaStep
 
     internal static DateFormulaStep ForAdjustWorkingDay(int sign)
         => new(DateFormulaStepKind.AdjustWorkingDay, sign, default, default);
+
+    /// <inheritdoc/>
+    public bool Equals(DateFormulaStep other)
+        => Kind == other.Kind
+        && SignedValue == other.SignedValue
+        && Unit == other.Unit
+        && WeekDay == other.WeekDay;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is DateFormulaStep other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => HashCode.Combine(Kind, SignedValue, Unit, WeekDay);
+
+    /// <summary>Returns <see langword="true"/> when both steps represent the same operation.</summary>
+    public static bool operator ==(DateFormulaStep left, DateFormulaStep right) => left.Equals(right);
+
+    /// <summary>Returns <see langword="true"/> when the steps represent different operations.</summary>
+    public static bool operator !=(DateFormulaStep left, DateFormulaStep right) => !left.Equals(right);
 }
 
 /// <summary>
@@ -84,7 +103,7 @@ public readonly struct DateFormulaStep
 /// Call <see cref="Compile(CultureInfo, ICalendarProvider)"/> to produce an executable delegate.
 /// </para>
 /// </remarks>
-public sealed class DateFormulaExpression : IFormattable
+public sealed class DateFormulaExpression : IFormattable, IEquatable<DateFormulaExpression>
 {
     private static readonly MethodInfo _adjustToDayOfWeekMethod =
         typeof(DateFormula).GetMethod("AdjustToDayOfWeek", BindingFlags.NonPublic | BindingFlags.Static)!;
@@ -362,6 +381,49 @@ public sealed class DateFormulaExpression : IFormattable
 
     private static string DayToString(DayOfWeek day, DateFormulaLanguage lang)
         => lang.Days.First(kvp => kvp.Value == day).Key;
+
+    // ── Equality ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A shared <see cref="IEqualityComparer{T}"/> for <see cref="DateFormulaExpression"/>
+    /// that delegates to <see cref="Equals(DateFormulaExpression)"/> and <see cref="GetHashCode()"/>.
+    /// Suitable for use as a dictionary or hash-set key comparer.
+    /// </summary>
+    public static IEqualityComparer<DateFormulaExpression> Comparer { get; }
+        = EqualityComparer<DateFormulaExpression>.Default;
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="other"/> represents the same formula
+    /// (same start/end anchor, same base period, and the same sequence of steps).
+    /// </summary>
+    public bool Equals(DateFormulaExpression? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return IsStart == other.IsStart
+            && BasePeriod == other.BasePeriod
+            && Steps.SequenceEqual(other.Steps);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is DateFormulaExpression other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = HashCode.Combine(IsStart, BasePeriod);
+        foreach (var step in Steps)
+            hash = HashCode.Combine(hash, step);
+        return hash;
+    }
+
+    /// <summary>Returns <see langword="true"/> when both expressions represent the same formula.</summary>
+    public static bool operator ==(DateFormulaExpression? left, DateFormulaExpression? right)
+        => left is null ? right is null : left.Equals(right);
+
+    /// <summary>Returns <see langword="true"/> when the expressions represent different formulas.</summary>
+    public static bool operator !=(DateFormulaExpression? left, DateFormulaExpression? right)
+        => !(left == right);
 }
 
 #pragma warning restore S3011

--- a/Utils/Dates/DateFormulaExpression.cs
+++ b/Utils/Dates/DateFormulaExpression.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace Utils.Dates;
+
+#pragma warning disable S3011 // Reflection should not be used to increase accessibility of classes, methods, or fields
+
+/// <summary>Describes the kind of operation represented by a single <see cref="DateFormulaStep"/>.</summary>
+public enum DateFormulaStepKind
+{
+    /// <summary>Adds or subtracts a fixed count of a calendar period.</summary>
+    AddPeriod,
+    /// <summary>Moves forward or backward to the nearest occurrence of a specific weekday.</summary>
+    AdjustToWeekDay,
+    /// <summary>Moves to the occurrence of a specific weekday within the same calendar week.</summary>
+    MoveToSameWeekDay,
+    /// <summary>Snaps to the next or previous working day.</summary>
+    AdjustWorkingDay,
+}
+
+/// <summary>Represents a single operation step within a <see cref="DateFormulaExpression"/>.</summary>
+public readonly struct DateFormulaStep
+{
+    /// <summary>The kind of operation this step performs.</summary>
+    public DateFormulaStepKind Kind { get; }
+
+    /// <summary>
+    /// Signed count for <see cref="DateFormulaStepKind.AddPeriod"/> (e.g., +3 or -2).
+    /// For <see cref="DateFormulaStepKind.AdjustToWeekDay"/> and <see cref="DateFormulaStepKind.AdjustWorkingDay"/>:
+    /// +1 means forward, -1 means backward.
+    /// Unused for <see cref="DateFormulaStepKind.MoveToSameWeekDay"/>.
+    /// </summary>
+    public int SignedValue { get; }
+
+    /// <summary>Calendar period unit, used only for <see cref="DateFormulaStepKind.AddPeriod"/>.</summary>
+    public PeriodTypeEnum Unit { get; }
+
+    /// <summary>
+    /// Target weekday, used for <see cref="DateFormulaStepKind.AdjustToWeekDay"/>
+    /// and <see cref="DateFormulaStepKind.MoveToSameWeekDay"/>.
+    /// </summary>
+    public DayOfWeek WeekDay { get; }
+
+    private DateFormulaStep(DateFormulaStepKind kind, int signedValue, PeriodTypeEnum unit, DayOfWeek weekDay)
+    {
+        Kind = kind;
+        SignedValue = signedValue;
+        Unit = unit;
+        WeekDay = weekDay;
+    }
+
+    internal static DateFormulaStep ForAddPeriod(int signedValue, PeriodTypeEnum unit)
+        => new(DateFormulaStepKind.AddPeriod, signedValue, unit, default);
+
+    internal static DateFormulaStep ForAdjustToWeekDay(int sign, DayOfWeek day)
+        => new(DateFormulaStepKind.AdjustToWeekDay, sign, default, day);
+
+    internal static DateFormulaStep ForMoveToSameWeekDay(DayOfWeek day)
+        => new(DateFormulaStepKind.MoveToSameWeekDay, 0, default, day);
+
+    internal static DateFormulaStep ForAdjustWorkingDay(int sign)
+        => new(DateFormulaStepKind.AdjustWorkingDay, sign, default, default);
+}
+
+/// <summary>
+/// Culture-neutral intermediate representation of a date formula.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <see cref="DateFormulaExpression"/> is produced from a culture-specific formula string
+/// (e.g., French <c>"FS+3O"</c> or English <c>"EW+3O"</c>) by <see cref="Parse(string, CultureInfo)"/>.
+/// All tokens are converted to culture-neutral enum values at parse time, so the same expression
+/// can be serialised into any supported culture's formula syntax.
+/// </para>
+/// <para>
+/// Call <see cref="ToString(CultureInfo)"/> with <see cref="CultureInfo.InvariantCulture"/> to obtain a
+/// stable English-token representation suitable for database persistence (the invariant culture
+/// falls back to the English token set).
+/// Call <see cref="Compile(CultureInfo, ICalendarProvider)"/> to produce an executable delegate.
+/// </para>
+/// </remarks>
+public sealed class DateFormulaExpression : IFormattable
+{
+    private static readonly MethodInfo _adjustToDayOfWeekMethod =
+        typeof(DateFormula).GetMethod("AdjustToDayOfWeek", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static readonly MethodInfo _moveToSameWeekDayMethod =
+        typeof(DateFormula).GetMethod("MoveToSameWeekDay", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    /// <summary>
+    /// <see langword="true"/> if the formula is anchored to the start of <see cref="BasePeriod"/>;
+    /// <see langword="false"/> if anchored to the end.
+    /// </summary>
+    public bool IsStart { get; }
+
+    /// <summary>The base calendar period that the input date is snapped to before steps are applied.</summary>
+    public PeriodTypeEnum BasePeriod { get; }
+
+    /// <summary>The ordered list of transformation steps applied after the base period is resolved.</summary>
+    public IReadOnlyList<DateFormulaStep> Steps { get; }
+
+    private DateFormulaExpression(bool isStart, PeriodTypeEnum basePeriod, IReadOnlyList<DateFormulaStep> steps)
+    {
+        IsStart = isStart;
+        BasePeriod = basePeriod;
+        Steps = steps;
+    }
+
+    /// <summary>
+    /// Parses <paramref name="formula"/> using the default language provider and <paramref name="culture"/>.
+    /// </summary>
+    public static DateFormulaExpression Parse(string formula, CultureInfo culture = null)
+        => Parse(formula, DateFormula.DefaultProvider, culture ?? CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Parses <paramref name="formula"/> using a custom <paramref name="provider"/> and <paramref name="culture"/>.
+    /// </summary>
+    public static DateFormulaExpression Parse(string formula, IDateFormulaLanguageProvider provider, CultureInfo culture = null)
+    {
+        ArgumentNullException.ThrowIfNull(formula);
+        ArgumentNullException.ThrowIfNull(provider);
+        culture ??= CultureInfo.CurrentCulture;
+
+        if (formula.Length < 2)
+            throw new ArgumentException("Formula is too short.", nameof(formula));
+
+        var lang = provider.GetLanguage(culture);
+
+        bool isStart = formula[0] == lang.Start;
+        if (!isStart && formula[0] != lang.End)
+            throw new ArgumentException("Invalid formula start token.", nameof(formula));
+
+        var basePeriod = DateFormula.ParsePeriod(formula[1], lang);
+
+        if (basePeriod is PeriodTypeEnum.Day or PeriodTypeEnum.WorkingDay)
+            throw new ArgumentException("Start/end of day and working day are not supported as a base period.", nameof(formula));
+
+        var steps = new List<DateFormulaStep>();
+        var index = 2;
+
+        while (index < formula.Length && (formula[index] == '+' || formula[index] == '-'))
+        {
+            var sign = formula[index];
+            var pos = index + 1;
+
+            if (pos < formula.Length && char.IsDigit(formula[pos]))
+            {
+                // +N unit  (e.g., +3O, -1M)
+                var startPos = pos;
+                while (pos < formula.Length && char.IsDigit(formula[pos])) pos++;
+                var value = int.Parse(formula[startPos..pos], CultureInfo.InvariantCulture);
+                if (sign == '-') value = -value;
+                if (pos >= formula.Length)
+                    throw new ArgumentException("Missing unit token.", nameof(formula));
+                var unit = DateFormula.ParsePeriod(formula[pos], lang);
+                steps.Add(DateFormulaStep.ForAddPeriod(value, unit));
+                index = pos + 1;
+            }
+            else if (pos < formula.Length && formula[pos] == lang.WorkingDay && pos + 1 == formula.Length)
+            {
+                // +O or -O as last character (single-char working-day snap)
+                steps.Add(DateFormulaStep.ForAdjustWorkingDay(sign == '+' ? 1 : -1));
+                index = formula.Length;
+                break;
+            }
+            else
+            {
+                // +Lu or -Mo (2-char weekday adjust) — always terminal
+                if (pos + 2 > formula.Length)
+                    throw new ArgumentException("Incomplete day-of-week token.", nameof(formula));
+                var dayStr = formula.Substring(pos, 2);
+                if (!lang.Days.TryGetValue(dayStr, out var dayOfWeek))
+                    throw new ArgumentException($"Unknown day token '{dayStr}'.", nameof(formula));
+                steps.Add(DateFormulaStep.ForAdjustToWeekDay(sign == '+' ? 1 : -1, dayOfWeek));
+                index = pos + 2;
+                break;
+            }
+        }
+
+        if (index < formula.Length)
+        {
+            if (formula.Length - index < 2)
+                throw new ArgumentException("Trailing token is too short.", nameof(formula));
+            var token = formula.Substring(index, 2);
+
+            if ((token[0] == '+' || token[0] == '-') && token[1] == lang.WorkingDay)
+            {
+                // +O / -O as final 2-char token after AddPeriod steps
+                steps.Add(DateFormulaStep.ForAdjustWorkingDay(token[0] == '+' ? 1 : -1));
+            }
+            else
+            {
+                // "Lu" / "Mo" — move to same-week occurrence of that weekday
+                if (!lang.Days.TryGetValue(token, out var dayOfWeek))
+                    throw new ArgumentException($"Unknown day token '{token}'.", nameof(formula));
+                steps.Add(DateFormulaStep.ForMoveToSameWeekDay(dayOfWeek));
+            }
+        }
+
+        return new DateFormulaExpression(isStart, basePeriod, steps);
+    }
+
+    /// <summary>
+    /// Builds a LINQ expression tree that evaluates this formula for a given <see cref="DateTime"/> input.
+    /// </summary>
+    /// <param name="culture">Culture used for calendar arithmetic and week-start day resolution.</param>
+    /// <param name="calendarProvider">Required when any step involves working days.</param>
+    /// <returns>A strongly-typed lambda expression ready for further composition or compilation.</returns>
+    public Expression<Func<DateTime, DateTime>> ToExpression(CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+    {
+        culture ??= CultureInfo.CurrentCulture;
+
+        var param = Expression.Parameter(typeof(DateTime), "d");
+
+        Expression expr = Expression.Call(
+            typeof(DateUtils).GetMethod(
+                IsStart ? nameof(DateUtils.StartOf) : nameof(DateUtils.EndOf),
+                BindingFlags.Public | BindingFlags.Static,
+                [typeof(DateTime), typeof(PeriodTypeEnum), typeof(CultureInfo)])!,
+            param,
+            Expression.Constant(BasePeriod),
+            Expression.Constant(culture));
+
+        foreach (var step in Steps)
+        {
+            switch (step.Kind)
+            {
+                case DateFormulaStepKind.AddPeriod:
+                    expr = DateFormula.CreateCalendarCall(culture, expr, step.Unit, step.SignedValue, calendarProvider);
+                    break;
+
+                case DateFormulaStepKind.AdjustToWeekDay:
+                    expr = Expression.Call(
+                        _adjustToDayOfWeekMethod,
+                        expr,
+                        Expression.Constant(step.WeekDay),
+                        Expression.Constant(step.SignedValue > 0));
+                    return Expression.Lambda<Func<DateTime, DateTime>>(
+                        Expression.Property(expr, nameof(DateTime.Date)), param);
+
+                case DateFormulaStepKind.MoveToSameWeekDay:
+                    expr = Expression.Call(
+                        _moveToSameWeekDayMethod,
+                        expr,
+                        Expression.Constant(step.WeekDay),
+                        Expression.Constant(culture.DateTimeFormat.FirstDayOfWeek));
+                    break;
+
+                case DateFormulaStepKind.AdjustWorkingDay:
+                    if (calendarProvider is null)
+                        throw new InvalidOperationException("Working day operations require a calendar provider.");
+                    var workingDayMethod = step.SignedValue > 0
+                        ? nameof(DateUtils.NextWorkingDay)
+                        : nameof(DateUtils.PreviousWorkingDay);
+                    expr = Expression.Call(
+                        typeof(DateUtils).GetMethod(workingDayMethod, BindingFlags.Public | BindingFlags.Static)!,
+                        expr,
+                        Expression.Constant(calendarProvider));
+                    return Expression.Lambda<Func<DateTime, DateTime>>(
+                        Expression.Property(expr, nameof(DateTime.Date)), param);
+            }
+        }
+
+        expr = Expression.Property(expr, nameof(DateTime.Date));
+        return Expression.Lambda<Func<DateTime, DateTime>>(expr, param);
+    }
+
+    /// <summary>
+    /// Compiles this expression into an executable delegate.
+    /// </summary>
+    /// <param name="culture">Culture used for calendar arithmetic and week-start day resolution.</param>
+    /// <param name="calendarProvider">Required when any step involves working days.</param>
+    public Func<DateTime, DateTime> Compile(CultureInfo culture = null, ICalendarProvider? calendarProvider = null)
+        => ToExpression(culture, calendarProvider).Compile();
+
+    /// <summary>
+    /// Renders this expression as a formula string in the language for <paramref name="culture"/>,
+    /// using the default language provider.
+    /// Pass <see cref="CultureInfo.InvariantCulture"/> to obtain the English-token form
+    /// suitable for database persistence.
+    /// </summary>
+    public string ToString(CultureInfo culture)
+        => ToString(DateFormula.DefaultProvider, culture ?? CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Renders this expression as a formula string in the language for <paramref name="culture"/>,
+    /// using an explicit <paramref name="provider"/>.
+    /// </summary>
+    public string ToString(IDateFormulaLanguageProvider provider, CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        var lang = provider.GetLanguage(culture ?? CultureInfo.InvariantCulture);
+        return RenderToString(lang);
+    }
+
+    /// <summary>Returns the English-token form of this expression.</summary>
+    public override string ToString() => ToString(CultureInfo.InvariantCulture);
+
+    /// <inheritdoc cref="IFormattable.ToString(string?, IFormatProvider?)"/>
+    public string ToString(string? format, IFormatProvider? formatProvider)
+        => ToString(formatProvider as CultureInfo ?? CultureInfo.InvariantCulture);
+
+    private string RenderToString(DateFormulaLanguage lang)
+    {
+        var sb = new StringBuilder();
+        sb.Append(IsStart ? lang.Start : lang.End);
+        sb.Append(PeriodToChar(BasePeriod, lang));
+
+        foreach (var step in Steps)
+        {
+            switch (step.Kind)
+            {
+                case DateFormulaStepKind.AddPeriod:
+                    sb.Append(step.SignedValue >= 0 ? '+' : '-');
+                    sb.Append(Math.Abs(step.SignedValue));
+                    sb.Append(PeriodToChar(step.Unit, lang));
+                    break;
+
+                case DateFormulaStepKind.AdjustToWeekDay:
+                    sb.Append(step.SignedValue > 0 ? '+' : '-');
+                    sb.Append(DayToString(step.WeekDay, lang));
+                    break;
+
+                case DateFormulaStepKind.MoveToSameWeekDay:
+                    sb.Append(DayToString(step.WeekDay, lang));
+                    break;
+
+                case DateFormulaStepKind.AdjustWorkingDay:
+                    sb.Append(step.SignedValue > 0 ? '+' : '-');
+                    sb.Append(lang.WorkingDay);
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static char PeriodToChar(PeriodTypeEnum period, DateFormulaLanguage lang) => period switch
+    {
+        PeriodTypeEnum.Day => lang.Day,
+        PeriodTypeEnum.Week => lang.Week,
+        PeriodTypeEnum.Month => lang.Month,
+        PeriodTypeEnum.Quarter => lang.Quarter,
+        PeriodTypeEnum.Year => lang.Year,
+        PeriodTypeEnum.WorkingDay => lang.WorkingDay,
+        _ => throw new ArgumentOutOfRangeException(nameof(period))
+    };
+
+    private static string DayToString(DayOfWeek day, DateFormulaLanguage lang)
+        => lang.Days.First(kvp => kvp.Value == day).Key;
+}
+
+#pragma warning restore S3011

--- a/UtilsTest/Objects/DateFormulaExpressionTests.cs
+++ b/UtilsTest/Objects/DateFormulaExpressionTests.cs
@@ -350,4 +350,22 @@ public class DateFormulaExpressionTests
     [ExpectedException(typeof(ArgumentException))]
     public void Parse_DayAsBasePeriod_Throws()
         => DateFormulaExpression.Parse("FJ", Fr);
+
+    [DataTestMethod]
+    [DataRow("FM+LuMa")]   // AdjustToWeekDay (+Lu) followed by MoveToSameWeekDay (Ma)
+    [DataRow("FM+LuXYZ")]  // AdjustToWeekDay (+Lu) followed by unknown tokens
+    [DataRow("FM+1JLuX")]  // MoveToSameWeekDay (Lu) with trailing garbage
+    public void Parse_ContentAfterTerminalOperation_Throws(string formula)
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => DateFormulaExpression.Parse(formula, Fr));
+    }
+
+    [TestMethod]
+    public void Steps_IsReadOnly_CannotBeMutatedByDowncast()
+    {
+        var expr = DateFormulaExpression.Parse("FM+1J", Fr);
+        // Steps is backed by ReadOnlyCollection, not List — the downcast must fail.
+        Assert.IsFalse(expr.Steps is List<DateFormulaStep>);
+    }
 }

--- a/UtilsTest/Objects/DateFormulaExpressionTests.cs
+++ b/UtilsTest/Objects/DateFormulaExpressionTests.cs
@@ -1,0 +1,353 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Utils.Dates;
+
+namespace UtilsTest.Objects;
+
+[TestClass]
+public class DateFormulaExpressionTests
+{
+    private sealed class WeekEndCalendarProvider : ICalendarProvider
+    {
+        private static readonly DayOfWeek[] _weekEnds = [DayOfWeek.Saturday, DayOfWeek.Sunday];
+
+        public int GetNonWorkingDaysCount(DateTime start, DateTime end) => GetHollydays(start, end).Count();
+        public IEnumerable<DateTime> GetHollydays(DateTime start, DateTime end)
+        {
+            for (var d = start.Date; d <= end.Date; d = d.AddDays(1))
+                if (System.Array.IndexOf(_weekEnds, d.DayOfWeek) >= 0)
+                    yield return d;
+        }
+        public IEnumerable<DateTime> GetWorkingDays(DateTime start, DateTime end)
+        {
+            for (var d = start.Date; d <= end.Date; d = d.AddDays(1))
+                if (System.Array.IndexOf(_weekEnds, d.DayOfWeek) < 0)
+                    yield return d;
+        }
+        public int GetWorkingDaysCount(DateTime start, DateTime end) => GetWorkingDays(start, end).Count();
+    }
+
+    private static readonly CultureInfo Fr = new("fr-FR");
+    private static readonly CultureInfo En = new("en-US");
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  Parse — IR properties
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Parse_EndOfWeekPlusWorkingDays_BuildsCorrectIR()
+    {
+        // "FS+3O" (French): End, Week, +3 WorkingDay
+        var expr = DateFormulaExpression.Parse("FS+3O", Fr);
+
+        Assert.IsFalse(expr.IsStart);
+        Assert.AreEqual(PeriodTypeEnum.Week, expr.BasePeriod);
+        Assert.AreEqual(1, expr.Steps.Count);
+        Assert.AreEqual(DateFormulaStepKind.AddPeriod, expr.Steps[0].Kind);
+        Assert.AreEqual(3, expr.Steps[0].SignedValue);
+        Assert.AreEqual(PeriodTypeEnum.WorkingDay, expr.Steps[0].Unit);
+    }
+
+    [TestMethod]
+    public void Parse_StartOfYearMinusMonth_BuildsCorrectIR()
+    {
+        // "DA-1M" (French): Start, Year, -1 Month
+        var expr = DateFormulaExpression.Parse("DA-1M", Fr);
+
+        Assert.IsTrue(expr.IsStart);
+        Assert.AreEqual(PeriodTypeEnum.Year, expr.BasePeriod);
+        Assert.AreEqual(1, expr.Steps.Count);
+        Assert.AreEqual(DateFormulaStepKind.AddPeriod, expr.Steps[0].Kind);
+        Assert.AreEqual(-1, expr.Steps[0].SignedValue);
+        Assert.AreEqual(PeriodTypeEnum.Month, expr.Steps[0].Unit);
+    }
+
+    [TestMethod]
+    public void Parse_AdjustToNextWeekday_BuildsCorrectIR()
+    {
+        // "FM+1J+Lu" (French): End, Month, +1 Day, then next Monday
+        var expr = DateFormulaExpression.Parse("FM+1J+Lu", Fr);
+
+        Assert.AreEqual(2, expr.Steps.Count);
+        Assert.AreEqual(DateFormulaStepKind.AddPeriod, expr.Steps[0].Kind);
+        Assert.AreEqual(DateFormulaStepKind.AdjustToWeekDay, expr.Steps[1].Kind);
+        Assert.AreEqual(1, expr.Steps[1].SignedValue);  // forward
+        Assert.AreEqual(DayOfWeek.Monday, expr.Steps[1].WeekDay);
+    }
+
+    [TestMethod]
+    public void Parse_MoveToSameWeekDay_BuildsCorrectIR()
+    {
+        // "FM+1JLu" (French): End, Month, +1 Day, then Monday in same week
+        var expr = DateFormulaExpression.Parse("FM+1JLu", Fr);
+
+        Assert.AreEqual(2, expr.Steps.Count);
+        Assert.AreEqual(DateFormulaStepKind.AddPeriod, expr.Steps[0].Kind);
+        Assert.AreEqual(DateFormulaStepKind.MoveToSameWeekDay, expr.Steps[1].Kind);
+        Assert.AreEqual(DayOfWeek.Monday, expr.Steps[1].WeekDay);
+    }
+
+    [TestMethod]
+    public void Parse_WorkingDaySnapAtEnd_BuildsCorrectIR()
+    {
+        // "FS+O" (French): End, Week, +WorkingDay snap
+        var expr = DateFormulaExpression.Parse("FS+O", Fr);
+
+        Assert.AreEqual(1, expr.Steps.Count);
+        Assert.AreEqual(DateFormulaStepKind.AdjustWorkingDay, expr.Steps[0].Kind);
+        Assert.AreEqual(1, expr.Steps[0].SignedValue);  // forward
+    }
+
+    [TestMethod]
+    public void Parse_WorkingDaySnapBackward_BuildsCorrectIR()
+    {
+        // "FS-O" (French): End, Week, -WorkingDay snap
+        var expr = DateFormulaExpression.Parse("FS-O", Fr);
+
+        Assert.AreEqual(1, expr.Steps.Count);
+        Assert.AreEqual(DateFormulaStepKind.AdjustWorkingDay, expr.Steps[0].Kind);
+        Assert.AreEqual(-1, expr.Steps[0].SignedValue);  // backward
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  ToString — round-trip in the same language
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ToString_FrenchRoundTrip_ReturnsSameFormula()
+    {
+        string[] frenchFormulas = ["FS+3O", "DA-1M", "FM+1J", "FM+1J+Lu", "FM+1JLu", "FS+O", "FS-O"];
+        foreach (var formula in frenchFormulas)
+        {
+            var expr = DateFormulaExpression.Parse(formula, Fr);
+            Assert.AreEqual(formula, expr.ToString(Fr), $"Round-trip failed for '{formula}'");
+        }
+    }
+
+    [TestMethod]
+    public void ToString_EnglishRoundTrip_ReturnsSameFormula()
+    {
+        string[] englishFormulas = ["EW+3O", "SY-1M", "EM+1D", "EM+1D+Mo", "EM+1DMo", "EW+O", "EW-O"];
+        foreach (var formula in englishFormulas)
+        {
+            var expr = DateFormulaExpression.Parse(formula, En);
+            Assert.AreEqual(formula, expr.ToString(En), $"Round-trip failed for '{formula}'");
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  ToString — cross-language rendering
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ToString_FrenchExprToEnglish_ReturnsEnglishFormula()
+    {
+        Assert.AreEqual("EW+3O", DateFormulaExpression.Parse("FS+3O", Fr).ToString(En));
+        Assert.AreEqual("SY-1M", DateFormulaExpression.Parse("DA-1M", Fr).ToString(En));
+        Assert.AreEqual("EM+1D", DateFormulaExpression.Parse("FM+1J", Fr).ToString(En));
+        Assert.AreEqual("EM+1D+Mo", DateFormulaExpression.Parse("FM+1J+Lu", Fr).ToString(En));
+        Assert.AreEqual("EM+1DMo", DateFormulaExpression.Parse("FM+1JLu", Fr).ToString(En));
+    }
+
+    [TestMethod]
+    public void ToString_EnglishExprToFrench_ReturnsFrenchFormula()
+    {
+        Assert.AreEqual("FS+3O", DateFormulaExpression.Parse("EW+3O", En).ToString(Fr));
+        Assert.AreEqual("DA-1M", DateFormulaExpression.Parse("SY-1M", En).ToString(Fr));
+        Assert.AreEqual("FM+1J", DateFormulaExpression.Parse("EM+1D", En).ToString(Fr));
+    }
+
+    [TestMethod]
+    public void ToString_FrenchExprToInvariantCulture_ReturnsEnglishFormula()
+    {
+        // InvariantCulture has TwoLetterISOLanguageName = "iv"; provider falls back to "en".
+        Assert.AreEqual("EW+3O", DateFormulaExpression.Parse("FS+3O", Fr).ToString(CultureInfo.InvariantCulture));
+        Assert.AreEqual("EM+1D", DateFormulaExpression.Parse("FM+1J", Fr).ToString(CultureInfo.InvariantCulture));
+        Assert.AreEqual("EW-O", DateFormulaExpression.Parse("FS-O", Fr).ToString(CultureInfo.InvariantCulture));
+    }
+
+    [TestMethod]
+    public void ToString_DefaultOverload_ReturnsEnglishForm()
+    {
+        var expr = DateFormulaExpression.Parse("FS+3O", Fr);
+        Assert.AreEqual("EW+3O", expr.ToString());
+    }
+
+    [TestMethod]
+    public void ToString_IFormattable_InvariantCulture_ReturnsEnglishForm()
+    {
+        IFormattable expr = DateFormulaExpression.Parse("FS+3O", Fr);
+        Assert.AreEqual("EW+3O", expr.ToString(null, CultureInfo.InvariantCulture));
+    }
+
+    [TestMethod]
+    public void ToString_IFormattable_FrenchProvider_ReturnsFrenchForm()
+    {
+        IFormattable expr = DateFormulaExpression.Parse("FS+3O", Fr);
+        Assert.AreEqual("FS+3O", expr.ToString(null, Fr));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  Compile — results match DateFormula.Calculate
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Compile_ProducesSameResultAsCalculate_EndOfMonthPlusDay()
+    {
+        var date = new DateTime(2023, 3, 15);
+        var expected = date.Calculate("FM+1J", Fr);
+
+        var fn = DateFormulaExpression.Parse("FM+1J", Fr).Compile(Fr);
+
+        Assert.AreEqual(expected, fn(date));
+    }
+
+    [TestMethod]
+    public void Compile_ProducesSameResultAsCalculate_StartOfYearMinusMonth()
+    {
+        var date = new DateTime(2023, 3, 15);
+        var expected = date.Calculate("DA-1M", Fr);
+
+        var fn = DateFormulaExpression.Parse("DA-1M", Fr).Compile(Fr);
+
+        Assert.AreEqual(expected, fn(date));
+    }
+
+    [TestMethod]
+    public void Compile_ProducesSameResultAsCalculate_EndOfMonthNextMonday()
+    {
+        var date = new DateTime(2023, 10, 15);
+        var expected = date.Calculate("FM+1J+Lu", Fr);
+
+        var fn = DateFormulaExpression.Parse("FM+1J+Lu", Fr).Compile(Fr);
+
+        Assert.AreEqual(expected, fn(date));
+    }
+
+    [TestMethod]
+    public void Compile_ProducesSameResultAsCalculate_WorkingDays()
+    {
+        ICalendarProvider calendar = new WeekEndCalendarProvider();
+        var date = new DateTime(2024, 4, 5);  // Friday
+        var expected = date.Calculate("FS+3O", Fr, calendar);
+
+        var fn = DateFormulaExpression.Parse("FS+3O", Fr).Compile(Fr, calendar);
+
+        Assert.AreEqual(expected, fn(date));
+    }
+
+    [TestMethod]
+    public void Compile_WorkingDaySnap_Forward()
+    {
+        ICalendarProvider calendar = new WeekEndCalendarProvider();
+        var date = new DateTime(2024, 4, 6);  // Saturday
+        var expected = date.Calculate("FS+O", Fr, calendar);
+
+        var fn = DateFormulaExpression.Parse("FS+O", Fr).Compile(Fr, calendar);
+
+        Assert.AreEqual(expected, fn(date));
+    }
+
+    [TestMethod]
+    public void Compile_EnglishFormula_SameResultAsCalculate()
+    {
+        var date = new DateTime(2023, 3, 15);
+        var expected = date.Calculate("EM+1D", En);
+
+        var fn = DateFormulaExpression.Parse("EM+1D", En).Compile(En);
+
+        Assert.AreEqual(expected, fn(date));
+    }
+
+    [TestMethod]
+    public void Compile_ParsedFromFrenchCompiledAsEnglish_SameResult()
+    {
+        // Parsing FR and EN representations of the same formula must produce identical results.
+        var date = new DateTime(2023, 3, 15);
+        var fromFr = DateFormulaExpression.Parse("FM+1J", Fr).Compile(Fr)(date);
+        var fromEn = DateFormulaExpression.Parse("EM+1D", En).Compile(En)(date);
+
+        Assert.AreEqual(fromFr, fromEn);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  Compile — missing calendar provider throws
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    [ExpectedException(typeof(InvalidOperationException))]
+    public void Compile_WorkingDaysWithoutCalendarProvider_Throws()
+    {
+        DateFormulaExpression.Parse("FS+3O", Fr).Compile(Fr);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(InvalidOperationException))]
+    public void Compile_WorkingDaySnapWithoutCalendarProvider_Throws()
+    {
+        DateFormulaExpression.Parse("FS+O", Fr).Compile(Fr);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  DateFormula.Parse overloads
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DateFormula_Parse_ReturnsSameIRAsDirectParse()
+    {
+        var direct = DateFormulaExpression.Parse("FM+1J", Fr);
+        var viaProp = DateFormula.Parse("FM+1J", Fr);
+
+        Assert.AreEqual(direct.IsStart, viaProp.IsStart);
+        Assert.AreEqual(direct.BasePeriod, viaProp.BasePeriod);
+        Assert.AreEqual(direct.Steps.Count, viaProp.Steps.Count);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  ToExpression — accessible expression tree
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ToExpression_ReturnsCompilableExpressionTree()
+    {
+        var expr = DateFormulaExpression.Parse("FM+1J", Fr);
+        var lambdaExpr = expr.ToExpression(Fr);
+
+        Assert.IsNotNull(lambdaExpr);
+        var fn = lambdaExpr.Compile();
+        var date = new DateTime(2023, 3, 15);
+        Assert.AreEqual(new DateTime(2023, 4, 1), fn(date));
+    }
+
+    [TestMethod]
+    public void DateFormula_ToExpression_ReturnsSameResultAsCompile()
+    {
+        var date = new DateTime(2023, 3, 15);
+        var lambdaExpr = DateFormula.ToExpression("FM+1J", Fr);
+        var fn = lambdaExpr.Compile();
+        var expected = date.Calculate("FM+1J", Fr);
+
+        Assert.AreEqual(expected, fn(date));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  Invalid inputs
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void Parse_TooShort_Throws()
+        => DateFormulaExpression.Parse("F", Fr);
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void Parse_InvalidStartToken_Throws()
+        => DateFormulaExpression.Parse("XM+1J", Fr);
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void Parse_DayAsBasePeriod_Throws()
+        => DateFormulaExpression.Parse("FJ", Fr);
+}

--- a/UtilsTest/Objects/DateFormulaExpressionTests.cs
+++ b/UtilsTest/Objects/DateFormulaExpressionTests.cs
@@ -368,4 +368,152 @@ public class DateFormulaExpressionTests
         // Steps is backed by ReadOnlyCollection, not List — the downcast must fail.
         Assert.IsFalse(expr.Steps is List<DateFormulaStep>);
     }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  Equality — DateFormulaStep (accessed via parsed IR)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void DateFormulaStep_EqualSteps_AreEqual()
+    {
+        // Both formulas produce AddPeriod(3, WorkingDay) as their only step.
+        var s1 = DateFormulaExpression.Parse("FM+3O", Fr).Steps[0];
+        var s2 = DateFormulaExpression.Parse("FM+3O", Fr).Steps[0];
+        Assert.IsTrue(s1 == s2);
+        Assert.AreEqual(s1.GetHashCode(), s2.GetHashCode());
+    }
+
+    [TestMethod]
+    public void DateFormulaStep_SameStepParsedInDifferentLanguages_AreEqual()
+    {
+        // FR "FM+1J" and EN "EM+1D" both produce AddPeriod(1, Day).
+        var frStep = DateFormulaExpression.Parse("FM+1J", Fr).Steps[0];
+        var enStep = DateFormulaExpression.Parse("EM+1D", En).Steps[0];
+        Assert.IsTrue(frStep == enStep);
+        Assert.AreEqual(frStep.GetHashCode(), enStep.GetHashCode());
+    }
+
+    [TestMethod]
+    public void DateFormulaStep_DifferentKind_AreNotEqual()
+    {
+        // "FM+1M" → AddPeriod(1, Month) ; "+O" snap → AdjustWorkingDay(+1)
+        var addPeriod    = DateFormulaExpression.Parse("FM+1M", Fr).Steps[0];
+        var workingDay   = DateFormulaExpression.Parse("FM+1M+O", Fr).Steps[1];
+        Assert.IsTrue(addPeriod != workingDay);
+    }
+
+    [TestMethod]
+    public void DateFormulaStep_DifferentSignedValue_AreNotEqual()
+    {
+        var plus3  = DateFormulaExpression.Parse("FM+3M", Fr).Steps[0];
+        var minus3 = DateFormulaExpression.Parse("FM-3M", Fr).Steps[0];
+        Assert.IsTrue(plus3 != minus3);
+    }
+
+    [TestMethod]
+    public void DateFormulaStep_DifferentWeekDay_AreNotEqual()
+    {
+        // "FM+1JLu" → [AddPeriod(1,Day), MoveToSameWeekDay(Monday)]
+        // "FM+1JVe" → [AddPeriod(1,Day), MoveToSameWeekDay(Friday)]
+        var monday = DateFormulaExpression.Parse("FM+1JLu", Fr).Steps[1];
+        var friday = DateFormulaExpression.Parse("FM+1JVe", Fr).Steps[1];
+        Assert.IsTrue(monday != friday);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  Equality — DateFormulaExpression
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Equals_SameFormula_ReturnsTrue()
+    {
+        var a = DateFormulaExpression.Parse("FM+1J", Fr);
+        var b = DateFormulaExpression.Parse("FM+1J", Fr);
+        Assert.IsTrue(a.Equals(b));
+        Assert.IsTrue(a == b);
+    }
+
+    [TestMethod]
+    public void Equals_EquivalentFormulasInDifferentLanguages_ReturnsTrue()
+    {
+        // "FM+1J" (FR) and "EM+1D" (EN) describe the same computation.
+        var fr = DateFormulaExpression.Parse("FM+1J", Fr);
+        var en = DateFormulaExpression.Parse("EM+1D", En);
+        Assert.IsTrue(fr.Equals(en));
+        Assert.IsTrue(fr == en);
+        Assert.AreEqual(fr.GetHashCode(), en.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Equals_DifferentBasePeriod_ReturnsFalse()
+    {
+        var month = DateFormulaExpression.Parse("FM+1J", Fr);
+        var year  = DateFormulaExpression.Parse("FA+1J", Fr);
+        Assert.IsFalse(month.Equals(year));
+        Assert.IsTrue(month != year);
+    }
+
+    [TestMethod]
+    public void Equals_DifferentStepCount_ReturnsFalse()
+    {
+        var simple   = DateFormulaExpression.Parse("FM+1J", Fr);
+        var withSnap = DateFormulaExpression.Parse("FM+1J+O", Fr);  // AdjustWorkingDay step added
+        Assert.IsFalse(simple.Equals(withSnap));
+    }
+
+    [TestMethod]
+    public void Equals_DifferentStartEnd_ReturnsFalse()
+    {
+        var start = DateFormulaExpression.Parse("DM+1J", Fr);
+        var end   = DateFormulaExpression.Parse("FM+1J", Fr);
+        Assert.IsFalse(start.Equals(end));
+        Assert.IsTrue(start != end);
+    }
+
+    [TestMethod]
+    public void Equals_Null_ReturnsFalse()
+    {
+        var expr = DateFormulaExpression.Parse("FM+1J", Fr);
+        Assert.IsFalse(expr.Equals(null));
+        Assert.IsTrue(expr != null);
+    }
+
+    [TestMethod]
+    public void Equals_ReferenceEqual_ReturnsTrue()
+    {
+        var expr = DateFormulaExpression.Parse("FM+1J", Fr);
+#pragma warning disable CS1718
+        Assert.IsTrue(expr == expr);
+#pragma warning restore CS1718
+    }
+
+    [TestMethod]
+    public void GetHashCode_EqualExpressions_SameHash()
+    {
+        var a = DateFormulaExpression.Parse("FS+3O", Fr);
+        var b = DateFormulaExpression.Parse("EW+3O", En);
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Comparer_CanBeUsedAsHashSetKey()
+    {
+        var fr = DateFormulaExpression.Parse("FM+1J", Fr);
+        var en = DateFormulaExpression.Parse("EM+1D", En);  // same formula
+
+        var set = new HashSet<DateFormulaExpression>(DateFormulaExpression.Comparer) { fr, en };
+
+        Assert.AreEqual(1, set.Count, "Equivalent expressions should occupy one slot in the set.");
+    }
+
+    [TestMethod]
+    public void Comparer_DifferentFormulas_OccupyDifferentSlots()
+    {
+        var a = DateFormulaExpression.Parse("FM+1J", Fr);
+        var b = DateFormulaExpression.Parse("FA+1J", Fr);
+
+        var set = new HashSet<DateFormulaExpression>(DateFormulaExpression.Comparer) { a, b };
+
+        Assert.AreEqual(2, set.Count);
+    }
 }

--- a/UtilsTest/Objects/DateFormulaTests.cs
+++ b/UtilsTest/Objects/DateFormulaTests.cs
@@ -131,11 +131,17 @@ public class DateFormulaTests
     [TestMethod]
     public void FormulaWorkingDaysUsesCalendar()
     {
+        // "FS+3O" from Friday 2024-04-05 (fr-FR, first-day-of-week = Monday):
+        //   "FS"  = EndOf(Week)  = Sunday 2024-04-07  (Mon Apr 1 + 7 days - 1 tick, .Date = Apr 7)
+        //   "+3O" = AddWorkingDays(Apr 7, 3) = Mon(1)=Apr 8, Tue(2)=Apr 9, Wed(3)=Apr 10
+        // The test previously expected Apr 11, which matched the old (buggy) EndOf(Week) formula
+        // that returned Monday Apr 8 instead of Sunday Apr 7 (#53). After the fix the correct
+        // result is Apr 10.
         var culture = new CultureInfo("fr-FR");
         ICalendarProvider provider = new WeekEndCalendarProvider();
         var date = new DateTime(2024, 4, 5); // Friday
         var result = date.Calculate("FS+3O", culture, provider);
-        Assert.AreEqual(new DateTime(2024, 4, 11), result);
+        Assert.AreEqual(new DateTime(2024, 4, 10), result);
     }
 
     [TestMethod]
@@ -160,13 +166,17 @@ public class DateFormulaTests
     [TestMethod]
     public void FormulaWorkingDayAdjust()
     {
+        // "FS" from Saturday 2024-04-06 (fr-FR, first-day-of-week = Monday):
+        //   EndOf(Week) = Sunday 2024-04-07
+        // "+O" = NextWorkingDay(Apr 7) = Monday Apr 8  (still correct)
+        // "-O" = PreviousWorkingDay(Apr 7) = Friday Apr 5  (was Apr 8 under old buggy EndOf #53)
         var culture = new CultureInfo("fr-FR");
         ICalendarProvider provider = new WeekEndCalendarProvider();
         var date = new DateTime(2024, 4, 6); // Saturday
         var result = date.Calculate("FS+O", culture, provider);
         Assert.AreEqual(new DateTime(2024, 4, 8), result);
         result = date.Calculate("FS-O", culture, provider);
-        Assert.AreEqual(new DateTime(2024, 4, 8), result);
+        Assert.AreEqual(new DateTime(2024, 4, 5), result);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Résumé

- **Correction des tests** : `FormulaWorkingDaysUsesCalendar` et `FormulaWorkingDayAdjust` attendaient les résultats de l'ancien bug `EndOf(Week)` (#53, corrigé en `0733a301`). Les dates attendues sont corrigées pour refléter le comportement correct.
- **Nouvelle classe `DateFormulaExpression`** : représentation intermédiaire (IR) culture-neutre entre la chaîne de formule et le delegate compilé.
- **Nouvelle classe `DateFormulaStep` / enum `DateFormulaStepKind`** : description culture-neutre de chaque étape de transformation.
- **Nouveaux membres publics sur `DateFormula`** : `Parse(...)` retourne l'IR, `ToExpression(...)` retourne l'arbre LINQ, en complément des `Compile(...)` existants.

## Fonctionnalité de l'IR

```csharp
// Parse depuis n'importe quelle langue
var expr = DateFormula.Parse(
    "FS+3O",
    new CultureInfo("fr-FR"));

// Sérialiser pour la base de données (InvariantCulture -> tokens anglais)
string stored = expr.ToString(CultureInfo.InvariantCulture); // EW+3O

// Rendre dans une autre langue
string enStr = expr.ToString(new CultureInfo("en-US")); // EW+3O
string frStr = expr.ToString(new CultureInfo("fr-FR")); // FS+3O

// Obtenir l'arbre d'expressions LINQ
var tree = expr.ToExpression(culture, calendarProvider);

// Compiler et exécuter
var fn = expr.Compile(culture, calendarProvider);
var result = fn(new DateTime(2024, 4, 5));
```

## Plan de test

- [x] `FormulaWorkingDaysUsesCalendar` — résultat corrigé à `2024-04-10`
- [x] `FormulaWorkingDayAdjust` — résultat `FS-O` corrigé à `2024-04-05`
- [x] 48 nouveaux tests `DateFormulaExpressionTests` : parsing IR, round-trip, rendu cross-langue, `ToExpression`, `Compile`, et erreurs attendues
- [x] Tous les tests `DateFormulaTests` existants passent sans modification du comportement observable

Generated with [Claude Code](https://claude.com/claude-code)