### PR TITLE
fix(Utils.OData): correct 12 audit findings

### DIFF
--- a/Utils.OData/ODataQueryBuilder.cs
+++ b/Utils.OData/ODataQueryBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Specialized;
+using System.Globalization;
 using Utils.Net;
 
 namespace Utils.OData;
@@ -25,23 +26,33 @@ public class ODataQueryBuilder
     /// <param name="query">Query definition used to build the request URL.</param>
     /// <param name="skip">Number of items to skip in addition to <see cref="IQuery.Skip"/>.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="UrlPrefix"/> or <paramref name="query"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="skip"/> is negative, when <see cref="IQuery.Skip"/> is negative, or when <see cref="IQuery.Top"/> is zero or negative.</exception>
+    /// <exception cref="OverflowException">Thrown when the combined skip value overflows <see cref="int"/>.</exception>
     public ODataQueryBuilder(string UrlPrefix, IQuery query, int skip = 0)
     {
         ArgumentNullException.ThrowIfNull(UrlPrefix);
         ArgumentNullException.ThrowIfNull(query);
+
+        if (skip < 0)
+            throw new ArgumentOutOfRangeException(nameof(skip), "Skip must be non-negative.");
+        if (query.Skip.HasValue && query.Skip.Value < 0)
+            throw new ArgumentOutOfRangeException(nameof(query), "Query.Skip must be non-negative.");
+        if (query.Top.HasValue && query.Top.Value <= 0)
+            throw new ArgumentOutOfRangeException(nameof(query), "Query.Top must be a positive integer when specified.");
+
+        int combinedSkip = checked(skip + (query.Skip ?? 0));
 
         var builder = new UriBuilderEx(UrlPrefix + "/" + query.Table);
 
         AddQueryString(builder.QueryString, "$select", query.Select);
         AddQueryString(builder.QueryString, "$filter", query.Filters);
         AddQueryString(builder.QueryString, "$orderby", query.OrderBy);
-        AddQueryString(builder.QueryString, "$skip", skip + (query.Skip ?? 0));
+        AddQueryString(builder.QueryString, "$skip", combinedSkip > 0 ? combinedSkip : (int?)null);
         AddQueryString(builder.QueryString, "$top", query.Top);
         AddQueryString(builder.QueryString, "$count", query.Count, false);
         AddQueryString(builder.QueryString, "$search", query.Search);
 
         Url = builder.GetUrlWithoutAuthorization();
-
     }
 
     /// <summary>
@@ -52,12 +63,17 @@ public class ODataQueryBuilder
     /// <param name="value">Parameter value to use.</param>
     private static void AddQueryString(QueryString queryString, string name, string? value)
     {
-        if (string.IsNullOrWhiteSpace(value)) queryString.Remove(name);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            queryString.Remove(name);
+            return;
+        }
         queryString[name] = value;
     }
 
     /// <summary>
     /// Adds a numeric parameter to the query string collection when a value is provided.
+    /// Uses invariant culture to ensure portable OData URLs regardless of the process locale.
     /// </summary>
     /// <param name="queryString">Target query string collection.</param>
     /// <param name="name">Parameter name to set.</param>
@@ -65,11 +81,12 @@ public class ODataQueryBuilder
     private static void AddQueryString(QueryString queryString, string name, int? value)
     {
         if (value is null) return;
-        queryString[name] = value?.ToString();
+        queryString[name] = value.Value.ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>
-    /// Adds a boolean parameter to the query string collection, removing it when the value equals the default one.
+    /// Adds a boolean parameter to the query string collection, omitting it when the value equals the default.
+    /// Serializes the value as OData-compliant lowercase literals (<c>true</c>/<c>false</c>).
     /// </summary>
     /// <param name="queryString">Target query string collection.</param>
     /// <param name="name">Parameter name to set.</param>
@@ -77,7 +94,11 @@ public class ODataQueryBuilder
     /// <param name="defaultValue">Optional default value used to skip serialization.</param>
     private static void AddQueryString(QueryString queryString, string name, bool value, bool? defaultValue = null)
     {
-        if (value == defaultValue) queryString.Remove(name);
-        queryString[name] = value.ToString();
+        if (value == defaultValue)
+        {
+            queryString.Remove(name);
+            return;
+        }
+        queryString[name] = value ? "true" : "false";
     }
 }

--- a/Utils.OData/QueryOData.cs
+++ b/Utils.OData/QueryOData.cs
@@ -204,7 +204,6 @@ public class QueryOData : IDisposable
         Dictionary<string, string>? metadatas = null;
         int totalRetrieved = 0;
         int? originalTop = parameter.Top;
-        bool hasAnyData = false;
 
         while (true)
         {
@@ -241,8 +240,6 @@ public class QueryOData : IDisposable
                 break;
             }
 
-            hasAnyData = true;
-
             int chunkCount = chunkDataArray.Count;
 
             foreach (JsonNode? item in chunkDataArray)
@@ -251,11 +248,6 @@ public class QueryOData : IDisposable
             }
 
             totalRetrieved += chunkCount;
-        }
-
-        if (!hasAnyData)
-        {
-            return new(1, "No data returned.");
         }
 
         return new((aggregatedValues, metadatas));
@@ -416,9 +408,9 @@ public class QueryOData : IDisposable
 
             writer.TryComplete();
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException oce)
         {
-            writer.TryComplete();
+            writer.TryComplete(oce);
         }
         catch (Exception exception)
         {
@@ -446,12 +438,18 @@ public class QueryOData : IDisposable
         ArgumentNullException.ThrowIfNull(rowConverter);
         ArgumentNullException.ThrowIfNull(writer);
         
+        int rowIndex = 0;
         foreach (JsonNode? entry in batch)
         {
-            object[] row = entry is JsonObject jsonObject
-                    ? rowConverter(jsonObject)
-                    : CreateEmptyRow(columns.Count);
+            if (entry is not JsonObject jsonObject)
+            {
+                throw new InvalidOperationException(
+                    $"Row {rowIndex} in the OData response is not a JSON object (actual type: {entry?.GetValueKind().ToString() ?? "null"}). " +
+                    "Only object entries are supported in the value array.");
+            }
+            object[] row = rowConverter(jsonObject);
             await writer.WriteAsync(row, cancellationToken);
+            rowIndex++;
         }
     }
 
@@ -854,14 +852,6 @@ public class QueryOData : IDisposable
             }
         }
 
-        /// <summary>
-        /// Finalizes the reader instance.
-        /// </summary>
-        ~ODataStreamingDataReader()
-        {
-            Dispose(disposing: false);
-        }
-
         /// <inheritdoc />
         public int FieldCount => _columns.Count;
 
@@ -890,13 +880,12 @@ public class QueryOData : IDisposable
         public void Dispose()
         {
             Dispose(disposing: true);
-            GC.SuppressFinalize(this);
         }
 
         /// <summary>
-        /// Releases unmanaged resources and optionally managed ones.
+        /// Releases managed resources.
         /// </summary>
-        /// <param name="disposing">Indicates whether managed resources should be released.</param>
+        /// <param name="disposing">Always <see langword="true"/>; kept for extensibility.</param>
         private void Dispose(bool disposing)
         {
             if (_isClosed)
@@ -912,15 +901,15 @@ public class QueryOData : IDisposable
                 {
                     _backgroundTask.Wait();
                 }
-                catch (AggregateException aggregate) when (aggregate.InnerExceptions.Count == 1)
+                catch (AggregateException aggregate)
+                        when (aggregate.InnerExceptions.Count == 1
+                              && aggregate.InnerExceptions[0] is OperationCanceledException)
                 {
-                    // Swallow exceptions during disposal to avoid masking the original exception.
-                    // AggregateException with a single OperationCanceledException is the expected case.
-                    _ = aggregate;
+                    // Suppress only cancellation that was initiated by this Dispose call.
                 }
                 catch (OperationCanceledException)
                 {
-                    // Ignore cancellation during disposal.
+                    // Suppress only cancellation that was initiated by this Dispose call.
                 }
 
                 _cancellationSource.Dispose();
@@ -976,7 +965,7 @@ public class QueryOData : IDisposable
             catch (OperationCanceledException)
             {
                 _currentRow = null;
-                return false;
+                throw;
             }
         }
 

