### PR TITLE
fix(Utils.NumberToString): deep-freeze nested configs and fix onValue for BigInteger (items 75, 76)

### DIFF
--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -1191,8 +1191,10 @@ namespace Utils.NumberToString
             /// <param name="localName">Optional language-specific alias (e.g. "genus" for German, "sijamuoto" for Finnish).</param>
             public VariantDimension(string name, IReadOnlyList<string> values, string? localName = null)
             {
+                ArgumentException.ThrowIfNullOrEmpty(name);
+                ArgumentNullException.ThrowIfNull(values);
                 Name = name;
-                Values = values;
+                Values = values.ToImmutableArray();
                 LocalName = localName;
             }
 
@@ -1222,8 +1224,10 @@ namespace Utils.NumberToString
             /// <param name="replacements">Replacement rules applied when this variant is active.</param>
             public VariantRule(IReadOnlyDictionary<string, string> constraints, IReadOnlyList<ReplacementRule> replacements)
             {
-                Constraints = constraints;
-                Replacements = replacements;
+                ArgumentNullException.ThrowIfNull(constraints);
+                ArgumentNullException.ThrowIfNull(replacements);
+                Constraints = constraints.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+                Replacements = replacements.ToImmutableArray();
             }
 
             /// <summary>Gets the dimension constraints (name → required value).</summary>
@@ -1255,9 +1259,12 @@ namespace Utils.NumberToString
                 string? suffix,
                 string? removeTrailing)
             {
-                Constraints = constraints;
-                Exceptions = exceptions;
-                WordRules = wordRules;
+                ArgumentNullException.ThrowIfNull(constraints);
+                ArgumentNullException.ThrowIfNull(exceptions);
+                ArgumentNullException.ThrowIfNull(wordRules);
+                Constraints = constraints.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+                Exceptions = exceptions.ToImmutableDictionary();
+                WordRules = wordRules.ToImmutableDictionary();
                 Suffix = suffix;
                 RemoveTrailing = removeTrailing;
             }

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -711,7 +711,7 @@ namespace Utils.NumberToString
             // variant rules, end triggers, and language finalization can be applied to "zero".
             string raw = abs == BigInteger.Zero ? Zero : ConvertRaw(abs, query);
             if (_rawAdjustFunction != null) raw = _rawAdjustFunction(raw);
-            raw = ApplyVariantRules(raw, query, abs <= long.MaxValue ? (long?)abs : null);
+            raw = ApplyVariantRules(raw, query, (BigInteger?)abs);
             raw = ApplyTriggers(raw, TriggerAt.End, null, query);
             string final = LanguageSpecifics.FinalizeWriting(LanguageIdentifier, raw);
 
@@ -777,7 +777,7 @@ namespace Utils.NumberToString
                 }
             }
 
-            return ApplyReplacements(result.ToString(), numericValue: abs <= long.MaxValue ? (long?)abs : null);
+            return ApplyReplacements(result.ToString(), numericValue: (BigInteger?)abs);
         }
 
         /// <summary>
@@ -834,7 +834,7 @@ namespace Utils.NumberToString
         /// The numeric value of the current group in scale mode (e.g. 1 for the thousands group
         /// in 1 000), evaluated against <see cref="ReplacementRule.OnValue"/>.
         /// </param>
