### PR TITLE
fix(Utils.NumberToString): audit items 88, 90, 91, 93, 94 (pass6)

### DIFF
--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.EN-GB.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.EN-GB.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    British English — derived from American English (EN) via baseOn.
+    Inherits all number and time rules from EN; overrides only the date format.
+
+    American format : {month} {ordinal-day}, {year}   →  "July second, two thousand twenty-six"
+    British format  : {ordinal-day} {month} {year}    →  "second July two thousand twenty-six"
+-->
+<Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
+	<Language baseOn="EN">
+		<Culture>EN-GB</Culture>
+		<Culture>EN-uk</Culture>
+		<DateFormat pattern="{ordinal-day} {month} {year}" />
+	</Language>
+</Numbers>

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.EN.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.EN.xml
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
         <Language
+                        baseOn="SCALE-SHORT"
                         groupSize="3"
                         separator=" "
-                        groupSeparator="," 
+                        groupSeparator=","
                         zero="zero"
                         minus="minus *"
                         decimalSeparator="point"
                         fractionSeparator="over"
         >
 		<Culture>EN</Culture>
-		<Culture>EN-uk</Culture>
 		<Culture>EN-us</Culture>
 		<Groups>
 			<Group level="1">
@@ -50,15 +50,6 @@
 				<Digit digit="9" string="nine hundred" buildString="nine hundred and *" />
 			</Group>
 		</Groups>
-		<NumberScale firstLetterUpperCase="false">
-			<StaticNames>
-				<Scale value="0" string=""/>
-				<Scale value="1" string="thousand"/>
-			</StaticNames>
-			<Suffixes>
-				<Suffix>on</Suffix>
-			</Suffixes>
-		</NumberScale>
 		<Exceptions>
 			<Number value="11" string="eleven" />
 			<Number value="12" string="twelve" />

--- a/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.SCALE.xml
+++ b/Utils.NumberToString/NumberConverterConfigurations/NumberConvertionConfiguration.SCALE.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Scale base configurations.
+    These languages are NOT intended for direct use.  They define only the
+    NumberScale section and the minimum required fields so that other language
+    configurations can inherit a complete scale definition via baseOn=.
+
+    SCALE-SHORT  Short scale (English/American system)
+                 10^3 = thousand, 10^6 = million, 10^9 = billion, …
+                 Suffix cycle: [on]  →  mill-on, bill-on, trill-on, …
+
+    SCALE-LONG   Long scale (continental European system)
+                 10^3 = thousand, 10^6 = million, 10^9 = milliard,
+                 10^12 = billion, 10^15 = billiard, …
+                 Suffix cycle: [on, ard]  →  mill-on, milliard, bill-on, …
+                 Note: suffix text is language-specific; override Suffixes in the
+                 derived configuration as needed (e.g. "on(s)"/"ard(s)" in French).
+-->
+<Numbers xmlns="Utils/NumberConvertionConfiguration.xsd">
+
+	<!-- ── Short scale ──────────────────────────────────────────────────────── -->
+	<Language
+		groupSize="3"
+		separator=" "
+		groupSeparator=","
+		zero="zero"
+		minus="minus *"
+	>
+		<Culture>SCALE-SHORT</Culture>
+		<Groups>
+			<Group level="1">
+				<Digit digit="0" string=""  />
+				<Digit digit="1" string="one" />
+				<Digit digit="2" string="two" />
+				<Digit digit="3" string="three" />
+				<Digit digit="4" string="four" />
+				<Digit digit="5" string="five" />
+				<Digit digit="6" string="six"  />
+				<Digit digit="7" string="seven" />
+				<Digit digit="8" string="eight" />
+				<Digit digit="9" string="nine" />
+			</Group>
+		</Groups>
+		<NumberScale firstLetterUpperCase="false">
+			<StaticNames>
+				<Scale value="0" string=""/>
+				<Scale value="1" string="thousand"/>
+			</StaticNames>
+			<Suffixes>
+				<Suffix>on</Suffix>
+			</Suffixes>
+		</NumberScale>
+	</Language>
+
+	<!-- ── Long scale ───────────────────────────────────────────────────────── -->
+	<Language
+		groupSize="3"
+		separator=" "
+		groupSeparator=","
+		zero="zero"
+		minus="minus *"
+	>
+		<Culture>SCALE-LONG</Culture>
+		<Groups>
+			<Group level="1">
+				<Digit digit="0" string=""  />
+				<Digit digit="1" string="one" />
+				<Digit digit="2" string="two" />
+				<Digit digit="3" string="three" />
+				<Digit digit="4" string="four" />
+				<Digit digit="5" string="five" />
+				<Digit digit="6" string="six"  />
+				<Digit digit="7" string="seven" />
+				<Digit digit="8" string="eight" />
+				<Digit digit="9" string="nine" />
+			</Group>
+		</Groups>
+		<NumberScale firstLetterUpperCase="false">
+			<StaticNames>
+				<Scale value="0" string=""/>
+				<Scale value="1" string="thousand"/>
+			</StaticNames>
+			<Suffixes>
+				<Suffix>on</Suffix>
+				<Suffix>ard</Suffix>
+			</Suffixes>
+		</NumberScale>
+	</Language>
+
+</Numbers>

--- a/Utils.NumberToString/NumberConverterResources.Designer.cs
+++ b/Utils.NumberToString/NumberConverterResources.Designer.cs
@@ -114,6 +114,13 @@ namespace Utils {
             }
         }
 
