### PR TITLE
fix(Utils.IO): audit pass-2 items 17, 18, 26, 27, 30

### DIFF
--- a/Utils.IO/DONE-2026-08-01.md
+++ b/Utils.IO/DONE-2026-08-01.md
@@ -4,7 +4,10 @@ This pass complements `TODO.md`. It focuses on serialization framing, dynamic re
 
 ## High priority
 
-### 17. LEB128 readers accept overlong and overflowing encodings
+### 17. LEB128 readers accept overlong and overflowing encodings ✅
+
+**Status: Fixed.** `ReadULEB128`/`ReadSLEB128` are now bounded to 10 bytes. The tenth byte is validated (continuation bit clear, ULEB128 payload ≤ `0x01`, SLEB128 payload a valid sign extension). Overlong encodings are rejected with `FormatException`; over-64-bit values raise `OverflowException`; truncation still raises `EndOfStreamException`. The reader consumes only the bytes needed to reach the error.
+
 
 `ReadULEB128` and `ReadSLEB128` keep reading while the continuation bit is set, with no 10-byte limit for 64-bit values and no validation of the final payload bits. Once `shift` reaches or exceeds 64, C# masks the shift count, so later bytes can overwrite earlier result bits instead of reliably overflowing.
 
@@ -14,7 +17,10 @@ This pass complements `TODO.md`. It focuses on serialization framing, dynamic re
 
 **Priority: P1.**
 
-### 18. Variable-length string prefix width silently defaults to four bytes and can truncate lengths
+### 18. Variable-length string prefix width silently defaults to four bytes and can truncate lengths ✅
+
+**Status: Fixed.** Both `ReadVariableLengthString` and `WriteVariableLengthString` reject any `sizeLength` other than 1, 2, or 4 with `ArgumentOutOfRangeException` before any I/O. The writer encodes first and verifies the byte length fits the selected prefix (255/65535/int.MaxValue), throwing without a partial write on overflow. A new `ReadVariableLengthString(..., int maxByteLength)` overload rejects negative lengths (`FormatException`) and enforces the maximum before allocation.
+
 
 `ReadVariableLengthString` and `WriteVariableLengthString` treat every `sizeLength` other than `1` or `2` as `4`. The writer casts encoded lengths to `byte` or `ushort` without checking that they fit.
 
@@ -88,7 +94,10 @@ The source generator searches globally for methods named `Read<Type.Name>` or `W
 
 **Priority: P1.**
 
-### 26. Whole-stream helpers remain unbounded despite the previous audit being marked complete
+### 26. Whole-stream helpers remain unbounded despite the previous audit being marked complete ✅
+
+**Status: Fixed.** `ReadToMemoryStream` and `ReadAllText` gained an optional `maxBytes` limit (checked before each 4096-byte block; source left open; buffer disposed on failure; BOM detection preserved). A new bounded `ReadBlock(Stream, byte[], int maxBytes)` overload scans for the delimiter with Knuth-Morris-Pratt over 4096-byte chunks, throws `InvalidOperationException` when the limit is exceeded and `EndOfStreamException` when EOF is reached before the separator. Negative limits raise `ArgumentOutOfRangeException`. The original unbounded `ReadBlock(Stream, byte[])` overload is unchanged.
+
 
 `ReadToEnd` gained a limit, but `ReadToMemoryStream`, `ReadAllText`, and `ReadBlock` still have no size limit. `ReadBlock` also reads byte by byte and stores the complete block before returning.
 
@@ -100,7 +109,10 @@ The source generator searches globally for methods named `Read<Type.Name>` or `W
 
 ## Medium priority
 
-### 27. Strict base decoding does not reject every incomplete unpadded quantum
+### 27. Strict base decoding does not reject every incomplete unpadded quantum ✅
+
+**Status: Fixed.** `BaseDecoderStream.Close` now derives the terminal validity from `BitsWidth`. The leftover-bit count equals `(sourceLength * BitsWidth) mod 8`; a terminal quantum is valid only when those leftover bits number fewer than one symbol (`dataLength < BitsWidth`), otherwise a `FormatException` is thrown. This rejects a single Base16 nibble, a single Base64 symbol, and the Base32 counts (1, 3, 6) that cannot complete a byte, while accepting the standard Base32 quanta (2, 4, 5, 7). Non-zero trailing bits still raise `FormatException`. Permissive mode is unaffected.
+
 
 Final validation is centered on whether an additional byte appears to have been produced and on padding count. For encodings without filler, such as base 16, a single symbol leaves four unresolved bits but can reach `Close` without a format error.
 
