### PR TITLE
fix(Utils.Net): items 40/43/59/62/64/65/67/68 - NetworkParameters, SMTP, POP3, NNTP

### DIFF
--- a/Utils.Net/Net/NetworkParameters.cs
+++ b/Utils.Net/Net/NetworkParameters.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Net;
 using System.Net.NetworkInformation;
-using System.Text;
 
 namespace Utils.Net
 {
@@ -12,6 +10,8 @@ namespace Utils.Net
     /// </summary>
     public class NetworkParameters
     {
+        private readonly IPAddress[] _dnsServers;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NetworkParameters"/> class and snapshots network information.
         /// </summary>
@@ -28,29 +28,29 @@ namespace Utils.Net
                     if (ipProperties.GatewayAddresses == null || ipProperties.GatewayAddresses.Count == 0) continue;
                     IPAddressCollection dnsAddresses = ipProperties.DnsAddresses;
 
-
                     foreach (IPAddress dnsAdress in dnsAddresses)
                     {
                         dnsServers.Add(dnsAdress);
                     }
                 }
             }
-            DnsServers = dnsServers.ToImmutableArray();
-            PrimaryDns = dnsServers.FirstOrDefault();
+            _dnsServers = dnsServers.ToArray();
+            PrimaryDns = _dnsServers.Length > 0 ? _dnsServers[0] : null;
         }
 
         /// <summary>
         /// Gets the network interfaces detected on the host at construction time.
         /// </summary>
         public NetworkInterface[] NetworkInterfaces { get; private set; }
+
         /// <summary>
         /// Gets the preferred DNS server resolved from the network interfaces, or <see langword="null"/> if no DNS server was discovered.
         /// </summary>
         public IPAddress? PrimaryDns { get; }
+
         /// <summary>
         /// Gets the collection of DNS servers discovered for the active network interfaces.
         /// </summary>
-        public IReadOnlyList< IPAddress> DnsServers { get; private set; }
-
+        public IPAddress[] DnsServers => (IPAddress[])_dnsServers.Clone();
     }
 }

--- a/Utils.Net/Net/NetworkParameters.cs
+++ b/Utils.Net/Net/NetworkParameters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Text;
@@ -34,7 +35,8 @@ namespace Utils.Net
                     }
                 }
             }
-            DnsServers = dnsServers.ToArray();
+            DnsServers = dnsServers.ToImmutableArray();
+            PrimaryDns = dnsServers.FirstOrDefault();
         }
 
         /// <summary>
@@ -42,13 +44,13 @@ namespace Utils.Net
         /// </summary>
         public NetworkInterface[] NetworkInterfaces { get; private set; }
         /// <summary>
-        /// Gets the preferred DNS server resolved from the network interfaces.
+        /// Gets the preferred DNS server resolved from the network interfaces, or <see langword="null"/> if no DNS server was discovered.
         /// </summary>
-        public IPAddress PrimaryDns => DnsServers[0];
+        public IPAddress? PrimaryDns { get; }
         /// <summary>
         /// Gets the collection of DNS servers discovered for the active network interfaces.
         /// </summary>
-        public IPAddress[] DnsServers { get; private set; }
+        public IReadOnlyList< IPAddress> DnsServers { get; private set; }
 
     }
 }

--- a/Utils.Net/Net/NntpClient.cs
+++ b/Utils.Net/Net/NntpClient.cs
@@ -143,7 +143,7 @@ public class NntpClient : CommandResponseClient
         DateTime utc = sinceUtc.Kind == DateTimeKind.Local ? sinceUtc.ToUniversalTime() : DateTime.SpecifyKind(sinceUtc, DateTimeKind.Utc);
         string date = utc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
         string time = utc.ToString("HHmmss", CultureInfo.InvariantCulture);
-        IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"NEWGROUPS {date} {time}", cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"NEWGROUPS {date} {time} GMT", cancellationToken).ConfigureAwait(false);
         await EnsureCompletionAsync(responses).ConfigureAwait(false);
         return await ReadMultilineAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -161,7 +161,7 @@ public class NntpClient : CommandResponseClient
         DateTime utc = sinceUtc.Kind == DateTimeKind.Local ? sinceUtc.ToUniversalTime() : DateTime.SpecifyKind(sinceUtc, DateTimeKind.Utc);
         string date = utc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
         string time = utc.ToString("HHmmss", CultureInfo.InvariantCulture);
-        IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"NEWNEWS {group} {date} {time}", cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"NEWNEWS {group} {date} {time} GMT", cancellationToken).ConfigureAwait(false);
         await EnsureCompletionAsync(responses).ConfigureAwait(false);
         IReadOnlyList<string> lines = await ReadMultilineAsync(cancellationToken).ConfigureAwait(false);
         List<int> ids = new();

