### PR TITLE
fix(Utils.Net): follow-up corrections to PR #525

### DIFF
--- a/Utils.Net/Net/NetworkParameters.cs
+++ b/Utils.Net/Net/NetworkParameters.cs
@@ -12,6 +12,7 @@ namespace Utils.Net
     /// </summary>
     public class NetworkParameters
     {
+        private readonly NetworkInterface[] _networkInterfaces;
         private readonly IPAddress[] _dnsServers;
 
         /// <summary>
@@ -19,10 +20,10 @@ namespace Utils.Net
         /// </summary>
         public NetworkParameters()
         {
-            NetworkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
+            _networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
 
-            var snapshots = new List<NetworkInterfaceSnapshot>(NetworkInterfaces.Length);
-            foreach (NetworkInterface networkInterface in NetworkInterfaces)
+            var snapshots = new List<NetworkInterfaceSnapshot>(_networkInterfaces.Length);
+            foreach (NetworkInterface networkInterface in _networkInterfaces)
             {
                 snapshots.Add(CreateSnapshot(networkInterface));
             }
@@ -34,7 +35,8 @@ namespace Utils.Net
         /// <summary>
         /// Gets the network interfaces detected on the host at construction time.
         /// </summary>
-        public NetworkInterface[] NetworkInterfaces { get; private set; }
+        /// <remarks>Returns a defensive copy; mutating the result does not affect this instance.</remarks>
+        public NetworkInterface[] NetworkInterfaces => (NetworkInterface[])_networkInterfaces.Clone();
 
         /// <summary>
         /// Gets the preferred DNS server resolved from the network interfaces, or <see langword="null"/> if no DNS server was discovered.

--- a/Utils.Net/Net/NetworkParameters.cs
+++ b/Utils.Net/Net/NetworkParameters.cs
@@ -13,6 +13,7 @@ namespace Utils.Net
     public class NetworkParameters
     {
         private readonly NetworkInterface[] _networkInterfaces;
+        private readonly IReadOnlyList<NetworkInterface> _networkInterfacesView;
         private readonly IPAddress[] _dnsServers;
 
         /// <summary>
@@ -21,6 +22,7 @@ namespace Utils.Net
         public NetworkParameters()
         {
             _networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
+            _networkInterfacesView = Array.AsReadOnly(_networkInterfaces);
 
             var snapshots = new List<NetworkInterfaceSnapshot>(_networkInterfaces.Length);
             foreach (NetworkInterface networkInterface in _networkInterfaces)
@@ -33,10 +35,11 @@ namespace Utils.Net
         }
 
         /// <summary>
-        /// Gets the network interfaces detected on the host at construction time as a read-only
-        /// view. The underlying collection is not copied; callers cannot replace or add elements.
+        /// Gets the network interfaces detected on the host at construction time as a stable
+        /// read-only view. The same instance is returned on every call; callers cannot replace
+        /// or add elements.
         /// </summary>
-        public IReadOnlyList<NetworkInterface> NetworkInterfaces => _networkInterfaces.AsReadOnly();
+        public IReadOnlyList<NetworkInterface> NetworkInterfaces => _networkInterfacesView;
 
         /// <summary>
         /// Gets the preferred DNS server resolved from the network interfaces, or <see langword="null"/> if no DNS server was discovered.

--- a/Utils.Net/Net/NetworkParameters.cs
+++ b/Utils.Net/Net/NetworkParameters.cs
@@ -33,10 +33,10 @@ namespace Utils.Net
         }
 
         /// <summary>
-        /// Gets the network interfaces detected on the host at construction time.
+        /// Gets the network interfaces detected on the host at construction time as a read-only
+        /// view. The underlying collection is not copied; callers cannot replace or add elements.
         /// </summary>
-        /// <remarks>Returns a defensive copy; mutating the result does not affect this instance.</remarks>
-        public NetworkInterface[] NetworkInterfaces => (NetworkInterface[])_networkInterfaces.Clone();
+        public IReadOnlyList<NetworkInterface> NetworkInterfaces => _networkInterfaces.AsReadOnly();
 
         /// <summary>
         /// Gets the preferred DNS server resolved from the network interfaces, or <see langword="null"/> if no DNS server was discovered.

--- a/Utils.Net/Net/NtpSupport.cs
+++ b/Utils.Net/Net/NtpSupport.cs
@@ -131,27 +131,33 @@ namespace Utils.Net
 
         public async Task<byte[]> ExchangeAsync(IPEndPoint endpoint, byte[] request, CancellationToken cancellationToken)
         {
+            ArgumentNullException.ThrowIfNull(endpoint);
+            ArgumentNullException.ThrowIfNull(request);
+            if (request.Length == 0)
+                throw new ArgumentException("The NTP request must not be empty.", nameof(request));
+
             using var client = new UdpClient(endpoint.AddressFamily);
             client.Connect(endpoint);
 
-            await client.SendAsync(request, request.Length).WaitAsync(cancellationToken).ConfigureAwait(false);
-
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutCts.CancelAfter(_receiveTimeout);
-            UdpReceiveResult result;
+            CancellationToken effectiveToken = timeoutCts.Token;
+
             try
             {
-                result = await client.ReceiveAsync(timeoutCts.Token).ConfigureAwait(false);
+                await client.SendAsync(request, request.Length).WaitAsync(effectiveToken).ConfigureAwait(false);
+
+                UdpReceiveResult result = await client.ReceiveAsync(effectiveToken).ConfigureAwait(false);
+
+                if (!result.RemoteEndPoint.Equals(endpoint))
+                    throw new System.IO.IOException("NTP response received from unexpected endpoint.");
+
+                return result.Buffer;
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
                 throw new SocketException((int)SocketError.TimedOut);
             }
-
-            if (!result.RemoteEndPoint.Equals(endpoint))
-                throw new System.IO.IOException("NTP response received from unexpected endpoint.");
-
-            return result.Buffer;
         }
     }
 }