+        /// <summary>Scale base configurations (SCALE-SHORT and SCALE-LONG) for use with baseOn.</summary>
+        internal static string NumberConvertionConfiguration_SCALE {
+            get {
+                return ResourceManager.GetString("NumberConvertionConfiguration.SCALE", resourceCulture);
+            }
+        }
+
         /// <summary>Slovak number-to-string configuration.</summary>
         internal static string NumberConvertionConfiguration_SK {
             get {
@@ -285,7 +292,16 @@ namespace Utils {
                 return ResourceManager.GetString("NumberConvertionConfiguration.EN", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   British English — derived from EN via baseOn, overrides DateFormat only.
+        /// </summary>
+        internal static string NumberConvertionConfiguration_EN_GB {
+            get {
+                return ResourceManager.GetString("NumberConvertionConfiguration.EN-GB", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Recherche une chaîne localisée semblable à &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
         ///&lt;Numbers xmlns=&quot;Utils/NumberConvertionConfiguration.xsd&quot;&gt;

--- a/Utils.NumberToString/NumberConverterResources.resx
+++ b/Utils.NumberToString/NumberConverterResources.resx
@@ -121,6 +121,9 @@
   <data name="NumberConvertionConfiguration" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>NumberConverterConfigurations\NumberConvertionConfiguration.xsd;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="NumberConvertionConfiguration.SCALE" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>NumberConverterConfigurations\NumberConvertionConfiguration.SCALE.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
   <data name="NumberConvertionConfiguration.AR" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>NumberConverterConfigurations\NumberConvertionConfiguration.AR.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
@@ -147,6 +150,9 @@
   </data>
   <data name="NumberConvertionConfiguration.EN" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>NumberConverterConfigurations\NumberConvertionConfiguration.EN.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="NumberConvertionConfiguration.EN-GB" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>NumberConverterConfigurations\NumberConvertionConfiguration.EN-GB.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="NumberConvertionConfiguration.ES" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>NumberConverterConfigurations\NumberConvertionConfiguration.ES.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -108,6 +108,9 @@ namespace Utils.NumberToString
             }
         }
 
+        /// <summary>Trims whitespace from a culture identifier at registration/lookup boundaries.</summary>
+        private static string NormalizeCulture(string culture) => culture.Trim();
+
         /// <summary>
         /// Parses a configuration document into converter instances keyed by culture name.
         /// </summary>
@@ -128,7 +131,7 @@ namespace Utils.NumberToString
             var docLanguageTypes = new Dictionary<string, LanguageType>(StringComparer.OrdinalIgnoreCase);
             foreach (var lang in obj.Languages)
                 foreach (var culture in lang.Cultures ?? [])
-                    docLanguageTypes.TryAdd(culture, lang);
+                    docLanguageTypes.TryAdd(NormalizeCulture(culture), lang);
 
             var result = new Dictionary<string, NumberToStringConverter>();
             foreach (var language in obj.Languages)
@@ -139,12 +142,13 @@ namespace Utils.NumberToString
 
                 // Cache the resolved LanguageType so other documents can reference it via baseOn.
                 foreach (var culture in resolved.Cultures ?? [])
-                    _cachedLanguageTypes.TryAdd(culture, resolved);
+                    _cachedLanguageTypes.TryAdd(NormalizeCulture(culture), resolved);
 
                 foreach (var culture in resolved.Cultures ?? [])
                 {
-                    if (!result.ContainsKey(culture))
-                        result.Add(culture, ReadConverter(resolved, culture));
+                    var key = NormalizeCulture(culture);
+                    if (!result.ContainsKey(key))
+                        result.Add(key, ReadConverter(resolved, key));
                 }
             }
             return result;
@@ -269,6 +273,41 @@ namespace Utils.NumberToString
         }
 
         /// <summary>
+        /// Validates that no two variant dimensions share a canonical name or alias (case-insensitive).
+        /// </summary>
+        private static void ValidateDimensionNames(
+            IReadOnlyList<NumberToStringConverter.VariantDimension> dims, string languageIdentifier)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var d in dims)
+            {
+                if (!seen.Add(d.Name))
+                    throw new InvalidOperationException(
+                        $"[{languageIdentifier}] Duplicate variant dimension name '{d.Name}'.");
+                if (!string.IsNullOrEmpty(d.LocalName) && !seen.Add(d.LocalName))
+                    throw new InvalidOperationException(
+                        $"[{languageIdentifier}] Variant dimension alias '{d.LocalName}' for '{d.Name}' " +
+                        $"collides with an existing name or alias.");
+            }
+        }
+
+        /// <summary>
+        /// Validates that static scale entries have unique, zero-based, contiguous integer indices.
+        /// </summary>
+        private static void ValidateStaticScaleIndices(
+            IReadOnlyList<NumberType> scales, string languageIdentifier)
+        {
+            var sorted = scales.OrderBy(s => s.Value).ToList();
+            for (int i = 0; i < sorted.Count; i++)
+            {
+                if (sorted[i].Value != i)
+                    throw new InvalidOperationException(
+                        $"[{languageIdentifier}] Static scale indices must be unique and contiguous starting at 0. " +
+                        $"Expected index {i} but found {sorted[i].Value}.");
+            }
+        }
+
+        /// <summary>
         /// Builds a converter for a specific language definition and culture identifier.
         /// </summary>
         /// <param name="language">The language definition deserialized from XML.</param>
@@ -278,6 +317,7 @@ namespace Utils.NumberToString
         {
             var confScale = language.NumberScale;
 
+            ValidateStaticScaleIndices(confScale.StaticNames.Scales, languageIdentifier);
             var scale = new NumberScale(
                 confScale.StaticNames.Scales.OrderBy(n => n.Value).Select(n => n.StringValue).ToArray(),
                 confScale.Suffixes?.Values?.ToArray() ?? Array.Empty<string>(),
@@ -291,12 +331,22 @@ namespace Utils.NumberToString
                 confScale.FirstLetterUpperCase
             );
 
-            static IEnumerable<NumberToStringConverter.ReplacementRule> ParseReplacements(ReplacementsListType list) =>
-                list?.Replacements?
-                    .Where(r => r.NewValue != null)
-                    .Select(r => new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue!, r.Scope, r.OnScale,
-                        r.OnValue))
-                ?? [];
+            IEnumerable<NumberToStringConverter.ReplacementRule> ParseReplacements(ReplacementsListType list)
+            {
+                if (list?.Replacements == null) return [];
+                var rules = new List<NumberToStringConverter.ReplacementRule>();
+                foreach (var r in list.Replacements)
+                {
+                    if (r.NewValue != null)
+                        rules.Add(new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue, r.Scope, r.OnScale, r.OnValue));
+                    else if (r.FormVariants == null || r.FormVariants.Count == 0)
+                        throw new InvalidOperationException(
+                            $"[{languageIdentifier}] Replacement for '{r.OldValue}' has neither a newValue " +
+                            $"nor child form-variant elements. Either add newValue or provide at least one <Variant>.");
+                    // else: no direct newValue but has form variants — handled by ExpandFormVariants in ParseVariantRules
+                }
+                return rules;
+            }
 
             static IReadOnlyList<NumberToStringConverter.VariantDimension> ParseVariantDimensions(VariantsType variants) =>
                 variants?.Dimensions?