--- a/Utils.Net/Net/NntpClient.cs
+++ b/Utils.Net/Net/NntpClient.cs
@@ -140,7 +140,7 @@ public class NntpClient : CommandResponseClient
     /// <returns>Collection of group names.</returns>
     public async Task<IReadOnlyList<string>> NewGroupsAsync(DateTime sinceUtc, CancellationToken cancellationToken = default)
     {
-        DateTime utc = sinceUtc.Kind == DateTimeKind.Utc ? sinceUtc : sinceUtc.ToUniversalTime();
+        DateTime utc = sinceUtc.Kind == DateTimeKind.Local ? sinceUtc.ToUniversalTime() : DateTime.SpecifyKind(sinceUtc, DateTimeKind.Utc);
         string date = utc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
         string time = utc.ToString("HHmmss", CultureInfo.InvariantCulture);
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"NEWGROUPS {date} {time}", cancellationToken).ConfigureAwait(false);
@@ -158,7 +158,7 @@ public class NntpClient : CommandResponseClient
     public async Task<IReadOnlyList<int>> NewNewsAsync(string group, DateTime sinceUtc, CancellationToken cancellationToken = default)
     {
         ValidateCommandArgument(group, nameof(group));
-        DateTime utc = sinceUtc.Kind == DateTimeKind.Utc ? sinceUtc : sinceUtc.ToUniversalTime();
+        DateTime utc = sinceUtc.Kind == DateTimeKind.Local ? sinceUtc.ToUniversalTime() : DateTime.SpecifyKind(sinceUtc, DateTimeKind.Utc);
         string date = utc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
         string time = utc.ToString("HHmmss", CultureInfo.InvariantCulture);
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"NEWNEWS {group} {date} {time}", cancellationToken).ConfigureAwait(false);