--- a/Utils.OData/QueryOData.cs
+++ b/Utils.OData/QueryOData.cs
@@ -53,11 +53,12 @@ public class QueryOData : IDisposable
     /// </summary>
     /// <remarks>This constructor sets up an <see cref="HttpClient"/> with default credentials and a timeout of 600
     /// seconds.</remarks>
-    /// <param name="baseUrl">The base URL for the OData service. Cannot be null.</param>
+    /// <param name="baseUrl">The base URL for the OData service. Must be a valid absolute HTTP or HTTPS URI.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="baseUrl"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="baseUrl"/> is not a valid absolute HTTP or HTTPS URI.</exception>
     public QueryOData(string baseUrl)
     {
-        BaseUrl = baseUrl ?? throw new ArgumentNullException(nameof(baseUrl));
+        BaseUrl = ValidateBaseUrl(baseUrl);
         _handler = new HttpClientHandler()
         {
             UseDefaultCredentials = true,
@@ -76,14 +77,35 @@ public class QueryOData : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="QueryOData"/> class with the specified base URL and HTTP client.
     /// </summary>
-    /// <param name="baseUrl">The base URL for the OData service. Cannot be null.</param>
+    /// <param name="baseUrl">The base URL for the OData service. Must be a valid absolute HTTP or HTTPS URI.</param>
     /// <param name="httpClient">The HTTP client used to send requests. Cannot be null.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="baseUrl"/> or <paramref name="httpClient"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="baseUrl"/> is not a valid absolute HTTP or HTTPS URI.</exception>
     public QueryOData(string baseUrl, HttpClient httpClient)
     {
-        BaseUrl = baseUrl ?? throw new ArgumentNullException(nameof(baseUrl));
+        BaseUrl = ValidateBaseUrl(baseUrl);
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _disposeClient = false;
+    }
+
+    /// <summary>
+    /// Validates the base URL at construction time and returns the normalized string.
+    /// </summary>
+    /// <param name="baseUrl">The base URL supplied by the caller.</param>
+    /// <returns>The validated base URL string.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="baseUrl"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when the URL is not an absolute HTTP or HTTPS URI.</exception>
+    private static string ValidateBaseUrl(string baseUrl)
+    {
+        ArgumentNullException.ThrowIfNull(baseUrl);
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri? uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException(
+                $"The base URL must be a valid absolute HTTP or HTTPS URI. Provided value: '{baseUrl}'.",
+                nameof(baseUrl));
+        }
+        return baseUrl;
     }
 
     /// <summary>
@@ -152,17 +174,17 @@ public class QueryOData : IDisposable
             }
 
             // Copy cookies to the handler container when available.
+            // BaseUrl is already validated as a valid URI in the constructor.
             if (_handler?.CookieContainer is not null && sourceRequest.Headers.TryGetValues("Cookie", out var cookieHeaders))
             {
                 var cookieHeader = string.Join("; ", cookieHeaders);
                 try
                 {
-                    var uri = new Uri(BaseUrl);
-                    _handler.CookieContainer.SetCookies(uri, cookieHeader);
+                    _handler.CookieContainer.SetCookies(new Uri(BaseUrl), cookieHeader);
                 }
-                catch
+                catch (System.Net.CookieException)
                 {
-                    // Ignore failures (for instance when BaseUrl is not a valid URI) and continue the request.
+                    // Malformed cookie header from the source request; skip forwarding and proceed.
                 }
             }
         }

--- a/Utils.OData/QueryOData.cs
+++ b/Utils.OData/QueryOData.cs
@@ -312,16 +312,39 @@ public class QueryOData : IDisposable
         }
 
         await using Stream firstStream = queryResult.Value;
-        var convertResult = ConvertDatas(firstStream, allowEmpty: false);
+        var convertResult = ConvertDatas(firstStream, allowEmpty: true);
         if (convertResult.IsError)
         {
             return new(convertResult.Error);
         }
 
         (JsonArray? Datas, Dictionary<string, string>? Metadatas) firstChunk = convertResult.Value;
+
+        // When the service returns no rows, build a valid empty reader without starting the streaming task.
         if (firstChunk.Datas is not JsonArray { Count: > 0 } firstBatch)
         {
-            return new(1, "No data returned.");
+            string[] selectedColumns = [];
+            string? selection = parameter.Select;
+            if (!string.IsNullOrWhiteSpace(selection)
+                    && !string.Equals(selection.Trim(), "*", StringComparison.Ordinal))
+            {
+                selectedColumns = selection.Split(',').Select(c => c.Trim()).ToArray();
+            }
+
+            IReadOnlyList<ColumnDefinition> emptyColumns = [];
+            if (selectedColumns.Length > 0)
+            {
+                var emptyMeta = await GetMetadataFromBaseAsync(cancellationToken);
+                Edmx? emptyEdmx = emptyMeta.IsError ? null : emptyMeta.Value;
+                string? emptyEntity = ExtractEntityName(firstChunk.Metadatas, parameter);
+                EntityType? emptyType = emptyEdmx is not null ? ResolveEntityType(emptyEdmx, emptyEntity) : null;
+                emptyColumns = BuildColumnDefinitions(selectedColumns, emptyType, emptyEdmx);
+            }
+
+            var emptyChannel = Channel.CreateBounded<object?[]>(1);
+            emptyChannel.Writer.TryComplete();
+            CancellationTokenSource emptyLinkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            return new(new ODataStreamingDataReader(emptyColumns, emptyChannel.Reader, emptyLinkedCts, Task.CompletedTask));
         }
 
         var metadataResult = await GetMetadataFromBaseAsync(cancellationToken);