--- a/UtilsTest/Net/DNSHeaderMergeTests.cs
+++ b/UtilsTest/Net/DNSHeaderMergeTests.cs
@@ -224,6 +224,10 @@ public class DNSHeaderMergeTests
         Assert.AreEqual(originalId, a.ID);
     }
 
+    /// <summary>
+    /// Verifies that <see cref="DNSHeader.MergeRecordsFrom"/> throws when the two question
+    /// sections have the same name but different numeric record types.
+    /// </summary>
     [TestMethod]
     public void MergeRecordsFrom_DifferentQuestionType_Throws()
     {
@@ -240,6 +244,10 @@ public class DNSHeaderMergeTests
         Assert.ThrowsException<InvalidOperationException>(() => a.MergeRecordsFrom(b));
     }
 
+    /// <summary>
+    /// Verifies that <see cref="DNSHeader.MergeRecordsFrom"/> throws when the two question
+    /// sections differ in DNS class (e.g., IN vs ALL).
+    /// </summary>
     [TestMethod]
     public void MergeRecordsFrom_DifferentQuestionClass_Throws()
     {
@@ -252,6 +260,10 @@ public class DNSHeaderMergeTests
         Assert.ThrowsException<InvalidOperationException>(() => a.MergeRecordsFrom(b));
     }
 
+    /// <summary>
+    /// Verifies that <see cref="DNSHeader.MergeRecordsFrom"/> throws when the two question
+    /// sections contain the same entries but in a different order.
+    /// </summary>
     [TestMethod]
     public void MergeRecordsFrom_DifferentQuestionOrder_Throws()
     {
@@ -269,6 +281,10 @@ public class DNSHeaderMergeTests
         Assert.ThrowsException<InvalidOperationException>(() => a.MergeRecordsFrom(b));
     }
 
+    /// <summary>
+    /// Verifies that <see cref="DNSHeader.MergeRecordsFrom"/> succeeds even when the two
+    /// headers carry different transaction IDs; the ID is not part of the compatibility check.
+    /// </summary>
     [TestMethod]
     public void MergeRecordsFrom_DifferentId_IsAllowed()
     {
@@ -279,12 +295,15 @@ public class DNSHeaderMergeTests
         b.ID = 200;
         b.Responses.Add(ARecord("b.example.com", "192.0.2.2"));
 
-        // Different IDs must not prevent the merge.
         a.MergeRecordsFrom(b);
 
         Assert.AreEqual(1, a.Responses.Count);
     }
 