--- a/Utils.Net/Net/NntpClient.cs
+++ b/Utils.Net/Net/NntpClient.cs
@@ -97,7 +97,7 @@ public class NntpClient : CommandResponseClient
         StringBuilder sb = new();
         foreach (string line in lines)
         {
-            if (line.Length > 1 && line[0] == '.')
+            if (line.StartsWith("..", StringComparison.Ordinal))
             {
                 sb.Append(line.AsSpan(1));
             }
@@ -140,8 +140,9 @@ public class NntpClient : CommandResponseClient
     /// <returns>Collection of group names.</returns>
     public async Task<IReadOnlyList<string>> NewGroupsAsync(DateTime sinceUtc, CancellationToken cancellationToken = default)
     {
-        string date = sinceUtc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
-        string time = sinceUtc.ToString("HHmmss", CultureInfo.InvariantCulture);
+        DateTime utc = sinceUtc.Kind == DateTimeKind.Utc ? sinceUtc : sinceUtc.ToUniversalTime();
+        string date = utc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+        string time = utc.ToString("HHmmss", CultureInfo.InvariantCulture);
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"NEWGROUPS {date} {time}", cancellationToken).ConfigureAwait(false);
         await EnsureCompletionAsync(responses).ConfigureAwait(false);
         return await ReadMultilineAsync(cancellationToken).ConfigureAwait(false);
@@ -157,8 +158,9 @@ public class NntpClient : CommandResponseClient
     public async Task<IReadOnlyList<int>> NewNewsAsync(string group, DateTime sinceUtc, CancellationToken cancellationToken = default)
     {
         ValidateCommandArgument(group, nameof(group));
-        string date = sinceUtc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
-        string time = sinceUtc.ToString("HHmmss", CultureInfo.InvariantCulture);
+        DateTime utc = sinceUtc.Kind == DateTimeKind.Utc ? sinceUtc : sinceUtc.ToUniversalTime();
+        string date = utc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+        string time = utc.ToString("HHmmss", CultureInfo.InvariantCulture);
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"NEWNEWS {group} {date} {time}", cancellationToken).ConfigureAwait(false);
         await EnsureCompletionAsync(responses).ConfigureAwait(false);
         IReadOnlyList<string> lines = await ReadMultilineAsync(cancellationToken).ConfigureAwait(false);
@@ -187,7 +189,7 @@ public class NntpClient : CommandResponseClient
         StringBuilder sb = new();
         foreach (string line in lines)
         {
-            if (line.Length > 1 && line[0] == '.')
+            if (line.StartsWith("..", StringComparison.Ordinal))
             {
                 sb.Append(line.AsSpan(1));
             }
@@ -214,7 +216,7 @@ public class NntpClient : CommandResponseClient
         StringBuilder sb = new();
         foreach (string line in lines)
         {
-            if (line.Length > 1 && line[0] == '.')
+            if (line.StartsWith("..", StringComparison.Ordinal))
             {
                 sb.Append(line.AsSpan(1));
             }
@@ -329,7 +331,7 @@ public class NntpClient : CommandResponseClient
             foreach (ServerResponse response in batch)
             {
                 string line = response.Message is null ? response.Code : $"{response.Code} {response.Message}";
-                if (line.TrimEnd() == ".")
+                if (line == ".")
                 {
                     return lines;
                 }

--- a/Utils.Net/Net/Pop3Client.cs
+++ b/Utils.Net/Net/Pop3Client.cs
@@ -149,7 +149,7 @@ public class Pop3Client : CommandResponseClient
         foreach (string line in lines)
         {
             string content = line.StartsWith("..", StringComparison.Ordinal) ? line[1..] : line;
-            builder.AppendLine(content);
+            builder.Append(content).Append("\r\n");
         }
         return builder.ToString();
     }
@@ -286,7 +286,7 @@ public class Pop3Client : CommandResponseClient
             foreach (ServerResponse response in batch)
             {
                 string line = response.Message is null ? response.Code : $"{response.Code} {response.Message}";
-                if (line.TrimEnd() == ".")
+                if (line == ".")
                 {
                     return lines;
                 }

--- a/Utils.Net/Net/SmtpClient.cs
+++ b/Utils.Net/Net/SmtpClient.cs
@@ -103,7 +103,7 @@ public class SmtpClient : CommandResponseClient
         ValidateCommandArgument(domain, nameof(domain));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"EHLO {domain}", cancellationToken).ConfigureAwait(false);
         List<string> extensions = new();
-        for (int i = 1; i < responses.Count - 1; i++)
+        for (int i = 1; i < responses.Count; i++)
         {
             if (!string.IsNullOrEmpty(responses[i].Message))
             {
@@ -194,10 +194,14 @@ public class SmtpClient : CommandResponseClient
     public async Task SendMailAsync(string from, IEnumerable<string> recipients, string data, CancellationToken cancellationToken = default)
     {
         ValidateCommandArgument(from, nameof(from));
+        if (recipients is null) throw new ArgumentNullException(nameof(recipients));
+        List<string> recipientList = new(recipients);
+        if (recipientList.Count == 0) throw new ArgumentException("At least one recipient is required.", nameof(recipients));
+        foreach (string rcpt in recipientList) ValidateCommandArgument(rcpt, nameof(recipients));
+
         await EnsureCompletionAsync(await SendCommandAsync($"MAIL FROM:<{from}>", cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
-        foreach (string rcpt in recipients)
+        foreach (string rcpt in recipientList)
         {
-            ValidateCommandArgument(rcpt, nameof(recipients));
             await EnsureCompletionAsync(await SendCommandAsync($"RCPT TO:<{rcpt}>", cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
         }
         await EnsureIntermediateAsync(await SendCommandAsync("DATA", cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);

--- a/Utils.Net/TODO-2026-07-17-pass5.md
+++ b/Utils.Net/TODO-2026-07-17-pass5.md
@@ -102,7 +102,7 @@ Constructors retain the caller-provided array directly, and the public property 
 
 **Priority: P2 host integration correctness.**
 
-### 40. `PrimaryDns` throws an incidental index exception when no DNS server was discovered
+### 40. ✅ `PrimaryDns` throws an incidental index exception when no DNS server was discovered
 
 `PrimaryDns` returns `DnsServers[0]` with no empty-state contract. Hosts with no eligible interface, restricted containers, transient network changes, or the gateway-filter issue above receive `IndexOutOfRangeException`.
 
@@ -126,7 +126,7 @@ The documentation says records are appended when IDs do not match, and the metho
 
 **Priority: P2 defensive API correctness.**
 
-### 43. Preview features are enabled package-wide without a demonstrated requirement
+### 43. ✅ Preview features are enabled package-wide without a demonstrated requirement
 
 `Utils.Net.csproj` targets only `net9.0` and enables preview features for the complete networking package. The inspected public APIs use ordinary supported runtime/language features.
 

--- a/Utils.Net/TODO-2026-07-19-pass7.md
+++ b/Utils.Net/TODO-2026-07-19-pass7.md
@@ -4,7 +4,7 @@ This pass complements the earlier `Utils.Net` audit files. It focuses on SMTP, P
 
 ## High-priority findings
 
-### 59. SMTP `EHLO` drops the final advertised extension
+### 59. ✅ SMTP `EHLO` drops the final advertised extension
 
 `EhloAsync` collects messages only for indexes `1` through `responses.Count - 2`. The final `250 ...` line is excluded even though SMTP servers commonly advertise a capability on that final line rather than using it only as a terminator.
 
@@ -34,7 +34,7 @@ This pass complements the earlier `Utils.Net` audit files. It focuses on SMTP, P
 
 **Priority: P1 state integrity.**
 
-### 62. SMTP accepts an empty recipient sequence and begins DATA without a valid envelope recipient
+### 62. ✅ SMTP accepts an empty recipient sequence and begins DATA without a valid envelope recipient
 
 The recipient enumerable is not validated for nullness or emptiness and is consumed only once inside the send flow.
 
@@ -54,7 +54,7 @@ User names and passwords are converted with `Encoding.ASCII`, replacing non-ASCI
 
 **Priority: P1 authentication correctness.**
 
-### 64. POP3 and NNTP multi-line terminators are accepted after trimming trailing whitespace
+### 64. ✅ POP3 and NNTP multi-line terminators are accepted after trimming trailing whitespace
 
 Both multi-line readers use `line.TrimEnd() == "."`. The protocol terminator is the exact octet sequence `".\r\n"`; a line such as `". "` is data, not a terminator.
 
@@ -64,7 +64,7 @@ Both multi-line readers use `line.TrimEnd() == "."`. The protocol terminator is 
 
 **Priority: P1 untrusted-response parsing.**
 
-### 65. POP3 message retrieval changes line endings to the host platform convention
+### 65. ✅ POP3 message retrieval changes line endings to the host platform convention
 
 `RetrieveAsync` rebuilds message text with `StringBuilder.AppendLine`, which uses `Environment.NewLine` rather than POP3/Internet message CRLF.
 
@@ -84,7 +84,7 @@ Both multi-line readers use `line.TrimEnd() == "."`. The protocol terminator is 
 
 **Priority: P1 response integrity.**
 
-### 67. NNTP UTC parameters are formatted without enforcing UTC semantics
+### 67. ✅ NNTP UTC parameters are formatted without enforcing UTC semantics
 
 `NewGroupsAsync` and `NewNewsAsync` accept parameters named `sinceUtc` but format the supplied `DateTime` directly. Local or unspecified values are sent unchanged with no `GMT` token and no conversion policy.
 
@@ -94,7 +94,7 @@ Both multi-line readers use `line.TrimEnd() == "."`. The protocol terminator is 
 
 **Priority: P1 temporal correctness.**
 
-### 68. NNTP dot-unstuffing accepts malformed single-dot-prefixed data
+### 68. ✅ NNTP dot-unstuffing accepts malformed single-dot-prefixed data
 
 Article, header, and body methods remove the first dot from every non-terminator line beginning with a dot. Correct dot-stuffed data begins with two dots; a malformed line such as `.abc` should not silently become `abc`.
 

--- a/Utils.Net/Utils.Net.csproj
+++ b/Utils.Net/Utils.Net.csproj
@@ -2,7 +2,6 @@
 
         <PropertyGroup>
                 <TargetFramework>net9.0</TargetFramework>
-                <EnablePreviewFeatures>True</EnablePreviewFeatures>
                 <AssemblyName>Utils.Net</AssemblyName>
                 <RootNamespace>Utils</RootNamespace>
                 <Copyright>Olivier MARTY 2025</Copyright>

--- a/UtilsTest/Net/NetClientProtocolTests.cs
+++ b/UtilsTest/Net/NetClientProtocolTests.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipelines;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>
+/// Unit tests covering audit items 40, 43, 59, 62, 64, 65, 67, 68.
+/// </summary>
+[TestClass]
+public class NetClientProtocolTests
+{
+    // ──────────────────────────────────────────────────────────────
+    // Infrastructure
+    // ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Wraps two separate read/write streams into one bidirectional stream,
+    /// used to inject fake server data into <see cref="CommandResponseClient"/>.
+    /// </summary>
+    private sealed class DuplexStream : Stream
+    {
+        private readonly Stream _readFrom;
+        private readonly Stream _writeTo;
+
+        public DuplexStream(Stream readFrom, Stream writeTo)
+        {
+            _readFrom = readFrom;
+            _writeTo = writeTo;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanWrite => true;
+        public override bool CanSeek => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override int Read(byte[] buffer, int offset, int count) => _readFrom.Read(buffer, offset, count);
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken ct) => _readFrom.ReadAsync(buffer, offset, count, ct);
+        public override void Write(byte[] buffer, int offset, int count) => _writeTo.Write(buffer, offset, count);
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ct) => _writeTo.WriteAsync(buffer, offset, count, ct);
+        public override void Flush() => _writeTo.Flush();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) { _readFrom.Dispose(); _writeTo.Dispose(); }
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Creates an in-process bidirectional pipe pair so that a fake server task and a
+    /// real protocol client can exchange lines without a real TCP connection.
+    /// </summary>
+    private static (DuplexStream clientStream, StreamWriter serverWriter, StreamReader serverReader) CreateTestPair()
+    {
+        Pipe serverToClient = new Pipe();
+        Pipe clientToServer = new Pipe();
+
+        DuplexStream clientStream = new DuplexStream(
+            serverToClient.Reader.AsStream(),
+            clientToServer.Writer.AsStream());
+
+        StreamWriter serverWriter = new StreamWriter(serverToClient.Writer.AsStream(), Encoding.ASCII)
+        {
+            NewLine = "\r\n",
+            AutoFlush = true
+        };
+        StreamReader serverReader = new StreamReader(clientToServer.Reader.AsStream(), Encoding.ASCII);
+
+        return (clientStream, serverWriter, serverReader);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Item 40 — NetworkParameters.PrimaryDns null-safe (no IndexOutOfRangeException)
+    // ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void NetworkParameters_PrimaryDns_EqualsFirstDnsServerOrNull()
+    {
+        NetworkParameters p = new NetworkParameters();
+        IPAddress[] dns = p.DnsServers;
+        IPAddress? expected = dns.Length > 0 ? dns[0] : null;
+        Assert.AreEqual(expected, p.PrimaryDns);
+    }
+
+    [TestMethod]
+    public void NetworkParameters_DnsServers_ReturnsDefensiveCopy()
+    {
+        NetworkParameters p = new NetworkParameters();
+        IPAddress[] first = p.DnsServers;
+        // Mutate the returned array
+        if (first.Length > 0) first[0] = IPAddress.Loopback;
+        IPAddress[] second = p.DnsServers;
+        // The mutation must not affect the stored state
+        Assert.AreEqual(p.PrimaryDns, second.Length > 0 ? second[0] : null);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Item 62 — SMTP: null / empty recipients validated before MAIL FROM
+    // ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SmtpClient_SendMailAsync_NullRecipients_ThrowsArgumentNullException()
+    {
+        SmtpClient client = new SmtpClient();
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(() =>
+            client.SendMailAsync("sender@example.com", null!, "body"));
+    }
+
+    [TestMethod]
+    public async Task SmtpClient_SendMailAsync_EmptyRecipients_ThrowsArgumentException()
+    {
+        SmtpClient client = new SmtpClient();
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            client.SendMailAsync("sender@example.com", new string[0], "body"));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Item 59 — SMTP EHLO: last extension line is included
+    // ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task SmtpClient_EhloAsync_IncludesLastExtension()
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+
+        Task serverTask = Task.Run(async () =>
+        {
+            // Greeting
+            await sw.WriteLineAsync("220 smtp.example.com ESMTP");
+            // Client reads greeting in OnConnect
+            _ = await sr.ReadLineAsync(); // discard EHLO command
+            await sw.WriteLineAsync("250-smtp.example.com Hello");
+            await sw.WriteLineAsync("250-SIZE 10240000");
+            await sw.WriteLineAsync("250 STARTTLS");
+            sw.BaseStream.Flush();
+        });
+
+        SmtpClient client = new SmtpClient();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+        IReadOnlyList<string> extensions = await client.EhloAsync("testclient.local");
+        await serverTask;
+
+        // The last "STARTTLS" line must be included
+        Assert.IsTrue(extensions.Contains("STARTTLS"),
+            $"Expected 'STARTTLS' in extensions but got: [{string.Join(", ", extensions)}]");
+        Assert.IsTrue(extensions.Contains("SIZE 10240000"),
+            "Expected 'SIZE 10240000' in extensions.");
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Item 65 — POP3 RETR: CRLF line endings preserved
+    // ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Pop3Client_RetrieveAsync_UsesCrlfLineEndings()
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("+OK POP3 ready");
+            _ = await sr.ReadLineAsync(); // RETR 1
+            await sw.WriteLineAsync("+OK message follows");
+            await sw.WriteLineAsync("Subject: hello");
+            await sw.WriteLineAsync("body text");
+            await sw.WriteLineAsync(".");
+            sw.BaseStream.Flush();
+        });
+
+        Pop3Client client = new Pop3Client();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+#pragma warning disable CS0618
+        string message = await client.RetrieveAsync(1);
+#pragma warning restore CS0618
+        await serverTask;
+
+        Assert.AreEqual("Subject: hello\r\nbody text\r\n", message);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Item 64 — POP3 exact terminator: ". " (dot-space) is data, not terminator
+    // ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Pop3Client_DotSpaceLine_IsDataNotTerminator()
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("+OK POP3 ready");
+            _ = await sr.ReadLineAsync(); // RETR 1
+            await sw.WriteLineAsync("+OK message follows");
+            // ". " must be treated as data (not the terminator ".")
+            await sw.WriteLineAsync(". ");
+            await sw.WriteLineAsync("next line");
+            await sw.WriteLineAsync(".");
+            sw.BaseStream.Flush();
+        });
+
+        Pop3Client client = new Pop3Client();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+#pragma warning disable CS0618
+        string message = await client.RetrieveAsync(1);
+#pragma warning restore CS0618
+        await serverTask;
+
+        // Both lines must be present; ". " is data, "next line" follows it
+        StringAssert.Contains(message, ". \r\n");
+        StringAssert.Contains(message, "next line\r\n");
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Item 68 — NNTP dot-unstuffing: only ".." lines are unstuffed
+    // ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task NntpClient_ArticleAsync_DoubleDotIsUnstuffed()
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("200 NNTP server ready");
+            _ = await sr.ReadLineAsync(); // ARTICLE 1
+            await sw.WriteLineAsync("220 1 <msg@example.com> article follows");
+            await sw.WriteLineAsync("..dot-prefixed content");
+            await sw.WriteLineAsync(".");
+            sw.BaseStream.Flush();
+        });
+
+        NntpClient client = new NntpClient();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+        string article = await client.ArticleAsync(1);
+        await serverTask;
+
+        // "..dot-prefixed content" → ".dot-prefixed content" after unstuffing
+        Assert.AreEqual(".dot-prefixed content\r\n", article);
+    }
+
+    [TestMethod]
+    public async Task NntpClient_ArticleAsync_SingleDotPrefixIsNotUnstuffed()
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("200 NNTP server ready");
+            _ = await sr.ReadLineAsync(); // ARTICLE 1
+            await sw.WriteLineAsync("220 1 <msg@example.com> article follows");
+            await sw.WriteLineAsync(".malformed");
+            await sw.WriteLineAsync(".");
+            sw.BaseStream.Flush();
+        });
+
+        NntpClient client = new NntpClient();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+        string article = await client.ArticleAsync(1);
+        await serverTask;
+
+        // ".malformed" must NOT be unstuffed — the leading dot is preserved
+        Assert.AreEqual(".malformed\r\n", article);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Item 67 — NNTP UTC: Unspecified Kind treated as UTC, not Local
+    // ──────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task NntpClient_NewGroupsAsync_UnspecifiedDateTimeKindSentAsUtc()
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+        string? capturedCommand = null;
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("200 NNTP server ready");
+            capturedCommand = await sr.ReadLineAsync(); // NEWGROUPS ...
+            await sw.WriteLineAsync("231 new newsgroups follow");
+            await sw.WriteLineAsync(".");
+            sw.BaseStream.Flush();
+        });
+
+        NntpClient client = new NntpClient();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+        // Unspecified kind: numeric value is 2024-01-15 08:30:00
+        DateTime unspecified = new DateTime(2024, 1, 15, 8, 30, 0, DateTimeKind.Unspecified);
+        await client.NewGroupsAsync(unspecified);
+        await serverTask;
+
+        // Must format the value as-is (treating Unspecified as UTC), not convert through local timezone
+        Assert.AreEqual("NEWGROUPS 20240115 083000", capturedCommand,
+            "DateTimeKind.Unspecified must be treated as UTC, not converted through local timezone.");
+    }
+}

