### PR TITLE
fix(Utils.NumberToString): audit items 68 and 71 (P1 linguistic correctness)

### DIFF
--- a/Utils.NumberToString/NumberConverterConfiguration.cs
+++ b/Utils.NumberToString/NumberConverterConfiguration.cs
@@ -613,12 +613,13 @@ public class DateFormatType
     [XmlAttribute("pattern")]
     public string Pattern { get; set; } = "";
 
-    /// <summary>
-    /// Special string used for the first day of the month (e.g. "premier" in French).
-    /// When set, overrides the ordinal form of day 1 in {ordinal-day}.
-    /// </summary>
+    /// <summary>Special string for day 1 in {ordinal-day} (e.g. "first" override).</summary>
     [XmlAttribute("firstDay")]
     public string? FirstDay { get; set; }
+
+    /// <summary>Special string for day 1 in {cardinal-day} (e.g. "premier" in French, "ersten" in German).</summary>
+    [XmlAttribute("firstCardinalDay")]
+    public string? FirstCardinalDay { get; set; }
 
     /// <summary>Connector between the date and the time when converting a DateTime.</summary>
     [XmlAttribute("dateTimeConnector")]

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.DE.xml
@@ -782,7 +782,6 @@
 			<Unit name="minute" singular="Minute"  plural="Minuten"  count1form="eine" />
 			<Unit name="second" singular="Sekunde" plural="Sekunden" count1form="eine" />
 		</TimeUnits>
-		<!-- firstDay="ersten" applies to both {cardinal-day} and {ordinal-day} when day == 1 -->
-		<DateFormat pattern="{cardinal-day}. {month} {year}" firstDay="ersten" />
+		<DateFormat pattern="{cardinal-day}. {month} {year}" firstCardinalDay="ersten" />
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.FR-fr-ca.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.FR-fr-ca.xml
@@ -119,6 +119,6 @@
 			<Unit name="minute" singular="minute"  plural="minutes"  />
 			<Unit name="second" singular="seconde" plural="secondes" />
 		</TimeUnits>
-		<DateFormat pattern="{cardinal-day} {month} {year}" firstDay="premier" />
+		<DateFormat pattern="{cardinal-day} {month} {year}" firstCardinalDay="premier" />
 	</Language>
 </Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.xsd
@@ -1405,10 +1405,19 @@
                                     <xs:attribute name="firstDay" type="xs:string" use="optional">
                                         <xs:annotation>
                                             <xs:documentation>
-                                                Special string for the first day of the month, applied to both
-                                                {ordinal-day} and {cardinal-day} when day == 1
+                                                Special string for the first day of the month applied only to
+                                                {ordinal-day} when day == 1.
+                                                When absent, the standard ordinal form of 1 is used.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="firstCardinalDay" type="xs:string" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Special string for the first day of the month applied only to
+                                                {cardinal-day} when day == 1
                                                 (e.g. "premier" in French, "ersten" in German).
-                                                When absent, the standard ordinal or cardinal form of 1 is used.
+                                                When absent, the standard cardinal form of 1 is used.
                                             </xs:documentation>
                                         </xs:annotation>
                                     </xs:attribute>

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -720,6 +720,7 @@ namespace Utils.NumberToString
                     .ToDictionary(u => u.Name, u => (u.Singular, u.Plural, u.Count1Form)),
                 DatePattern = language.DateFormat?.Pattern,
                 DateFirstDay = language.DateFormat?.FirstDay,
+                DateFirstCardinalDay = language.DateFormat?.FirstCardinalDay,
                 DateTimeConnector = language.DateFormat?.DateTimeConnector,
             };
 

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -145,6 +145,7 @@ namespace Utils.NumberToString
                          ?? ImmutableDictionary<string, (string Singular, string Plural, string? Count1Form)>.Empty;
             _datePattern = options.DatePattern;
             _dateFirstDay = options.DateFirstDay;
+            _dateFirstCardinalDay = options.DateFirstCardinalDay;
             _dateTimeConnector = options.DateTimeConnector;
             // Index both canonical name and localName so both are accepted in API calls and XML constraints.
             _dimensionIndex = VariantDimensions
@@ -313,8 +314,11 @@ namespace Utils.NumberToString
         /// <summary>Gets the date pattern string (tokens: {month}, {ordinal-day}, {cardinal-day}, {year}).</summary>
         public string? DatePattern => _datePattern;
 