+    /// <summary>
+    /// Verifies that <see cref="DNSHeader.MergeRecordsFrom"/> does not alter the source header:
+    /// the record count stays the same and the existing record reference is unchanged.
+    /// </summary>
     [TestMethod]
     public void MergeRecordsFrom_DoesNotModifySource()
     {
@@ -301,6 +320,10 @@ public class DNSHeaderMergeTests
         Assert.AreSame(sourceRecord, b.Responses[0], "Source record reference must not be replaced.");
     }
 
+    /// <summary>
+    /// Verifies that when <see cref="DNSHeader.MergeRecordsFrom"/> throws due to incompatible
+    /// question sections, the target header's response collection is left unmodified.
+    /// </summary>
     [TestMethod]
     public void MergeRecordsFrom_IncompatibleQuestions_DoesNotModifyTarget()
     {
@@ -308,7 +331,6 @@ public class DNSHeaderMergeTests
         a.Responses.Add(ARecord("a.example.com", "192.0.2.1"));
         int countBefore = a.Responses.Count;
 
-        // Incompatible question section → merge must throw.
         var b = ResponseWithQuestion("other.com");
         b.Responses.Add(ARecord("b.example.com", "192.0.2.2"));
 
@@ -316,6 +338,10 @@ public class DNSHeaderMergeTests
         Assert.AreEqual(countBefore, a.Responses.Count);
     }
 
+    /// <summary>
+    /// Verifies that <see cref="DNSHeader.MergeRecordsFrom"/> preserves the target header's
+    /// transaction ID and flag values after a successful merge.
+    /// </summary>
     [TestMethod]
     public void MergeRecordsFrom_PreservesTargetIdAndFlags()
     {

--- a/UtilsTest/Net/DNSHeaderMergeTests.cs
+++ b/UtilsTest/Net/DNSHeaderMergeTests.cs
@@ -292,16 +292,17 @@ public class DNSHeaderMergeTests
         a.Responses.Add(ARecord("a.example.com", "192.0.2.1"));
 
         var b = ResponseWithQuestion();
-        b.Responses.Add(ARecord("b.example.com", "192.0.2.2"));
-        int sourceCountBefore = b.Responses.Count;
+        var sourceRecord = ARecord("b.example.com", "192.0.2.2");
+        b.Responses.Add(sourceRecord);
 
         a.MergeRecordsFrom(b);
 
-        Assert.AreEqual(sourceCountBefore, b.Responses.Count);
+        Assert.AreEqual(1, b.Responses.Count, "Source record count must not change.");
+        Assert.AreSame(sourceRecord, b.Responses[0], "Source record reference must not be replaced.");
     }
 
     [TestMethod]
-    public void MergeRecordsFrom_Failure_DoesNotModifyTarget()
+    public void MergeRecordsFrom_IncompatibleQuestions_DoesNotModifyTarget()
     {
         var a = ResponseWithQuestion("example.com");
         a.Responses.Add(ARecord("a.example.com", "192.0.2.1"));

--- a/UtilsTest/Net/DNSHeaderMergeTests.cs
+++ b/UtilsTest/Net/DNSHeaderMergeTests.cs
@@ -224,4 +224,117 @@ public class DNSHeaderMergeTests
         Assert.AreEqual(originalId, a.ID);
     }
 