@@ -700,7 +723,7 @@ public class QueryOData : IDisposable
     private static IReadOnlyList<ColumnDefinition> BuildColumnDefinitions(
             IReadOnlyList<string> columnNames,
             EntityType? entityType,
-            Edmx metadata)
+            Edmx? metadata)
     {
         if (columnNames is null)
         {
@@ -1087,10 +1110,14 @@ public class QueryOData : IDisposable
                 throw new ArgumentOutOfRangeException(nameof(bufferoffset), "Buffer offset must be non-negative.");
             if (bufferoffset > buffer.Length)
                 throw new ArgumentOutOfRangeException(nameof(bufferoffset), "Buffer offset exceeds buffer length.");
+            if (length > buffer.Length - bufferoffset)
+                throw new ArgumentException(
+                    "The requested copy length exceeds the available buffer capacity (bufferoffset + length > buffer.Length).",
+                    nameof(length));
 
             int sourceOffset = (int)fieldOffset;
             int available = Math.Max(0, data.Length - sourceOffset);
-            int count = Math.Min(available, Math.Min(length, buffer.Length - bufferoffset));
+            int count = Math.Min(available, length);
             if (count > 0)
                 Array.Copy(data, sourceOffset, buffer, bufferoffset, count);
 
@@ -1119,10 +1146,14 @@ public class QueryOData : IDisposable
                 throw new ArgumentOutOfRangeException(nameof(bufferoffset), "Buffer offset must be non-negative.");
             if (bufferoffset > buffer.Length)
                 throw new ArgumentOutOfRangeException(nameof(bufferoffset), "Buffer offset exceeds buffer length.");
+            if (length > buffer.Length - bufferoffset)
+                throw new ArgumentException(
+                    "The requested copy length exceeds the available buffer capacity (bufferoffset + length > buffer.Length).",
+                    nameof(length));
 
             int sourceOffset = (int)fieldoffset;
             int available = Math.Max(0, data.Length - sourceOffset);
-            int count = Math.Min(available, Math.Min(length, buffer.Length - bufferoffset));
+            int count = Math.Min(available, length);
             if (count > 0)
                 data.CopyTo(sourceOffset, buffer, bufferoffset, count);
 

--- a/Utils.OData/QueryOData.cs
+++ b/Utils.OData/QueryOData.cs
@@ -335,6 +335,11 @@ public class QueryOData : IDisposable
             if (selectedColumns.Length > 0)
             {
                 var emptyMeta = await GetMetadataFromBaseAsync(cancellationToken);
+                // A metadata failure is intentionally ignored here: an empty result set is a
+                // valid OData response and must not become an error just because the schema
+                // endpoint is unavailable.  Columns fall back to generic (object/DBNull)
+                // types.  The non-empty path, by contrast, does propagate metadata errors
+                // because type converters are required to materialise rows correctly.
                 Edmx? emptyEdmx = emptyMeta.IsError ? null : emptyMeta.Value;
                 string? emptyEntity = ExtractEntityName(firstChunk.Metadatas, parameter);
                 EntityType? emptyType = emptyEdmx is not null ? ResolveEntityType(emptyEdmx, emptyEntity) : null;

--- a/Utils.OData/QueryOData.cs
+++ b/Utils.OData/QueryOData.cs
@@ -848,7 +848,12 @@ public class QueryOData : IDisposable
             _ordinals = new Dictionary<string, int>(columns.Count, StringComparer.OrdinalIgnoreCase);
             foreach (ColumnDefinition column in columns)
             {
-                _ordinals[column.Name] = column.Ordinal;
+                if (!_ordinals.TryAdd(column.Name, column.Ordinal))
+                {
+                    throw new ArgumentException(
+                        $"Duplicate column name '{column.Name}' (case-insensitive) detected in the schema. " +
+                        "Each column must have a unique name.");
+                }
             }
         }
 
@@ -1039,23 +1044,33 @@ public class QueryOData : IDisposable
         /// <inheritdoc />
         public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length)
         {
+            if (fieldOffset < 0)
+                throw new ArgumentOutOfRangeException(nameof(fieldOffset), "Field offset must be non-negative.");
+            if (fieldOffset > int.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(fieldOffset), "Field offset exceeds the supported int range.");
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+
             object value = GetValue(i);
             if (value is DBNull)
-            {
                 return 0;
-            }
 
             if (value is not byte[] data)
-            {
                 throw new InvalidCastException($"Column {i} does not contain binary data.");
-            }
 
-            int available = Math.Max(0, data.Length - (int)fieldOffset);
-            int count = Math.Min(available, length);
-            if (buffer is not null && count > 0)
-            {
-                Array.Copy(data, (int)fieldOffset, buffer, bufferoffset, count);
-            }
+            if (buffer is null)
+                return data.Length;
+
+            if (bufferoffset < 0)
+                throw new ArgumentOutOfRangeException(nameof(bufferoffset), "Buffer offset must be non-negative.");
+            if (bufferoffset > buffer.Length)
+                throw new ArgumentOutOfRangeException(nameof(bufferoffset), "Buffer offset exceeds buffer length.");
+
+            int sourceOffset = (int)fieldOffset;
+            int available = Math.Max(0, data.Length - sourceOffset);
+            int count = Math.Min(available, Math.Min(length, buffer.Length - bufferoffset));
+            if (count > 0)
+                Array.Copy(data, sourceOffset, buffer, bufferoffset, count);
 
             return count;
         }
@@ -1066,13 +1081,28 @@ public class QueryOData : IDisposable
         /// <inheritdoc />
         public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length)
         {
+            if (fieldoffset < 0)
+                throw new ArgumentOutOfRangeException(nameof(fieldoffset), "Field offset must be non-negative.");
+            if (fieldoffset > int.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(fieldoffset), "Field offset exceeds the supported int range.");
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+
             string data = GetString(i);
-            int available = Math.Max(0, data.Length - (int)fieldoffset);
-            int count = Math.Min(available, length);
-            if (buffer is not null && count > 0)
-            {
-                data.CopyTo((int)fieldoffset, buffer, bufferoffset, count);
-            }
+
+            if (buffer is null)
+                return data.Length;
+
+            if (bufferoffset < 0)
+                throw new ArgumentOutOfRangeException(nameof(bufferoffset), "Buffer offset must be non-negative.");
+            if (bufferoffset > buffer.Length)
+                throw new ArgumentOutOfRangeException(nameof(bufferoffset), "Buffer offset exceeds buffer length.");
+
+            int sourceOffset = (int)fieldoffset;
+            int available = Math.Max(0, data.Length - sourceOffset);
+            int count = Math.Min(available, Math.Min(length, buffer.Length - bufferoffset));
+            if (count > 0)
+                data.CopyTo(sourceOffset, buffer, bufferoffset, count);
 
             return count;
         }

--- a/Utils.OData/TODO-2026-07-11-pass3.md
+++ b/Utils.OData/TODO-2026-07-11-pass3.md
@@ -4,7 +4,7 @@ Third review of `Utils.OData`, focused on the streaming `IDataReader`, cancellat
 
 ## High-priority findings
 
-### 39. Streaming cancellation is silently converted into successful end-of-data
+### 39. **[FIXED]** Streaming cancellation is silently converted into successful end-of-data
 
 `StreamBatchesAsync` catches `OperationCanceledException` and completes the channel without an error. `ODataStreamingDataReader.Read` also catches `OperationCanceledException` and returns `false`.
 
@@ -14,7 +14,7 @@ Third review of `Utils.OData`, focused on the streaming `IDataReader`, cancellat
 
 **Priority: P1 data-completeness correctness.**
 
-### 40. Reader disposal blocks synchronously and suppresses background failures
+### 40. **[FIXED]** Reader disposal blocks synchronously and suppresses background failures
 
 `ODataStreamingDataReader.Dispose` cancels the linked token and then calls `_backgroundTask.Wait()`. It catches and discards any single-inner `AggregateException`, not only cancellation.
 
@@ -24,7 +24,7 @@ Third review of `Utils.OData`, focused on the streaming `IDataReader`, cancellat
 
 **Priority: P1 lifecycle and error integrity.**
 
-### 41. The reader finalizer invokes managed cancellation but cannot complete managed cleanup
+### 41. **[FIXED]** The reader finalizer invokes managed cancellation but cannot complete managed cleanup
 
 The finalizer calls `Dispose(false)`, which sets `_isClosed` and calls `_cancellationSource.Cancel()`, but deliberately does not wait for the task or dispose the cancellation source.
 
@@ -34,7 +34,7 @@ The finalizer calls `Dispose(false)`, which sets `_isClosed` and calls `_cancell
 
 **Priority: P1 resource lifecycle.**
 
-### 42. `GetBytes` and `GetChars` do not validate offsets, lengths, or destination bounds
+### 42. **[FIXED]** `GetBytes` and `GetChars` do not validate offsets, lengths, or destination bounds
 
 Both methods cast `long` field offsets directly to `int`, accept negative offsets and lengths, and delegate destination bounds to incidental array exceptions. Values above `int.MaxValue` wrap during the cast.
 
@@ -44,7 +44,7 @@ Both methods cast `long` field offsets directly to `int`, accept negative offset
 
 **Priority: P1 `IDataReader` contract correctness.**
 
-### 43. Duplicate column names silently overwrite ordinal mappings
+### 43. **[FIXED]** Duplicate column names silently overwrite ordinal mappings
 
 The ordinal dictionary uses case-insensitive assignment (`_ordinals[column.Name] = column.Ordinal`). Duplicate names, including names differing only by case, silently leave only the last ordinal addressable by name while both columns remain accessible by index.
 
@@ -54,7 +54,7 @@ The ordinal dictionary uses case-insensitive assignment (`_ordinals[column.Name]
 
 **Priority: P1 schema integrity.**
 
-### 44. Non-object entries are silently emitted as rows containing only `DBNull`
+### 44. **[FIXED]** Non-object entries are silently emitted as rows containing only `DBNull`
 
 `WriteBatchAsync` converts every array entry that is not a `JsonObject` into an empty row of the configured width.
 

--- a/Utils.OData/TODO.md
+++ b/Utils.OData/TODO.md
@@ -4,7 +4,7 @@ Initial review of the `Utils.OData` package, focused on URI/query construction, 
 
 ## Critical and high-priority findings
 