-        private string ApplyVariantRules(string text, IReadOnlyDictionary<string, string> query, long? numericValue = null, int? scaleGroupNumber = null, long scaleGroupValue = 0)
+        private string ApplyVariantRules(string text, IReadOnlyDictionary<string, string> query, BigInteger? numericValue = null, int? scaleGroupNumber = null, long scaleGroupValue = 0)
         {
             if (VariantRules.Count == 0 || query.Count == 0) return text;
 
@@ -856,7 +856,7 @@ namespace Utils.NumberToString
                     else
                     {
                         if (_hasScaleSpecificVariantRules && replacement.OnScale is not null) continue;
-                        if (replacement.OnValue is not null && (numericValue is null || !replacement.OnValue.Contains(numericValue.Value)))
+                        if (replacement.OnValue is not null && (numericValue is null || !OnValueInRange(replacement.OnValue, numericValue.Value)))
                             continue;
                     }
                     text = ApplyVariantReplacement(text, replacement);
@@ -881,6 +881,23 @@ namespace Utils.NumberToString
         /// </param>
         private string ApplyVariantRulesForScale(string text, IReadOnlyDictionary<string, string> query, int groupNumber, long groupNumericValue = 0) =>
             ApplyVariantRules(text, query, scaleGroupNumber: groupNumber, scaleGroupValue: groupNumericValue);
+
+        // Evaluates whether a BigInteger value is within an IntRange<long>.
+        // IntRange<long> can only represent values in [long.MinValue, long.MaxValue].
+        // For values outside that range, we approximate using the boundary: if the range contains
+        // long.MaxValue, it most likely has an open (+∞) upper bound and should match any larger
+        // positive integer. The rare edge case of a range whose upper bound is exactly long.MaxValue
+        // (not open) is treated as a match — this is an acceptable false positive given the
+        // practical impossibility of that configuration for number-to-string rules.
+        private static bool OnValueInRange(IntRange<long> range, BigInteger value)
+        {
+            if (value >= long.MinValue && value <= long.MaxValue)
+                return range.Contains((long)value);
+            // value is outside [long.MinValue, long.MaxValue].
+            // An open-upper-bound sub-range would necessarily contain long.MaxValue,
+            // so we use Contains(long.MaxValue) as a proxy.
+            return value > 0 && range.Contains(long.MaxValue);
+        }
 
         /// <summary>
         /// Applies a single replacement rule to <paramref name="text"/> according to its scope.
@@ -1000,7 +1017,7 @@ namespace Utils.NumberToString
         /// <see langword="null"/> suppresses <c>onValue</c> filtering (rule fires regardless).
         /// </param>
         /// <returns>The value after applying any matching replacements.</returns>
-        private string ApplyReplacements(string value, int? groupNumber = null, long? numericValue = null)
+        private string ApplyReplacements(string value, int? groupNumber = null, BigInteger? numericValue = null)
         {
             if (string.IsNullOrEmpty(value) || Replacements.Count == 0)
                 return value;
@@ -1010,7 +1027,7 @@ namespace Utils.NumberToString
                 foreach (var rule in _scaleReplacements)
                 {
                     if (!rule.OnScale!.Contains(groupNumber.Value)) continue;
-                    if (rule.OnValue is not null && (numericValue is null || !rule.OnValue.Contains(numericValue.Value)))
+                    if (rule.OnValue is not null && (numericValue is null || !OnValueInRange(rule.OnValue, numericValue.Value)))
                         continue;
                     value = ApplyVariantReplacement(value, rule);
                 }
@@ -1024,7 +1041,7 @@ namespace Utils.NumberToString
             {
                 foreach (var rule in _valueFilteredGlobalReplacements)
                 {
-                    if (rule.OnValue!.Contains(numericValue.Value))
+                    if (OnValueInRange(rule.OnValue!, numericValue.Value))
                         value = ApplyVariantReplacement(value, rule);
                 }
             }

--- a/Utils.NumberToString/TODO-2026-07-11-pass3.md
+++ b/Utils.NumberToString/TODO-2026-07-11-pass3.md
@@ -4,7 +4,7 @@ Follow-up review focused on effective immutability, arbitrary-precision rule fil
 
 ## High priority
 
-### 75. Converter configuration is only shallowly immutable
+### 75. ✅ Converter configuration is only shallowly immutable
 
 The converter copies top-level rule collections with `ToImmutableArray`/`ToImmutableDictionary`, but several contained model objects retain caller-owned mutable collections:
 

--- a/Utils.NumberToString/TODO-2026-07-11-pass3.md
+++ b/Utils.NumberToString/TODO-2026-07-11-pass3.md
@@ -22,7 +22,7 @@ The constructor then builds `_dimensionIndex`, `_sortedVariantRules`, and `_hasS
 
 **Priority: P1 determinism and thread safety.**
 
-### 76. `onValue` rules silently stop working above `long.MaxValue`
+### 76. ✅ `onValue` rules silently stop working above `long.MaxValue`
 
 Cardinal conversion supports `BigInteger`, but global variant/replacement filtering passes the numeric value only when the absolute value fits in `long`; otherwise it passes `null`. `ApplyVariantRules` treats a null numeric value as non-matching for `OnValue`, and global value-filtered replacements are skipped entirely.
 

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
@@ -1227,4 +1227,57 @@ public class NumberToStringConverterAuditFixesTests
             new NumberToStringConverter.OrdinalVariantRule(
                 new Dictionary<string, string>(), new Dictionary<long, string>(), null!, null, null));
     }
+
+    // ── Item 76 — onValue rules must not be silently suppressed for BigInteger > long.MaxValue ──
+
+    private static NumberToStringConverter BuildEnWithOnValueRule(string onValue) =>
+        new(new NumberToStringConverterOptions(EN)
+        {
+            Replacements =
+            [
+                ..EN.Replacements,
+                new NumberToStringConverter.ReplacementRule(
+                    "hundred", "HUNDRED",
+                    ReplacementScope.Anywhere,
+                    onScale: null,
+                    onValue: NumberToStringConverter.ParseRangeExpression(onValue))
+            ]
+        });
+
+    [TestMethod]
+    public void OnValueRule_SmallValue_WithinLongRange_FiresCorrectly()
+    {
+        // Baseline: onValue="1.." fires for a small value that contains "hundred".
+        var c = BuildEnWithOnValueRule("1..");
+        var result = c.Convert(100); // "one hundred"
+        StringAssert.Contains(result, "HUNDRED",
+            $"onValue='1..' must fire for value 100 (within long range); got: {result}");
+    }
+
+    [TestMethod]
+    public void OnValueRule_BigIntegerAboveLongMax_FiresForOpenUpperBound()
+    {
+        // 10^20 is well above long.MaxValue (~9.2×10^18).
+        // The assembled text for 10^20 in English is "one hundred quintillion".
+        // A global replacement rule with onValue="1.." (= [1, +∞)) must fire
+        // because the range has an open upper bound; previously it was silently
+        // suppressed (numericValue was passed as null for large BigIntegers).
+        var c = BuildEnWithOnValueRule("1..");
+        var hugeValue = BigInteger.Pow(10, 20);
+        var result = c.Convert(hugeValue);
+        StringAssert.Contains(result, "HUNDRED",
+            $"onValue='1..' must fire for BigInteger > long.MaxValue; got: {result}");
+    }
+
+    [TestMethod]
+    public void OnValueRule_BigIntegerAboveLongMax_DoesNotFireForClosedRange()
+    {
+        // A rule with onValue="1..100" (closed upper bound far below long.MaxValue)
+        // must NOT fire for 10^20, since 10^20 is not in [1, 100].
+        var c = BuildEnWithOnValueRule("1..100");
+        var hugeValue = BigInteger.Pow(10, 20);
+        var result = c.Convert(hugeValue);
+        Assert.IsFalse(result.Contains("HUNDRED"),
+            $"onValue='1..100' must NOT fire for BigInteger > long.MaxValue; got: {result}");
+    }
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
@@ -1097,4 +1097,134 @@ public class NumberToStringConverterAuditFixesTests
         Assert.ThrowsException<ArgumentOutOfRangeException>(() => new NumberToStringConverter(opts),
             "MaxNumber = -1 must be rejected; a negative maximum makes every conversion fail");
     }
+
+    // ── Item 75 — nested configuration objects must be deep-frozen ────────────
+
+    [TestMethod]
+    public void VariantDimension_MutatingSourceListAfterConstruction_DoesNotAffectValues()
+    {
+        var source = new List<string> { "masc", "fem" };
+        var dim = new NumberToStringConverter.VariantDimension("gender", source);
+
+        source.Add("neut");
+
+        Assert.AreEqual(2, dim.Values.Count,
+            "VariantDimension.Values must not reflect mutations made to the source list after construction");
+    }
+
+    [TestMethod]
+    public void VariantDimension_NullName_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => new NumberToStringConverter.VariantDimension(null!, ["masc"]));
+    }
+
+    [TestMethod]
+    public void VariantDimension_EmptyName_ThrowsArgumentException()
+    {
+        Assert.ThrowsException<ArgumentException>(
+            () => new NumberToStringConverter.VariantDimension("", ["masc"]));
+    }
+
+    [TestMethod]
+    public void VariantDimension_NullValues_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => new NumberToStringConverter.VariantDimension("gender", null!));
+    }
+
+    [TestMethod]
+    public void VariantRule_MutatingSourceConstraintsAfterConstruction_DoesNotAffectRule()
+    {
+        var constraints = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["gender"] = "fem" };
+        var rule = new NumberToStringConverter.VariantRule(
+            constraints,
+            [new NumberToStringConverter.ReplacementRule("un", "une", ReplacementScope.LastWord)]);
+
+        constraints["case"] = "nominative";
+
+        Assert.AreEqual(1, rule.Constraints.Count,
+            "VariantRule.Constraints must not reflect mutations to the source dictionary after construction");
+    }
+
+    [TestMethod]
+    public void VariantRule_MutatingSourceReplacementsAfterConstruction_DoesNotAffectRule()
+    {
+        var replacements = new List<NumberToStringConverter.ReplacementRule>
+        {
+            new("un", "une", ReplacementScope.LastWord)
+        };
+        var rule = new NumberToStringConverter.VariantRule(
+            new Dictionary<string, string>(),
+            replacements);
+
+        replacements.Add(new NumberToStringConverter.ReplacementRule("deux", "deux", ReplacementScope.LastWord));
+
+        Assert.AreEqual(1, rule.Replacements.Count,
+            "VariantRule.Replacements must not reflect mutations to the source list after construction");
+    }
+
+    [TestMethod]
+    public void VariantRule_NullConstraints_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => new NumberToStringConverter.VariantRule(null!, []));
+    }
+
+    [TestMethod]
+    public void VariantRule_NullReplacements_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(
+            () => new NumberToStringConverter.VariantRule(new Dictionary<string, string>(), null!));
+    }
+
+    [TestMethod]
+    public void OrdinalVariantRule_MutatingSourceExceptionsAfterConstruction_DoesNotAffectRule()
+    {
+        var exceptions = new Dictionary<long, string> { [1L] = "premier" };
+        var rule = new NumberToStringConverter.OrdinalVariantRule(
+            new Dictionary<string, string>(), exceptions, new Dictionary<string, string>(), null, null);
+
+        exceptions[2L] = "deuxième";
+
+        Assert.AreEqual(1, rule.Exceptions.Count,
+            "OrdinalVariantRule.Exceptions must not reflect mutations to the source dictionary after construction");
+    }
+
+    [TestMethod]
+    public void OrdinalVariantRule_MutatingSourceWordRulesAfterConstruction_DoesNotAffectRule()
+    {
+        var wordRules = new Dictionary<string, string> { ["one"] = "first" };
+        var rule = new NumberToStringConverter.OrdinalVariantRule(
+            new Dictionary<string, string>(), new Dictionary<long, string>(), wordRules, null, null);
+
+        wordRules["two"] = "second";
+
+        Assert.AreEqual(1, rule.WordRules.Count,
+            "OrdinalVariantRule.WordRules must not reflect mutations to the source dictionary after construction");
+    }
+
+    [TestMethod]
+    public void OrdinalVariantRule_NullConstraints_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() =>
+            new NumberToStringConverter.OrdinalVariantRule(
+                null!, new Dictionary<long, string>(), new Dictionary<string, string>(), null, null));
+    }
+
+    [TestMethod]
+    public void OrdinalVariantRule_NullExceptions_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() =>
+            new NumberToStringConverter.OrdinalVariantRule(
+                new Dictionary<string, string>(), null!, new Dictionary<string, string>(), null, null));
+    }
+
+    [TestMethod]
+    public void OrdinalVariantRule_NullWordRules_ThrowsArgumentNullException()
+    {
+        Assert.ThrowsException<ArgumentNullException>(() =>
+            new NumberToStringConverter.OrdinalVariantRule(
+                new Dictionary<string, string>(), new Dictionary<long, string>(), null!, null, null));
+    }
 }


### PR DESCRIPTION
## Summary

- **Item 75** -- Nested configuration objects (VariantDimension, VariantRule, OrdinalVariantRule) now deep-copy all supplied collections into immutable structures at construction time. Prior to this, callers could mutate source lists/dictionaries after construction, silently altering converter behaviour while the pre-built indexes remained stale. Null guards added for all required collection parameters.

- **Item 76** -- onValue-filtered replacement rules are now correctly evaluated for BigInteger values above long.MaxValue. Previously, numericValue was passed as null for large values, silently bypassing all onValue predicates. The internal numericValue parameter was changed from long? to BigInteger?; a new OnValueInRange helper approximates open-upper-bound sub-ranges by checking Contains(long.MaxValue).

## Test plan

- 13 tests for item 75: post-construction mutation isolation on all three types, null-parameter rejection
- 3 tests for item 76: onValue baseline (small value), BigInteger > long.MaxValue with open upper bound fires, BigInteger with closed range does not fire
- 97 audit tests, 661 total -- all green
- Full test suite passes locally

Generated with Claude Code