+    [TestMethod]
+    public void MergeRecordsFrom_DifferentQuestionType_Throws()
+    {
+        var reqA = new DNSRequestRecord("A", "example.com");
+        reqA.RequestType = 1;   // A record numeric type
+        var a = new DNSHeader { QrBit = DNSQRBit.Response };
+        a.Requests.Add(reqA);
+
+        var reqB = new DNSRequestRecord("AAAA", "example.com");
+        reqB.RequestType = 28;  // AAAA record numeric type
+        var b = new DNSHeader { QrBit = DNSQRBit.Response };
+        b.Requests.Add(reqB);
+
+        Assert.ThrowsException<InvalidOperationException>(() => a.MergeRecordsFrom(b));
+    }
+
+    [TestMethod]
+    public void MergeRecordsFrom_DifferentQuestionClass_Throws()
+    {
+        var a = new DNSHeader { QrBit = DNSQRBit.Response };
+        a.Requests.Add(new DNSRequestRecord("A", "example.com", DNSClassId.IN));
+
+        var b = new DNSHeader { QrBit = DNSQRBit.Response };
+        b.Requests.Add(new DNSRequestRecord("A", "example.com", DNSClassId.ALL));
+
+        Assert.ThrowsException<InvalidOperationException>(() => a.MergeRecordsFrom(b));
+    }
+
+    [TestMethod]
+    public void MergeRecordsFrom_DifferentQuestionOrder_Throws()
+    {
+        var q1 = new DNSRequestRecord("A", "alpha.example.com");
+        var q2 = new DNSRequestRecord("A", "beta.example.com");
+
+        var a = new DNSHeader { QrBit = DNSQRBit.Response };
+        a.Requests.Add(q1);
+        a.Requests.Add(q2);
+
+        var b = new DNSHeader { QrBit = DNSQRBit.Response };
+        b.Requests.Add((DNSRequestRecord)q2.Clone());
+        b.Requests.Add((DNSRequestRecord)q1.Clone());
+
+        Assert.ThrowsException<InvalidOperationException>(() => a.MergeRecordsFrom(b));
+    }
+
+    [TestMethod]
+    public void MergeRecordsFrom_DifferentId_IsAllowed()
+    {
+        var a = ResponseWithQuestion();
+        a.ID = 100;
+
+        var b = ResponseWithQuestion();
+        b.ID = 200;
+        b.Responses.Add(ARecord("b.example.com", "192.0.2.2"));
+
+        // Different IDs must not prevent the merge.
+        a.MergeRecordsFrom(b);
+
+        Assert.AreEqual(1, a.Responses.Count);
+    }
+
+    [TestMethod]
+    public void MergeRecordsFrom_DoesNotModifySource()
+    {
+        var a = ResponseWithQuestion();
+        a.Responses.Add(ARecord("a.example.com", "192.0.2.1"));
+
+        var b = ResponseWithQuestion();
+        b.Responses.Add(ARecord("b.example.com", "192.0.2.2"));
+        int sourceCountBefore = b.Responses.Count;
+
+        a.MergeRecordsFrom(b);
+
+        Assert.AreEqual(sourceCountBefore, b.Responses.Count);
+    }
+
+    [TestMethod]
+    public void MergeRecordsFrom_Failure_DoesNotModifyTarget()
+    {
+        var a = ResponseWithQuestion("example.com");
+        a.Responses.Add(ARecord("a.example.com", "192.0.2.1"));
+        int countBefore = a.Responses.Count;
+
+        // Incompatible question section → merge must throw.
+        var b = ResponseWithQuestion("other.com");
+        b.Responses.Add(ARecord("b.example.com", "192.0.2.2"));
+
+        Assert.ThrowsException<InvalidOperationException>(() => a.MergeRecordsFrom(b));
+        Assert.AreEqual(countBefore, a.Responses.Count);
+    }
+
+    [TestMethod]
+    public void MergeRecordsFrom_PreservesTargetIdAndFlags()
+    {
+        var a = ResponseWithQuestion();
+        a.ID = 42;
+        a.AuthoritativeAnswer = true;
+        a.RecursionDesired = true;
+        ushort originalId = a.ID;
+
+        var b = ResponseWithQuestion();
+        b.ID = 99;
+        b.AuthoritativeAnswer = true;
+        b.RecursionDesired = true;
+        b.Responses.Add(ARecord("b.example.com", "192.0.2.2"));
+
+        a.MergeRecordsFrom(b);
+
+        Assert.AreEqual(originalId, a.ID, "ID must be preserved after merge.");
+        Assert.IsTrue(a.AuthoritativeAnswer, "AuthoritativeAnswer flag must be preserved.");
+        Assert.IsTrue(a.RecursionDesired, "RecursionDesired flag must be preserved.");
+    }
+
 }

--- a/UtilsTest/Net/NetworkParametersDiscoveryTests.cs
+++ b/UtilsTest/Net/NetworkParametersDiscoveryTests.cs
@@ -126,20 +126,18 @@ public class NetworkParametersDiscoveryTests
     }
 
     [TestMethod]