-### 1. Boolean query parameters are always emitted, including `$count=false`
+### 1. **[FIXED]** Boolean query parameters are always emitted, including `$count=false`
 
 `ODataQueryBuilder.AddQueryString(..., bool value, bool? defaultValue)` removes the parameter when it equals the default, but then immediately assigns it again unconditionally:
 
@@ -21,7 +21,7 @@ The constructor calls this method for `$count` with `defaultValue: false`, so `$
 
 **Priority: P0 deterministic query-generation bug.**
 
-### 2. String query parameters are removed and then immediately assigned again
+### 2. **[FIXED]** String query parameters are removed and then immediately assigned again
 
 The string overload performs:
 
@@ -36,7 +36,7 @@ Therefore the stated “adds or removes” contract is not implemented. Dependin
 
 **Priority: P1 URI correctness.**
 
-### 3. Numeric OData options use the current culture
+### 3. **[FIXED]** Numeric OData options use the current culture
 
 `$skip` and `$top` are serialized with `value.ToString()` rather than `CultureInfo.InvariantCulture`.
 
@@ -62,7 +62,7 @@ There is no validation that the base URI is absolute HTTP(S), no normalization o
 
 **Priority: P1 URL integrity and security boundary.**
 
-### 5. `skip`, `Top`, and `Skip` accept invalid/overflowing values
+### 5. **[FIXED]** `skip`, `Top`, and `Skip` accept invalid/overflowing values
 
 `ODataQueryBuilder` computes `skip + (query.Skip ?? 0)` with ordinary `int` arithmetic and no validation. Negative values are accepted, and sufficiently large values can overflow before serialization.
 
@@ -102,7 +102,7 @@ When a source cookie header is supplied, the code calls `CookieContainer.SetCook
 
 **Priority: P1 session isolation and concurrency.**
 
-### 9. Base URL and request URI validation are deferred and failures are swallowed in cookie handling
+### 9. **[FIXED]** Base URL and request URI validation are deferred and failures are swallowed in cookie handling
 
 Constructors accept any non-null string. Cookie propagation catches every exception from URI parsing and silently continues, while the eventual request may fail later with a different exception.
 
@@ -142,7 +142,7 @@ The LINQ literal formatter converts every enum to its underlying `Int64`. OData 
 
 ## Medium-priority findings
 
-### 13. Empty successful result sets are returned as errors
+### 13. **[FIXED]** Empty successful result sets are returned as errors
 
 `QueryToJSon` returns error code 1 with “No data returned” when no rows are found; `QueryToDataReader` follows the same pattern. An empty collection is normally a successful OData query result, not an exceptional transport or protocol failure.
 

--- a/Utils.OData/TODO.md
+++ b/Utils.OData/TODO.md
@@ -142,7 +142,7 @@ The LINQ literal formatter converts every enum to its underlying `Int64`. OData 
 
 ## Medium-priority findings
 
-### 13. **[FIXED]** Empty successful result sets are returned as errors
+### 13. **[FIXED]** Empty successful result sets are returned as errors (both QueryToJSon and QueryToDataReader)
 
 `QueryToJSon` returns error code 1 with “No data returned” when no rows are found; `QueryToDataReader` follows the same pattern. An empty collection is normally a successful OData query result, not an exceptional transport or protocol failure.
 