--- a/UtilsTest/Net/NetClientProtocolTests.cs
+++ b/UtilsTest/Net/NetClientProtocolTests.cs
@@ -81,7 +81,7 @@ public class NetClientProtocolTests
     }
 
     // ──────────────────────────────────────────────────────────────
-    // Item 40 — NetworkParameters.PrimaryDns null-safe (no IndexOutOfRangeException)
+    // Item 40 — NetworkParameters.PrimaryDns null-safe
     // ──────────────────────────────────────────────────────────────
 
     [TestMethod]
@@ -98,15 +98,13 @@ public class NetClientProtocolTests
     {
         NetworkParameters p = new NetworkParameters();
         IPAddress[] first = p.DnsServers;
-        // Mutate the returned array
         if (first.Length > 0) first[0] = IPAddress.Loopback;
         IPAddress[] second = p.DnsServers;
-        // The mutation must not affect the stored state
         Assert.AreEqual(p.PrimaryDns, second.Length > 0 ? second[0] : null);
     }
 
     // ──────────────────────────────────────────────────────────────
-    // Item 62 — SMTP: null / empty recipients validated before MAIL FROM
+    // Item 62 — SMTP: recipients validated before any network I/O
     // ──────────────────────────────────────────────────────────────
 
     [TestMethod]
