### PR TITLE
fix(Utils.NumberToString): exact BigInteger onValue via IntRange<T>.Contains (item 76)

### DIFF
--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -856,7 +856,7 @@ namespace Utils.NumberToString
                     else
                     {
                         if (_hasScaleSpecificVariantRules && replacement.OnScale is not null) continue;
-                        if (replacement.OnValue is not null && (numericValue is null || !OnValueInRange(replacement.OnValue, numericValue.Value)))
+                        if (replacement.OnValue is not null && (numericValue is null || !replacement.OnValue.Contains(numericValue.Value)))
                             continue;
                     }
                     text = ApplyVariantReplacement(text, replacement);
@@ -881,23 +881,6 @@ namespace Utils.NumberToString
         /// </param>
         private string ApplyVariantRulesForScale(string text, IReadOnlyDictionary<string, string> query, int groupNumber, long groupNumericValue = 0) =>
             ApplyVariantRules(text, query, scaleGroupNumber: groupNumber, scaleGroupValue: groupNumericValue);
-
-        // Evaluates whether a BigInteger value is within an IntRange<long>.
-        // IntRange<long> can only represent values in [long.MinValue, long.MaxValue].
-        // For values outside that range, we approximate using the boundary: if the range contains
-        // long.MaxValue, it most likely has an open (+∞) upper bound and should match any larger
-        // positive integer. The rare edge case of a range whose upper bound is exactly long.MaxValue
-        // (not open) is treated as a match — this is an acceptable false positive given the
-        // practical impossibility of that configuration for number-to-string rules.
-        private static bool OnValueInRange(IntRange<long> range, BigInteger value)
-        {
-            if (value >= long.MinValue && value <= long.MaxValue)
-                return range.Contains((long)value);
-            // value is outside [long.MinValue, long.MaxValue].
-            // An open-upper-bound sub-range would necessarily contain long.MaxValue,
-            // so we use Contains(long.MaxValue) as a proxy.
-            return value > 0 && range.Contains(long.MaxValue);
-        }
 
         /// <summary>
         /// Applies a single replacement rule to <paramref name="text"/> according to its scope.
@@ -1027,7 +1010,7 @@ namespace Utils.NumberToString
                 foreach (var rule in _scaleReplacements)
                 {
                     if (!rule.OnScale!.Contains(groupNumber.Value)) continue;
-                    if (rule.OnValue is not null && (numericValue is null || !OnValueInRange(rule.OnValue, numericValue.Value)))
+                    if (rule.OnValue is not null && (numericValue is null || !rule.OnValue.Contains(numericValue.Value)))
                         continue;
                     value = ApplyVariantReplacement(value, rule);
                 }
@@ -1041,7 +1024,7 @@ namespace Utils.NumberToString
             {
                 foreach (var rule in _valueFilteredGlobalReplacements)
                 {
-                    if (OnValueInRange(rule.OnValue!, numericValue.Value))
+                    if (rule.OnValue!.Contains(numericValue.Value))
                         value = ApplyVariantReplacement(value, rule);
                 }
             }

--- a/Utils/Range/IntRange.cs
+++ b/Utils/Range/IntRange.cs
@@ -491,6 +491,37 @@ namespace Utils.Range
         }
 
         /// <summary>