-    public void NetworkInterfaces_GetterReturnsDefensiveCopy()
+    public void NetworkInterfaces_GetterReturnsReadOnlyView()
     {
         var parameters = new NetworkParameters();
-        NetworkInterface[] first = parameters.NetworkInterfaces;
-        NetworkInterface[] second = parameters.NetworkInterfaces;
+        IReadOnlyList<NetworkInterface> first = parameters.NetworkInterfaces;
+        IReadOnlyList<NetworkInterface> second = parameters.NetworkInterfaces;
 
+        Assert.IsNotNull(first);
+        // Each call produces a new wrapper object around the same internal array.
         Assert.AreNotSame(first, second);
-
-        if (first.Length > 0)
-        {
-            NetworkInterface original = first[0];
-            first[0] = null!;
-            Assert.AreSame(original, parameters.NetworkInterfaces[0]);
-        }
+        Assert.AreEqual(first.Count, second.Count);
+        for (int i = 0; i < first.Count; i++)
+            Assert.AreSame(first[i], second[i]);
     }
 
     [TestMethod]

--- a/UtilsTest/Net/NetworkParametersDiscoveryTests.cs
+++ b/UtilsTest/Net/NetworkParametersDiscoveryTests.cs
@@ -126,6 +126,23 @@ public class NetworkParametersDiscoveryTests
     }
 
     [TestMethod]
+    public void NetworkInterfaces_GetterReturnsDefensiveCopy()
+    {
+        var parameters = new NetworkParameters();
+        NetworkInterface[] first = parameters.NetworkInterfaces;
+        NetworkInterface[] second = parameters.NetworkInterfaces;
+
+        Assert.AreNotSame(first, second);
+
+        if (first.Length > 0)
+        {
+            NetworkInterface original = first[0];
+            first[0] = null!;
+            Assert.AreSame(original, parameters.NetworkInterfaces[0]);
+        }
+    }
+
+    [TestMethod]
     public void SelectDnsServers_PreservesOsEnumerationOrder()
     {
         var result = NetworkParameters.SelectDnsServers(new[]

--- a/UtilsTest/Net/NetworkParametersDiscoveryTests.cs
+++ b/UtilsTest/Net/NetworkParametersDiscoveryTests.cs
@@ -125,6 +125,10 @@ public class NetworkParametersDiscoveryTests
         Assert.AreNotSame(first, second);
     }
 
+    /// <summary>
+    /// Verifies that <see cref="NetworkParameters.NetworkInterfaces"/> returns the same cached
+    /// <see cref="IReadOnlyList{T}"/> instance on every call.
+    /// </summary>
     [TestMethod]
     public void NetworkInterfaces_GetterReturnsReadOnlyView()
     {
@@ -133,11 +137,7 @@ public class NetworkParametersDiscoveryTests
         IReadOnlyList<NetworkInterface> second = parameters.NetworkInterfaces;
 
         Assert.IsNotNull(first);
-        // Each call produces a new wrapper object around the same internal array.
-        Assert.AreNotSame(first, second);
-        Assert.AreEqual(first.Count, second.Count);
-        for (int i = 0; i < first.Count; i++)
-            Assert.AreSame(first[i], second[i]);
+        Assert.AreSame(first, second);
     }
 
     [TestMethod]

--- a/UtilsTest/Net/NtpClientTests.cs
+++ b/UtilsTest/Net/NtpClientTests.cs
@@ -248,6 +248,10 @@ public class NtpClientTests
             () => new UdpNtpTransport(System.Threading.Timeout.InfiniteTimeSpan));
     }
 