@@ -125,8 +123,36 @@ public class NetClientProtocolTests
             client.SendMailAsync("sender@example.com", new string[0], "body"));
     }
 
+    [TestMethod]
+    public async Task SmtpClient_SendMailAsync_InvalidRecipient_NoBytesSentToServer()
+    {
+        // Verifies that recipient validation happens before any MAIL FROM is transmitted.
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+
+        bool mailFromSent = false;
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("220 smtp.example.com ESMTP");
+            // Respond to MAIL FROM if it arrives
+            string? line = await sr.ReadLineAsync();
+            if (line is not null && line.StartsWith("MAIL FROM", StringComparison.OrdinalIgnoreCase))
+                mailFromSent = true;
+        });
+
+        SmtpClient client = new SmtpClient();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+
+        // Second recipient has a CR, which ValidateCommandArgument rejects before MAIL FROM
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            client.SendMailAsync("sender@example.com", new[] { "good@example.com", "bad\rrecipient" }, "body"));
+
+        // Give the server task a moment to detect MAIL FROM if it had been sent
+        await Task.WhenAny(serverTask, Task.Delay(200));
+        Assert.IsFalse(mailFromSent, "MAIL FROM must not be sent when a recipient fails validation.");
+    }
+
     // ──────────────────────────────────────────────────────────────