@@ -124,7 +136,10 @@ The constructors accept any stream, but `BytesLeft` accesses both `Length` and `
 
 **Priority: P2.**
 
-### 30. Stream wrappers do not implement modern span and asynchronous paths explicitly
+### 30. Stream wrappers do not implement modern span and asynchronous paths explicitly ✅
+
+**Status: Fixed.** `PartialStream` was already covered (2026-07-31). `StreamCopier` now implements `Write(ReadOnlySpan<byte>)`, `WriteAsync` (array + memory), `FlushAsync`, and `DisposeAsync`; each takes a target snapshot, attempts every target, aggregates errors into `AggregateException`, and gives cancellation priority (`OperationCanceledException`) when requested before the loop. `Dispose` is now idempotent via a `_disposed` flag. `BaseEncoderStream` extracts a shared `EncodeCore(ReadOnlySpan<byte>)` used by `Write(byte[],…)`, `Write(ReadOnlySpan<byte>)`, and the async writes; a `SemaphoreSlim(1,1)` serializes concurrent async writes so encoder state never interleaves; cancellation observed before encoding leaves state unchanged; `DisposeAsync` finalizes through `Close` then `base.DisposeAsync`.
+
 
 `PartialStream`, `StreamCopier`, and `BaseEncoderStream` override only array-based synchronous operations. Calls through `Read(Span<byte>)`, `Write(ReadOnlySpan<byte>)`, `ReadAsync`, or `WriteAsync` therefore depend on base-class fallback behavior, which may allocate, execute synchronously, or provide weak cancellation semantics.
 

--- a/Utils.IO/IO/BaseEncoding/BaseDecoderStream.cs
+++ b/Utils.IO/IO/BaseEncoding/BaseDecoderStream.cs
@@ -140,22 +140,21 @@ public class BaseDecoderStream : TextWriter
         {
             if (dataLength > 0)
             {
-                int targetLength = (int)Math.Floor(sourceLength * BaseDescriptor.BitsWidth / 8d);
-                if (actualTargetLength > targetLength)
+                // dataLength holds the leftover bits after all whole bytes were emitted, i.e.
+                // (sourceLength * BitsWidth) mod 8. A valid terminal quantum leaves fewer than one
+                // symbol worth of bits (dataLength < BitsWidth): those bits are discarded padding.
+                // When dataLength >= BitsWidth an extra, unusable symbol was supplied — for example a
+                // single Base16 or Base64 symbol — which can never complete a byte and is a format error.
+                int bitsWidth = BaseDescriptor.BitsWidth;
+                if (strict)
                 {
-                    if (strict)
-                    {
-                        // Verify trailing bits are zero
-                        int trailingBits = dataLength;
-                        int mask = (1 << trailingBits) - 1;
-                        if ((currentValue & mask) != 0)
-                            throw new FormatException("Non-zero trailing bits in final quantum.");
-                    }
+                    if (dataLength >= bitsWidth)
+                        throw new FormatException($"Incomplete final quantum: {dataLength} leftover bit(s) do not form a valid terminal group.");
 
-                    // Align remaining bits and write the last byte
-                    currentValue <<= BaseDescriptor.BitsWidth;
-                    dataLength += BaseDescriptor.BitsWidth - 8;
-                    Stream.WriteByte((byte)((currentValue >> dataLength) & 0xFF));
+                    // The leftover bits are padding and must all be zero.
+                    int mask = (1 << dataLength) - 1;
+                    if ((currentValue & mask) != 0)
+                        throw new FormatException("Non-zero trailing bits in final quantum.");
                 }
             }
 

--- a/Utils.IO/IO/BaseEncoding/BaseEncoderStream.cs
+++ b/Utils.IO/IO/BaseEncoding/BaseEncoderStream.cs
@@ -105,6 +105,8 @@ public class BaseEncoderStream : Stream
     private int shift;
     private int dataWidth;
     private bool _closed;
+    // 0 = not disposed; 1 = disposed. Written atomically so DisposeAsync is idempotent under concurrency.
+    private int _disposeState;
 
     /// <summary>
     /// Serializes concurrent asynchronous writes so encoder state is never interleaved across awaits.
@@ -265,6 +267,10 @@ public class BaseEncoderStream : Stream
     /// <returns>A task that completes once finalization has run.</returns>
     public override async ValueTask DisposeAsync()
     {
+        // Atomically claim the dispose slot; any subsequent caller returns immediately.
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
+            return;
+
         // Acquire the gate to ensure any concurrent async write completes before we finalize.
         // Close() itself is synchronous and idempotent; it must run while we hold the gate.
         await _asyncGate.WaitAsync().ConfigureAwait(false);

--- a/Utils.IO/IO/BaseEncoding/BaseEncoderStream.cs
+++ b/Utils.IO/IO/BaseEncoding/BaseEncoderStream.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Utils.IO.BaseEncoding;
 
@@ -105,6 +107,11 @@ public class BaseEncoderStream : Stream
     private bool _closed;
 
     /// <summary>
+    /// Serializes concurrent asynchronous writes so encoder state is never interleaved across awaits.
+    /// </summary>
+    private readonly SemaphoreSlim _asyncGate = new(1, 1);
+
+    /// <summary>
     /// Encodes the provided byte buffer and writes the resulting characters.
     /// </summary>
     /// <param name="buffer">Source buffer.</param>
@@ -114,10 +121,32 @@ public class BaseEncoderStream : Stream
     public override void Write(byte[] buffer, int offset, int count)
     {
         ObjectDisposedException.ThrowIf(_closed, this);
-        int end = offset + count;
-        for (int idx = offset; idx < end; idx++)
+        Stream.ValidateBufferArguments(buffer, offset, count);
+        EncodeCore(new ReadOnlySpan<byte>(buffer, offset, count));
+    }
+
+    /// <summary>
+    /// Encodes the provided span of bytes and writes the resulting characters.
+    /// </summary>
+    /// <param name="buffer">Source span.</param>
+    /// <exception cref="ObjectDisposedException">Thrown when writing after the stream is closed.</exception>
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        ObjectDisposedException.ThrowIf(_closed, this);
+        EncodeCore(buffer);
+    }
+
+    /// <summary>
+    /// Core encoding loop shared by every synchronous and asynchronous write path. It consumes the source
+    /// bytes eight bits at a time, emits a base symbol whenever <see cref="Depth"/> bits are available, and
+    /// inserts the configured line separator and indentation when <see cref="MaxDataWidth"/> is reached.
+    /// </summary>
+    /// <param name="data">The binary data to encode.</param>
+    private void EncodeCore(ReadOnlySpan<byte> data)
+    {
+        for (int idx = 0; idx < data.Length; idx++)
         {
-            byte b = buffer[idx];
+            byte b = data[idx];
             position++;
             value = (value << 8) | b;
             shift += 8;
@@ -140,6 +169,64 @@ public class BaseEncoderStream : Stream
                     }
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously encodes the specified buffer range. Encoding is CPU-bound and runs synchronously under
+    /// a serialization gate; the underlying writer is not flushed here. Cancellation observed before encoding
+    /// starts leaves the encoder state unchanged.
+    /// </summary>
+    /// <param name="buffer">The source buffer.</param>
+    /// <param name="offset">The offset of the first byte to encode.</param>
+    /// <param name="count">The number of bytes to encode.</param>
+    /// <param name="cancellationToken">A token observed before encoding begins.</param>
+    /// <returns>A task that completes when the data has been encoded.</returns>
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+
+    /// <summary>
+    /// Asynchronously encodes the specified memory buffer. Encoding is CPU-bound and runs synchronously under
+    /// a serialization gate; the underlying writer is not flushed here. Cancellation observed before encoding
+    /// starts leaves the encoder state unchanged.
+    /// </summary>
+    /// <param name="buffer">The source buffer.</param>
+    /// <param name="cancellationToken">A token observed before encoding begins.</param>
+    /// <returns>A task that completes when the data has been encoded.</returns>
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_closed, this);
+        // A cancelled call must not modify state, so check before acquiring the gate or encoding.
+        cancellationToken.ThrowIfCancellationRequested();
+        await _asyncGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_closed, this);
+            cancellationToken.ThrowIfCancellationRequested();
+            EncodeCore(buffer.Span);
+        }
+        finally
+        {
+            _asyncGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously flushes the underlying writer.
+    /// </summary>
+    /// <param name="cancellationToken">A token observed before flushing.</param>
+    /// <returns>A task that completes when the writer has been flushed.</returns>
+    public override async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await _asyncGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await TargetWriter.FlushAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _asyncGate.Release();
         }
     }
 
@@ -167,6 +254,20 @@ public class BaseEncoderStream : Stream
 
         Flush();
         base.Close();
+    }
+
+    /// <summary>
+    /// Asynchronously finalizes the encoding (flushing remaining bits and padding through <see cref="Close"/>)
+    /// and then releases base resources. Safe to call more than once.
+    /// </summary>
+    /// <returns>A task that completes once finalization has run.</returns>
+    public override async ValueTask DisposeAsync()
+    {
+        // Close() performs the padding/finalization and is idempotent.
+        Close();
+        await base.DisposeAsync().ConfigureAwait(false);
+        _asyncGate.Dispose();
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/Utils.IO/IO/BaseEncoding/BaseEncoderStream.cs
+++ b/Utils.IO/IO/BaseEncoding/BaseEncoderStream.cs
@@ -259,12 +259,23 @@ public class BaseEncoderStream : Stream
     /// <summary>
     /// Asynchronously finalizes the encoding (flushing remaining bits and padding through <see cref="Close"/>)
     /// and then releases base resources. Safe to call more than once.
+    /// The gate is acquired before finalization so that a concurrent <see cref="WriteAsync"/> in progress
+    /// completes before the padding and the <see cref="SemaphoreSlim"/> are disposed.
     /// </summary>
     /// <returns>A task that completes once finalization has run.</returns>
     public override async ValueTask DisposeAsync()
     {
-        // Close() performs the padding/finalization and is idempotent.
-        Close();
+        // Acquire the gate to ensure any concurrent async write completes before we finalize.
+        // Close() itself is synchronous and idempotent; it must run while we hold the gate.
+        await _asyncGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            Close();
+        }
+        finally
+        {
+            _asyncGate.Release();
+        }
         await base.DisposeAsync().ConfigureAwait(false);
         _asyncGate.Dispose();
         GC.SuppressFinalize(this);

--- a/Utils.IO/IO/Serialization/ReaderWriterExtensions.cs
+++ b/Utils.IO/IO/Serialization/ReaderWriterExtensions.cs
@@ -236,9 +236,12 @@ public static class ReaderWriterExtensions
                     result |= -(1L << shift);
 
                 // Reject overlong encodings: a redundant final group that only repeats the sign already
-                // established by the previous group's high (0x40) bit. The tenth byte is never redundant
-                // because it carries the otherwise unrepresentable 64th bit.
-                if (byteCount > 1 && byteCount < Leb128MaxBytes)
+                // established by the previous group's high (0x40) bit.
+                // Applied to the tenth byte as well: long.MinValue and long.MaxValue both require the tenth
+                // byte because their bit-63 disagrees with what byte-9's sign would imply, so they are
+                // never flagged. Values that could terminate at byte 9 — zero, -1, and any value whose
+                // bit-62 already carries the correct bit-63 sign — are overlong if encoded with a tenth byte.
+                if (byteCount > 1)
                 {
                     bool previousSignSet = (previousPayload & 0x40) != 0;
                     if (payload == 0x00 && !previousSignSet)

--- a/Utils.IO/IO/Serialization/ReaderWriterExtensions.cs
+++ b/Utils.IO/IO/Serialization/ReaderWriterExtensions.cs
@@ -27,16 +27,62 @@ public static class ReaderWriterExtensions
     /// </summary>
     /// <param name="reader">The reader to read from.</param>
     /// <param name="encoding">Encoding of the string.</param>
-    /// <param name="sizeLength">Number of bytes used to store the length.</param>
+    /// <param name="sizeLength">Number of bytes used to store the length. Must be 1, 2, or 4.</param>
+    /// <returns>The decoded string.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="sizeLength"/> is not 1, 2, or 4.</exception>
+    /// <exception cref="FormatException">Thrown when a four-byte prefix contains a negative length.</exception>
     public static string ReadVariableLengthString(this Reader reader, Encoding encoding, int sizeLength = sizeof(int))
+        => ReadVariableLengthString(reader, encoding, sizeLength, int.MaxValue);
+
+    /// <summary>
+    /// Reads a length-prefixed string from the reader, enforcing a maximum byte length before allocation.
+    /// </summary>
+    /// <param name="reader">The reader to read from.</param>
+    /// <param name="encoding">Encoding of the string.</param>
+    /// <param name="sizeLength">Number of bytes used to store the length. Must be 1, 2, or 4.</param>
+    /// <param name="maxByteLength">
+    /// The maximum number of encoded bytes accepted for the payload. A length read from the stream that
+    /// exceeds this value is rejected before any payload allocation.
+    /// </param>
+    /// <returns>The decoded string.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="sizeLength"/> is not 1, 2, or 4, when <paramref name="maxByteLength"/> is negative,
+    /// or when the length read from the stream exceeds <paramref name="maxByteLength"/>.
+    /// </exception>
+    /// <exception cref="FormatException">Thrown when a four-byte prefix contains a negative length.</exception>
+    public static string ReadVariableLengthString(this Reader reader, Encoding encoding, int sizeLength, int maxByteLength)
     {
+        // Validate all arguments before performing any I/O so a bad call does not consume bytes.
+        ValidateSizeLength(sizeLength);
+        if (maxByteLength < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxByteLength), "The maximum byte length must be non-negative.");
+
         int length = sizeLength switch
         {
             1 => reader.ReadByte(),
             2 => reader.Read<UInt16>(),
             _ => reader.Read<Int32>()
         };
+
+        // A four-byte prefix is signed on the wire; reject negative lengths explicitly.
+        if (length < 0)
+            throw new FormatException($"The length prefix contains a negative value ({length}).");
+        // Enforce the configured maximum before allocating the payload buffer.
+        if (length > maxByteLength)
+            throw new ArgumentOutOfRangeException(nameof(maxByteLength), $"The declared length {length} exceeds the maximum allowed byte length {maxByteLength}.");
+
         return encoding.GetString(reader.ReadBytes(length));
+    }
+
+    /// <summary>
+    /// Validates that a length-prefix width is one of the supported values (1, 2, or 4 bytes).
+    /// </summary>
+    /// <param name="sizeLength">The prefix width to validate.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="sizeLength"/> is not 1, 2, or 4.</exception>
+    private static void ValidateSizeLength(int sizeLength)
+    {
+        if (sizeLength is not (1 or 2 or 4))
+            throw new ArgumentOutOfRangeException(nameof(sizeLength), sizeLength, "The length prefix width must be 1, 2, or 4 bytes.");
     }
 
     /// <summary>
@@ -68,49 +114,144 @@ public static class ReaderWriterExtensions
     }
 
     /// <summary>
+    /// Maximum number of bytes a 64-bit LEB128 value may occupy (ceil(64 / 7) = 10).
+    /// </summary>
+    private const int Leb128MaxBytes = 10;
+
+    /// <summary>
     /// Reads an unsigned LEB128-encoded integer from the reader.
     /// </summary>
+    /// <remarks>
+    /// The reader is bounded to 10 bytes for a 64-bit value. The tenth byte must have its continuation
+    /// bit clear and a payload of at most <c>0x01</c> (a single high bit), because 9 groups of 7 bits
+    /// already cover 63 bits. Overlong encodings such as <c>80 00</c> for zero are rejected: a group whose
+    /// payload is zero and whose continuation bit is clear is only valid when it is the first byte.
+    /// </remarks>
     /// <param name="reader">The reader to read from.</param>
     /// <returns>The unsigned integer decoded from the LEB128 byte sequence.</returns>
     /// <exception cref="EndOfStreamException">Thrown when the stream ends before the value is complete.</exception>
+    /// <exception cref="FormatException">Thrown when the encoding is non-canonical (overlong).</exception>
+    /// <exception cref="OverflowException">Thrown when the encoded value does not fit in a <see cref="ulong"/>.</exception>
     public static ulong ReadULEB128(this IReader reader)
     {
         ulong result = 0;
         int shift = 0;
+        int byteCount = 0;
         int raw;
-        do
+        while (true)
         {
             raw = reader.ReadByte();
-            if (raw < 0) throw new EndOfStreamException("Unexpected end of stream reading ULEB128.");
-            result |= (ulong)(raw & 0x7F) << shift;
+            if (raw < 0)
+                throw new EndOfStreamException("Unexpected end of stream reading ULEB128.");
+            byteCount++;
+
+            int payload = raw & 0x7F;
+            bool more = (raw & 0x80) != 0;
+
+            if (byteCount == Leb128MaxBytes)
+            {
+                // Only the lowest bit remains available (63 bits already consumed by 9 groups).
+                if (more)
+                    throw new OverflowException("ULEB128 value exceeds 64 bits (continuation bit set on the tenth byte).");
+                if (payload > 0x01)
+                    throw new OverflowException("ULEB128 value exceeds 64 bits (tenth byte payload greater than 0x01).");
+            }
+            else if (byteCount > Leb128MaxBytes)
+            {
+                // Guarded by the continuation check above, but kept as a defensive bound.
+                throw new OverflowException("ULEB128 value exceeds 64 bits.");
+            }
+
+            result |= (ulong)payload << shift;
+
+            if (!more)
+            {
+                // Reject a non-canonical trailing zero group (e.g. 80 00). A zero payload with the
+                // continuation bit clear is only canonical when it is the very first byte.
+                if (byteCount > 1 && payload == 0)
+                    throw new FormatException("Non-canonical (overlong) ULEB128 encoding.");
+                return result;
+            }
+
             shift += 7;
         }
-        while ((raw & 0x80) != 0);
-        return result;
     }
 
     /// <summary>
     /// Reads a signed LEB128-encoded integer from the reader.
     /// </summary>
+    /// <remarks>
+    /// The reader is bounded to 10 bytes for a 64-bit value. On the tenth byte the bits above the sign
+    /// bit (bit 62 of the accumulated value) must be a valid sign extension: all zero for a non-negative
+    /// value and all one for a negative value. Overlong encodings — a trailing <c>00</c> group extending a
+    /// non-negative value or a trailing <c>7F</c> group extending a negative value — are rejected as
+    /// non-canonical.
+    /// </remarks>
     /// <param name="reader">The reader to read from.</param>
     /// <returns>The signed integer decoded from the LEB128 byte sequence.</returns>
     /// <exception cref="EndOfStreamException">Thrown when the stream ends before the value is complete.</exception>
+    /// <exception cref="FormatException">Thrown when the encoding is non-canonical (overlong).</exception>
+    /// <exception cref="OverflowException">Thrown when the encoded value does not fit in a <see cref="long"/>.</exception>
     public static long ReadSLEB128(this IReader reader)
     {
         long result = 0;
         int shift = 0;
+        int byteCount = 0;
+        int previousPayload = 0;
         int raw;
-        do
+        while (true)
         {
             raw = reader.ReadByte();
-            if (raw < 0) throw new EndOfStreamException("Unexpected end of stream reading SLEB128.");
-            result |= (long)(raw & 0x7F) << shift;
+            if (raw < 0)
+                throw new EndOfStreamException("Unexpected end of stream reading SLEB128.");
+            byteCount++;
+
+            int payload = raw & 0x7F;
+            bool more = (raw & 0x80) != 0;
+
+            if (byteCount == Leb128MaxBytes)
+            {
+                if (more)
+                    throw new OverflowException("SLEB128 value exceeds 64 bits (continuation bit set on the tenth byte).");
+                // 9 groups fill 63 bits (bits 0..62). Only bit 63 is representable on the tenth byte;
+                // the remaining payload bits must be a valid sign extension of that single bit:
+                // 0x00 for a non-negative value or 0x7F for a negative value.
+                int signBit = payload & 0x01;
+                int expected = signBit == 0 ? 0x00 : 0x7F;
+                if (payload != expected)
+                    throw new OverflowException("SLEB128 value exceeds 64 bits (invalid sign extension on the tenth byte).");
+            }
+            else if (byteCount > Leb128MaxBytes)
+            {
+                throw new OverflowException("SLEB128 value exceeds 64 bits.");
+            }
+
+            result |= (long)payload << shift;
             shift += 7;
+
+            if (!more)
+            {
+                // Apply sign extension for the terminating group when it is representable.
+                if (shift < 64 && (raw & 0x40) != 0)
+                    result |= -(1L << shift);
+
+                // Reject overlong encodings: a redundant final group that only repeats the sign already
+                // established by the previous group's high (0x40) bit. The tenth byte is never redundant
+                // because it carries the otherwise unrepresentable 64th bit.
+                if (byteCount > 1 && byteCount < Leb128MaxBytes)
+                {
+                    bool previousSignSet = (previousPayload & 0x40) != 0;
+                    if (payload == 0x00 && !previousSignSet)
+                        throw new FormatException("Non-canonical (overlong) SLEB128 encoding of a non-negative value.");
+                    if (payload == 0x7F && previousSignSet)
+                        throw new FormatException("Non-canonical (overlong) SLEB128 encoding of a negative value.");
+                }
+
+                return result;
+            }
+
+            previousPayload = payload;
         }
-        while ((raw & 0x80) != 0);
-        if (shift < 64 && (raw & 0x40) != 0)
-            result |= -(1L << shift);
-        return result;
     }
 
     /// <summary>
@@ -156,9 +297,26 @@ public static class ReaderWriterExtensions
     /// <param name="value">String value to write.</param>
     /// <param name="encoding">Encoding of the string.</param>
     /// <param name="sizeLength">Number of bytes used to store the length prefix (1, 2, or 4).</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="sizeLength"/> is not 1, 2, or 4, or when the encoded byte length does not
+    /// fit in the selected prefix width. No bytes are written when this exception is thrown.
+    /// </exception>
     public static void WriteVariableLengthString(this Writer writer, string value, Encoding encoding, int sizeLength = sizeof(int))
     {
+        // Validate the prefix width before touching the writer so an invalid call performs no I/O.
+        ValidateSizeLength(sizeLength);
+
+        // Encode first and verify the length fits the prefix so the failure happens before any partial write.
         var bytes = encoding.GetBytes(value);
+        long max = sizeLength switch
+        {
+            1 => byte.MaxValue,
+            2 => ushort.MaxValue,
+            _ => int.MaxValue
+        };
+        if (bytes.Length > max)
+            throw new ArgumentOutOfRangeException(nameof(value), $"The encoded string is {bytes.Length} bytes, which does not fit in a {sizeLength}-byte length prefix (maximum {max}).");
+
         switch (sizeLength)
         {
             case 1:

--- a/Utils.IO/IO/StreamCopier.cs
+++ b/Utils.IO/IO/StreamCopier.cs
@@ -124,6 +124,7 @@ public class StreamCopier : Stream, IList<Stream>
     /// </summary>
     public override void Flush()
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         List<Exception>? errors = null;
         foreach (Stream s in _targets)
         {
@@ -161,6 +162,7 @@ public class StreamCopier : Stream, IList<Stream>
     /// <param name="count">The number of bytes to write.</param>
     public override void Write(byte[] buffer, int offset, int count)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         List<Exception>? errors = null;
         // Snapshot to guard against concurrent modification
         Stream[] snapshot = [.. _targets];
@@ -174,15 +176,22 @@ public class StreamCopier : Stream, IList<Stream>
     }
 
     /// <summary>
-    /// Writes a span of bytes to all target streams by copying the span into a temporary array and
-    /// delegating to the array-based fan-out <see cref="Write(byte[], int, int)"/>.
+    /// Writes a span of bytes to all target streams. Every target receives the same span without any
+    /// intermediate allocation. Errors are aggregated in the same way as <see cref="Write(byte[], int, int)"/>.
     /// </summary>
     /// <param name="buffer">The span of bytes to broadcast to every target.</param>
     public override void Write(ReadOnlySpan<byte> buffer)
     {
-        // Materialize once so all targets receive the identical payload; then reuse the fan-out policy.
-        byte[] copy = buffer.ToArray();
-        Write(copy, 0, copy.Length);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        List<Exception>? errors = null;
+        Stream[] snapshot = [.. _targets];
+        foreach (Stream s in snapshot)
+        {
+            try { s.Write(buffer); }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+        }
+        if (errors is not null)
+            throw new AggregateException("One or more target streams failed to write.", errors);
     }
 
     /// <summary>
@@ -208,6 +217,7 @@ public class StreamCopier : Stream, IList<Stream>
     /// <returns>A task that completes when every target has been attempted.</returns>
     public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         // Snapshot first so concurrent list mutations do not affect this operation.
         Stream[] snapshot = [.. _targets];
         // Cancellation observed before any target is touched aborts the whole operation.
@@ -232,6 +242,7 @@ public class StreamCopier : Stream, IList<Stream>
     /// <returns>A task that completes when every target has been attempted.</returns>
     public override async Task FlushAsync(CancellationToken cancellationToken)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         Stream[] snapshot = [.. _targets];
         if (cancellationToken.IsCancellationRequested)
             throw new OperationCanceledException(cancellationToken);
@@ -296,6 +307,7 @@ public class StreamCopier : Stream, IList<Stream>
     /// Asynchronously disposes the current <see cref="StreamCopier"/>. If <see cref="closeAllTargetsOnDispose"/>
     /// is <see langword="true"/>, all target streams are asynchronously disposed; every target is attempted
     /// even if one fails and errors are aggregated. The method is idempotent.
+    /// After disposal all write and flush operations throw <see cref="ObjectDisposedException"/>.
     /// </summary>
     /// <returns>A task that completes once disposal has been attempted for every target.</returns>
     public override async ValueTask DisposeAsync()
@@ -306,9 +318,10 @@ public class StreamCopier : Stream, IList<Stream>
 
         GC.SuppressFinalize(this);
 
+        List<Exception>? errors = null;
+
         if (closeAllTargetsOnDispose)
         {
-            List<Exception>? errors = null;
             foreach (Stream s in _targets)
             {
                 try
@@ -319,9 +332,15 @@ public class StreamCopier : Stream, IList<Stream>
                 catch (Exception ex) { (errors ??= []).Add(ex); }
             }
             _targets.Clear();
-            if (errors is not null)
-                throw new AggregateException("One or more target streams failed to dispose.", errors);
         }
+
+        // Signal to the base Stream that this instance is disposed so that the runtime and
+        // callers using the base-class abstraction observe consistent disposed semantics.
+        try { await base.DisposeAsync().ConfigureAwait(false); }
+        catch (Exception ex) { (errors ??= []).Add(ex); }
+
+        if (errors is not null)
+            throw new AggregateException("One or more streams failed during asynchronous disposal.", errors);
     }
 
     #endregion

--- a/Utils.IO/IO/StreamCopier.cs
+++ b/Utils.IO/IO/StreamCopier.cs
@@ -3,6 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Utils.IO;
 
@@ -43,6 +45,12 @@ public class StreamCopier : Stream, IList<Stream>
     /// dispose/close all target streams in <see cref="_targets"/>.
     /// </summary>
     private readonly bool closeAllTargetsOnDispose;
+
+    /// <summary>
+    /// Tracks whether this instance has already been disposed so that <see cref="Dispose(bool)"/>
+    /// and <see cref="DisposeAsync"/> are idempotent.
+    /// </summary>
+    private bool _disposed;
 
     #region Constructors
 
@@ -166,22 +174,153 @@ public class StreamCopier : Stream, IList<Stream>
     }
 
     /// <summary>
+    /// Writes a span of bytes to all target streams by copying the span into a temporary array and
+    /// delegating to the array-based fan-out <see cref="Write(byte[], int, int)"/>.
+    /// </summary>
+    /// <param name="buffer">The span of bytes to broadcast to every target.</param>
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        // Materialize once so all targets receive the identical payload; then reuse the fan-out policy.
+        byte[] copy = buffer.ToArray();
+        Write(copy, 0, copy.Length);
+    }
+
+    /// <summary>
+    /// Asynchronously writes the specified buffer range to every target stream. A snapshot of the targets
+    /// is taken before the loop; all targets are attempted even if earlier ones fail, and errors are
+    /// aggregated. Cancellation requested before the loop takes priority over target failures.
+    /// </summary>
+    /// <param name="buffer">The source buffer.</param>
+    /// <param name="offset">The offset of the first byte to write.</param>
+    /// <param name="count">The number of bytes to write.</param>
+    /// <param name="cancellationToken">A token used to observe cancellation before the operation starts.</param>
+    /// <returns>A task that completes when every target has been attempted.</returns>
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+
+    /// <summary>
+    /// Asynchronously writes the specified memory buffer to every target stream. A snapshot of the targets
+    /// is taken before the loop; all targets are attempted even if earlier ones fail, and errors are
+    /// aggregated. Cancellation requested before the loop takes priority over target failures.
+    /// </summary>
+    /// <param name="buffer">The source buffer.</param>
+    /// <param name="cancellationToken">A token used to observe cancellation before the operation starts.</param>
+    /// <returns>A task that completes when every target has been attempted.</returns>
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        // Snapshot first so concurrent list mutations do not affect this operation.
+        Stream[] snapshot = [.. _targets];
+        // Cancellation observed before any target is touched aborts the whole operation.
+        if (cancellationToken.IsCancellationRequested)
+            throw new OperationCanceledException(cancellationToken);
+
+        List<Exception>? errors = null;
+        foreach (Stream s in snapshot)
+        {
+            try { await s.WriteAsync(buffer, cancellationToken).ConfigureAwait(false); }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+        }
+        ThrowAggregatedOrCancellation(errors, cancellationToken, "One or more target streams failed to write.");
+    }
+
+    /// <summary>
+    /// Asynchronously flushes every target stream. A snapshot is taken before the loop; all targets are
+    /// attempted even if earlier ones fail, and errors are aggregated. Cancellation requested before the
+    /// loop takes priority over target failures.
+    /// </summary>
+    /// <param name="cancellationToken">A token used to observe cancellation before the operation starts.</param>
+    /// <returns>A task that completes when every target has been attempted.</returns>
+    public override async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        Stream[] snapshot = [.. _targets];
+        if (cancellationToken.IsCancellationRequested)
+            throw new OperationCanceledException(cancellationToken);
+
+        List<Exception>? errors = null;
+        foreach (Stream s in snapshot)
+        {
+            try { await s.FlushAsync(cancellationToken).ConfigureAwait(false); }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+        }
+        ThrowAggregatedOrCancellation(errors, cancellationToken, "One or more target streams failed to flush.");
+    }
+
+    /// <summary>
+    /// Throws an aggregated error, an <see cref="OperationCanceledException"/>, or nothing depending on the
+    /// collected errors and cancellation state. When cancellation was requested it takes priority over any
+    /// aggregated target failures.
+    /// </summary>
+    /// <param name="errors">The collected target errors, or <see langword="null"/> when none occurred.</param>
+    /// <param name="cancellationToken">The token whose cancellation state is checked.</param>
+    /// <param name="message">The message used for the aggregated exception.</param>
+    private static void ThrowAggregatedOrCancellation(List<Exception>? errors, CancellationToken cancellationToken, string message)
+    {
+        if (cancellationToken.IsCancellationRequested)
+            throw new OperationCanceledException(cancellationToken);
+        if (errors is not null)
+            throw new AggregateException(message, errors);
+    }
+
+    /// <summary>
     /// Disposes the current <see cref="StreamCopier"/>. If <see cref="closeAllTargetsOnDispose"/>
-    /// is <see langword="true"/>, all target streams will also be disposed.
+    /// is <see langword="true"/>, all target streams will also be disposed. The method is idempotent.
     /// </summary>
     /// <param name="disposing">Whether this method is being called from a managed context.</param>
     protected override void Dispose(bool disposing)
     {
+        if (_disposed)
+        {
+            base.Dispose(disposing);
+            return;
+        }
+        _disposed = true;
+
         base.Dispose(disposing);
 
         if (disposing && closeAllTargetsOnDispose)
         {
-            // Close/Dispose each stream in the list
+            // Attempt every target even if one fails; aggregate the errors.
+            List<Exception>? errors = null;
             foreach (Stream s in _targets)
             {
-                s?.Dispose();
+                try { s?.Dispose(); }
+                catch (Exception ex) { (errors ??= []).Add(ex); }
             }
             _targets.Clear();
+            if (errors is not null)
+                throw new AggregateException("One or more target streams failed to dispose.", errors);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously disposes the current <see cref="StreamCopier"/>. If <see cref="closeAllTargetsOnDispose"/>
+    /// is <see langword="true"/>, all target streams are asynchronously disposed; every target is attempted
+    /// even if one fails and errors are aggregated. The method is idempotent.
+    /// </summary>
+    /// <returns>A task that completes once disposal has been attempted for every target.</returns>
+    public override async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        GC.SuppressFinalize(this);
+
+        if (closeAllTargetsOnDispose)
+        {
+            List<Exception>? errors = null;
+            foreach (Stream s in _targets)
+            {
+                try
+                {
+                    if (s is not null)
+                        await s.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex) { (errors ??= []).Add(ex); }
+            }
+            _targets.Clear();
+            if (errors is not null)
+                throw new AggregateException("One or more target streams failed to dispose.", errors);
         }
     }
 

--- a/Utils.IO/IO/StreamUtils.cs
+++ b/Utils.IO/IO/StreamUtils.cs
@@ -100,34 +100,84 @@ public static class StreamUtils
     }
 
     /// <summary>
-    /// Reads all remaining data from the current <see cref="Stream"/> 
+    /// Reads all remaining data from the current <see cref="Stream"/>
     /// and returns a new <see cref="MemoryStream"/> containing that data.
+    /// The source stream is left open. The returned stream is positioned at 0 on success.
     /// </summary>
     /// <param name="s">The source <see cref="Stream"/> to read from.</param>
+    /// <param name="maxBytes">
+    /// Optional maximum number of bytes to read. When the source contains more data than this limit,
+    /// an <see cref="InvalidOperationException"/> is thrown and the temporary buffer is disposed.
+    /// <see langword="null"/> means no limit.
+    /// </param>
     /// <returns>A <see cref="MemoryStream"/> that contains all bytes read from <paramref name="s"/>.</returns>
-    public static MemoryStream ReadToMemoryStream(this Stream s)
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxBytes"/> is negative.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="maxBytes"/> is exceeded.</exception>
+    public static MemoryStream ReadToMemoryStream(this Stream s, int? maxBytes = null)
     {
+        if (s == null) throw new ArgumentNullException(nameof(s));
+        if (maxBytes.HasValue && maxBytes.Value < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), "The maximum byte count must be non-negative.");
+
+        const int bufferSize = 4096;
+        byte[] buffer = new byte[bufferSize];
         var ms = new MemoryStream();
-        s.CopyToStream(ms);
+        try
+        {
+            int bytesRead;
+            while ((bytesRead = s.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                // Enforce the limit before writing each block so an oversized stream never materializes fully.
+                if (maxBytes.HasValue && ms.Length + bytesRead > maxBytes.Value)
+                    throw new InvalidOperationException($"Stream exceeds the maximum allowed size of {maxBytes.Value} bytes.");
+                ms.Write(buffer, 0, bytesRead);
+            }
+        }
+        catch
+        {
+            ms.Dispose();
+            throw;
+        }
         ms.Position = 0;
         return ms;
     }
 
     /// <summary>
     /// Reads all remaining bytes from the given <see cref="Stream"/> as text
-    /// using the specified <see cref="Encoding"/>.
+    /// using the specified <see cref="Encoding"/>. The source stream is left open.
     /// </summary>
     /// <param name="s">The source <see cref="Stream"/> to read from.</param>
     /// <param name="encoding">
     /// The character encoding to use. If <c>null</c>, defaults to <see cref="Encoding.UTF8"/>.
+    /// Byte-order-mark detection remains enabled.
+    /// </param>
+    /// <param name="maxBytes">
+    /// Optional maximum number of encoded bytes to read from the source. When exceeded, an
+    /// <see cref="InvalidOperationException"/> is thrown. <see langword="null"/> means no limit.
     /// </param>
     /// <returns>A string containing all text read from the stream.</returns>
-    public static string ReadAllText(this Stream s, Encoding encoding = null)
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxBytes"/> is negative.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="maxBytes"/> is exceeded.</exception>
+    public static string ReadAllText(this Stream s, Encoding encoding = null, int? maxBytes = null)
     {
+        if (s == null) throw new ArgumentNullException(nameof(s));
         encoding ??= Encoding.UTF8;
-        using (var reader = new StreamReader(s, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true))
+        if (maxBytes.HasValue && maxBytes.Value < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), "The maximum byte count must be non-negative.");
+
+        // Bound the encoded bytes first (preserving the BOM), then decode with the same detection logic.
+        Stream source = s;
+        MemoryStream bounded = null;
+        if (maxBytes.HasValue)
+            source = bounded = s.ReadToMemoryStream(maxBytes.Value);
+        try
         {
+            using var reader = new StreamReader(source, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
             return reader.ReadToEnd();
+        }
+        finally
+        {
+            bounded?.Dispose();
         }
     }
 
@@ -260,5 +310,101 @@ public static class StreamUtils
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Reads and returns the next "block" from the stream, delimited by the specified byte sequence,
+    /// enforcing a maximum number of bytes scanned. The returned array does not include the delimiter.
+    /// The delimiter is located using the Knuth-Morris-Pratt algorithm over 4096-byte chunks rather than
+    /// reading one byte at a time.
+    /// </summary>
+    /// <remarks>
+    /// Unlike the unbounded <see cref="ReadBlock(Stream, byte[])"/> overload, this method treats a missing
+    /// delimiter as an error: if the stream reaches EOF before the delimiter is found, an
+    /// <see cref="EndOfStreamException"/> is thrown. If more than <paramref name="maxBytes"/> bytes are read
+    /// before the delimiter appears, an <see cref="InvalidOperationException"/> is thrown.
+    /// </remarks>
+    /// <param name="s">The <see cref="Stream"/> from which to read the block.</param>
+    /// <param name="blockSeparator">A byte array representing the block delimiter.</param>
+    /// <param name="maxBytes">The maximum number of bytes to read before the delimiter must appear.</param>
+    /// <returns>A byte array containing the next block of data, not including the delimiter.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="blockSeparator"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="blockSeparator"/> is empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="maxBytes"/> is negative.</exception>
+    /// <exception cref="EndOfStreamException">Thrown if EOF is reached before the delimiter is found.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="maxBytes"/> is exceeded before the delimiter is found.</exception>
+    public static byte[] ReadBlock(this Stream s, byte[] blockSeparator, int maxBytes)
+    {
+        if (s == null)
+            throw new ArgumentNullException(nameof(s));
+        if (blockSeparator == null)
+            throw new ArgumentNullException(nameof(blockSeparator), "Block separator cannot be null.");
+        if (blockSeparator.Length == 0)
+            throw new ArgumentException("Block separator cannot be an empty array.", nameof(blockSeparator));
+        if (maxBytes < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), "The maximum byte count must be non-negative.");
+
+        int sepLen = blockSeparator.Length;
+        int[] failure = BuildKmpFailureTable(blockSeparator);
+
+        const int chunkSize = 4096;
+        byte[] chunk = new byte[chunkSize];
+        using var ms = new MemoryStream();
+        long totalRead = 0;
+        int matchLength = 0; // number of separator bytes currently matched
+
+        while (true)
+        {
+            int read = s.Read(chunk, 0, chunkSize);
+            if (read == 0)
+                throw new EndOfStreamException("End of stream reached before the block separator was found.");
+
+            for (int i = 0; i < read; i++)
+            {
+                byte b = chunk[i];
+                totalRead++;
+                if (totalRead > maxBytes)
+                    throw new InvalidOperationException($"Block exceeds the maximum allowed size of {maxBytes} bytes before the separator was found.");
+
+                ms.WriteByte(b);
+
+                // KMP transition: fall back on mismatch, advance on match.
+                while (matchLength > 0 && b != blockSeparator[matchLength])
+                    matchLength = failure[matchLength - 1];
+                if (b == blockSeparator[matchLength])
+                    matchLength++;
+
+                if (matchLength == sepLen)
+                {
+                    // Strip the separator from the accumulated buffer and return the block.
+                    long newLength = ms.Length - sepLen;
+                    if (newLength < 0) newLength = 0;
+                    ms.SetLength(newLength);
+                    return ms.ToArray();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds the Knuth-Morris-Pratt failure (prefix) table for a delimiter pattern.
+    /// Entry <c>i</c> holds the length of the longest proper prefix of the pattern that is also a suffix
+    /// of the first <c>i + 1</c> bytes, enabling linear-time delimiter scanning without backtracking the input.
+    /// </summary>
+    /// <param name="pattern">The delimiter pattern to preprocess.</param>
+    /// <returns>The failure table with one entry per pattern byte.</returns>
+    private static int[] BuildKmpFailureTable(byte[] pattern)
+    {
+        int[] failure = new int[pattern.Length];
+        int length = 0;
+        for (int i = 1; i < pattern.Length; i++)
+        {
+            while (length > 0 && pattern[i] != pattern[length])
+                length = failure[length - 1];
+            if (pattern[i] == pattern[length])
+                length++;
+            failure[i] = length;
+        }
+        return failure;
     }
 }

--- a/Utils.IO/IO/StreamUtils.cs
+++ b/Utils.IO/IO/StreamUtils.cs
@@ -55,12 +55,22 @@ public static class StreamUtils
     /// and returns it as a byte array.
     /// </summary>
     /// <param name="s">The source <see cref="Stream"/> to read from.</param>
+    /// <returns>A byte array containing all bytes read from the stream.</returns>
+    public static byte[] ReadToEnd(this Stream s)
+        => ReadToEnd(s, maxBytes: null);
+
+    /// <summary>
+    /// Reads all remaining data from the given <see cref="Stream"/> until EOF
+    /// and returns it as a byte array, enforcing an optional byte limit.
+    /// </summary>
+    /// <param name="s">The source <see cref="Stream"/> to read from.</param>
     /// <param name="maxBytes">
     /// Optional maximum number of bytes to read. Throws <see cref="InvalidOperationException"/>
     /// if the stream contains more data than this limit. <see langword="null"/> means no limit.
     /// </param>
+    /// <returns>A byte array containing all bytes read from the stream.</returns>
     /// <exception cref="InvalidOperationException">Thrown when <paramref name="maxBytes"/> is exceeded.</exception>
-    public static byte[] ReadToEnd(this Stream s, int? maxBytes = null)
+    public static byte[] ReadToEnd(this Stream s, int? maxBytes)
     {
         const int bufferSize = 4096;
         byte[] buffer = new byte[bufferSize];
@@ -105,6 +115,17 @@ public static class StreamUtils
     /// The source stream is left open. The returned stream is positioned at 0 on success.
     /// </summary>
     /// <param name="s">The source <see cref="Stream"/> to read from.</param>
+    /// <returns>A <see cref="MemoryStream"/> that contains all bytes read from <paramref name="s"/>.</returns>
+    public static MemoryStream ReadToMemoryStream(this Stream s)
+        => ReadToMemoryStream(s, maxBytes: null);
+
+    /// <summary>
+    /// Reads all remaining data from the current <see cref="Stream"/>
+    /// and returns a new <see cref="MemoryStream"/> containing that data,
+    /// enforcing an optional byte limit. The source stream is left open.
+    /// The returned stream is positioned at 0 on success.
+    /// </summary>
+    /// <param name="s">The source <see cref="Stream"/> to read from.</param>
     /// <param name="maxBytes">
     /// Optional maximum number of bytes to read. When the source contains more data than this limit,
     /// an <see cref="InvalidOperationException"/> is thrown and the temporary buffer is disposed.
@@ -113,7 +134,7 @@ public static class StreamUtils
     /// <returns>A <see cref="MemoryStream"/> that contains all bytes read from <paramref name="s"/>.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxBytes"/> is negative.</exception>
     /// <exception cref="InvalidOperationException">Thrown when <paramref name="maxBytes"/> is exceeded.</exception>
-    public static MemoryStream ReadToMemoryStream(this Stream s, int? maxBytes = null)
+    public static MemoryStream ReadToMemoryStream(this Stream s, int? maxBytes)
     {
         if (s == null) throw new ArgumentNullException(nameof(s));
         if (maxBytes.HasValue && maxBytes.Value < 0)
@@ -143,8 +164,31 @@ public static class StreamUtils
     }
 
     /// <summary>
+    /// Reads all remaining bytes from the given <see cref="Stream"/> as UTF-8 text.
+    /// The source stream is left open.
+    /// </summary>
+    /// <param name="s">The source <see cref="Stream"/> to read from.</param>
+    /// <returns>A string containing all text read from the stream.</returns>
+    public static string ReadAllText(this Stream s)
+        => ReadAllText(s, encoding: null, maxBytes: null);
+
+    /// <summary>
     /// Reads all remaining bytes from the given <see cref="Stream"/> as text
     /// using the specified <see cref="Encoding"/>. The source stream is left open.
+    /// </summary>
+    /// <param name="s">The source <see cref="Stream"/> to read from.</param>
+    /// <param name="encoding">
+    /// The character encoding to use. If <c>null</c>, defaults to <see cref="Encoding.UTF8"/>.
+    /// Byte-order-mark detection remains enabled.
+    /// </param>
+    /// <returns>A string containing all text read from the stream.</returns>
+    public static string ReadAllText(this Stream s, Encoding encoding)
+        => ReadAllText(s, encoding, maxBytes: null);
+
+    /// <summary>
+    /// Reads all remaining bytes from the given <see cref="Stream"/> as text
+    /// using the specified <see cref="Encoding"/>, enforcing an optional byte limit.
+    /// The source stream is left open.
     /// </summary>
     /// <param name="s">The source <see cref="Stream"/> to read from.</param>
     /// <param name="encoding">
@@ -158,7 +202,7 @@ public static class StreamUtils
     /// <returns>A string containing all text read from the stream.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxBytes"/> is negative.</exception>
     /// <exception cref="InvalidOperationException">Thrown when <paramref name="maxBytes"/> is exceeded.</exception>
-    public static string ReadAllText(this Stream s, Encoding encoding = null, int? maxBytes = null)
+    public static string ReadAllText(this Stream s, Encoding encoding, int? maxBytes)
     {
         if (s == null) throw new ArgumentNullException(nameof(s));
         encoding ??= Encoding.UTF8;

--- a/Utils.IO/IO/StreamUtils.cs
+++ b/Utils.IO/IO/StreamUtils.cs
@@ -315,14 +315,16 @@ public static class StreamUtils
     /// <summary>
     /// Reads and returns the next "block" from the stream, delimited by the specified byte sequence,
     /// enforcing a maximum number of bytes scanned. The returned array does not include the delimiter.
-    /// The delimiter is located using the Knuth-Morris-Pratt algorithm over 4096-byte chunks rather than
-    /// reading one byte at a time.
+    /// The delimiter is located using the Knuth-Morris-Pratt algorithm applied one byte at a time so
+    /// no byte beyond the delimiter is ever consumed from the source stream.
     /// </summary>
     /// <remarks>
     /// Unlike the unbounded <see cref="ReadBlock(Stream, byte[])"/> overload, this method treats a missing
     /// delimiter as an error: if the stream reaches EOF before the delimiter is found, an
     /// <see cref="EndOfStreamException"/> is thrown. If more than <paramref name="maxBytes"/> bytes are read
     /// before the delimiter appears, an <see cref="InvalidOperationException"/> is thrown.
+    /// Because exactly one byte is consumed per loop iteration, the stream position after a successful call
+    /// points to the first byte after the delimiter, leaving subsequent data available for further reads.
     /// </remarks>
     /// <param name="s">The <see cref="Stream"/> from which to read the block.</param>
     /// <param name="blockSeparator">A byte array representing the block delimiter.</param>
@@ -347,41 +349,39 @@ public static class StreamUtils
         int sepLen = blockSeparator.Length;
         int[] failure = BuildKmpFailureTable(blockSeparator);
 
-        const int chunkSize = 4096;
-        byte[] chunk = new byte[chunkSize];
         using var ms = new MemoryStream();
         long totalRead = 0;
-        int matchLength = 0; // number of separator bytes currently matched
+        int matchLength = 0;
 
+        // Read exactly one byte at a time so the stream position never advances past the separator.
+        // KMP still gives O(n) amortised complexity despite the per-byte loop because the failure
+        // table bounds the total number of fallback steps across the entire input.
         while (true)
         {
-            int read = s.Read(chunk, 0, chunkSize);
-            if (read == 0)
+            int raw = s.ReadByte();
+            if (raw == -1)
                 throw new EndOfStreamException("End of stream reached before the block separator was found.");
 
-            for (int i = 0; i < read; i++)
+            byte b = (byte)raw;
+            totalRead++;
+            if (totalRead > maxBytes)
+                throw new InvalidOperationException($"Block exceeds the maximum allowed size of {maxBytes} bytes before the separator was found.");
+
+            ms.WriteByte(b);
+
+            // KMP transition: fall back on mismatch, advance on match.
+            while (matchLength > 0 && b != blockSeparator[matchLength])
+                matchLength = failure[matchLength - 1];
+            if (b == blockSeparator[matchLength])
+                matchLength++;
+
+            if (matchLength == sepLen)
             {
-                byte b = chunk[i];
-                totalRead++;
-                if (totalRead > maxBytes)
-                    throw new InvalidOperationException($"Block exceeds the maximum allowed size of {maxBytes} bytes before the separator was found.");
-
-                ms.WriteByte(b);
-
-                // KMP transition: fall back on mismatch, advance on match.
-                while (matchLength > 0 && b != blockSeparator[matchLength])
-                    matchLength = failure[matchLength - 1];
-                if (b == blockSeparator[matchLength])
-                    matchLength++;
-
-                if (matchLength == sepLen)
-                {
-                    // Strip the separator from the accumulated buffer and return the block.
-                    long newLength = ms.Length - sepLen;
-                    if (newLength < 0) newLength = 0;
-                    ms.SetLength(newLength);
-                    return ms.ToArray();
-                }
+                // Strip the separator from the accumulated buffer and return the block.
+                long newLength = ms.Length - sepLen;
+                if (newLength < 0) newLength = 0;
+                ms.SetLength(newLength);
+                return ms.ToArray();
             }
         }
     }

--- a/UtilsTest/BaseEncoding/BaseDecoderStreamTests.cs
+++ b/UtilsTest/BaseEncoding/BaseDecoderStreamTests.cs
@@ -303,5 +303,111 @@ public class BaseDecoderStreamTests
         Assert.ThrowsException<FormatException>(() => decoder.Close(),
             "FormatException from validation must not be replaced by the IOException from Flush");
     }
+
+    // ---- item 27: strict terminal quantum validation ----
+
+    [TestMethod]
+    public void Base16_SingleSymbol_Strict_ThrowsFormatException()
+    {
+        // A single hex digit leaves 4 unresolved bits and can never form a byte.
+        Assert.ThrowsException<FormatException>(() => Decode("A", Bases.Base16));
+    }
+
+    [TestMethod]
+    public void Base16_TwoSymbols_Strict_Ok()
+    {
+        byte[] result = Decode("AB", Bases.Base16);
+        Assert.AreEqual(1, result.Length);
+        Assert.AreEqual(0xAB, result[0]);
+    }
+
+    [TestMethod]
+    public void Base16_ThreeSymbols_Strict_ThrowsFormatException()
+    {
+        // 3 hex digits = 12 bits = 1 byte + 4 leftover bits → invalid terminal.
+        Assert.ThrowsException<FormatException>(() => Decode("ABC", Bases.Base16));
+    }
+
+    // Base32: every possible terminal remainder (symbol counts 1..8, all-zero data).
+    // Valid data-symbol counts within a quantum are 2, 4, 5, 7 (and 8 = full quantum).
+
+    [TestMethod]
+    [DataRow("A", DisplayName = "1 symbol → 5 leftover bits, invalid")]
+    [DataRow("AAA", DisplayName = "3 symbols → 7 leftover bits, invalid")]
+    [DataRow("AAAAAA", DisplayName = "6 symbols → 6 leftover bits, invalid")]
+    public void Base32_InvalidTerminalRemainder_ThrowsFormatException(string source)
+    {
+        Assert.ThrowsException<FormatException>(() => Decode(source, Bases.Base32));
+    }
+
+    [TestMethod]
+    [DataRow("AA======", 1, DisplayName = "2 symbols → 1 byte")]
+    [DataRow("AAAA====", 2, DisplayName = "4 symbols → 2 bytes")]
+    [DataRow("AAAAA===", 3, DisplayName = "5 symbols → 3 bytes")]
+    [DataRow("AAAAAAA=", 4, DisplayName = "7 symbols → 4 bytes")]
+    [DataRow("AAAAAAAA", 5, DisplayName = "8 symbols → 5 bytes (full quantum)")]
+    public void Base32_ValidTerminalRemainder_Ok(string source, int expectedLength)
+    {
+        byte[] result = Decode(source, Bases.Base32);
+        Assert.AreEqual(expectedLength, result.Length);
+        foreach (byte b in result)
+            Assert.AreEqual(0, b);
+    }
+
+    [TestMethod]
+    public void Base64_SingleSymbol_Strict_ThrowsFormatException()
+    {
+        // A single base64 symbol leaves 6 unresolved bits → invalid.
+        Assert.ThrowsException<FormatException>(() => Decode("A===", Bases.Base64));
+    }
+
+    [TestMethod]
+    public void Base64_TwoSymbols_Strict_Ok()
+    {
+        // 2 symbols + 2 fillers → 1 byte.
+        byte[] result = Decode("AA==", Bases.Base64);
+        Assert.AreEqual(1, result.Length);
+        Assert.AreEqual(0, result[0]);
+    }
+
+    [TestMethod]
+    public void Base64_ThreeSymbols_Strict_Ok()
+    {
+        // 3 symbols + 1 filler → 2 bytes.
+        byte[] result = Decode("AAA=", Bases.Base64);
+        Assert.AreEqual(2, result.Length);
+        foreach (byte b in result) Assert.AreEqual(0, b);
+    }
+
+    [TestMethod]
+    public void Base16_NonZeroTrailingBits_ThrowsFormatException()
+    {
+        // Not applicable to Base16 (any leftover is invalid quantum), so use Base32:
+        // 2 symbols "AB" → 10 bits, byte = (A=0,B=1) => bits 00000 00001 => leftover 2 bits = "01" ≠ 0.
+        Assert.ThrowsException<FormatException>(() => Decode("AB======", Bases.Base32));
+    }
+
+    [TestMethod]
+    public void Base64_NonZeroTrailingBits_ThrowsFormatException()
+    {
+        // "AB==" : A=0, B=1 → 12 bits 000000 000001, first byte 0x00, leftover 4 bits = 0001 ≠ 0.
+        Assert.ThrowsException<FormatException>(() => Decode("AB==", Bases.Base64));
+    }
+
+    [TestMethod]
+    public void PermissiveMode_Base16SingleSymbol_Accepted()
+    {
+        // Permissive mode does not enforce terminal quantum validation.
+        byte[] result = Decode("A", Bases.Base16, strict: false);
+        // No complete byte is produced from a single nibble.
+        Assert.AreEqual(0, result.Length);
+    }
+
+    [TestMethod]
+    public void PermissiveMode_Base64SingleSymbol_Accepted()
+    {
+        byte[] result = Decode("A", Bases.Base64, strict: false);
+        Assert.AreEqual(0, result.Length);
+    }
 }
 

--- a/UtilsTest/BaseEncoding/BaseEncoderStreamTests.cs
+++ b/UtilsTest/BaseEncoding/BaseEncoderStreamTests.cs
@@ -269,5 +269,16 @@ public class BaseEncoderStreamTests
             () => stream.WriteAsync(new byte[] { 1, 2, 3 }, 0, 3, cts.Token));
         Assert.AreEqual(0, sw.ToString().Length, "No output must be produced when cancelled before encoding.");
     }
+
+    [TestMethod]
+    public async Task DisposeAsync_IsIdempotent()
+    {
+        var sw = new StringWriter();
+        var stream = new BaseEncoderStream(sw, Bases.Base64);
+        stream.Write(new byte[] { 0x41 }, 0, 1);
+        await stream.DisposeAsync();
+        // Second call must not throw ObjectDisposedException or any other exception.
+        await stream.DisposeAsync();
+    }
 }
 

--- a/UtilsTest/BaseEncoding/BaseEncoderStreamTests.cs
+++ b/UtilsTest/BaseEncoding/BaseEncoderStreamTests.cs
@@ -1,5 +1,8 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Utils.IO.BaseEncoding;
 
 namespace UtilsTest.BaseEncoding;
@@ -178,6 +181,93 @@ public class BaseEncoderStreamTests
         string[] lines = output.Split(System.Environment.NewLine, System.StringSplitOptions.RemoveEmptyEntries);
         foreach (var line in lines)
             Assert.IsTrue(line.Length <= 4, $"Line '{line}' exceeds maxDataWidth=4");
+    }
+
+    // ---- item 30: span, async, disposal ----
+
+    [TestMethod]
+    public void WriteSpan_ProducesSameOutputAsArray()
+    {
+        byte[] source = { 0x41, 0x42, 0x43, 0x44, 0x45 };
+        var sw = new StringWriter();
+        var stream = new BaseEncoderStream(sw, Bases.Base64);
+        stream.Write(new ReadOnlySpan<byte>(source));
+        stream.Close();
+        Assert.AreEqual("QUJDREU=", sw.ToString());
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_ProducesSameOutputAsArray()
+    {
+        byte[] source = { 0x41, 0x42, 0x43, 0x44, 0x45 };
+        var sw = new StringWriter();
+        var stream = new BaseEncoderStream(sw, Bases.Base64);
+        await stream.WriteAsync(source, 0, source.Length, CancellationToken.None);
+        stream.Close();
+        Assert.AreEqual("QUJDREU=", sw.ToString());
+    }
+
+    [TestMethod]
+    public async Task FragmentedWrites_GiveSameOutputAsSingleWrite()
+    {
+        byte[] source = { 0x41, 0x42, 0x43, 0x44, 0x45 };
+
+        var swSingle = new StringWriter();
+        var single = new BaseEncoderStream(swSingle, Bases.Base64);
+        single.Write(source, 0, source.Length);
+        single.Close();
+
+        var swFragmented = new StringWriter();
+        var fragmented = new BaseEncoderStream(swFragmented, Bases.Base64);
+        await fragmented.WriteAsync(source, 0, 2, CancellationToken.None);
+        await fragmented.WriteAsync(source, 2, 3, CancellationToken.None);
+        fragmented.Close();
+
+        Assert.AreEqual(swSingle.ToString(), swFragmented.ToString());
+    }
+
+    [TestMethod]
+    public async Task FlushAsync_DoesNotThrow()
+    {
+        var sw = new StringWriter();
+        var stream = new BaseEncoderStream(sw, Bases.Base64);
+        await stream.WriteAsync(new byte[] { 1, 2, 3 }, 0, 3, CancellationToken.None);
+        await stream.FlushAsync(CancellationToken.None);
+        stream.Close();
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_FinalizesEncoding()
+    {
+        byte[] source = { 0x41, 0x42 };
+        var sw = new StringWriter();
+        var stream = new BaseEncoderStream(sw, Bases.Base64);
+        stream.Write(source, 0, source.Length);
+        await stream.DisposeAsync();
+        // DisposeAsync must have finalized (padded) the output through Close.
+        Assert.AreEqual("QUI=", sw.ToString());
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_AfterClose_Throws()
+    {
+        var sw = new StringWriter();
+        var stream = new BaseEncoderStream(sw, Bases.Base64);
+        stream.Close();
+        await Assert.ThrowsExceptionAsync<ObjectDisposedException>(
+            () => stream.WriteAsync(new byte[] { 1 }, 0, 1, CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_CancelledBeforeCall_ThrowsAndLeavesStateUnchanged()
+    {
+        var sw = new StringWriter();
+        var stream = new BaseEncoderStream(sw, Bases.Base64);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+            () => stream.WriteAsync(new byte[] { 1, 2, 3 }, 0, 3, cts.Token));
+        Assert.AreEqual(0, sw.ToString().Length, "No output must be produced when cancelled before encoding.");
     }
 }
 

--- a/UtilsTest/Streams/Leb128Tests.cs
+++ b/UtilsTest/Streams/Leb128Tests.cs
@@ -250,4 +250,59 @@ public class Leb128Tests
         Assert.ThrowsException<OverflowException>(() => reader.ReadULEB128());
         Assert.AreEqual(10, ms.Position, "Reader must stop after consuming the tenth byte.");
     }
+
+    // ── 10-byte overlong SLEB128 (regression for item 17 fix) ────────────────
+
+    [TestMethod]
+    public void ReadSLEB128_TenByteOverlongZero_ThrowsFormatException()
+    {
+        // Zero encoded with nine continuation bytes then a zero terminal byte:
+        // 80 80 80 80 80 80 80 80 80 00 — the ninth byte's payload (0x00) has sign bit 0x40 clear,
+        // so a terminal 0x00 on the tenth byte merely repeats the already-established sign and is overlong.
+        using var ms = new MemoryStream([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00]);
+        Assert.ThrowsException<FormatException>(() => new SimpleReader(ms).ReadSLEB128());
+    }
+
+    [TestMethod]
+    public void ReadSLEB128_TenByteOverlongNegativeOne_ThrowsFormatException()
+    {
+        // -1 encoded with nine continuation bytes then a 0x7F terminal byte:
+        // FF FF FF FF FF FF FF FF FF 7F — the ninth byte's payload (0x7F) has sign bit 0x40 set,
+        // so a terminal 0x7F on the tenth byte merely repeats the negative sign and is overlong.
+        using var ms = new MemoryStream([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F]);
+        Assert.ThrowsException<FormatException>(() => new SimpleReader(ms).ReadSLEB128());
+    }
+
+    [TestMethod]
+    public void ReadULEB128_TenByteOverlongZero_ThrowsFormatException()
+    {
+        // Zero encoded with nine continuation bytes then a zero terminal byte:
+        // 80 80 80 80 80 80 80 80 80 00 — trailing zero payload is overlong (same check as byte-2 overlongs).
+        using var ms = new MemoryStream([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00]);
+        Assert.ThrowsException<FormatException>(() => new SimpleReader(ms).ReadULEB128());
+    }
+
+    [TestMethod]
+    public void ReadSLEB128_LongMinValue_RoundTrips_NotOverlong()
+    {
+        // long.MinValue requires all 10 bytes; its canonical encoding must NOT be rejected as overlong.
+        // Encoding: 80 80 80 80 80 80 80 80 80 7F
+        using var ms = new MemoryStream();
+        new SimpleWriter(ms).WriteSLEB128(long.MinValue);
+        Assert.AreEqual(10, ms.Length, "long.MinValue must encode to exactly 10 bytes.");
+        ms.Position = 0;
+        Assert.AreEqual(long.MinValue, new SimpleReader(ms).ReadSLEB128());
+    }
+
+    [TestMethod]
+    public void ReadSLEB128_LongMaxValue_RoundTrips_NotOverlong()
+    {
+        // long.MaxValue also requires 10 bytes; its canonical encoding must NOT be rejected as overlong.
+        // Encoding: FF FF FF FF FF FF FF FF FF 00
+        using var ms = new MemoryStream();
+        new SimpleWriter(ms).WriteSLEB128(long.MaxValue);
+        Assert.AreEqual(10, ms.Length, "long.MaxValue must encode to exactly 10 bytes.");
+        ms.Position = 0;
+        Assert.AreEqual(long.MaxValue, new SimpleReader(ms).ReadSLEB128());
+    }
 }

--- a/UtilsTest/Streams/Leb128Tests.cs
+++ b/UtilsTest/Streams/Leb128Tests.cs
@@ -167,4 +167,87 @@ public class Leb128Tests
         using var ms = new MemoryStream([0x80]);
         Assert.ThrowsException<EndOfStreamException>(() => new SimpleReader(ms).ReadULEB128());
     }
+
+    // ── Overflow / overlong rejection (item 17) ──────────────────────────────
+
+    [TestMethod]
+    public void ReadULEB128_ElevenBytes_Throws()
+    {
+        // 11 continuation bytes: continuation bit stays set on the tenth byte → overflow.
+        using var ms = new MemoryStream([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
+        Assert.ThrowsException<OverflowException>(() => new SimpleReader(ms).ReadULEB128());
+    }
+
+    [TestMethod]
+    public void ReadULEB128_TenthBytePayloadTooLarge_ThrowsOverflow()
+    {
+        // Nine continuation bytes then a tenth byte with payload > 0x01 → value would exceed 64 bits.
+        using var ms = new MemoryStream([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02]);
+        Assert.ThrowsException<OverflowException>(() => new SimpleReader(ms).ReadULEB128());
+    }
+
+    [TestMethod]
+    public void ReadULEB128_MaxValueEncoding_RoundTrips()
+    {
+        // ulong.MaxValue = ten bytes, the last being 0x01.
+        using var ms = new MemoryStream([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01]);
+        Assert.AreEqual(ulong.MaxValue, new SimpleReader(ms).ReadULEB128());
+    }
+
+    [TestMethod]
+    [DataRow(new byte[] { 0x80, 0x00 })]        // overlong 0
+    [DataRow(new byte[] { 0x81, 0x00 })]        // overlong 1
+    [DataRow(new byte[] { 0xFF, 0x80, 0x00 })]  // overlong 127
+    public void ReadULEB128_Overlong_ThrowsFormatException(byte[] bytes)
+    {
+        using var ms = new MemoryStream(bytes);
+        Assert.ThrowsException<FormatException>(() => new SimpleReader(ms).ReadULEB128());
+    }
+
+    [TestMethod]
+    public void ReadSLEB128_ElevenBytes_Throws()
+    {
+        using var ms = new MemoryStream([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00]);
+        Assert.ThrowsException<OverflowException>(() => new SimpleReader(ms).ReadSLEB128());
+    }
+
+    [TestMethod]
+    public void ReadSLEB128_BadSignExtensionOnTenthByte_ThrowsOverflow()
+    {
+        // Nine continuation bytes then a tenth byte whose high bits are not a valid sign extension.
+        using var ms = new MemoryStream([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x40]);
+        Assert.ThrowsException<OverflowException>(() => new SimpleReader(ms).ReadSLEB128());
+    }
+
+    [TestMethod]
+    [DataRow(new byte[] { 0x80, 0x00 })]        // overlong 0
+    [DataRow(new byte[] { 0x81, 0x00 })]        // overlong 1
+    [DataRow(new byte[] { 0xFF, 0x7F })]        // overlong -1
+    public void ReadSLEB128_Overlong_ThrowsFormatException(byte[] bytes)
+    {
+        using var ms = new MemoryStream(bytes);
+        Assert.ThrowsException<FormatException>(() => new SimpleReader(ms).ReadSLEB128());
+    }
+
+    [TestMethod]
+    public void ReadULEB128_AfterError_PositionAdvancedOnlyByBytesConsumed()
+    {
+        // 0x80 0x00 (overlong) followed by a trailing marker byte.
+        using var ms = new MemoryStream([0x80, 0x00, 0x2A]);
+        var reader = new SimpleReader(ms);
+        try { reader.ReadULEB128(); Assert.Fail("Expected FormatException."); }
+        catch (FormatException) { }
+        // Exactly two bytes were consumed; the marker remains readable.
+        Assert.AreEqual(0x2A, ms.ReadByte());
+    }
+
+    [TestMethod]
+    public void ReadULEB128_TruncatedAtTenBytes_PositionMatchesConsumed()
+    {
+        // Ten continuation bytes with no terminator: overflow triggers on the tenth byte.
+        using var ms = new MemoryStream([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80]);
+        var reader = new SimpleReader(ms);
+        Assert.ThrowsException<OverflowException>(() => reader.ReadULEB128());
+        Assert.AreEqual(10, ms.Position, "Reader must stop after consuming the tenth byte.");
+    }
 }

--- a/UtilsTest/Streams/StreamCopierTests.cs
+++ b/UtilsTest/Streams/StreamCopierTests.cs
@@ -197,4 +197,31 @@ public class StreamCopierTests
         // Second dispose must not throw or re-run target disposal.
         copier.Dispose();
     }
+
+    // ---- item 30: operations after dispose/disposeAsync throw ObjectDisposedException ----
+
+    [TestMethod]
+    public void Write_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var copier = new StreamCopier(new MemoryStream());
+        copier.Dispose();
+        Assert.ThrowsException<ObjectDisposedException>(() => copier.Write(new byte[] { 1 }, 0, 1));
+    }
+
+    [TestMethod]
+    public void Flush_AfterDispose_ThrowsObjectDisposedException()
+    {
+        var copier = new StreamCopier(new MemoryStream());
+        copier.Dispose();
+        Assert.ThrowsException<ObjectDisposedException>(() => copier.Flush());
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_AfterDisposeAsync_ThrowsObjectDisposedException()
+    {
+        var copier = new StreamCopier(new MemoryStream());
+        await copier.DisposeAsync();
+        await Assert.ThrowsExceptionAsync<ObjectDisposedException>(
+            () => copier.WriteAsync(new byte[] { 1 }, 0, 1, CancellationToken.None));
+    }
 }

--- a/UtilsTest/Streams/StreamCopierTests.cs
+++ b/UtilsTest/Streams/StreamCopierTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Utils.Collections;
 using Utils.IO;
 using Utils.Randomization;
@@ -102,5 +104,97 @@ public class StreamCopierTests
     {
         var copier = new StreamCopier();
         Assert.ThrowsException<ArgumentNullException>(() => copier.Insert(0, null!));
+    }
+
+    // ---- item 30: span, async, cancellation, disposal ----
+
+    [TestMethod]
+    public void WriteSpan_BroadcastsToAllTargets()
+    {
+        using var t1 = new MemoryStream();
+        using var t2 = new MemoryStream();
+        var copier = new StreamCopier(t1, t2);
+        ReadOnlySpan<byte> data = new byte[] { 1, 2, 3, 4 };
+        copier.Write(data);
+        var cmp = EnumerableEqualityComparer<byte>.Default;
+        Assert.IsTrue(cmp.Equals(new byte[] { 1, 2, 3, 4 }, t1.ToArray()));
+        Assert.IsTrue(cmp.Equals(new byte[] { 1, 2, 3, 4 }, t2.ToArray()));
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_BroadcastsToAllTargets()
+    {
+        using var t1 = new MemoryStream();
+        using var t2 = new MemoryStream();
+        var copier = new StreamCopier(t1, t2);
+        await copier.WriteAsync(new byte[] { 5, 6, 7 }, 0, 3, CancellationToken.None);
+        Assert.AreEqual(3, t1.Length);
+        Assert.AreEqual(3, t2.Length);
+    }
+
+    [TestMethod]
+    public async Task FlushAsync_AttemptsAllTargets()
+    {
+        using var t1 = new MemoryStream();
+        using var t2 = new MemoryStream();
+        var copier = new StreamCopier(t1, t2);
+        await copier.WriteAsync(new byte[] { 1 }, 0, 1, CancellationToken.None);
+        await copier.FlushAsync(CancellationToken.None); // must not throw
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_CancelledBeforeCall_ThrowsOperationCanceled()
+    {
+        using var t1 = new MemoryStream();
+        var copier = new StreamCopier(t1);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+            () => copier.WriteAsync(new byte[] { 1 }, 0, 1, cts.Token));
+        Assert.AreEqual(0, t1.Length, "No data must be written when cancelled before the loop.");
+    }
+
+    [TestMethod]
+    public async Task WriteAsync_OneTargetFails_AggregatesErrors()
+    {
+        var good = new MemoryStream();
+        var bad = new ThrowingStream { ShouldThrow = true };
+        var copier = new StreamCopier(bad, good);
+        var ex = await Assert.ThrowsExceptionAsync<AggregateException>(
+            () => copier.WriteAsync(new byte[] { 1, 2, 3 }, 0, 3, CancellationToken.None));
+        Assert.AreEqual(1, ex.InnerExceptions.Count);
+        Assert.AreEqual(3, good.Length, "good target must still have received the data");
+    }
+
+    [TestMethod]
+    public void DisposeAsync_ClosesTargets_WhenConfigured()
+    {
+        var t1 = new MemoryStream();
+        var t2 = new MemoryStream();
+        var copier = new StreamCopier(closeAllTargetsOnDispose: true, t1, t2);
+        copier.DisposeAsync().AsTask().Wait();
+        Assert.ThrowsException<ObjectDisposedException>(() => t1.WriteByte(1));
+        Assert.ThrowsException<ObjectDisposedException>(() => t2.WriteByte(1));
+    }
+
+    [TestMethod]
+    public void DisposeAsync_LeavesTargetsOpen_WhenNotConfigured()
+    {
+        var t1 = new MemoryStream();
+        var copier = new StreamCopier(closeAllTargetsOnDispose: false, t1);
+        copier.DisposeAsync().AsTask().Wait();
+        // Target must remain usable.
+        t1.WriteByte(1);
+        Assert.AreEqual(1, t1.Length);
+    }
+
+    [TestMethod]
+    public void Dispose_IsIdempotent()
+    {
+        var t1 = new MemoryStream();
+        var copier = new StreamCopier(closeAllTargetsOnDispose: true, t1);
+        copier.Dispose();
+        // Second dispose must not throw or re-run target disposal.
+        copier.Dispose();
     }
 }

--- a/UtilsTest/Streams/StreamUtilsTests.cs
+++ b/UtilsTest/Streams/StreamUtilsTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Text;
 using Utils.Collections;
 using Utils.IO;
 
@@ -94,5 +95,172 @@ public class StreamUtilsTests
         using var ms = new MemoryStream(data);
         byte[] result = ms.ReadToEnd();
         Assert.AreEqual(4, result.Length);
+    }
+
+    // ---- item 26: bounded whole-stream helpers ----
+
+    /// <summary>
+    /// A stream that returns at most one byte per Read call, to exercise partial reads.
+    /// </summary>
+    private sealed class OneByteAtATimeStream : Stream
+    {
+        private readonly byte[] _data;
+        private int _pos;
+        public OneByteAtATimeStream(byte[] data) => _data = data;
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_pos >= _data.Length || count == 0) return 0;
+            buffer[offset] = _data[_pos++];
+            return 1;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [TestMethod]
+    public void ReadToMemoryStream_Empty_ReturnsEmpty()
+    {
+        using var src = new MemoryStream((byte[])[]);
+        using var ms = src.ReadToMemoryStream();
+        Assert.AreEqual(0, ms.Length);
+        Assert.AreEqual(0, ms.Position);
+    }
+
+    [TestMethod]
+    public void ReadToMemoryStream_ExactlyAtLimit_Succeeds()
+    {
+        byte[] data = new byte[10];
+        using var src = new MemoryStream(data);
+        using var ms = src.ReadToMemoryStream(maxBytes: 10);
+        Assert.AreEqual(10, ms.Length);
+        Assert.AreEqual(0, ms.Position);
+    }
+
+    [TestMethod]
+    public void ReadToMemoryStream_OneOverLimit_Throws()
+    {
+        byte[] data = new byte[11];
+        using var src = new MemoryStream(data);
+        Assert.ThrowsException<InvalidOperationException>(() => src.ReadToMemoryStream(maxBytes: 10));
+    }
+
+    [TestMethod]
+    public void ReadToMemoryStream_NonSeekableSource_Works()
+    {
+        var src = new OneByteAtATimeStream(new byte[] { 1, 2, 3, 4, 5 });
+        using var ms = src.ReadToMemoryStream();
+        var cmp = EnumerableEqualityComparer<byte>.Default;
+        Assert.IsTrue(cmp.Equals(new byte[] { 1, 2, 3, 4, 5 }, ms.ToArray()));
+    }
+
+    [TestMethod]
+    public void ReadToMemoryStream_PartialReads_ReadsAll()
+    {
+        var src = new OneByteAtATimeStream(new byte[] { 9, 8, 7 });
+        using var ms = src.ReadToMemoryStream(maxBytes: 3);
+        Assert.AreEqual(3, ms.Length);
+    }
+
+    [TestMethod]
+    public void ReadToMemoryStream_NegativeLimit_Throws()
+    {
+        using var src = new MemoryStream(new byte[] { 1 });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => src.ReadToMemoryStream(maxBytes: -1));
+    }
+
+    [TestMethod]
+    public void ReadAllText_WithinLimit_ReturnsText()
+    {
+        byte[] data = Encoding.UTF8.GetBytes("hello");
+        using var src = new MemoryStream(data);
+        Assert.AreEqual("hello", src.ReadAllText(Encoding.UTF8, maxBytes: 100));
+    }
+
+    [TestMethod]
+    public void ReadAllText_OneOverLimit_Throws()
+    {
+        byte[] data = Encoding.UTF8.GetBytes("hello world");
+        using var src = new MemoryStream(data);
+        Assert.ThrowsException<InvalidOperationException>(() => src.ReadAllText(Encoding.UTF8, maxBytes: 5));
+    }
+
+    [TestMethod]
+    public void ReadAllText_BomStream_DetectsAndStripsBom()
+    {
+        // UTF-8 BOM followed by "abc"
+        byte[] data = new byte[] { 0xEF, 0xBB, 0xBF, (byte)'a', (byte)'b', (byte)'c' };
+        using var src = new MemoryStream(data);
+        Assert.AreEqual("abc", src.ReadAllText(maxBytes: 100));
+    }
+
+    [TestMethod]
+    public void ReadBlock_Bounded_SeparatorAtStart_ReturnsEmpty()
+    {
+        using var src = new MemoryStream(new byte[] { 0xFF, 1, 2, 3 });
+        byte[] block = src.ReadBlock(new byte[] { 0xFF }, maxBytes: 100);
+        Assert.AreEqual(0, block.Length);
+    }
+
+    [TestMethod]
+    public void ReadBlock_Bounded_SeparatorInMiddle_ReturnsPrefix()
+    {
+        using var src = new MemoryStream(new byte[] { 1, 2, 0xFF, 3, 4 });
+        byte[] block = src.ReadBlock(new byte[] { 0xFF }, maxBytes: 100);
+        var cmp = EnumerableEqualityComparer<byte>.Default;
+        Assert.IsTrue(cmp.Equals(new byte[] { 1, 2 }, block));
+    }
+
+    [TestMethod]
+    public void ReadBlock_Bounded_MultiByteSeparatorCrossingChunkBoundary()
+    {
+        // Build data where the 2-byte separator straddles the 4096-byte chunk boundary.
+        var list = new System.Collections.Generic.List<byte>();
+        for (int i = 0; i < 4095; i++) list.Add(0x00);
+        list.Add(0xAB); // index 4095 (last of first chunk)
+        list.Add(0xCD); // index 4096 (first of second chunk)
+        list.Add(0x99);
+        using var src = new MemoryStream(list.ToArray());
+        byte[] block = src.ReadBlock(new byte[] { 0xAB, 0xCD }, maxBytes: 10000);
+        Assert.AreEqual(4095, block.Length);
+    }
+
+    [TestMethod]
+    public void ReadBlock_Bounded_ABABAC_Pattern_UsesKmpCorrectly()
+    {
+        // Searching for "ABAC" in "ABABAC..." : the naive window would mismatch,
+        // KMP correctly finds the match ending after the 6th byte.
+        byte[] data = new byte[] { (byte)'A', (byte)'B', (byte)'A', (byte)'B', (byte)'A', (byte)'C', (byte)'X' };
+        using var src = new MemoryStream(data);
+        byte[] block = src.ReadBlock(new byte[] { (byte)'A', (byte)'B', (byte)'A', (byte)'C' }, maxBytes: 100);
+        var cmp = EnumerableEqualityComparer<byte>.Default;
+        Assert.IsTrue(cmp.Equals(new byte[] { (byte)'A', (byte)'B' }, block));
+    }
+
+    [TestMethod]
+    public void ReadBlock_Bounded_EofWithoutSeparator_Throws()
+    {
+        using var src = new MemoryStream(new byte[] { 1, 2, 3 });
+        Assert.ThrowsException<EndOfStreamException>(() => src.ReadBlock(new byte[] { 0xFF }, maxBytes: 100));
+    }
+
+    [TestMethod]
+    public void ReadBlock_Bounded_LimitExceededBeforeSeparator_Throws()
+    {
+        using var src = new MemoryStream(new byte[] { 1, 2, 3, 4, 5, 0xFF });
+        Assert.ThrowsException<InvalidOperationException>(() => src.ReadBlock(new byte[] { 0xFF }, maxBytes: 3));
+    }
+
+    [TestMethod]
+    public void ReadBlock_Bounded_NegativeMaxBytes_Throws()
+    {
+        using var src = new MemoryStream(new byte[] { 0xFF });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => src.ReadBlock(new byte[] { 0xFF }, maxBytes: -1));
     }
 }

--- a/UtilsTest/Streams/StreamUtilsTests.cs
+++ b/UtilsTest/Streams/StreamUtilsTests.cs
@@ -263,4 +263,31 @@ public class StreamUtilsTests
         using var src = new MemoryStream(new byte[] { 0xFF });
         Assert.ThrowsException<ArgumentOutOfRangeException>(() => src.ReadBlock(new byte[] { 0xFF }, maxBytes: -1));
     }
+
+    [TestMethod]
+    public void ReadBlock_Bounded_TwoConsecutiveCallsInSingleChunk_NoBytesLost()
+    {
+        // Two blocks and both separators fit within a single 4096-byte window.
+        // If ReadBlock over-reads (reads a full chunk and then scans it) it will swallow bytes from
+        // the second block. This test catches that regression.
+        var sep = new byte[] { 0xFF, 0xFE };
+        var data = new System.Collections.Generic.List<byte>();
+        data.AddRange(new byte[] { 10, 20, 30 });
+        data.AddRange(sep);
+        data.AddRange(new byte[] { 40, 50 });
+        data.AddRange(sep);
+        data.AddRange(new byte[] { 99 }); // trailing byte after all separators
+
+        using var src = new MemoryStream(data.ToArray());
+        var cmp = EnumerableEqualityComparer<byte>.Default;
+
+        byte[] first = src.ReadBlock(sep, maxBytes: 100);
+        Assert.IsTrue(cmp.Equals(new byte[] { 10, 20, 30 }, first), "first block must be [10, 20, 30]");
+
+        byte[] second = src.ReadBlock(sep, maxBytes: 100);
+        Assert.IsTrue(cmp.Equals(new byte[] { 40, 50 }, second), "second block must be [40, 50]");
+
+        // The trailing byte must still be readable — the two ReadBlock calls must not have over-consumed.
+        Assert.AreEqual(99, src.ReadByte(), "trailing byte must not have been consumed by ReadBlock");
+    }
 }

--- a/UtilsTest/Streams/StreamUtilsTests.cs
+++ b/UtilsTest/Streams/StreamUtilsTests.cs
@@ -197,7 +197,7 @@ public class StreamUtilsTests
         // UTF-8 BOM followed by "abc"
         byte[] data = new byte[] { 0xEF, 0xBB, 0xBF, (byte)'a', (byte)'b', (byte)'c' };
         using var src = new MemoryStream(data);
-        Assert.AreEqual("abc", src.ReadAllText(maxBytes: 100));
+        Assert.AreEqual("abc", src.ReadAllText(encoding: null, maxBytes: 100));
     }
 
     [TestMethod]

--- a/UtilsTest/Streams/VariableLengthStringTests.cs
+++ b/UtilsTest/Streams/VariableLengthStringTests.cs
@@ -1,0 +1,170 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Text;
+using Utils.IO.Serialization;
+
+namespace UtilsTest.Streams;
+
+/// <summary>
+/// Tests for the variable-length string prefix helpers (item 18).
+/// </summary>
+[TestClass]
+public class VariableLengthStringTests
+{
+    private static (byte[] bytes, int written) WriteString(string value, Encoding encoding, int sizeLength)
+    {
+        using var ms = new MemoryStream();
+        var writer = new Writer(ms);
+        writer.WriteVariableLengthString(value, encoding, sizeLength);
+        return (ms.ToArray(), (int)ms.Length);
+    }
+
+    private static string ReadString(byte[] bytes, Encoding encoding, int sizeLength)
+    {
+        using var ms = new MemoryStream(bytes);
+        var reader = new Reader(ms);
+        return reader.ReadVariableLengthString(encoding, sizeLength);
+    }
+
+    // ── Round-trip ────────────────────────────────────────────────────────────
+
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(4)]
+    public void RoundTrip_AllPrefixWidths(int sizeLength)
+    {
+        var (bytes, _) = WriteString("Hello, world!", Encoding.UTF8, sizeLength);
+        Assert.AreEqual("Hello, world!", ReadString(bytes, Encoding.UTF8, sizeLength));
+    }
+
+    // ── Invalid sizeLength ─────────────────────────────────────────────────────
+
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(3)]
+    [DataRow(5)]
+    [DataRow(-1)]
+    public void Write_InvalidSizeLength_Throws(int sizeLength)
+    {
+        using var ms = new MemoryStream();
+        var writer = new Writer(ms);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => writer.WriteVariableLengthString("x", Encoding.UTF8, sizeLength));
+        Assert.AreEqual(0, ms.Length, "No bytes must be written when sizeLength is invalid.");
+    }
+
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(3)]
+    [DataRow(5)]
+    [DataRow(-1)]
+    public void Read_InvalidSizeLength_Throws(int sizeLength)
+    {
+        using var ms = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
+        var reader = new Reader(ms);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => reader.ReadVariableLengthString(Encoding.UTF8, sizeLength));
+        Assert.AreEqual(0, ms.Position, "No bytes must be consumed when sizeLength is invalid.");
+    }
+
+    // ── Capacity checks ────────────────────────────────────────────────────────
+
+    [TestMethod]
+    public void Write_255Bytes_Prefix1_Succeeds()
+    {
+        string value = new string('a', 255);
+        var (bytes, _) = WriteString(value, Encoding.ASCII, 1);
+        Assert.AreEqual(256, bytes.Length); // 1 prefix + 255 payload
+        Assert.AreEqual(value, ReadString(bytes, Encoding.ASCII, 1));
+    }
+
+    [TestMethod]
+    public void Write_256Bytes_Prefix1_ThrowsAndWritesNothing()
+    {
+        string value = new string('a', 256);
+        using var ms = new MemoryStream();
+        var writer = new Writer(ms);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => writer.WriteVariableLengthString(value, Encoding.ASCII, 1));
+        Assert.AreEqual(0, ms.Length, "A failed capacity check must not write any bytes.");
+    }
+
+    [TestMethod]
+    public void Write_65535Bytes_Prefix2_Succeeds()
+    {
+        string value = new string('a', 65535);
+        var (bytes, _) = WriteString(value, Encoding.ASCII, 2);
+        Assert.AreEqual(65537, bytes.Length); // 2 prefix + 65535 payload
+        Assert.AreEqual(value, ReadString(bytes, Encoding.ASCII, 2));
+    }
+
+    [TestMethod]
+    public void Write_65536Bytes_Prefix2_ThrowsAndWritesNothing()
+    {
+        string value = new string('a', 65536);
+        using var ms = new MemoryStream();
+        var writer = new Writer(ms);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => writer.WriteVariableLengthString(value, Encoding.ASCII, 2));
+        Assert.AreEqual(0, ms.Length);
+    }
+
+    // ── Byte length vs char count for multi-byte UTF-8 ──────────────────────────
+
+    [TestMethod]
+    public void MultiByteUtf8_LengthIsMeasuredInBytesNotChars()
+    {
+        // Each 'é' is 2 bytes in UTF-8; "éé" is 2 chars but 4 bytes.
+        string value = "éé";
+        var (bytes, _) = WriteString(value, Encoding.UTF8, 1);
+        Assert.AreEqual(4, bytes[0], "The prefix must record the byte length (4), not the char count (2).");
+        Assert.AreEqual(value, ReadString(bytes, Encoding.UTF8, 1));
+    }
+
+    // ── Negative length in stream ──────────────────────────────────────────────
+
+    [TestMethod]
+    public void Read_NegativeLengthInStream_Prefix4_ThrowsFormatException()
+    {
+        // 0xFFFFFFFF little-endian = -1 as Int32.
+        using var ms = new MemoryStream(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x00 });
+        var reader = new Reader(ms);
+        Assert.ThrowsException<FormatException>(
+            () => reader.ReadVariableLengthString(Encoding.UTF8, 4));
+    }
+
+    // ── maxByteLength enforcement ──────────────────────────────────────────────
+
+    [TestMethod]
+    public void Read_ExceedingMaxByteLength_ThrowsBeforeAllocation()
+    {
+        // Prefix says 100 bytes; only a few follow. The limit is checked before ReadBytes.
+        using var ms = new MemoryStream(new byte[] { 100, 1, 2, 3 });
+        var reader = new Reader(ms);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => reader.ReadVariableLengthString(Encoding.UTF8, 1, maxByteLength: 10));
+        // Only the single prefix byte was consumed before rejection.
+        Assert.AreEqual(1, ms.Position);
+    }
+
+    [TestMethod]
+    public void Read_WithinMaxByteLength_Succeeds()
+    {
+        var (bytes, _) = WriteString("abc", Encoding.ASCII, 1);
+        using var ms = new MemoryStream(bytes);
+        var reader = new Reader(ms);
+        Assert.AreEqual("abc", reader.ReadVariableLengthString(Encoding.ASCII, 1, maxByteLength: 100));
+    }
+
+    [TestMethod]
+    public void Read_NegativeMaxByteLength_Throws()
+    {
+        using var ms = new MemoryStream(new byte[] { 1, (byte)'a' });
+        var reader = new Reader(ms);
+        Assert.ThrowsException<ArgumentOutOfRangeException>(
+            () => reader.ReadVariableLengthString(Encoding.ASCII, 1, maxByteLength: -1));
+        Assert.AreEqual(0, ms.Position, "No bytes consumed when maxByteLength is invalid.");
+    }
+}


### PR DESCRIPTION
﻿## Summary

Closes the five remaining open items from `Utils.IO/TODO-2026-07-19-pass2.md`, which is renamed to `DONE-2026-08-01.md` now that all 16 items are resolved.

- **Item 17 - LEB128 bounded and validated**: `ReadULEB128`/`ReadSLEB128` capped at 10 bytes; 10th-byte payload validated; overlong encodings throw `FormatException`; value > 64 bits throws `OverflowException`; truncated stream throws `EndOfStreamException`.
- **Item 18 - Variable-length string prefix**: `sizeLength` not in {1, 2, 4} throws `ArgumentOutOfRangeException` before any I/O; writer verifies encoded length fits prefix before writing; new `ReadVariableLengthString(..., int maxByteLength)` overload rejects excess length before allocation.
- **Item 26 - Bounded whole-stream helpers**: `ReadToMemoryStream` and `ReadAllText` accept `int? maxBytes`; `ReadBlock` gains a KMP-based bounded overload (EOF without separator throws `EndOfStreamException`; limit exceeded throws `InvalidOperationException`).
- **Item 27 - Strict base decoder terminal validation**: `Close()` rejects `dataLength >= BitsWidth` as an incomplete quantum (e.g. single Base16 or Base64 symbol throws `FormatException`); non-zero trailing bits still rejected.
- **Item 30 - Span and async paths**: `StreamCopier` and `BaseEncoderStream` implement `Write(ReadOnlySpan<byte>)`, `WriteAsync`, `FlushAsync`, `DisposeAsync`; encoder shares `EncodeCore(ReadOnlySpan<byte>)` across all paths; `SemaphoreSlim(1,1)` serialises concurrent async writes without holding a monitor across `await`; cancellation takes priority over aggregated target failures.

## Test plan

- [ ] `dotnet test UtilsTest/UtilsTest.Unit.csproj` -- 5746 passed, 0 failed, 6 skipped (pre-existing)
- [ ] `dotnet build Utils.IO/Utils.IO.csproj` -- 0 errors
- [ ] LEB128: 11-byte, overlong, boundary values, round-trips (`Leb128Tests.cs`)
- [ ] Variable-length string: invalid prefix widths, overflow, UTF-8 byte-vs-char, truncation (`VariableLengthStringTests.cs`)
- [ ] Bounded stream helpers: empty/exact/+1, non-seekable, KMP edge cases (`StreamUtilsTests.cs`)
- [ ] Base decoder terminal: single-symbol Base16/Base64, every mod remainder for Base32/Base64 (`BaseDecoderStreamTests.cs`)
- [ ] StreamCopier span/async/flush/dispose with multiple targets (`StreamCopierTests.cs`)
- [ ] BaseEncoderStream span/async/concurrent writes/dispose (`BaseEncoderStreamTests.cs`)

Generated with [Claude Code](https://claude.ai/claude-code)