--- a/UtilsTest/OData/ODataQueryBuilderTests.cs
+++ b/UtilsTest/OData/ODataQueryBuilderTests.cs
@@ -1,0 +1,289 @@
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.OData;
+
+namespace UtilsTest.OData;
+
+/// <summary>
+/// Tests for <see cref="ODataQueryBuilder"/> covering URI generation correctness
+/// (items 1, 2, 3, 5 of the Utils.OData audit).
+/// </summary>
+[TestClass]
+public class ODataQueryBuilderTests
+{
+    private static string BuildUrl(IQuery query, string baseUrl = "https://example.org/odata", int skip = 0)
+    {
+        string raw = new ODataQueryBuilder(baseUrl, query, skip).Url;
+        return Uri.UnescapeDataString(raw);
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 1 — Boolean parameter omission/emission (P0)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void Count_False_IsOmittedFromUrl()
+    {
+        var query = new Query { Table = "Products", Count = false };
+        string url = BuildUrl(query);
+        Assert.IsFalse(url.Contains("$count", StringComparison.OrdinalIgnoreCase),
+            $"$count should be omitted when false but found in: {url}");
+    }
+
+    [TestMethod]
+    public void Count_True_IsEmittedAsLowercase()
+    {
+        var query = new Query { Table = "Products", Count = true };
+        string url = BuildUrl(query);
+        StringAssert.Contains(url, "$count=true",
+            $"$count=true should be present when Count is true, got: {url}");
+        Assert.IsFalse(url.Contains("$count=True", StringComparison.Ordinal),
+            "Boolean must be serialized as lowercase OData literal");
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 2 — String parameter removal/assignment correctness (P1)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void Filter_Null_IsOmittedFromUrl()
+    {
+        var query = new Query { Table = "Products", Filters = null };
+        string url = BuildUrl(query);
+        Assert.IsFalse(url.Contains("$filter", StringComparison.OrdinalIgnoreCase),
+            $"$filter should be absent when null: {url}");
+    }
+
+    [TestMethod]
+    public void Filter_WhitespaceOnly_IsOmittedFromUrl()
+    {
+        var query = new Query { Table = "Products", Filters = "   " };
+        string url = BuildUrl(query);
+        Assert.IsFalse(url.Contains("$filter", StringComparison.OrdinalIgnoreCase),
+            $"$filter should be absent when whitespace-only: {url}");
+    }
+
+    [TestMethod]
+    public void Filter_EmptyString_IsOmittedFromUrl()
+    {
+        var query = new Query { Table = "Products", Filters = "" };
+        string url = BuildUrl(query);
+        Assert.IsFalse(url.Contains("$filter", StringComparison.OrdinalIgnoreCase),
+            $"$filter should be absent when empty: {url}");
+    }
+
+    [TestMethod]
+    public void Filter_ValidValue_IsIncludedInUrl()
+    {
+        var query = new Query { Table = "Products", Filters = "Name eq 'Widget'" };
+        string url = BuildUrl(query);
+        Assert.IsTrue(url.Contains("$filter=", StringComparison.OrdinalIgnoreCase),
+            $"$filter should be present when non-empty, got: {url}");
+    }
+
+    [TestMethod]
+    public void Select_Null_IsOmittedFromUrl()
+    {
+        var query = new Query { Table = "Products", Select = null };
+        string url = BuildUrl(query);
+        Assert.IsFalse(url.Contains("$select", StringComparison.OrdinalIgnoreCase),
+            $"$select should be absent when null: {url}");
+    }
+
+    [TestMethod]
+    public void Search_EmptyString_IsOmittedFromUrl()
+    {
+        var query = new Query { Table = "Products", Search = "" };
+        string url = BuildUrl(query);
+        Assert.IsFalse(url.Contains("$search", StringComparison.OrdinalIgnoreCase),
+            $"$search should be absent when empty: {url}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 3 — Numeric options use invariant culture (P1)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void Top_UsesInvariantCulture_UnderArabicCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-SA");
+            var query = new Query { Table = "Products", Top = 100 };
+            string url = BuildUrl(query);
+            StringAssert.Contains(url, "$top=100",
+                $"$top must use invariant digits, got: {url}");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [TestMethod]
+    public void Skip_UsesInvariantCulture_UnderFarsiCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("fa-IR");
+            var query = new Query { Table = "Products" };
+            string url = BuildUrl(query, skip: 50);
+            StringAssert.Contains(url, "$skip=50",
+                $"$skip must use invariant digits, got: {url}");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [TestMethod]
+    public void Skip_UsesInvariantCulture_UnderFrenchCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            var query = new Query { Table = "Products", Top = 1000 };
+            string url = BuildUrl(query, skip: 2000);
+            StringAssert.Contains(url, "$top=1000", $"$top must not use culture-specific separators: {url}");
+            StringAssert.Contains(url, "$skip=2000", $"$skip must not use culture-specific separators: {url}");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 5 — Paging input validation (P1)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void NegativeSkipArgument_ThrowsArgumentOutOfRange()
+    {
+        var query = new Query { Table = "Products" };
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => BuildUrl(query, skip: -1));
+    }
+
+    [TestMethod]
+    public void NegativeQuerySkip_ThrowsArgumentOutOfRange()
+    {
+        var query = new Query { Table = "Products", Skip = -5 };
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => BuildUrl(query));
+    }
+
+    [TestMethod]
+    public void ZeroTop_ThrowsArgumentOutOfRange()
+    {
+        var query = new Query { Table = "Products", Top = 0 };
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => BuildUrl(query));
+    }
+
+    [TestMethod]
+    public void NegativeTop_ThrowsArgumentOutOfRange()
+    {
+        var query = new Query { Table = "Products", Top = -10 };
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => BuildUrl(query));
+    }
+
+    [TestMethod]
+    public void OverflowingCombinedSkip_ThrowsOverflowException()
+    {
+        var query = new Query { Table = "Products", Skip = int.MaxValue };
+        Assert.ThrowsException<OverflowException>(() => BuildUrl(query, skip: 1));
+    }
+
+    [TestMethod]
+    public void ZeroSkip_IsOmittedFromUrl()
+    {
+        var query = new Query { Table = "Products" };
+        string url = BuildUrl(query, skip: 0);
+        Assert.IsFalse(url.Contains("$skip=0", StringComparison.OrdinalIgnoreCase),
+            $"$skip=0 is redundant and should be omitted: {url}");
+    }
+
+    [TestMethod]
+    public void ZeroQuerySkip_IsOmittedFromUrl()
+    {
+        var query = new Query { Table = "Products", Skip = 0 };
+        string url = BuildUrl(query);
+        Assert.IsFalse(url.Contains("$skip=0", StringComparison.OrdinalIgnoreCase),
+            $"$skip=0 is redundant and should be omitted: {url}");
+    }
+
+    [TestMethod]
+    public void CombinedSkip_IsComputedCorrectly()
+    {
+        var query = new Query { Table = "Products", Skip = 10 };
+        string url = BuildUrl(query, skip: 20);
+        StringAssert.Contains(url, "$skip=30",
+            $"Combined skip should be 30, got: {url}");
+    }
+
+    // -----------------------------------------------------------------------
+    // General URL construction
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void NullBaseUrl_ThrowsArgumentNullException()
+    {
+        var query = new Query { Table = "Products" };
+        Assert.ThrowsException<ArgumentNullException>(() => new ODataQueryBuilder(null!, query));
+    }
+
+    [TestMethod]
+    public void NullQuery_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() => new ODataQueryBuilder("https://example.org", null!));
+    }
+
+    [TestMethod]
+    public void AllDefaultOptions_ProducesMinimalUrl()
+    {
+        var query = new Query { Table = "Products" };
+        string url = BuildUrl(query);
+        Assert.IsFalse(url.Contains("$count"), $"No optional params should be emitted: {url}");
+        Assert.IsFalse(url.Contains("$skip"), $"No optional params should be emitted: {url}");
+        Assert.IsFalse(url.Contains("$top"), $"No optional params should be emitted: {url}");
+        Assert.IsFalse(url.Contains("$filter"), $"No optional params should be emitted: {url}");
+        Assert.IsFalse(url.Contains("$orderby"), $"No optional params should be emitted: {url}");
+        Assert.IsFalse(url.Contains("$select"), $"No optional params should be emitted: {url}");
+        Assert.IsFalse(url.Contains("$search"), $"No optional params should be emitted: {url}");
+    }
+
+    [TestMethod]
+    public void Top_Null_IsOmittedFromUrl()
+    {
+        var query = new Query { Table = "Products", Top = null };
+        string url = BuildUrl(query);
+        Assert.IsFalse(url.Contains("$top", StringComparison.OrdinalIgnoreCase),
+            $"$top should be absent when null: {url}");
+    }
+
+    [TestMethod]
+    public void AllOptionsSpecified_AllPresentInUrl()
+    {
+        var query = new Query
+        {
+            Table = "Products",
+            Select = "Id,Name",
+            Filters = "Id gt 0",
+            OrderBy = "Name asc",
+            Skip = 5,
+            Top = 10,
+            Count = true,
+            Search = "widget"
+        };
+        string url = BuildUrl(query);
+        Assert.IsTrue(url.Contains("$select="), $"Missing $select: {url}");
+        Assert.IsTrue(url.Contains("$filter="), $"Missing $filter: {url}");
+        Assert.IsTrue(url.Contains("$orderby="), $"Missing $orderby: {url}");
+        Assert.IsTrue(url.Contains("$skip="), $"Missing $skip: {url}");
+        Assert.IsTrue(url.Contains("$top="), $"Missing $top: {url}");
+        Assert.IsTrue(url.Contains("$count=true"), $"Missing $count=true: {url}");
+        Assert.IsTrue(url.Contains("$search="), $"Missing $search: {url}");
+    }
+}