@@ -312,6 +362,7 @@ namespace Utils.NumberToString
             // Used when loading variant constraints from XML attributes so that <Variant genus="…">
             // and <Variant gender="…"> are treated identically after German was renamed.
             var parsedDimensions = ParseVariantDimensions(language.Variants);
+            ValidateDimensionNames(parsedDimensions, languageIdentifier);
             var nameNormalizer = parsedDimensions
                 .SelectMany(d => string.IsNullOrEmpty(d.LocalName)
                     ? (IEnumerable<(string, string)>)[(d.Name, d.Name)]
@@ -438,7 +489,13 @@ namespace Utils.NumberToString
                             ?.Values ?? (IReadOnlyList<string>)[];
 
                         var entries = node.Forms.Split(',');
-                        for (int i = 0; i < Math.Min(entries.Length, dimValues.Count); i++)
+                        if (entries.Length != dimValues.Count)
+                            throw new InvalidOperationException(
+                                $"Dimension '{dimName}' declares {dimValues.Count} value(s) " +
+                                $"({string.Join(", ", dimValues)}) but forms=\"{node.Forms}\" " +
+                                $"supplies {entries.Length} entry/entries. " +
+                                $"The number of comma-separated forms must match the number of declared dimension values.");
+                        for (int i = 0; i < dimValues.Count; i++)
                         {
                             var form = entries[i].Trim();
                             if (string.IsNullOrEmpty(form)) continue;

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -446,7 +446,10 @@ namespace Utils.NumberToString
                         throw new InvalidOperationException(
                             $"[{languageIdentifier}] Replacement for '{r.OldValue}' inside a Variant rule has neither " +
                             $"a newValue nor child form-variant elements.");
-                    // else: form variants on nested replacements are currently not expanded in this path.
+                    else
+                        throw new InvalidOperationException(
+                            $"[{languageIdentifier}] Replacement for '{r.OldValue}' inside a Variant rule has form-variant " +
+                            $"children, which are not supported at this nesting level. Use a flat Variant element instead.");
                 }
 
                 foreach (var dimValue in dimValues)

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -167,7 +167,7 @@ namespace Utils.NumberToString
             LanguageType child,
             IReadOnlyDictionary<string, LanguageType> docLanguages)
         {
-            string baseKey = child.BaseOn;
+            string baseKey = NormalizeCulture(child.BaseOn);
 
             // Prefer the already-resolved version from the cache (handles multi-document chains
             // and in-order same-document chains where the base was already processed).
@@ -434,11 +434,17 @@ namespace Utils.NumberToString
                             ? [variant.VariantValue]
                             : [""];
 
-                var replacements = (variant.Replacements ?? [])
-                    .Where(r => r.NewValue != null)
-                    .Select(r => new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue!, r.Scope, r.OnScale,
-                        r.OnValue))
-                    .ToList();
+                var replacements = new List<NumberToStringConverter.ReplacementRule>();
+                foreach (var r in variant.Replacements ?? [])
+                {
+                    if (r.NewValue != null)
+                        replacements.Add(new NumberToStringConverter.ReplacementRule(r.OldValue, r.NewValue, r.Scope, r.OnScale, r.OnValue));
+                    else if (r.FormVariants == null || r.FormVariants.Count == 0)
+                        throw new InvalidOperationException(
+                            $"[{languageIdentifier}] Replacement for '{r.OldValue}' inside a Variant rule has neither " +
+                            $"a newValue nor child form-variant elements.");
+                    // else: form variants on nested replacements are currently not expanded in this path.
+                }
 
                 foreach (var dimValue in dimValues)
                 {
@@ -498,7 +504,11 @@ namespace Utils.NumberToString
                         for (int i = 0; i < dimValues.Count; i++)
                         {
                             var form = entries[i].Trim();
-                            if (string.IsNullOrEmpty(form)) continue;
+                            if (string.IsNullOrEmpty(form))
+                                throw new InvalidOperationException(
+                                    $"Dimension '{dimName}' value '{dimValues[i]}' (index {i}) has an empty form " +
+                                    $"in forms=\"{node.Forms}\". All entries must be non-empty; " +
+                                    $"use a named Variant element for partial mappings.");
                             var leafConstraints = new Dictionary<string, string>(constraints, StringComparer.OrdinalIgnoreCase)
                                 { [dimName] = dimValues[i] };
                             yield return (leafConstraints, form);

--- a/Utils.NumberToString/NumberToStringConverter.Globalization.cs
+++ b/Utils.NumberToString/NumberToStringConverter.Globalization.cs
@@ -17,12 +17,15 @@ namespace Utils.NumberToString
         static NumberToStringConverter()
         {
             InitializeConfigurations(
+                // Scale bases must be loaded before any language that uses baseOn to reference them.
+                NumberConverterResources.NumberConvertionConfiguration_SCALE,
                 NumberConverterResources.NumberConvertionConfiguration_FR_fr_ca,
                 NumberConverterResources.NumberConvertionConfiguration_FR_be_ch,
                 NumberConverterResources.NumberConvertionConfiguration_DE,
                 NumberConverterResources.NumberConvertionConfiguration_DE_ch,
                 NumberConverterResources.NumberConvertionConfiguration_DA,
                 NumberConverterResources.NumberConvertionConfiguration_EN,
+                NumberConverterResources.NumberConvertionConfiguration_EN_GB,
                 NumberConverterResources.NumberConvertionConfiguration_ES,
                 NumberConverterResources.NumberConvertionConfiguration_BG,
                 NumberConverterResources.NumberConvertionConfiguration_CA,

--- a/Utils.NumberToString/NumberToStringConverter.cs
+++ b/Utils.NumberToString/NumberToStringConverter.cs
@@ -35,6 +35,7 @@ namespace Utils.NumberToString
         public static NumberToStringConverter GetConverter(string culture)
         {
             ArgumentException.ThrowIfNullOrEmpty(culture);
+            culture = culture.Trim();
             if (culture.Length < 2)
                 throw new ArgumentException("Culture code must be at least 2 characters.", nameof(culture));
 

--- a/Utils.NumberToString/TODO-2026-07-11-pass4.md
+++ b/Utils.NumberToString/TODO-2026-07-11-pass4.md
@@ -26,15 +26,9 @@ The static constructor initializes every embedded language configuration in one 
 
 **Priority: P1 availability and deployment safety.**
 
-### 88. `forms=` cardinal expansion silently truncates mismatched form counts
+### 88. `forms=` cardinal expansion silently truncates mismatched form counts ✅ Fixed PR #509
 
-`ExpandFormVariants` splits `forms` and iterates only to `Math.Min(entries.Length, dimValues.Count)`. Extra forms are ignored; missing forms leave declared dimension values without a rule; empty entries are skipped silently.
-
-**Risk:** a typo or reordered dimension list changes grammatical output without configuration failure. The XSD documentation presents positional forms as mapping to the dimension's ordered values, but the implementation accepts incomplete or surplus mappings.
-
-**Fix:** require the number of entries to equal the number of declared dimension values, unless an explicit sparse syntax is introduced. Report the dimension, expected values, supplied forms, and XML location.
-
-**Priority: P1 linguistic configuration correctness.**
+`ExpandFormVariants` now requires `entries.Length == dimValues.Count` and throws `InvalidOperationException` with dimension name, expected count, and supplied count when they differ.
 
 ### 89. Implicit ordinal fallback depends on traversal/declaration order
 
@@ -46,25 +40,13 @@ When an ordinal exception/rule omits its base `string`/`to` and supplies form va
 
 **Priority: P1 deterministic linguistic behavior.**
 
-### 90. Dimension aliases can collide during XML loading before contextual validation
+### 90. Dimension aliases can collide during XML loading before contextual validation ✅ Fixed PR #509
 
-The loader builds `nameNormalizer` with `ToDictionary` over canonical names and local aliases. Two dimensions sharing a canonical name/alias, or one alias equal to another canonical name case-insensitively, throw a generic duplicate-key exception before `ValidateVariantReferences` can provide a language-specific diagnostic.
+`ValidateDimensionNames` now validates canonical names and aliases (case-insensitive) before `nameNormalizer` is built, throwing `InvalidOperationException` with the colliding name and culture identifier.
 
-**Risk:** configuration failure lacks the conflicting dimension declarations and can be difficult to trace in a large locale file.
+### 91. Culture identifiers are accepted without canonical normalization ✅ Fixed PR #509
 
-**Fix:** validate canonical names and aliases explicitly before dictionary construction, reject empty/whitespace names and case-insensitive collisions, and include the culture/language path in diagnostics.
-
-**Priority: P1 configuration diagnostics.**
-
-### 91. Culture identifiers are accepted without canonical normalization
-
-Culture strings from XML and public registration are used directly as dictionary keys with case-insensitive comparison, but are not trimmed, normalized through `CultureInfo`, or validated as BCP-47 identifiers. Values such as `"fr-FR "`, underscore variants, or malformed subtags can become registered yet unreachable through normal lookup/fallback.
-
-**Risk:** apparently registered cultures silently fall back to another language, while duplicate logical cultures may exist under non-canonical spellings.
-
-**Fix:** trim and canonicalize identifiers at parse/registration boundaries, preserve explicitly supported neutral/custom identifiers through a documented policy, and reject malformed or colliding canonical keys.
-
-**Priority: P1 lookup correctness.**
+`NormalizeCulture` (trim) is applied at all registration/lookup boundaries in `ReadConfiguration` and at the top of `GetConverter`. Culture keys with leading/trailing whitespace now resolve to the same converter as their trimmed equivalent.
 
 ### 92. `baseOn` cannot distinguish “inherit” from intentional empty overrides for many fields
 
@@ -78,27 +60,13 @@ Culture strings from XML and public registration are used directly as dictionary
 
 ## Medium priority
 
-### 93. Static scale names are sorted but not checked for contiguous scale indices
+### 93. Static scale names are sorted but not checked for contiguous scale indices ✅ Fixed PR #509
 
-`ReadConverter` orders static scale entries by their numeric `value` and then discards the values, passing only the strings to `NumberScale`. Missing, duplicate, or non-zero-based indices therefore shift names to different scale positions instead of preserving/rejecting the declared mapping.
+`ValidateStaticScaleIndices` now requires the sorted `value` attributes to be unique, contiguous integers starting at 0, throwing `InvalidOperationException` with the expected vs. found index.
 
-**Risk:** a missing scale entry can make every subsequent large number use the wrong scale name.
+### 94. XML replacements without `newValue` are silently omitted outside form variants ✅ Fixed PR #509
 
-**Fix:** require unique contiguous indices starting at the documented base, or store static names in an indexed dictionary that preserves explicit positions and rejects holes according to policy.
-
-**Priority: P2 scale correctness.**
-
-### 94. XML replacements without `newValue` are silently omitted outside form variants
-
-`ParseReplacements` filters out entries whose `NewValue` is null. This is valid when child form variants provide all replacements, but an accidentally omitted `newValue` with no valid child forms disappears without error.
-
-The same filtering occurs for replacements nested in variant rules.
-
-**Risk:** intended transformations simply do not run and no configuration diagnostic identifies the incomplete rule.
-
-**Fix:** require either a base replacement value or at least one valid expanded variant form. Reject empty rules after expansion and report their `oldValue` and owning culture.
-
-**Priority: P2 configuration diagnostics.**
+`ParseReplacements` now throws `InvalidOperationException` for any replacement that has neither `newValue` nor at least one `<Variant>` child, identifying the `oldValue` and culture in the message.
 
 ### 95. The schema permits structurally weak digit and fraction lists that runtime assumes are complete
 

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
@@ -1418,4 +1418,206 @@ public class NumberToStringConverterAuditFixesTests
         Assert.AreEqual("two/second", result,
             $"First-day overrides must not apply for day 2; got: '{result}'");
     }
+
+    // ── Item 88 — forms= count must match dimension value count ──────────────
+
+    [TestMethod]
+    public void ReadConfiguration_FormsTooFew_ThrowsInvalidOperation()
+    {
+        // Dimension declares 3 values; forms= provides only 2 → must reject.
+        string xml = BuildXmlWithForms("dim1", "a,b,c", "X,Y");
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "dim1",
+            "Exception must identify the offending dimension name");
+        StringAssert.Contains(ex.Message, "3",
+            "Exception must state the expected count");
+        StringAssert.Contains(ex.Message, "2",
+            "Exception must state the actual count");
+    }
+
+    [TestMethod]
+    public void ReadConfiguration_FormsTooMany_ThrowsInvalidOperation()
+    {
+        // Dimension declares 2 values; forms= provides 3 → must reject.
+        string xml = BuildXmlWithForms("dim1", "a,b", "X,Y,Z");
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "dim1");
+    }
+
+    [TestMethod]
+    public void ReadConfiguration_FormsExactCount_Succeeds()
+    {
+        // Exact count (2 values, 2 forms) must load without error.
+        string xml = BuildXmlWithForms("dim1", "a,b", "X,Y");
+        var converters = NumberToStringConverter.ReadConfiguration(xml);
+        Assert.IsTrue(converters.Count > 0, "Valid forms count must produce at least one converter");
+    }
+
+    // ── Item 90 — dimension alias collisions are reported clearly ─────────────
+
+    [TestMethod]
+    public void ReadConfiguration_DuplicateDimensionName_ThrowsInvalidOperation()
+    {
+        // Two dimensions with the same canonical name must be rejected.
+        string xml = BuildXmlWithDuplicateDimension(canonical1: "gender", alias1: null,
+                                                    canonical2: "gender", alias2: null);
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "gender",
+            "Exception must identify the colliding dimension name");
+    }
+
+    [TestMethod]
+    public void ReadConfiguration_AliasCollidesWithCanonicalName_ThrowsInvalidOperation()
+    {
+        // Dimension "case" with alias "gender" collides with the canonical name of another dimension "gender".
+        string xml = BuildXmlWithDuplicateDimension(canonical1: "gender", alias1: null,
+                                                    canonical2: "case", alias2: "gender");
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "gender");
+    }
+
+    // ── Item 91 — culture identifiers are trimmed at registration boundaries ──
+
+    [TestMethod]
+    public void GetConverter_CultureWithLeadingTrailingSpace_ResolvesSamAsWithout()
+    {
+        // "EN" and " EN " must resolve to the same converter.
+        var plain = NumberToStringConverter.GetConverter("EN");
+        var spaced = NumberToStringConverter.GetConverter(" EN ");
+        Assert.AreSame(plain, spaced,
+            "GetConverter must trim whitespace from culture identifiers before lookup");
+    }
+
+    [TestMethod]
+    public void ReadConfiguration_CultureWithSpaces_RegisteredAndLookupSucceeds()
+    {
+        // A culture registered as " XTEST " must be found as "XTEST".
+        string xml = BuildMinimalXml(" XTEST ");
+        var converters = NumberToStringConverter.ReadConfiguration(xml);
+        Assert.IsTrue(converters.ContainsKey("XTEST"),
+            "ReadConfiguration must trim culture keys before registering them");
+    }
+
+    // ── Item 93 — static scale indices must be zero-based and contiguous ──────
+
+    [TestMethod]
+    public void ReadConfiguration_StaticScaleSkipsIndex_ThrowsInvalidOperation()
+    {
+        // indices 0 and 2 (gap at 1) must be rejected.
+        string xml = BuildXmlWithScaleIndices(0, 2);
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "contiguous",
+            "Exception must mention contiguous indices requirement");
+    }
+
+    [TestMethod]
+    public void ReadConfiguration_StaticScaleStartsAtOne_ThrowsInvalidOperation()
+    {
+        // An index starting at 1 (missing 0) must be rejected.
+        string xml = BuildXmlWithScaleIndices(1, 2);
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "0",
+            "Exception must mention that index 0 is expected first");
+    }
+
+    [TestMethod]
+    public void ReadConfiguration_StaticScaleContiguous_Succeeds()
+    {
+        // Indices 0, 1 (the normal pattern) must succeed.
+        string xml = BuildXmlWithScaleIndices(0, 1);
+        var converters = NumberToStringConverter.ReadConfiguration(xml);
+        Assert.IsTrue(converters.Count > 0, "Contiguous scale indices must load successfully");
+    }
+
+    // ── Item 94 — replacement without newValue or form variants is rejected ───
+
+    [TestMethod]
+    public void ReadConfiguration_ReplacementWithoutNewValueOrVariants_ThrowsInvalidOperation()
+    {
+        string xml = BuildXmlWithBareReplacement("one");
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "one",
+            "Exception must identify the incomplete replacement's oldValue");
+        StringAssert.Contains(ex.Message, "newValue",
+            "Exception must mention the missing newValue");
+    }
+
+    // ── XML helpers for configuration audit tests ─────────────────────────────
+
+    private static string BuildXmlWithForms(string dimName, string dimValues, string forms) => $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Numbers xmlns=""Utils/NumberConvertionConfiguration.xsd"">
+  <Language groupSize=""3"" separator="" "" groupSeparator="","" zero=""zero"" minus=""minus *"">
+    <Culture>XTEST</Culture>
+    <Groups><Group level=""1""><Digit digit=""0"" string=""zero"" /><Digit digit=""1"" string=""one"" /></Group></Groups>
+    <NumberScale><StaticNames><Scale value=""0"" string="""" /></StaticNames></NumberScale>
+    <Variants>
+      <Dimension name=""{dimName}"" values=""{dimValues}"" />
+    </Variants>
+    <Replacements>
+      <Replacement oldValue=""zero"" scope=""Standalone"">
+        <Variant type=""{dimName}"" forms=""{forms}"" />
+      </Replacement>
+    </Replacements>
+  </Language>
+</Numbers>";
+
+    private static string BuildXmlWithDuplicateDimension(
+        string canonical1, string? alias1, string canonical2, string? alias2)
+    {
+        string attr1 = alias1 != null ? $@" localName=""{alias1}""" : "";
+        string attr2 = alias2 != null ? $@" localName=""{alias2}""" : "";
+        return $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Numbers xmlns=""Utils/NumberConvertionConfiguration.xsd"">
+  <Language groupSize=""3"" separator="" "" groupSeparator="","" zero=""zero"" minus=""minus *"">
+    <Culture>XTEST</Culture>
+    <Groups><Group level=""1""><Digit digit=""0"" string=""zero"" /><Digit digit=""1"" string=""one"" /></Group></Groups>
+    <NumberScale><StaticNames><Scale value=""0"" string="""" /></StaticNames></NumberScale>
+    <Variants>
+      <Dimension name=""{canonical1}""{attr1} values=""a,b"" />
+      <Dimension name=""{canonical2}""{attr2} values=""x,y"" />
+    </Variants>
+  </Language>
+</Numbers>";
+    }
+
+    private static string BuildMinimalXml(string culture) => $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Numbers xmlns=""Utils/NumberConvertionConfiguration.xsd"">
+  <Language groupSize=""3"" separator="" "" groupSeparator="","" zero=""zero"" minus=""minus *"">
+    <Culture>{culture}</Culture>
+    <Groups><Group level=""1""><Digit digit=""0"" string=""zero"" /><Digit digit=""1"" string=""one"" /></Group></Groups>
+    <NumberScale><StaticNames><Scale value=""0"" string="""" /></StaticNames></NumberScale>
+  </Language>
+</Numbers>";
+
+    private static string BuildXmlWithScaleIndices(params int[] indices)
+    {
+        var scales = string.Concat(indices.Select(i => $@"<Scale value=""{i}"" string=""s{i}"" />"));
+        return $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Numbers xmlns=""Utils/NumberConvertionConfiguration.xsd"">
+  <Language groupSize=""3"" separator="" "" groupSeparator="","" zero=""zero"" minus=""minus *"">
+    <Culture>XTEST</Culture>
+    <Groups><Group level=""1""><Digit digit=""0"" string=""zero"" /><Digit digit=""1"" string=""one"" /></Group></Groups>
+    <NumberScale><StaticNames>{scales}</StaticNames></NumberScale>
+  </Language>
+</Numbers>";
+    }
+
+    private static string BuildXmlWithBareReplacement(string oldValue) => $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Numbers xmlns=""Utils/NumberConvertionConfiguration.xsd"">
+  <Language groupSize=""3"" separator="" "" groupSeparator="","" zero=""zero"" minus=""minus *"">
+    <Culture>XTEST</Culture>
+    <Groups><Group level=""1""><Digit digit=""0"" string=""zero"" /><Digit digit=""1"" string=""one"" /></Group></Groups>
+    <NumberScale><StaticNames><Scale value=""0"" string="""" /></StaticNames></NumberScale>
+    <Replacements>
+      <Replacement oldValue=""{oldValue}"" scope=""Standalone"" />
+    </Replacements>
+  </Language>
+</Numbers>";
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
@@ -1549,6 +1549,61 @@ public class NumberToStringConverterAuditFixesTests
             "Exception must mention the missing newValue");
     }
 
+    // ── Follow-up: baseOn normalization (review finding) ─────────────────────
+
+    [TestMethod]
+    public void ReadConfiguration_BaseOnWithSpaces_ResolvesSuccessfully()
+    {
+        // Base culture registered with spaces; child references it via baseOn with spaces.
+        // Both must load without error, proving NormalizeCulture is applied to baseOn.
+        string xml = BuildXmlWithBaseOn(baseCulture: " XBASE ", childCulture: "XCHILD", baseOnValue: " XBASE ");
+        var converters = NumberToStringConverter.ReadConfiguration(xml);
+        Assert.IsTrue(converters.ContainsKey("XBASE"), "Base culture must be registered as 'XBASE'");
+        Assert.IsTrue(converters.ContainsKey("XCHILD"), "Child culture must resolve baseOn and load successfully");
+    }
+
+    // ── Follow-up: empty entries inside forms= are rejected (review finding) ──
+
+    [TestMethod]
+    public void ReadConfiguration_FormsWithLeadingEmptyEntry_ThrowsInvalidOperation()
+    {
+        // Count matches (2 values, 2 entries) but first entry is empty → must reject.
+        string xml = BuildXmlWithForms("dim1", "a,b", ",b");
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "dim1",
+            "Exception must identify the dimension");
+        StringAssert.Contains(ex.Message, "a",
+            "Exception must identify the dimension value that lacks a form");
+    }
+
+    [TestMethod]
+    public void ReadConfiguration_FormsWithTrailingEmptyEntry_ThrowsInvalidOperation()
+    {
+        // Count matches (2 values, 2 entries) but last entry is empty → must reject.
+        string xml = BuildXmlWithForms("dim1", "a,b", "X,");
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "dim1");
+        StringAssert.Contains(ex.Message, "b",
+            "Exception must identify the dimension value that lacks a form");
+    }
+
+    // ── Follow-up: item 94 in nested Variant rules (review finding) ───────────
+
+    [TestMethod]
+    public void ReadConfiguration_NestedVariantBareReplacement_ThrowsInvalidOperation()
+    {
+        // A <Replacement> inside a <Variant> rule with no newValue and no <Variant> children must throw.
+        string xml = BuildXmlWithNestedBareReplacement(dimName: "gender", dimValues: "a,b", dimValue: "a", oldValue: "one");
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "one",
+            "Exception must identify the incomplete replacement's oldValue");
+        StringAssert.Contains(ex.Message, "newValue",
+            "Exception must mention the missing newValue");
+    }
+
     // ── XML helpers for configuration audit tests ─────────────────────────────
 
     private static string BuildXmlWithForms(string dimName, string dimValues, string forms) => $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
@@ -1618,6 +1673,36 @@ public class NumberToStringConverterAuditFixesTests
     <Replacements>
       <Replacement oldValue=""{oldValue}"" scope=""Standalone"" />
     </Replacements>
+  </Language>
+</Numbers>";
+
+    private static string BuildXmlWithBaseOn(string baseCulture, string childCulture, string baseOnValue) => $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Numbers xmlns=""Utils/NumberConvertionConfiguration.xsd"">
+  <Language groupSize=""3"" separator="" "" groupSeparator="","" zero=""zero"" minus=""minus *"">
+    <Culture>{baseCulture}</Culture>
+    <Groups><Group level=""1""><Digit digit=""0"" string=""zero"" /><Digit digit=""1"" string=""one"" /></Group></Groups>
+    <NumberScale><StaticNames><Scale value=""0"" string="""" /></StaticNames></NumberScale>
+  </Language>
+  <Language groupSize=""3"" separator="" "" groupSeparator="","" zero=""zero"" minus=""minus *"" baseOn=""{baseOnValue}"">
+    <Culture>{childCulture}</Culture>
+    <Groups><Group level=""1""><Digit digit=""0"" string=""zero"" /><Digit digit=""1"" string=""one"" /></Group></Groups>
+    <NumberScale><StaticNames><Scale value=""0"" string="""" /></StaticNames></NumberScale>
+  </Language>
+</Numbers>";
+
+    private static string BuildXmlWithNestedBareReplacement(
+        string dimName, string dimValues, string dimValue, string oldValue) => $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Numbers xmlns=""Utils/NumberConvertionConfiguration.xsd"">
+  <Language groupSize=""3"" separator="" "" groupSeparator="","" zero=""zero"" minus=""minus *"">
+    <Culture>XTEST</Culture>
+    <Groups><Group level=""1""><Digit digit=""0"" string=""zero"" /><Digit digit=""1"" string=""one"" /></Group></Groups>
+    <NumberScale><StaticNames><Scale value=""0"" string="""" /></StaticNames></NumberScale>
+    <Variants>
+      <Dimension name=""{dimName}"" values=""{dimValues}"" />
+      <Variant type=""{dimName}"" variant=""{dimValue}"">
+        <Replacement oldValue=""{oldValue}"" scope=""Standalone"" />
+      </Variant>
+    </Variants>
   </Language>
 </Numbers>";
 }

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterAuditFixesTests.cs
@@ -1604,6 +1604,22 @@ public class NumberToStringConverterAuditFixesTests
             "Exception must mention the missing newValue");
     }
 