-    // Item 59 — SMTP EHLO: last extension line is included
+    // Item 59 — SMTP EHLO: last extension line included
     // ──────────────────────────────────────────────────────────────
 
     [TestMethod]
@@ -136,10 +162,8 @@ public class NetClientProtocolTests
 
         Task serverTask = Task.Run(async () =>
         {
-            // Greeting
             await sw.WriteLineAsync("220 smtp.example.com ESMTP");
-            // Client reads greeting in OnConnect
-            _ = await sr.ReadLineAsync(); // discard EHLO command
+            _ = await sr.ReadLineAsync(); // EHLO command
             await sw.WriteLineAsync("250-smtp.example.com Hello");
             await sw.WriteLineAsync("250-SIZE 10240000");
             await sw.WriteLineAsync("250 STARTTLS");
@@ -151,15 +175,14 @@ public class NetClientProtocolTests
         IReadOnlyList<string> extensions = await client.EhloAsync("testclient.local");
         await serverTask;
 
-        // The last "STARTTLS" line must be included
         Assert.IsTrue(extensions.Contains("STARTTLS"),
-            $"Expected 'STARTTLS' in extensions but got: [{string.Join(", ", extensions)}]");
+            $"Last extension 'STARTTLS' must be included. Got: [{string.Join(", ", extensions)}]");
         Assert.IsTrue(extensions.Contains("SIZE 10240000"),
-            "Expected 'SIZE 10240000' in extensions.");
+            "Middle extension 'SIZE 10240000' must also be included.");
     }
 
     // ──────────────────────────────────────────────────────────────
-    // Item 65 — POP3 RETR: CRLF line endings preserved
+    // Item 65 — POP3 RETR: explicit CRLF line endings
     // ──────────────────────────────────────────────────────────────
 
     [TestMethod]
@@ -180,16 +203,14 @@ public class NetClientProtocolTests
 
         Pop3Client client = new Pop3Client();
         await client.ConnectAsync(clientStream, leaveOpen: false);
-#pragma warning disable CS0618
         string message = await client.RetrieveAsync(1);
-#pragma warning restore CS0618
         await serverTask;
 
         Assert.AreEqual("Subject: hello\r\nbody text\r\n", message);
     }
 
     // ──────────────────────────────────────────────────────────────
-    // Item 64 — POP3 exact terminator: ". " (dot-space) is data, not terminator
+    // Item 64 — Exact terminator: ". " is data, not terminator (POP3 and NNTP)
     // ──────────────────────────────────────────────────────────────
 
     [TestMethod]
@@ -202,7 +223,6 @@ public class NetClientProtocolTests
             await sw.WriteLineAsync("+OK POP3 ready");
             _ = await sr.ReadLineAsync(); // RETR 1
             await sw.WriteLineAsync("+OK message follows");
-            // ". " must be treated as data (not the terminator ".")
             await sw.WriteLineAsync(". ");
             await sw.WriteLineAsync("next line");
             await sw.WriteLineAsync(".");
@@ -211,14 +231,36 @@ public class NetClientProtocolTests
 
         Pop3Client client = new Pop3Client();
         await client.ConnectAsync(clientStream, leaveOpen: false);
-#pragma warning disable CS0618
         string message = await client.RetrieveAsync(1);
-#pragma warning restore CS0618
         await serverTask;
 
-        // Both lines must be present; ". " is data, "next line" follows it
         StringAssert.Contains(message, ". \r\n");
         StringAssert.Contains(message, "next line\r\n");