-        /// <summary>Gets the special string for day 1 in date ordinal rendering (e.g. "premier" in French).</summary>
+        /// <summary>Gets the special string for day 1 in {ordinal-day} (e.g. "first" override).</summary>
         public string? DateFirstDay => _dateFirstDay;
+
+        /// <summary>Gets the special string for day 1 in {cardinal-day} (e.g. "premier" in French, "ersten" in German).</summary>
+        public string? DateFirstCardinalDay => _dateFirstCardinalDay;
 
         /// <summary>Gets the connector inserted between date and time in DateTime conversion.</summary>
         public string? DateTimeConnector => _dateTimeConnector;
@@ -343,6 +347,7 @@ namespace Utils.NumberToString
         private readonly ImmutableDictionary<string, (string Singular, string Plural, string? Count1Form)> _timeUnits;
         private readonly string? _datePattern;
         private readonly string? _dateFirstDay;
+        private readonly string? _dateFirstCardinalDay;
         private readonly string? _dateTimeConnector;
 
         /// <summary>
@@ -589,7 +594,7 @@ namespace Utils.NumberToString
                 if (activeSuffix != null)
                 {
                     BigInteger fracNumerator = BigInteger.Parse(digits);
-                    var valueText = Convert(fracNumerator, variants).Replace("-", " ");
+                    var valueText = Convert(fracNumerator, variants);
                     // Use BigInteger to avoid long overflow when fractional digits exceed 18.
                     long fracPluralProxy = fracNumerator <= 1 ? (long)fracNumerator : 2L;
                     result.Append(valueText).Append(Separator).Append(activeSuffix.ToPlural(fracPluralProxy));
@@ -1349,12 +1354,12 @@ namespace Utils.NumberToString
                 Fractions.TryGetValue(digits, out var suffix) &&
                 BigInteger.Abs(numerator) <= long.MaxValue)
             {
-                string valueText = (variants is { Length: > 0 } ? Convert(numerator, variants) : Convert(numerator)).Replace("-", " ");
+                string valueText = variants is { Length: > 0 } ? Convert(numerator, variants) : Convert(numerator);
                 return string.Concat(valueText, Separator, suffix.ToPlural((long)BigInteger.Abs(numerator))).Trim();
             }
 
-            string numeratorText = (variants is { Length: > 0 } ? Convert(numerator, variants) : Convert(numerator)).Replace("-", " ");
-            string denominatorText = (variants is { Length: > 0 } ? Convert(denominator, variants) : Convert(denominator)).Replace("-", " ");
+            string numeratorText = variants is { Length: > 0 } ? Convert(numerator, variants) : Convert(numerator);
+            string denominatorText = variants is { Length: > 0 } ? Convert(denominator, variants) : Convert(denominator);
 
             string connector = FractionSeparator;
             return string.Concat(numeratorText, Separator, connector, Separator, denominatorText).Trim();
@@ -1711,9 +1716,9 @@ namespace Utils.NumberToString
                 throw new NotSupportedException($"Language '{LanguageIdentifier}' has no <DateFormat> configuration.");
 
             string month = GetMonthName(date.Month);
-            // firstDay overrides both {ordinal-day} and {cardinal-day} when day == 1
-            string cardinalDay = (date.Day == 1 && _dateFirstDay != null)
-                ? _dateFirstDay
+            // _dateFirstDay overrides {ordinal-day} for day 1; _dateFirstCardinalDay overrides {cardinal-day} for day 1.
+            string cardinalDay = (date.Day == 1 && _dateFirstCardinalDay != null)
+                ? _dateFirstCardinalDay
                 : Convert(date.Day, variants);
             string ordinalDay = (date.Day == 1 && _dateFirstDay != null)
                 ? _dateFirstDay

--- a/Utils.NumberToString/NumberToStringConverterOptions.cs
+++ b/Utils.NumberToString/NumberToStringConverterOptions.cs
@@ -171,10 +171,16 @@ public sealed class NumberToStringConverterOptions
     public string? DatePattern { get; set; }
 
     /// <summary>
-    /// Special string used for the first day of the month (e.g. "premier" in French).
-    /// When set, overrides the ordinal form of day 1 in {ordinal-day}.
+    /// Special string for day 1 in {ordinal-day} (e.g. "first" override).
+    /// When set, replaces the standard ordinal form of 1 in ordinal-day slots.
     /// </summary>
     public string? DateFirstDay { get; set; }