+    [TestMethod]
+    public void ReadConfiguration_NestedVariantFormVariantReplacement_ThrowsInvalidOperation()
+    {
+        // A <Replacement> inside a structural <Variant> rule that has form-variant children
+        // (instead of newValue) must be rejected — not silently ignored.
+        string xml = BuildXmlWithNestedFormVariantReplacement(
+            structDim: "case", structValues: "nom,acc", structValue: "acc",
+            formDim: "gender", formValues: "m,f", oldValue: "one");
+        var ex = Assert.ThrowsException<InvalidOperationException>(
+            () => NumberToStringConverter.ReadConfiguration(xml));
+        StringAssert.Contains(ex.Message, "one",
+            "Exception must identify the replacement's oldValue");
+        StringAssert.Contains(ex.Message, "form-variant",
+            "Exception must mention form-variant children");
+    }
+
     // ── XML helpers for configuration audit tests ─────────────────────────────
 
     private static string BuildXmlWithForms(string dimName, string dimValues, string forms) => $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
@@ -1701,6 +1717,26 @@ public class NumberToStringConverterAuditFixesTests
       <Dimension name=""{dimName}"" values=""{dimValues}"" />
       <Variant type=""{dimName}"" variant=""{dimValue}"">
         <Replacement oldValue=""{oldValue}"" scope=""Standalone"" />