+    /// <summary>
+    /// Verifies that <see cref="UdpNtpTransport.ExchangeAsync"/> throws
+    /// <see cref="ArgumentNullException"/> when <paramref name="endpoint"/> is <see langword="null"/>.
+    /// </summary>
     [TestMethod]
     public async Task UdpNtpTransport_NullEndpoint_ThrowsArgumentNullException()
     {
@@ -258,6 +262,10 @@ public class NtpClientTests
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Verifies that <see cref="UdpNtpTransport.ExchangeAsync"/> throws
+    /// <see cref="ArgumentNullException"/> when the request buffer is <see langword="null"/>.
+    /// </summary>
     [TestMethod]
     public async Task UdpNtpTransport_NullRequest_ThrowsArgumentNullException()
     {
@@ -269,6 +277,10 @@ public class NtpClientTests
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Verifies that <see cref="UdpNtpTransport.ExchangeAsync"/> throws
+    /// <see cref="ArgumentException"/> when the request buffer is empty.
+    /// </summary>
     [TestMethod]
     public async Task UdpNtpTransport_EmptyRequest_ThrowsArgumentException()
     {

--- a/UtilsTest/Net/NtpClientTests.cs
+++ b/UtilsTest/Net/NtpClientTests.cs
@@ -249,6 +249,27 @@ public class NtpClientTests
     }
 
     [TestMethod]
+    public async Task UdpNtpTransport_NullEndpoint_ThrowsArgumentNullException()
+    {
+        var transport = new UdpNtpTransport(TimeSpan.FromSeconds(1));
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+            () => transport.ExchangeAsync(null!, new byte[48], CancellationToken.None))
+            .ConfigureAwait(false);
+    }
+
+    [TestMethod]
+    public async Task UdpNtpTransport_NullRequest_ThrowsArgumentNullException()
+    {
+        var transport = new UdpNtpTransport(TimeSpan.FromSeconds(1));
+        var endpoint = new IPEndPoint(IPAddress.Loopback, 123);
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+            () => transport.ExchangeAsync(endpoint, null!, CancellationToken.None))
+            .ConfigureAwait(false);
+    }
+
+    [TestMethod]
     public async Task UdpNtpTransport_EmptyRequest_ThrowsArgumentException()
     {
         var transport = new UdpNtpTransport(TimeSpan.FromSeconds(1));

--- a/UtilsTest/Net/NtpClientTests.cs
+++ b/UtilsTest/Net/NtpClientTests.cs
@@ -249,6 +249,17 @@ public class NtpClientTests
     }
 
     [TestMethod]