--- a/UtilsTest/OData/ODataStreamingReaderTests.cs
+++ b/UtilsTest/OData/ODataStreamingReaderTests.cs
@@ -1,0 +1,322 @@
+using System.Text.Json.Nodes;
+using System.Threading.Channels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.OData;
+
+namespace UtilsTest.OData;
+
+/// <summary>
+/// Tests for <see cref="ODataStreamingDataReader"/> (private nested type) covering
+/// items 42 and 43 of the Utils.OData audit:
+/// — GetBytes/GetChars argument validation
+/// — Duplicate column name detection.
+/// </summary>
+[TestClass]
+public class ODataStreamingReaderTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static readonly Type ReaderType = typeof(QueryOData).GetNestedType(
+        "ODataStreamingDataReader",
+        System.Reflection.BindingFlags.NonPublic)!;
+
+    private static readonly Type ColDefType = typeof(QueryOData).GetNestedType(
+        "ColumnDefinition",
+        System.Reflection.BindingFlags.NonPublic)!;
+
+    private static object MakeColumnDefinition(string name, Type clrType, int ordinal,
+        Func<JsonNode?, object>? converter = null)
+    {
+        converter ??= _ => DBNull.Value;
+        return ColDefType.GetConstructors()[0].Invoke([name, clrType, ordinal, converter]);
+    }
+
+    private static System.Collections.IList MakeColumnList(params object[] cols)
+    {
+        var listType = typeof(System.Collections.Generic.List<>).MakeGenericType(ColDefType);
+        var list = (System.Collections.IList)Activator.CreateInstance(listType)!;
+        foreach (var col in cols)
+            list.Add(col);
+        return list;
+    }
+
+    private static System.Data.IDataReader CreateReader(
+        System.Collections.IList columns,
+        ChannelReader<object?[]> channelReader,
+        CancellationTokenSource cts,
+        Task backgroundTask)
+    {
+        var ctor = ReaderType.GetConstructors(
+            System.Reflection.BindingFlags.Public
+            | System.Reflection.BindingFlags.NonPublic
+            | System.Reflection.BindingFlags.Instance)[0];
+        return (System.Data.IDataReader)ctor.Invoke([columns, channelReader, cts, backgroundTask]);
+    }
+
+    private static (System.Data.IDataReader reader, ChannelWriter<object?[]> writer)
+        CreateReaderWithChannel(params object[] columnDefs)
+    {
+        var channel = Channel.CreateBounded<object?[]>(100);
+        using var cts = new CancellationTokenSource();
+        var columns = MakeColumnList(columnDefs);
+        var reader = CreateReader(columns, channel.Reader, cts, Task.CompletedTask);
+        return (reader, channel.Writer);
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 42 — GetBytes argument validation (P1)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void GetBytes_NullBuffer_ReturnsFieldLength()
+    {
+        byte[] fieldValue = [1, 2, 3, 4, 5];
+        Func<JsonNode?, object> converter = _ => fieldValue;
+        var col = MakeColumnDefinition("Data", typeof(byte[]), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite([fieldValue]);
+
+        reader.Read();
+        long length = reader.GetBytes(0, 0, null, 0, 0);
+        Assert.AreEqual(5, length, "Null buffer must return total field length");
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public void GetBytes_NegativeFieldOffset_ThrowsArgumentOutOfRange()
+    {
+        byte[] fieldValue = [1, 2, 3];
+        Func<JsonNode?, object> converter = _ => fieldValue;
+        var col = MakeColumnDefinition("Data", typeof(byte[]), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite([fieldValue]);
+        reader.Read();
+
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => reader.GetBytes(0, -1, null, 0, 0),
+            "Negative field offset must throw ArgumentOutOfRangeException");
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public void GetBytes_OverflowingFieldOffset_ThrowsArgumentOutOfRange()
+    {
+        byte[] fieldValue = [1, 2, 3];
+        Func<JsonNode?, object> converter = _ => fieldValue;
+        var col = MakeColumnDefinition("Data", typeof(byte[]), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite([fieldValue]);
+        reader.Read();
+
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => reader.GetBytes(0, (long)int.MaxValue + 1, null, 0, 0),
+            "Field offset > int.MaxValue must throw ArgumentOutOfRangeException");
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public void GetBytes_NegativeLength_ThrowsArgumentOutOfRange()
+    {
+        byte[] fieldValue = [1, 2, 3];
+        Func<JsonNode?, object> converter = _ => fieldValue;
+        var col = MakeColumnDefinition("Data", typeof(byte[]), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite([fieldValue]);
+        reader.Read();
+
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => reader.GetBytes(0, 0, new byte[10], 0, -1),
+            "Negative length must throw ArgumentOutOfRangeException");
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public void GetBytes_CopiesCorrectData()
+    {
+        byte[] fieldValue = [10, 20, 30, 40, 50];
+        Func<JsonNode?, object> converter = _ => fieldValue;
+        var col = MakeColumnDefinition("Data", typeof(byte[]), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite([fieldValue]);
+        reader.Read();
+
+        var dest = new byte[3];
+        long count = reader.GetBytes(0, 1, dest, 0, 3);
+        Assert.AreEqual(3, count);
+        CollectionAssert.AreEqual(new byte[] { 20, 30, 40 }, dest);
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 42 — GetChars argument validation (P1)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void GetChars_NullBuffer_ReturnsFieldLength()
+    {
+        Func<JsonNode?, object> converter = _ => "Hello";
+        var col = MakeColumnDefinition("Text", typeof(string), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite(["Hello"]);
+        reader.Read();
+
+        long length = reader.GetChars(0, 0, null, 0, 0);
+        Assert.AreEqual(5, length, "Null buffer must return total field character count");
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public void GetChars_NegativeFieldOffset_ThrowsArgumentOutOfRange()
+    {
+        Func<JsonNode?, object> converter = _ => "Hello";
+        var col = MakeColumnDefinition("Text", typeof(string), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite(["Hello"]);
+        reader.Read();
+
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => reader.GetChars(0, -1, null, 0, 0));
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public void GetChars_OverflowingFieldOffset_ThrowsArgumentOutOfRange()
+    {
+        Func<JsonNode?, object> converter = _ => "Hello";
+        var col = MakeColumnDefinition("Text", typeof(string), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite(["Hello"]);
+        reader.Read();
+
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => reader.GetChars(0, (long)int.MaxValue + 1, null, 0, 0));
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public void GetChars_NegativeLength_ThrowsArgumentOutOfRange()
+    {
+        Func<JsonNode?, object> converter = _ => "Hello";
+        var col = MakeColumnDefinition("Text", typeof(string), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite(["Hello"]);
+        reader.Read();
+
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => reader.GetChars(0, 0, new char[10], 0, -1));
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public void GetChars_CopiesCorrectCharacters()
+    {
+        Func<JsonNode?, object> converter = _ => "Hello";
+        var col = MakeColumnDefinition("Text", typeof(string), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite(["Hello"]);
+        reader.Read();
+
+        var dest = new char[3];
+        long count = reader.GetChars(0, 1, dest, 0, 3);
+        Assert.AreEqual(3, count);
+        CollectionAssert.AreEqual(new[] { 'e', 'l', 'l' }, dest);
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 43 — Duplicate column name rejection (P1)
+    // -----------------------------------------------------------------------
+
+    private static ArgumentException ThrowsArgumentExceptionFromReflectedCtor(Action act)
+    {
+        // Reflection wraps constructor exceptions in TargetInvocationException.
+        var tie = Assert.ThrowsException<System.Reflection.TargetInvocationException>(act);
+        Assert.IsInstanceOfType<ArgumentException>(tie.InnerException,
+            "Inner exception must be ArgumentException");
+        return (ArgumentException)tie.InnerException!;
+    }
+
+    [TestMethod]
+    public void DuplicateColumnName_ThrowsArgumentException()
+    {
+        var col1 = MakeColumnDefinition("Name", typeof(string), 0);
+        var col2 = MakeColumnDefinition("Name", typeof(string), 1);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        using var cts = new CancellationTokenSource();
+        var columns = MakeColumnList(col1, col2);
+
+        ThrowsArgumentExceptionFromReflectedCtor(
+            () => CreateReader(columns, channel.Reader, cts, Task.CompletedTask));
+    }
+
+    [TestMethod]
+    public void DuplicateColumnName_CaseInsensitive_ThrowsArgumentException()
+    {
+        var col1 = MakeColumnDefinition("name", typeof(string), 0);
+        var col2 = MakeColumnDefinition("NAME", typeof(string), 1);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        using var cts = new CancellationTokenSource();
+        var columns = MakeColumnList(col1, col2);
+
+        ThrowsArgumentExceptionFromReflectedCtor(
+            () => CreateReader(columns, channel.Reader, cts, Task.CompletedTask));
+    }
+
+    [TestMethod]
+    public void UniqueColumnNames_DoNotThrow()
+    {
+        var col1 = MakeColumnDefinition("Id", typeof(int), 0);
+        var col2 = MakeColumnDefinition("Name", typeof(string), 1);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var columns = MakeColumnList(col1, col2);
+
+        // Dispose the reader before the cts so the reader can cancel cleanly.
+        var reader = CreateReader(columns, channel.Reader, cts, Task.CompletedTask);
+        Assert.IsNotNull(reader, "Reader with unique columns must be created successfully");
+        reader.Dispose();
+        cts.Dispose();
+    }
+}

--- a/UtilsTest/OData/ODataStreamingReaderTests.cs
+++ b/UtilsTest/OData/ODataStreamingReaderTests.cs
@@ -149,6 +149,27 @@ public class ODataStreamingReaderTests
     }
 
     [TestMethod]
+    public void GetBytes_DestinationRangeOverflow_ThrowsArgumentException()
+    {
+        byte[] fieldValue = [1, 2, 3, 4, 5];
+        Func<JsonNode?, object> converter = _ => fieldValue;
+        var col = MakeColumnDefinition("Data", typeof(byte[]), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite([fieldValue]);
+        reader.Read();
+
+        // Buffer has 3 slots, offset 1 leaves 2 free, but we request 3 bytes → overflow.
+        Assert.ThrowsException<ArgumentException>(
+            () => reader.GetBytes(0, 0, new byte[3], 1, 3),
+            "bufferoffset + length > buffer.Length must throw ArgumentException");
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
     public void GetBytes_CopiesCorrectData()
     {
         byte[] fieldValue = [10, 20, 30, 40, 50];
@@ -241,6 +262,26 @@ public class ODataStreamingReaderTests
 
         Assert.ThrowsException<ArgumentOutOfRangeException>(
             () => reader.GetChars(0, 0, new char[10], 0, -1));
+        reader.Dispose();
+        cts.Dispose();
+    }
+
+    [TestMethod]
+    public void GetChars_DestinationRangeOverflow_ThrowsArgumentException()
+    {
+        Func<JsonNode?, object> converter = _ => "Hello";
+        var col = MakeColumnDefinition("Text", typeof(string), 0, converter);
+        var channel = Channel.CreateBounded<object?[]>(10);
+        var cts = new CancellationTokenSource();
+        var reader = CreateReader(MakeColumnList(col), channel.Reader, cts, Task.CompletedTask);
+
+        channel.Writer.TryWrite(["Hello"]);
+        reader.Read();
+
+        // Buffer has 3 slots, offset 1 leaves 2 free, but we request 3 chars → overflow.
+        Assert.ThrowsException<ArgumentException>(
+            () => reader.GetChars(0, 0, new char[3], 1, 3),
+            "bufferoffset + length > buffer.Length must throw ArgumentException");
         reader.Dispose();
         cts.Dispose();
     }

--- a/UtilsTest/OData/QueryODataBaseUrlTests.cs
+++ b/UtilsTest/OData/QueryODataBaseUrlTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.OData;
+
+namespace UtilsTest.OData;
+
+/// <summary>
+/// Tests for <see cref="QueryOData"/> base URL validation (item 9 of the audit).
+/// Validates that the constructor rejects unsupported schemes and malformed URLs
+/// at construction time rather than deferring errors to request time.
+/// </summary>
+[TestClass]
+public class QueryODataBaseUrlTests
+{
+    // -----------------------------------------------------------------------
+    // Valid base URLs
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void Constructor_HttpUrl_DoesNotThrow()
+    {
+        using var client = new System.Net.Http.HttpClient();
+        using var sut = new QueryOData("http://example.org/odata", client);
+        Assert.AreEqual("http://example.org/odata", sut.BaseUrl);
+    }
+
+    [TestMethod]
+    public void Constructor_HttpsUrl_DoesNotThrow()
+    {
+        using var client = new System.Net.Http.HttpClient();
+        using var sut = new QueryOData("https://example.org/odata", client);
+        Assert.AreEqual("https://example.org/odata", sut.BaseUrl);
+    }
+
+    // -----------------------------------------------------------------------
+    // Invalid base URLs — must fail at construction time (not later)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void Constructor_NullBaseUrl_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => new QueryOData(null!));
+    }
+
+    [TestMethod]
+    public void Constructor_NullBaseUrl_WithClient_ThrowsArgumentNullException()
+    {
+        using var client = new System.Net.Http.HttpClient();
+        Assert.ThrowsException<ArgumentNullException>(
+            () => new QueryOData(null!, client));
+    }
+
+    [TestMethod]
+    public void Constructor_RelativeUrl_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => new QueryOData("/odata"));
+    }
+
+    [TestMethod]
+    public void Constructor_NonHttpScheme_File_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => new QueryOData("file:///C:/data"));
+    }
+
+    [TestMethod]
+    public void Constructor_NonHttpScheme_Ftp_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => new QueryOData("ftp://example.org/data"));
+    }
+
+    [TestMethod]
+    public void Constructor_PlainString_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => new QueryOData("not-a-url"));
+    }
+
+    [TestMethod]
+    public void Constructor_EmptyString_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => new QueryOData(string.Empty));
+    }
+
+    [TestMethod]
+    public void Constructor_WhitespaceString_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => new QueryOData("   "));
+    }
+}

--- a/UtilsTest/OData/QueryODataBehaviourTests.cs
+++ b/UtilsTest/OData/QueryODataBehaviourTests.cs
@@ -1,0 +1,291 @@
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Channels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.OData;
+
+namespace UtilsTest.OData;
+
+/// <summary>
+/// Tests for <see cref="QueryOData"/> covering items 13, 39, 40, 41, 44
+/// of the Utils.OData audit (empty results, cancellation semantics, disposal,
+/// finalizer removal, and non-object row rejection).
+/// </summary>
+[TestClass]
+public class QueryODataBehaviourTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers — build in-memory JSON streams
+    // -----------------------------------------------------------------------
+
+    private static Stream MakeJsonStream(string json)
+        => new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+    private static Stream EmptyODataStream()
+        => MakeJsonStream("""{"value":[]}""");
+
+    private static Stream SingleRowODataStream()
+        => MakeJsonStream("""{"value":[{"Id":1,"Name":"Widget"}]}""");
+
+    private static Stream NonObjectRowStream()
+        => MakeJsonStream("""{"value":[42]}""");
+
+    private static Stream NullRowStream()
+        => MakeJsonStream("""{"value":[null]}""");
+
+    private static Stream ArrayRowStream()
+        => MakeJsonStream("""{"value":[[1,2,3]]}""");
+
+    // -----------------------------------------------------------------------
+    // Item 13 — Empty result is not an error (P2)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void ConvertDatas_EmptyValueArray_ReturnsSuccessWithEmptyArray()
+    {
+        // Access ConvertDatas via reflection since it is private
+        var method = typeof(QueryOData).GetMethod(
+            "ConvertDatas",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.IsNotNull(method, "ConvertDatas helper must exist");
+
+        using var stream = EmptyODataStream();
+        var result = method.Invoke(null, [stream, true /* allowEmpty */]);
+
+        Assert.IsNotNull(result, "Result must not be null");
+
+        // ReturnValue<(JsonArray?, Dictionary?)> — check IsError via reflection
+        var resultType = result.GetType();
+        var isErrorProp = resultType.GetProperty("IsError");
+        Assert.IsNotNull(isErrorProp);
+        Assert.IsFalse((bool)isErrorProp.GetValue(result)!,
+            "An empty response must be a success, not an error");
+    }
+
+    [TestMethod]
+    public void ConvertDatas_EmptyValueArray_AllowEmptyFalse_ReturnsError()
+    {
+        var method = typeof(QueryOData).GetMethod(
+            "ConvertDatas",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.IsNotNull(method);
+
+        using var stream = EmptyODataStream();
+        var result = method.Invoke(null, [stream, false /* allowEmpty */]);
+        Assert.IsNotNull(result);
+
+        var isErrorProp = result.GetType().GetProperty("IsError");
+        Assert.IsNotNull(isErrorProp);
+        Assert.IsTrue((bool)isErrorProp.GetValue(result)!,
+            "Empty response with allowEmpty=false must return an error");
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 39 — Cancellation propagates through the channel (P1)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public async Task Channel_WhenCompletedWithOce_IsNotSuccess()
+    {
+        // Verifies that a channel completed with an OperationCanceledException surfaces the
+        // cancellation rather than completing successfully — so callers can distinguish EOF
+        // from cancellation.
+        var channel = Channel.CreateBounded<object?[]>(10);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        channel.Writer.TryComplete(new OperationCanceledException(cts.Token));
+
+        bool caughtOce = false;
+        try
+        {
+            await channel.Reader.Completion;
+        }
+        catch (OperationCanceledException)
+        {
+            caughtOce = true;
+        }
+
+        Assert.IsTrue(caughtOce || channel.Reader.Completion.IsCanceled || channel.Reader.Completion.IsFaulted,
+            "Completion must not succeed silently when the channel was completed with an OCE");
+        Assert.IsFalse(channel.Reader.Completion.IsCompletedSuccessfully,
+            "Completion must not be IsCompletedSuccessfully when cancelled");
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 40 — Dispose swallows only cancellation, not arbitrary errors (P1)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void ODataStreamingDataReader_Dispose_DoesNotThrow_WhenBackgroundTaskCancelled()
+    {
+        var colDefs = BuildColumnDefinitions();
+        var channel = Channel.CreateBounded<object?[]>(1);
+        using var cts = new CancellationTokenSource();
+
+        // Background task that completes immediately after cancellation
+        var tcs = new TaskCompletionSource();
+        cts.Cancel();
+        tcs.SetCanceled(cts.Token);
+        var backgroundTask = tcs.Task;
+
+        var reader = CreateReaderViaReflection(colDefs, channel.Reader, cts, backgroundTask);
+        // Must not throw even though the background task is cancelled
+        reader.Dispose();
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 41 — No finalizer on ODataStreamingDataReader (P1)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void ODataStreamingDataReader_HasNoFinalizer()
+    {
+        // The type must not declare a destructor; GC.SuppressFinalize is pointless without one.
+        var readerType = typeof(QueryOData).GetNestedType(
+            "ODataStreamingDataReader",
+            System.Reflection.BindingFlags.NonPublic);
+        Assert.IsNotNull(readerType, "ODataStreamingDataReader nested type must exist");
+
+        // Finalizers compile to a method named 'Finalize'.
+        // Use DeclaredOnly to exclude the inherited System.Object.Finalize.
+        var finalize = readerType.GetMethod(
+            "Finalize",
+            System.Reflection.BindingFlags.NonPublic
+            | System.Reflection.BindingFlags.Instance
+            | System.Reflection.BindingFlags.DeclaredOnly);
+        Assert.IsNull(finalize, "ODataStreamingDataReader must not declare a finalizer");
+    }
+
+    // -----------------------------------------------------------------------
+    // Item 44 — Non-object entries in value array must throw (P1)
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void WriteBatchAsync_ScalarEntry_ThrowsInvalidOperationException()
+    {
+        var method = typeof(QueryOData).GetMethod(
+            "WriteBatchAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.IsNotNull(method, "WriteBatchAsync helper must exist");
+
+        var batch = JsonNode.Parse("""[42]""")!.AsArray();
+        var columns = BuildColumnDefinitions();
+        var converter = BuildConverter(columns);
+        var channel = Channel.CreateBounded<object?[]>(10);
+
+        var task = (Task)method.Invoke(null, [batch, columns, converter, channel.Writer, CancellationToken.None])!;
+
+        var ex = Assert.ThrowsException<AggregateException>(() => task.Wait());
+        Assert.IsInstanceOfType<InvalidOperationException>(ex.InnerException,
+            "A scalar value in the OData value array must raise InvalidOperationException");
+    }
+
+    [TestMethod]
+    public void WriteBatchAsync_NullEntry_ThrowsInvalidOperationException()
+    {
+        var method = typeof(QueryOData).GetMethod(
+            "WriteBatchAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.IsNotNull(method);
+
+        var batch = JsonNode.Parse("""[null]""")!.AsArray();
+        var columns = BuildColumnDefinitions();
+        var converter = BuildConverter(columns);
+        var channel = Channel.CreateBounded<object?[]>(10);
+
+        var task = (Task)method.Invoke(null, [batch, columns, converter, channel.Writer, CancellationToken.None])!;
+
+        var ex = Assert.ThrowsException<AggregateException>(() => task.Wait());
+        Assert.IsInstanceOfType<InvalidOperationException>(ex.InnerException,
+            "A null entry in the OData value array must raise InvalidOperationException");
+    }
+
+    [TestMethod]
+    public void WriteBatchAsync_ArrayEntry_ThrowsInvalidOperationException()
+    {
+        var method = typeof(QueryOData).GetMethod(
+            "WriteBatchAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.IsNotNull(method);
+
+        var batch = JsonNode.Parse("""[[1,2,3]]""")!.AsArray();
+        var columns = BuildColumnDefinitions();
+        var converter = BuildConverter(columns);
+        var channel = Channel.CreateBounded<object?[]>(10);
+
+        var task = (Task)method.Invoke(null, [batch, columns, converter, channel.Writer, CancellationToken.None])!;
+
+        var ex = Assert.ThrowsException<AggregateException>(() => task.Wait());
+        Assert.IsInstanceOfType<InvalidOperationException>(ex.InnerException,
+            "A nested array in the OData value array must raise InvalidOperationException");
+    }
+
+    [TestMethod]
+    public void WriteBatchAsync_ValidObjectEntries_WritesToChannel()
+    {
+        var method = typeof(QueryOData).GetMethod(
+            "WriteBatchAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.IsNotNull(method);
+
+        var batch = JsonNode.Parse("""[{"Id":1},{"Id":2}]""")!.AsArray();
+        var columns = BuildColumnDefinitions();
+        var converter = BuildConverter(columns);
+        var channel = Channel.CreateBounded<object?[]>(10);
+
+        var task = (Task)method.Invoke(null, [batch, columns, converter, channel.Writer, CancellationToken.None])!;
+        task.Wait();
+
+        Assert.IsTrue(channel.Reader.TryRead(out _), "First row should be readable");
+        Assert.IsTrue(channel.Reader.TryRead(out _), "Second row should be readable");
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    private static System.Data.IDataReader CreateReaderViaReflection(
+        object columnDefs,
+        ChannelReader<object?[]> channelReader,
+        CancellationTokenSource cts,
+        Task task)
+    {
+        var readerType = typeof(QueryOData).GetNestedType(
+            "ODataStreamingDataReader",
+            System.Reflection.BindingFlags.NonPublic)!;
+        var ctor = readerType.GetConstructors(
+            System.Reflection.BindingFlags.Public
+            | System.Reflection.BindingFlags.NonPublic
+            | System.Reflection.BindingFlags.Instance)[0];
+
+        return (System.Data.IDataReader)ctor.Invoke([columnDefs, channelReader, cts, task]);
+    }
+
+    private static object BuildColumnDefinitions()
+    {
+        var colDefType = typeof(QueryOData).GetNestedType(
+            "ColumnDefinition",
+            System.Reflection.BindingFlags.NonPublic)!;
+        var ctor = colDefType.GetConstructors()[0];
+
+        Func<JsonNode?, object> converter = node => node?.GetValue<int>() ?? (object)DBNull.Value;
+        var col = ctor.Invoke(["Id", typeof(int), 0, converter]);
+
+        var listType = typeof(System.Collections.Generic.List<>).MakeGenericType(colDefType);
+        var list = (System.Collections.IList)Activator.CreateInstance(listType)!;
+        list.Add(col);
+
+        var roListType = typeof(System.Collections.Generic.IReadOnlyList<>).MakeGenericType(colDefType);
+        return list;
+    }
+
+    private static Func<JsonObject, object[]> BuildConverter(object columns)
+    {
+        // Use the private CompileRowConverter method
+        var method = typeof(QueryOData).GetMethod(
+            "CompileRowConverter",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        return (Func<JsonObject, object[]>)method.Invoke(null, [columns])!;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes 12 high-priority findings from the three Utils.OData audit passes (`TODO.md`, `TODO-2026-07-11-pass3.md`), with 56 new unit tests covering all corrected behaviours.

### Items fixed

Item 1 (P0): $count=false (and other boolean defaults) emitted unconditionally - fixed by returning early after Remove, serializing as lowercase true/false.
Item 2 (P1): String parameters removed then immediately re-assigned - fixed by returning early after Remove.
Item 3 (P1): $skip/$top serialized with ToString() instead of CultureInfo.InvariantCulture.
Item 5 (P1): Negative skip/top values and overflow not validated - ODataQueryBuilder constructor now validates and uses checked arithmetic.
Item 9 (P1): Base URL validation deferred to request time - QueryOData constructors now validate the HTTP/HTTPS scheme at construction; only CookieException is silenced.
Item 13 (P2): Empty result sets returned as error code 1 - now returned as a successful empty collection.
Item 39 (P1): Streaming cancellation silently reported as normal EOF - channel completed with OperationCanceledException; Read() rethrows.
Item 40 (P1): Dispose suppressed all single-inner AggregateException, not just cancellation.
Item 41 (P1): ODataStreamingDataReader declared a finalizer for managed-only resources - removed.
Item 42 (P1): GetBytes/GetChars accepted negative offsets, overflowing offsets, and negative lengths without validation.
Item 43 (P1): Duplicate column names (including case-only collisions) silently overwrote ordinal mappings.
Item 44 (P1): Non-JsonObject entries in the OData value array emitted as silent all-DBNull rows - now raises InvalidOperationException.

## Test plan

- 56 new unit tests in UtilsTest/OData/ covering all corrected behaviours and edge cases
- Full suite (4950 tests) passes with no regressions
- TODO files updated with [FIXED] markers

Generated with [Claude Code](https://claude.com/claude-code)