+
+    /// <summary>
+    /// Special string for day 1 in {cardinal-day} (e.g. "premier" in French, "ersten" in German).
+    /// When set, replaces the standard cardinal form of 1 in cardinal-day slots.
+    /// </summary>
+    public string? DateFirstCardinalDay { get; set; }
 
     /// <summary>Connector inserted between date and time when converting a DateTime (defaults to Separator).</summary>
     public string? DateTimeConnector { get; set; }
@@ -229,6 +235,7 @@ public sealed class NumberToStringConverterOptions
         TimeUnits = source.TimeUnits;
         DatePattern = source.DatePattern;
         DateFirstDay = source.DateFirstDay;
+        DateFirstCardinalDay = source.DateFirstCardinalDay;
         DateTimeConnector = source.DateTimeConnector;
     }
 

--- a/Utils.NumberToString/TODO-2026-07-11-pass2.md
+++ b/Utils.NumberToString/TODO-2026-07-11-pass2.md
@@ -64,7 +64,7 @@ Any non-negative value is passed directly to `decimal.Round(number, mandatoryDec
 
 **Priority: P1 API correctness.**
 
-### 68. Hyphens are removed from decimal and fraction components regardless of language rules
+### 68. ✅ Hyphens are removed from decimal and fraction components regardless of language rules
 
 Named decimal fractions and both fraction numerator/denominator paths call `.Replace("-", " ")` on already generated number text. This globally rewrites every hyphen, even when hyphenation is linguistically meaningful or configured as the normal separator.
 
@@ -96,7 +96,7 @@ For a configurable word connector such as `"and"`, every trailing `a`, `n`, or `
 
 **Priority: P1 semantic correctness.**
 
-### 71. `DateFirstDay` overrides both ordinal and cardinal day placeholders
+### 71. ✅ `DateFirstDay` overrides both ordinal and cardinal day placeholders
 
 For day 1, `_dateFirstDay` replaces both `{ordinal-day}` and `{cardinal-day}`. A special form such as French `premier` is appropriate for an ordinal placeholder but not for a deliberately cardinal pattern.
 

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
@@ -6,7 +6,7 @@ using Utils.NumberToString;
 namespace UtilsTest.Mathematics.Numbers;
 
 /// <summary>
-/// Tests for audit findings 47–71 from the Utils.NumberToString TODO files (pass 1 and pass 2).
+/// Tests for audit findings 47–71, 68, 71, 75–78 from the Utils.NumberToString TODO files.
 /// </summary>
 [TestClass]
 public class NumberToStringConverterAuditFixesTests
@@ -1305,5 +1305,117 @@ public class NumberToStringConverterAuditFixesTests
         var result = c.Convert(hugeValue);
         Assert.IsFalse(result.Contains("HUNDRED"),
             $"onValue='{long.MaxValue}' must NOT fire for 10^20; got: {result}");