+      </Variant>
+    </Variants>
+  </Language>
+</Numbers>";
+
+    private static string BuildXmlWithNestedFormVariantReplacement(
+        string structDim, string structValues, string structValue,
+        string formDim, string formValues, string oldValue) => $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Numbers xmlns=""Utils/NumberConvertionConfiguration.xsd"">
+  <Language groupSize=""3"" separator="" "" groupSeparator="","" zero=""zero"" minus=""minus *"">
+    <Culture>XTEST</Culture>
+    <Groups><Group level=""1""><Digit digit=""0"" string=""zero"" /><Digit digit=""1"" string=""one"" /></Group></Groups>
+    <NumberScale><StaticNames><Scale value=""0"" string="""" /></StaticNames></NumberScale>
+    <Variants>
+      <Dimension name=""{structDim}"" values=""{structValues}"" />
+      <Dimension name=""{formDim}"" values=""{formValues}"" />
+      <Variant type=""{structDim}"" variant=""{structValue}"">
+        <Replacement oldValue=""{oldValue}"" scope=""Standalone"">
+          <Variant type=""{formDim}"" forms=""x,y"" />
+        </Replacement>
       </Variant>
     </Variants>
   </Language>

--- a/UtilsTest/Mathematics/Numbers/NumberToStringConverterTimeAndNewLangTests.cs
+++ b/UtilsTest/Mathematics/Numbers/NumberToStringConverterTimeAndNewLangTests.cs
@@ -335,4 +335,81 @@ public class NumberToStringConverterTimeAndNewLangTests
         Assert.IsFalse(hr.SupportsTimeConversion);
         Assert.ThrowsException<NotSupportedException>(() => hr.Convert(new TimeSpan(1, 0, 0)));
     }
+
+    // ─── EN-GB (British English, derived from EN via baseOn) ──────────────────
+
+    [TestMethod]
+    public void Convert_EN_GB_BasicNumbers_SameAsEN()
+    {
+        // Numbers must be identical to EN since EN-GB inherits all number rules.
+        var en = NumberToStringConverter.GetConverter("EN");
+        var gb = NumberToStringConverter.GetConverter("EN-GB");
+        Assert.AreEqual(en.Convert(0),        gb.Convert(0));
+        Assert.AreEqual(en.Convert(1),        gb.Convert(1));
+        Assert.AreEqual(en.Convert(42),       gb.Convert(42));
+        Assert.AreEqual(en.Convert(1_000),    gb.Convert(1_000));
+        Assert.AreEqual(en.Convert(1_000_000), gb.Convert(1_000_000));
+    }
+
+    [TestMethod]
+    public void Convert_EN_GB_DateFormat_DayBeforeMonth()
+    {
+        // British format: {ordinal-day} {month} {year} → "second July ..."
+        var gb = NumberToStringConverter.GetConverter("EN-GB");
+        Assert.IsTrue(gb.SupportsDateConversion);
+        string result = gb.Convert(new DateOnly(2026, 7, 2));
+        Assert.IsTrue(result.StartsWith("second July"),
+            $"British date must start with ordinal-day then month; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void Convert_EN_GB_DateFormat_FirstOfMonth()
+    {
+        // firstDay override must still apply in British format.
+        var gb = NumberToStringConverter.GetConverter("EN-GB");
+        string result = gb.Convert(new DateOnly(2026, 7, 1));
+        Assert.IsTrue(result.StartsWith("first July"),
+            $"British date for day 1 must use 'first'; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void Convert_EN_US_DateFormat_MonthBeforeDay()
+    {
+        // American format: {month} {ordinal-day}, {year} — unchanged.
+        var us = NumberToStringConverter.GetConverter("EN-us");
+        string result = us.Convert(new DateOnly(2026, 7, 2));
+        Assert.IsTrue(result.StartsWith("July second"),
+            $"American date must start with month then ordinal-day; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void GetConverter_EN_uk_UsesBritishDateFormat()
+    {
+        // EN-uk culture alias moved to EN-GB; must use British date format.
+        var uk  = NumberToStringConverter.GetConverter("EN-uk");
+        string result = uk.Convert(new DateOnly(2026, 7, 2));
+        Assert.IsTrue(result.StartsWith("second July"),
+            $"EN-uk must use British date format; got: '{result}'");
+    }
+
+    [TestMethod]
+    public void Convert_EN_GB_Ordinals_SameAsEN()
+    {
+        var en = NumberToStringConverter.GetConverter("EN");
+        var gb = NumberToStringConverter.GetConverter("EN-GB");
+        Assert.IsTrue(gb.SupportsOrdinals);
+        Assert.AreEqual(en.ConvertOrdinal(1),  gb.ConvertOrdinal(1));
+        Assert.AreEqual(en.ConvertOrdinal(2),  gb.ConvertOrdinal(2));
+        Assert.AreEqual(en.ConvertOrdinal(21), gb.ConvertOrdinal(21));
+    }
+
+    [TestMethod]
+    public void Convert_EN_GB_ScaleNames_InheritedFromScaleShort()
+    {
+        // EN-GB inherits EN → SCALE-SHORT chain; scale names must match EN exactly.
+        var en = NumberToStringConverter.GetConverter("EN");
+        var gb = NumberToStringConverter.GetConverter("EN-GB");
+        Assert.AreEqual(en.Convert(1_000_000_000L),     gb.Convert(1_000_000_000L));
+        Assert.AreEqual(en.Convert(1_000_000_000_000L), gb.Convert(1_000_000_000_000L));
+    }
 }


### PR DESCRIPTION
## Summary

This PR now combines two related pieces of work in `Utils.NumberToString`:

1. **Configuration validation and diagnostics** for audit items 88, 90, 91, 93 and 94.
2. **Shared scale bases and British English support** through the existing `baseOn` inheritance mechanism.

## Audit fixes

- **Item 88 — `forms=` cardinality and completeness**
  - Rejects too few or too many comma-separated entries.
  - Rejects empty positional entries instead of silently skipping them.
  - Diagnostics include the dimension, expected values, actual count and offending index/value.

- **Item 90 — variant dimension name collisions**
  - Validates canonical dimension names and local aliases case-insensitively before building the normalizer.
  - Reports duplicate names and alias collisions with the owning culture.

- **Item 91 — culture normalization**
  - Trims culture identifiers at registration and lookup boundaries.
  - Applies the same normalization to `baseOn` references.
  - `GetConverter(" EN ")` now resolves identically to `GetConverter("EN")`.

- **Item 93 — static scale indices**
  - Requires unique, zero-based and contiguous static scale indices.
  - Rejects gaps, duplicates and non-zero starts with an explicit diagnostic.

- **Item 94 — invalid replacement definitions**
  - Rejects replacements without `newValue` or usable form variants.
  - Applies the validation to both top-level replacements and replacements nested inside structural `Variant` rules.
  - Explicitly rejects form-variant children at unsupported nesting levels instead of silently discarding them.

## Shared scale configurations

Adds `NumberConvertionConfiguration.SCALE.xml` with two reusable inheritance bases:

- `SCALE-SHORT` — short scale (`thousand`, `million`, `billion`, `trillion`, …)
- `SCALE-LONG` — long scale infrastructure (`thousand`, `million`, `milliard`, `billion`, `billiard`, …)

The scale configuration is loaded before language files so derived configurations can reference it through `baseOn`.

## English configuration changes

- `EN` now inherits its number scale from `SCALE-SHORT`.
- The redundant `<NumberScale>` block was removed from the English configuration.
- `EN-us` remains attached to the American English date format.

## British English

Adds `NumberConvertionConfiguration.EN-GB.xml`, derived from `EN` via `baseOn="EN"`.

It inherits number, ordinal, fraction, time, year and scale rules, and overrides only the date pattern:

```text
American: July second, two thousand twenty-six
British:  second July two thousand twenty-six
```

Registered cultures:

- `EN-GB`
- `EN-uk`

## Inheritance chain

```text
SCALE-SHORT
    └── EN / EN-us
        └── EN-GB / EN-uk
```

## Test coverage

- `forms=` too few, too many, exact count and empty-entry cases
- duplicate dimension names and alias collisions
- culture trimming and normalized `baseOn`
- invalid static scale indices and valid contiguous indices
- incomplete replacements at top level and inside structural variants
- unsupported nested form-variant replacements
- EN-GB basic numbers, ordinals and inherited scale names
- American and British date formats
- first day of month rendering
- `EN-uk` alias routing
- existing regression suite passes

## Notes

- `SCALE-LONG` is infrastructure for future language configurations and is not yet used by an existing locale.
- The scale bases are registered through the same configuration cache as ordinary cultures.

🤖 Generated with Claude Code and updated after review.