+    public async Task UdpNtpTransport_EmptyRequest_ThrowsArgumentException()
+    {
+        var transport = new UdpNtpTransport(TimeSpan.FromSeconds(1));
+        var endpoint = new IPEndPoint(IPAddress.Loopback, 123);
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(
+            () => transport.ExchangeAsync(endpoint, new byte[0], CancellationToken.None))
+            .ConfigureAwait(false);
+    }
+
+    [TestMethod]
     public async Task GetTimeAsync_FractionConversion_IsAccurateWithinOneTickOrDocumentedTolerance()
     {
         DateTime baseTime = new(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/docs/migration/Utils.Net-vNext.md
+++ b/docs/migration/Utils.Net-vNext.md
@@ -88,25 +88,51 @@ before calling `MergeRecordsFrom`, as differing flags now throw `InvalidOperatio
 
 ---
 
-## NetworkParameters — DNS server ordering no longer uses interface index as metric
+## NetworkParameters — DNS server ordering follows OS enumeration order
 
 ### What changed
 
-`NetworkParameters.SelectDnsServers` previously sorted interfaces by `IPv4InterfaceProperties.Index`
-as a tiebreaker (labelled "metric"). This value is an interface identifier, not a routing priority.
-The sort key has been removed; interfaces with the same gateway status are now returned in OS
-enumeration order.
+`NetworkParameters.SelectDnsServers` previously sorted active interfaces — favouring those with a
+default gateway and using `IPv4InterfaceProperties.Index` as a tiebreaker. Both of these sort
+keys have been removed.
+
+DNS servers are now collected in strict OS enumeration order:
+1. Iterate `NetworkInterface.GetAllNetworkInterfaces()` in the order the OS provides.
+2. Include every `OperationalStatus.Up` interface, regardless of whether it has a default gateway.
+3. Within each interface, preserve the order of `DnsAddresses`.
+4. Exclude wildcard/unspecified and multicast addresses.
+5. Deduplicate, keeping the first-seen occurrence.
 
 ### Why
 
-Using the interface index as a routing metric produced incorrect ordering on many systems.
-OS enumeration order is a more faithful representation of the system's DNS priority.
+The previous "gateway-first" heuristic silently broke split-DNS, VPN, and point-to-point
+configurations where the most specific resolver is reachable through an interface without a
+default gateway. A VPN resolver listed first by the OS would be moved after a public DNS server
+on an Ethernet interface that happened to have a default gateway, causing all internal names to
+resolve through the wrong server.
+
+OS enumeration order is the closest approximation to what the system administrator or
+VPN software intended.
 
 ### Impact
 
-The relative order of DNS servers from interfaces with the same gateway status may change.
-In practice this only affects machines with multiple active network interfaces (e.g. Wi-Fi and
-Ethernet simultaneously) where the previously incorrect sort was already unreliable.
+The order of DNS servers returned by `DnsServers` and `PrimaryDns` may change on machines with
+multiple active network interfaces. If your application relied on the previous gateway-first
+ordering, review whether the new OS-enumeration order is correct for your network topology.
+
+### Note on VPN and split-DNS
+
+If a VPN interface appears first in OS enumeration, its resolver is now correctly prioritised.
+A negative DNS response from that resolver (NXDOMAIN) is a valid response and prevents fallback
+to a subsequent public resolver for the same name — which is the expected split-DNS behaviour.
+
+---
+
+## NTP — internal transport changes (no migration required)
+
+The UDP transport used by `NtpClient` (`UdpNtpTransport`) is an internal implementation detail.
+Its constructor and `ExchangeAsync` method are not part of the public API. No migration is required
+for callers of the public `NtpClient.GetTimeAsync` overloads.
 
 ---
 


### PR DESCRIPTION
## Contexte

Corrections de suivi à la PR #525 (`c35e8513`), qui a durci les invariants ARP, l'agrégation d'erreurs DNS, le fallback NTP et le rejet des broadcasts.

Quatre points restaient à adresser après relecture.

---

## Modifications

### 1. `UdpNtpTransport` — validation des arguments et timeout étendu au send

**`Utils.Net/Net/NtpSupport.cs`**

- `ArgumentNullException.ThrowIfNull(endpoint)` et `ThrowIfNull(request)` ajoutés en tête de `ExchangeAsync`.
- Rejet d'une requête vide (`request.Length == 0`) avec `ArgumentException`.
- Le `CancellationTokenSource` de timeout est créé **avant** le `SendAsync`, de sorte que le timeout interne couvre l'envoi **et** la réception (la version précédente ne couvrait que la réception).

**`UtilsTest/Net/NtpClientTests.cs`**

- Nouveau test `UdpNtpTransport_EmptyRequest_ThrowsArgumentException`.

### 2. `NetworkParameters.NetworkInterfaces` — copie défensive

**`Utils.Net/Net/NetworkParameters.cs`**

- Champ privé `_networkInterfaces` (anciennement propriété publique avec setter privé).
- Propriété `NetworkInterfaces` calculée : `(NetworkInterface[])_networkInterfaces.Clone()`.
- Même type de retour qu'avant — aucune rupture d'API, aucune entrée supplémentaire dans l'allowlist.

### 3. Sept tests `MergeRecordsFrom` manquants

**`UtilsTest/Net/DNSHeaderMergeTests.cs`**

| Test | Invariant vérifié |
|---|---|
| `DifferentQuestionType_Throws` | Types de question différents (`RequestType` interne) |
| `DifferentQuestionClass_Throws` | Classes de question différentes (`IN` vs `ALL`) |
| `DifferentQuestionOrder_Throws` | Ordre des questions différent |
| `DifferentId_IsAllowed` | IDs différents autorisés (ID ignoré par `MergeRecordsFrom`) |
| `DoesNotModifySource` | La source n'est pas mutée |
| `Failure_DoesNotModifyTarget` | Atomicité : la cible n'est pas mutée en cas d'échec |
| `PreservesTargetIdAndFlags` | L'ID et les flags de la cible sont préservés après fusion |

### 4. Guide de migration corrigé

**`docs/migration/Utils.Net-vNext.md`**

- Section DNS réécrite : toute référence au tri par présence de passerelle supprimée ; contrat OS-order documenté avec note split-DNS/VPN.
- Nouvelle section _NTP — internal transport changes (no migration required)_ ajoutée.

---

## Critères d'acceptation

- [ ] `dotnet build` : 0 erreurs, 0 avertissements
- [ ] 110 tests Network/DNS/NTP passent (58 unit + 52 autres)
- [ ] `eng/validate-public-api.ps1` : vert (aucune rupture API non enregistrée)
- [ ] CI complète verte avant fusion