+    }
+
+    // ── Item 68 — Hyphens must be preserved in fraction and decimal components ─
+
+    [TestMethod]
+    public void ConvertFraction_EN_HyphenatedNumerator_HyphenPreserved_NamedSuffix()
+    {
+        // 21/100 → denominator 100 is a power of 10 → named suffix path ("hundredths").
+        // The numerator "twenty-one" must retain its hyphen; no .Replace("-", " ").
+        string result = EN.ConvertFraction(21, 100);
+        StringAssert.Contains(result, "twenty-one",
+            $"Hyphen in 'twenty-one' must be preserved in named-suffix fraction path; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void ConvertFraction_EN_HyphenatedNumerator_HyphenPreserved_OverConnector()
+    {
+        // 21/7 → denominator 7 is not a power of 10 → "over" connector path.
+        // The numerator "twenty-one" must retain its hyphen.
+        string result = EN.ConvertFraction(21, 7);
+        StringAssert.Contains(result, "twenty-one",
+            $"Hyphen in 'twenty-one' must be preserved in over-connector fraction path; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void ConvertFraction_EN_HyphenatedDenominator_HyphenPreserved_OverConnector()
+    {
+        // 1/21 → denominator "twenty-one" must retain its hyphen in the over-connector path.
+        string result = EN.ConvertFraction(1, 21);
+        StringAssert.Contains(result, "twenty-one",
+            $"Hyphen in denominator 'twenty-one' must be preserved; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void Convert_Decimal_EN_HyphenatedFractionPart_HyphenPreserved()
+    {
+        // 0.21 with a named decimal suffix forces the fractional part through Convert(21).
+        // "twenty-one" must appear without hyphen stripping in the decimal output.
+        var c = EN;
+        string result = c.Convert(0.21m);
+        StringAssert.Contains(result, "twenty-one",
+            $"Hyphen in decimal fraction 'twenty-one' must be preserved; got: '{result}'");
+    }
+
+    // ── Item 71 — DateFirstDay applies only to {{ordinal-day}}; DateFirstCardinalDay to {{cardinal-day}} ─
+
+    [TestMethod]
+    public void Convert_DateOnly_DateFirstDay_AppliesToOrdinalDayOnly()
+    {
+        // A pattern with both {ordinal-day} and {cardinal-day}:
+        // DateFirstDay → only {ordinal-day} for day 1;
+        // {cardinal-day} for day 1 uses the standard cardinal form.
+        var opts = new NumberToStringConverterOptions(EN)
+        {
+            DatePattern = "{cardinal-day}/{ordinal-day}",
+            DateFirstDay = "PREMIER"
+        };
+        var c = new NumberToStringConverter(opts);
+        string result = c.Convert(new DateOnly(2026, 1, 1));
+        // ordinal-day → "PREMIER", cardinal-day → standard cardinal "one"
+        Assert.AreEqual("one/PREMIER", result,
+            $"DateFirstDay must apply only to {{ordinal-day}}, not {{cardinal-day}}; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void Convert_DateOnly_DateFirstCardinalDay_AppliesToCardinalDayOnly()
+    {
+        // DateFirstCardinalDay → only {cardinal-day} for day 1;
+        // {ordinal-day} for day 1 uses the standard ordinal form.
+        var opts = new NumberToStringConverterOptions(EN)
+        {
+            DatePattern = "{cardinal-day}/{ordinal-day}",
+            DateFirstCardinalDay = "ERSTEN"
+        };
+        var c = new NumberToStringConverter(opts);
+        string result = c.Convert(new DateOnly(2026, 1, 1));
+        // cardinal-day → "ERSTEN", ordinal-day → standard ordinal "first"
+        Assert.AreEqual("ERSTEN/first", result,
+            $"DateFirstCardinalDay must apply only to {{cardinal-day}}, not {{ordinal-day}}; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void Convert_DateOnly_BothFirstDayOverrides_Independent()
+    {
+        // Both overrides set independently.
+        var opts = new NumberToStringConverterOptions(EN)
+        {
+            DatePattern = "{cardinal-day}/{ordinal-day}",
+            DateFirstDay = "ORDINAL-FIRST",
+            DateFirstCardinalDay = "CARDINAL-FIRST"
+        };
+        var c = new NumberToStringConverter(opts);
+        string result = c.Convert(new DateOnly(2026, 1, 1));
+        Assert.AreEqual("CARDINAL-FIRST/ORDINAL-FIRST", result,
+            $"Both overrides must apply to their respective tokens independently; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void Convert_DateOnly_FirstDayOverrides_NotAppliedForOtherDays()
+    {
+        // Overrides must only fire for day == 1.
+        var opts = new NumberToStringConverterOptions(EN)
+        {
+            DatePattern = "{cardinal-day}/{ordinal-day}",
+            DateFirstDay = "ORDINAL-FIRST",
+            DateFirstCardinalDay = "CARDINAL-FIRST"
+        };
+        var c = new NumberToStringConverter(opts);
+        string result = c.Convert(new DateOnly(2026, 1, 2));
+        // day 2 → standard forms, no overrides
+        Assert.AreEqual("two/second", result,
+            $"First-day overrides must not apply for day 2; got: '{result}'");
     }
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterENTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterENTests.cs
@@ -170,7 +170,7 @@ namespace UtilsTest.Mathematics.Numbers
         {
             (decimal Number, string Expected)[] tests = [
                 (1.5m, "one point five tenths"),
-                (12.34m, "twelve point thirty four hundredths"),
+                (12.34m, "twelve point thirty-four hundredths"),
             ];
 
             var converter = NumberToStringConverter.GetConverter("en-UK");

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterFractionConnectorTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterFractionConnectorTests.cs
@@ -97,8 +97,8 @@ namespace UtilsTest.Mathematics.Numbers
             const int numerator = 117;
             const int denominator = 1013;
 
-            string numeratorText = converter.Convert(numerator).Replace("-", " ");
-            string denominatorText = converter.Convert(denominator).Replace("-", " ");
+            string numeratorText = converter.Convert(numerator);
+            string denominatorText = converter.Convert(denominator);
 
             string combined = string.Concat(
                 numeratorText,

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterTimeAndNewLangTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterTimeAndNewLangTests.cs
@@ -165,7 +165,7 @@ public class NumberToStringConverterTimeAndNewLangTests
     public void Convert_DateOnly_FR_FirstOfMonth()
     {
         var fr = NumberToStringConverter.GetConverter("FR");
-        // firstDay="premier" applies to {cardinal-day} too when day == 1
+        // firstCardinalDay="premier" applies to {cardinal-day} when day == 1
         string result = fr.Convert(new DateOnly(2026, 7, 1));
         Assert.IsTrue(result.StartsWith("premier juillet"), $"Actual: {result}");
     }
@@ -185,7 +185,7 @@ public class NumberToStringConverterTimeAndNewLangTests
     public void Convert_DateOnly_DE_FirstDay_CardinalDay()
     {
         var de = NumberToStringConverter.GetConverter("DE");
-        // firstDay="ersten" must also apply to {cardinal-day} when day == 1
+        // firstCardinalDay="ersten" applies to {cardinal-day} when day == 1
         string result = de.Convert(new DateOnly(2026, 7, 1));
         Assert.IsTrue(result.StartsWith("ersten. Juli"), $"Actual: {result}");
     }


### PR DESCRIPTION
## Summary

- **Item 68 (P1):** Remove unconditional hyphen stripping from fraction/decimal composition. Four `.Replace("-", " ")` calls removed from `BuildFractionText` and the named-decimal-suffix path. Hyphens in generated text (e.g. "twenty-one hundredths") are now preserved. Wolof numbers that use hyphens as digit separators are no longer silently corrupted.
- **Item 71 (P1):** `DateFirstDay` was applying its override to both `{ordinal-day}` and `{cardinal-day}`, despite being documented as ordinal-only. A new `DateFirstCardinalDay` property/field/XSD attribute covers the cardinal slot independently. DE and FR fr-ca configs migrated from `firstDay` to `firstCardinalDay`.

## Changes

| File | Change |
|---|---|
| `NumberToStringConverter.cs` | Remove 4 `.Replace("-"," ")` calls; add `_dateFirstCardinalDay` field/property/constructor; fix `Convert(DateOnly)` routing |
| `NumberToStringConverterOptions.cs` | Add `DateFirstCardinalDay` + clone support |
| `NumberConverterConfiguration.cs` | Add `FirstCardinalDay` with `[XmlAttribute("firstCardinalDay")]`; update `FirstDay` doc |
| `NumberToStringConverter.Globalization.cs` | Map `FirstCardinalDay` from config |
| `NumberConvertionConfiguration.xsd` | Update `firstDay` doc; add `firstCardinalDay` attribute |
| `NumberConvertionConfiguration.DE.xml` | `firstDay="ersten"` to `firstCardinalDay="ersten"` |
| `NumberConvertionConfiguration.FR-fr-ca.xml` | `firstDay="premier"` to `firstCardinalDay="premier"` |
| `TODO-2026-07-11-pass2.md` | Mark items 68 and 71 done |
| `NumberToStringConverterAuditFixesTests.cs` | 8 new tests (4 per item); total 107 audit tests |
| `NumberToStringConverterENTests.cs` | Update expected: "thirty four hundredths" to "thirty-four hundredths" |
| `NumberToStringConverterFractionConnectorTests.cs` | Remove `.Replace("-"," ")` from expected-value construction |
| `NumberToStringConverterTimeAndNewLangTests.cs` | Update DE/FR first-day test comments |

## Test plan

- [ ] 668 total unit tests pass
- [ ] 107 audit tests pass (8 new)
- [ ] `ConvertFraction(EN, 21, 100)` returns "twenty-one hundredths" (hyphen preserved)
- [ ] `ConvertFraction(EN, 21, 7)` returns "twenty-one over seven" (hyphen preserved)
- [ ] Wolof fraction 117/1013 preserves "juróom-ñaar" (no silent stripping)
- [ ] `DateFirstDay` only overrides the ordinal-day token
- [ ] `DateFirstCardinalDay` only overrides the cardinal-day token
- [ ] Both overrides are independent when a pattern contains both tokens
- [ ] DE `Convert(DateOnly 2026-07-01)` returns "ersten. Juli ..."
- [ ] FR `Convert(DateOnly 2026-07-01)` returns "premier juillet ..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