+    }
+
+    [TestMethod]
+    public async Task NntpClient_ArticleAsync_DotSpaceLine_IsDataNotTerminator()
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("200 NNTP server ready");
+            _ = await sr.ReadLineAsync(); // ARTICLE 1
+            await sw.WriteLineAsync("220 1 <msg@example.com> article follows");
+            await sw.WriteLineAsync(". ");
+            await sw.WriteLineAsync("normal line");
+            await sw.WriteLineAsync(".");
+            sw.BaseStream.Flush();
+        });
+
+        NntpClient client = new NntpClient();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+        string article = await client.ArticleAsync(1);
+        await serverTask;
+
+        StringAssert.Contains(article, ". \r\n");
+        StringAssert.Contains(article, "normal line\r\n");
     }
 
     // ──────────────────────────────────────────────────────────────
@@ -245,7 +287,6 @@ public class NetClientProtocolTests
         string article = await client.ArticleAsync(1);
         await serverTask;
 
-        // "..dot-prefixed content" → ".dot-prefixed content" after unstuffing
         Assert.AreEqual(".dot-prefixed content\r\n", article);
     }
 
@@ -269,16 +310,65 @@ public class NetClientProtocolTests
         string article = await client.ArticleAsync(1);
         await serverTask;
 
-        // ".malformed" must NOT be unstuffed — the leading dot is preserved
         Assert.AreEqual(".malformed\r\n", article);
     }
 
-    // ──────────────────────────────────────────────────────────────
-    // Item 67 — NNTP UTC: Unspecified Kind treated as UTC, not Local
-    // ──────────────────────────────────────────────────────────────
+    [TestMethod]
+    public async Task NntpClient_HeaderAsync_DoubleDotIsUnstuffed()
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("200 NNTP server ready");
+            _ = await sr.ReadLineAsync(); // HEADER 1
+            await sw.WriteLineAsync("221 1 <msg@example.com> head follows");
+            await sw.WriteLineAsync("..encoded-header");
+            await sw.WriteLineAsync(".");
+            sw.BaseStream.Flush();
+        });
+
+        NntpClient client = new NntpClient();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+        string header = await client.HeaderAsync(1);
+        await serverTask;
+
+        Assert.AreEqual(".encoded-header\r\n", header);
+    }
 
     [TestMethod]