+        /// Checks whether a <see cref="BigInteger"/> value is contained in any of the intervals.
+        /// Converts each finite bound to <see cref="BigInteger"/> for an exact comparison, so values
+        /// outside the range of <typeparamref name="T"/> (e.g. above <see cref="long.MaxValue"/>) are
+        /// evaluated correctly against open or closed bounds.
+        /// </summary>
+        public bool Contains(BigInteger value)
+        {
+            foreach (var range in _ranges)
+            {
+                BigInteger? min = range.Minimum.HasValue
+                    ? BigInteger.CreateChecked(range.Minimum.Value)
+                    : null;
+                BigInteger? max = range.Maximum.HasValue
+                    ? BigInteger.CreateChecked(range.Maximum.Value)
+                    : null;
+
+                bool aboveMin = min is null || value >= min.Value;
+                bool belowMax = max is null || value <= max.Value;
+
+                if (aboveMin && belowMax)
+                    return true;
+
+                // Ranges are sorted by minimum: once value < this range's minimum,
+                // no subsequent range can match.
+                if (min.HasValue && value < min.Value)
+                    return false;
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Produces the union of two IntRange sets (|).
         /// </summary>
         public static IntRange<T> Union(IntRange<T> left, IntRange<T> right)

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
@@ -1280,4 +1280,30 @@ public class NumberToStringConverterAuditFixesTests
         Assert.IsFalse(result.Contains("HUNDRED"),
             $"onValue='1..100' must NOT fire for BigInteger > long.MaxValue; got: {result}");
     }
+
+    [TestMethod]
+    public void OnValueRule_BigIntegerAboveLongMax_DoesNotFireForClosedLongMaxRange()
+    {
+        // A rule with onValue="1..9223372036854775807" has a closed upper bound at exactly
+        // long.MaxValue. 10^20 > long.MaxValue, so it is outside [1, long.MaxValue] and
+        // the rule must NOT fire. The previous approximation (Contains(long.MaxValue) as proxy
+        // for "open upper bound") incorrectly returned true for this case.
+        var c = BuildEnWithOnValueRule($"1..{long.MaxValue}");
+        var hugeValue = BigInteger.Pow(10, 20);
+        var result = c.Convert(hugeValue);
+        Assert.IsFalse(result.Contains("HUNDRED"),
+            $"onValue='1..{long.MaxValue}' must NOT fire for 10^20 (above the closed upper bound); got: {result}");
+    }
+
+    [TestMethod]
+    public void OnValueRule_BigIntegerAboveLongMax_DoesNotFireForExactLongMax()
+    {
+        // A rule with onValue="9223372036854775807" (the single exact value long.MaxValue)
+        // must NOT fire for 10^20, which is strictly greater than long.MaxValue.
+        var c = BuildEnWithOnValueRule($"{long.MaxValue}");
+        var hugeValue = BigInteger.Pow(10, 20);
+        var result = c.Convert(hugeValue);
+        Assert.IsFalse(result.Contains("HUNDRED"),
+            $"onValue='{long.MaxValue}' must NOT fire for 10^20; got: {result}");
+    }
 }


### PR DESCRIPTION
## Summary

- Ajoute `Contains(BigInteger)` à `IntRange<T>` (`Utils/Range/IntRange.cs`) : chaque borne finie est convertie en `BigInteger` via `BigInteger.CreateChecked<T>`, ce qui rend la comparaison exacte quelle que soit la magnitude de la valeur ; les bornes nulles restent −∞ / +∞.
- Supprime `OnValueInRange` de `NumberToStringConverter` et remplace les 3 sites d'appel par `range.Contains(bigIntValue)`.
- Ajoute les 2 tests manquants signalés en relecture :
  - `OnValueRule_BigIntegerAboveLongMax_DoesNotFireForClosedLongMaxRange` — `onValue=1..9223372036854775807` avec `10^20` → doit **ne pas** déclencher.
  - `OnValueRule_BigIntegerAboveLongMax_DoesNotFireForExactLongMax` — `onValue=9223372036854775807` avec `10^20` → doit **ne pas** déclencher.

Le P2 (valeurs inférieures à `long.MinValue` avec borne inférieure ouverte) est également couvert par la même méthode.

## Test plan

- [ ] 99 tests `NumberToStringConverterAuditFixesTests` passent, dont les 5 tests item 76.
- [ ] Les 2 nouveaux tests (`DoesNotFireForClosedLongMaxRange`, `DoesNotFireForExactLongMax`) **échouaient** avec l'ancienne implémentation `OnValueInRange` et **passent** maintenant.
- [ ] Pas de régression dans les tests `IntRangeTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)