-    public async Task NntpClient_NewGroupsAsync_UnspecifiedDateTimeKindSentAsUtc()
+    public async Task NntpClient_BodyAsync_DoubleDotIsUnstuffed()
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("200 NNTP server ready");
+            _ = await sr.ReadLineAsync(); // BODY 1
+            await sw.WriteLineAsync("222 1 <msg@example.com> body follows");
+            await sw.WriteLineAsync("..encoded-body-line");
+            await sw.WriteLineAsync(".");
+            sw.BaseStream.Flush();
+        });
+
+        NntpClient client = new NntpClient();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+        string body = await client.BodyAsync(1);
+        await serverTask;
+
+        Assert.AreEqual(".encoded-body-line\r\n", body);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Item 67 — NNTP UTC: all three DateTimeKind values send "GMT"
+    //
+    // Policy:
+    //   Utc         → value transmitted as-is with GMT token
+    //   Local       → converted to UTC then transmitted with GMT token
+    //   Unspecified → interpreted as UTC (no local conversion) with GMT token
+    // ──────────────────────────────────────────────────────────────
+
+    private static async Task<string?> CaptureNewGroupsCommandAsync(DateTime sinceUtc)
     {
         (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
         string? capturedCommand = null;
@@ -286,7 +376,7 @@ public class NetClientProtocolTests
         Task serverTask = Task.Run(async () =>
         {
             await sw.WriteLineAsync("200 NNTP server ready");
-            capturedCommand = await sr.ReadLineAsync(); // NEWGROUPS ...
+            capturedCommand = await sr.ReadLineAsync();
             await sw.WriteLineAsync("231 new newsgroups follow");
             await sw.WriteLineAsync(".");
             sw.BaseStream.Flush();
@@ -294,13 +384,90 @@ public class NetClientProtocolTests
 
         NntpClient client = new NntpClient();
         await client.ConnectAsync(clientStream, leaveOpen: false);
-        // Unspecified kind: numeric value is 2024-01-15 08:30:00
-        DateTime unspecified = new DateTime(2024, 1, 15, 8, 30, 0, DateTimeKind.Unspecified);
-        await client.NewGroupsAsync(unspecified);
+        await client.NewGroupsAsync(sinceUtc);
         await serverTask;
+        return capturedCommand;
+    }
 
-        // Must format the value as-is (treating Unspecified as UTC), not convert through local timezone
-        Assert.AreEqual("NEWGROUPS 20240115 083000", capturedCommand,
-            "DateTimeKind.Unspecified must be treated as UTC, not converted through local timezone.");
+    private static async Task<string?> CaptureNewNewsCommandAsync(DateTime sinceUtc)
+    {
+        (DuplexStream clientStream, StreamWriter sw, StreamReader sr) = CreateTestPair();
+        string? capturedCommand = null;
+
+        Task serverTask = Task.Run(async () =>
+        {
+            await sw.WriteLineAsync("200 NNTP server ready");
+            capturedCommand = await sr.ReadLineAsync();
+            await sw.WriteLineAsync("230 list of new articles follows");
+            await sw.WriteLineAsync(".");
+            sw.BaseStream.Flush();
+        });
+
+        NntpClient client = new NntpClient();
+        await client.ConnectAsync(clientStream, leaveOpen: false);
+        await client.NewNewsAsync("misc.test", sinceUtc);
+        await serverTask;
+        return capturedCommand;
+    }
+
+    [TestMethod]
+    public async Task NntpClient_NewGroupsAsync_UtcKind_SendsGmt()
+    {
+        DateTime utcValue = new DateTime(2024, 3, 10, 14, 0, 0, DateTimeKind.Utc);
+        string? cmd = await CaptureNewGroupsCommandAsync(utcValue);
+        Assert.AreEqual("NEWGROUPS 20240310 140000 GMT", cmd);
+    }
+
+    [TestMethod]
+    public async Task NntpClient_NewGroupsAsync_UnspecifiedKind_TreatedAsUtcWithGmt()
+    {
+        DateTime unspecified = new DateTime(2024, 1, 15, 8, 30, 0, DateTimeKind.Unspecified);
+        string? cmd = await CaptureNewGroupsCommandAsync(unspecified);
+        // Unspecified is treated as UTC: numeric values must be unchanged, GMT appended
+        Assert.AreEqual("NEWGROUPS 20240115 083000 GMT", cmd,
+            "DateTimeKind.Unspecified must be forwarded as-is (treated as UTC) with the GMT token.");
+    }
+
+    [TestMethod]
+    public async Task NntpClient_NewGroupsAsync_LocalKind_ConvertedToUtcWithGmt()
+    {
+        // Build a Local value and derive the expected UTC string independently,
+        // so the assertion is correct regardless of the CI machine's timezone.
+        DateTime localValue = new DateTime(2024, 6, 21, 12, 0, 0, DateTimeKind.Local);
+        DateTime expectedUtc = localValue.ToUniversalTime();
+        string expectedCommand =
+            $"NEWGROUPS {expectedUtc:yyyyMMdd} {expectedUtc:HHmmss} GMT";
+
+        string? cmd = await CaptureNewGroupsCommandAsync(localValue);
+        Assert.AreEqual(expectedCommand, cmd);
+    }
+
+    [TestMethod]
+    public async Task NntpClient_NewNewsAsync_UtcKind_SendsGmt()
+    {
+        DateTime utcValue = new DateTime(2024, 3, 10, 14, 0, 0, DateTimeKind.Utc);
+        string? cmd = await CaptureNewNewsCommandAsync(utcValue);
+        Assert.AreEqual("NEWNEWS misc.test 20240310 140000 GMT", cmd);
+    }
+
+    [TestMethod]
+    public async Task NntpClient_NewNewsAsync_UnspecifiedKind_TreatedAsUtcWithGmt()
+    {
+        DateTime unspecified = new DateTime(2024, 1, 15, 8, 30, 0, DateTimeKind.Unspecified);
+        string? cmd = await CaptureNewNewsCommandAsync(unspecified);
+        Assert.AreEqual("NEWNEWS misc.test 20240115 083000 GMT", cmd,
+            "DateTimeKind.Unspecified must be forwarded as-is (treated as UTC) with the GMT token.");
+    }
+
+    [TestMethod]
+    public async Task NntpClient_NewNewsAsync_LocalKind_ConvertedToUtcWithGmt()
+    {
+        DateTime localValue = new DateTime(2024, 6, 21, 12, 0, 0, DateTimeKind.Local);
+        DateTime expectedUtc = localValue.ToUniversalTime();
+        string expectedCommand =
+            $"NEWNEWS misc.test {expectedUtc:yyyyMMdd} {expectedUtc:HHmmss} GMT";
+
+        string? cmd = await CaptureNewNewsCommandAsync(localValue);
+        Assert.AreEqual(expectedCommand, cmd);
     }
 }


### PR DESCRIPTION
﻿## Items addressed

| Item | File | Change |
|------|------|--------|
| 40 | NetworkParameters.cs | PrimaryDns returns null when no DNS server; DnsServers is IPAddress[] with defensive clone |
| 43 | Utils.Net.csproj | EnablePreviewFeatures removed |
| 59 | SmtpClient.cs | EhloAsync collects all EHLO lines including the last one |
| 62 | SmtpClient.cs | SendMailAsync validates and materialises recipients before MAIL FROM |
| 64 | Pop3Client.cs, NntpClient.cs | Multi-line terminator uses exact equality (line == '.') — dot-space is data, not terminator |
| 65 | Pop3Client.cs | RetrieveAsync appends explicit CRLF instead of platform-dependent AppendLine |
| 67 | NntpClient.cs | NewGroupsAsync/NewNewsAsync treat Unspecified as UTC; all paths append GMT token |
| 68 | NntpClient.cs | ArticleAsync/HeaderAsync/BodyAsync unstuff only double-dot lines; single-dot prefix kept as-is |

## DateTime policy (item 67)

| Kind | Behaviour |
|------|-----------|
| Utc | transmitted as-is with GMT |
| Local | converted to UTC, transmitted with GMT |
| Unspecified | interpreted as UTC (no local conversion), transmitted with GMT |

## Tests

19 tests in UtilsTest/Net/NetClientProtocolTests.cs:
- NetworkParameters: PrimaryDns coherence + defensive copy
- SMTP: null recipients, empty recipients, invalid-recipient pre-flight (no bytes before MAIL FROM), last EHLO extension
- POP3: explicit CRLF, dot-space as data
- NNTP: dot-space as data, double-dot unstuffing in Article/Header/Body, single-dot kept, all three DateTimeKind x NewGroups + NewNews

5424 unit tests pass.