### PR TITLE
fix(Utils.Net): exclusive protocol exchanges, streaming payloads, strict SMTP/POP3/NNTP parsing & structured protocol errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ All notable changes to this project will be documented in this file.
 - Added strict SMTP paths/options, strict UTF-8 SASL, exclusive mail transactions, and bounded verified RSET recovery.
 - POP3 and NNTP mandatory numeric responses are strict; NEWNEWS and `INntpArticleStore.ListNewsSinceAsync` use message IDs, and NEXT returns null only for 421.
 
+### `omy.Utils.Fonts`
+
+- **Breaking:** hardened SFNT/TrueType parsing against hostile input (second quality/security audit
+  pass, items 21-39 of `Utils.Fonts/TODO-2026-07-19-pass2.md`). Unsigned wire types throughout
+  (`numTables`, table offsets/lengths/checksums, `loca` Offset16/32, `cmap` counts/offsets, composite
+  glyph indices); new `TrueTypeFontParsingOptions`/`FontValidationMode` (strict/permissive) with
+  structured `FontDiagnostic`s and `FontParseException`; bounded resource limits (font/table size,
+  table count, `cmap` subtable count, composite glyph depth/components/points) enforced before
+  allocation; SFNT directory entries preserved in an ordered list instead of a lossy `SortedSet`
+  (duplicate tags, aliases, and overlaps are now detected and policy-driven instead of silently
+  dropped); read-only table/font checksum computation instead of temporarily zeroing bytes in the
+  source stream; bounded per-table stream slices instead of eagerly duplicating every table into a
+  fresh buffer; cycle- and budget-guarded compound glyph resolution; immutable `CmapTable.CMaps` and
+  `GlyphCompound.Instructions`.
+- **Breaking:** `GlyphCompound.getGlyphIndex(int)` renamed to `GetGlyphIndex(int)` and returns
+  `ushort`; `GlyphCompound.Instructions` is `ReadOnlyMemory<byte>` instead of `byte[]`;
+  `CmapTable.CMaps` is `IReadOnlyList<CMapFormatBase>` instead of an array; several `short`-typed
+  fields widened to `ushort`/`int` (`TrueTypeFont.TablesCount`/`SearchRange`/`EntrySelector`/
+  `RangeShift`, `CmapTable.Version`/`NumberSubtables`, `GlyphBase.Length`).
+- New: `TrueTypeFont.ParseFont`/`ParseFontAsync` overloads taking `TrueTypeFontParsingOptions`;
+  `TrueTypeFont.Diagnostics`; `WriteFont(Stream, TrueTypeFontWritingOptions)`/`WriteFontAsync`.
+- Preview language features disabled and `LangVersion` pinned for the package (was not actually
+  relying on any preview-only feature).
+- See `docs/releasing/MigrationTo2.0.md` and `docs/releasing/AcceptedApiBreaks.md#omy-utils-fonts`.
+
 ## [2.0.0-rc.1] - Release candidate
 
 ### `omy.Utils`
@@ -147,7 +172,7 @@ All notable changes to this project will be documented in this file.
 - Added `omy.Utils.Parser` (v0.1.0): self-describing universal parser framework. Tokenizes and parses any ANTLR4 grammar at runtime without code generation. Includes `LexerEngine`, `ParserEngine`, `Antlr4GrammarConverter`, and `RuleResolver`.
 - Added XML documentation (English) to all `Utils.Parser` public and private members.
 - Added `PackageTags`, `PackageReadmeFile`, `RepositoryUrl`, `RepositoryType`, and `PackageProjectUrl` to `omy.Utils.Parser.csproj`.
-- Added `RepositoryUrl`, `RepositoryType`, and `PackageProjectUrl` to all other packable project files.
+- Added `RepositoryUrl`, `RepositoryType`, and `RepositoryUrl` to all other packable project files.
 - Added consumer-focused documentation, getting started guide, GitHub About proposal, and release process notes.
 - Marked internal projects (`Utils.Expressions.CSyntax`, `Utils.Parser.VisualStudio.Worker`) as non-packable to keep NuGet metadata scope limited to published packages.
 - Documented package family overview and usage in the root README and base package README.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed — `omy.Utils.Net` (BREAKING)
 - Added exclusive protocol exchanges, fail-closed poisoned sessions, structured response exceptions, and bounded streaming POP3/NNTP payload APIs.
 - Added strict SMTP paths/options, strict UTF-8 SASL, exclusive mail transactions, and bounded verified RSET recovery.
-- POP3 and NNTP mandatory numeric responses are strict; NEWNEWS returns message IDs and NEXT returns null only for 421.
+- POP3 and NNTP mandatory numeric responses are strict; NEWNEWS and `INntpArticleStore.ListNewsSinceAsync` use message IDs, and NEXT returns null only for 421.
 
 ## [2.0.0-rc.1] - Release candidate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,36 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed — `omy.Utils.Net` (BREAKING)
-- Added exclusive protocol exchanges, fail-closed poisoned sessions, structured response exceptions, and bounded streaming POP3/NNTP payload APIs.
-- Added strict SMTP paths/options, strict UTF-8 SASL, exclusive mail transactions, and bounded verified RSET recovery.
-- POP3 and NNTP mandatory numeric responses are strict; NEWNEWS and `INntpArticleStore.ListNewsSinceAsync` use message IDs, and NEXT returns null only for 421.
-
-### `omy.Utils.Fonts`
-
-- **Breaking:** hardened SFNT/TrueType parsing against hostile input (second quality/security audit
-  pass, items 21-39 of `Utils.Fonts/TODO-2026-07-19-pass2.md`). Unsigned wire types throughout
-  (`numTables`, table offsets/lengths/checksums, `loca` Offset16/32, `cmap` counts/offsets, composite
-  glyph indices); new `TrueTypeFontParsingOptions`/`FontValidationMode` (strict/permissive) with
-  structured `FontDiagnostic`s and `FontParseException`; bounded resource limits (font/table size,
-  table count, `cmap` subtable count, composite glyph depth/components/points) enforced before
-  allocation; SFNT directory entries preserved in an ordered list instead of a lossy `SortedSet`
-  (duplicate tags, aliases, and overlaps are now detected and policy-driven instead of silently
-  dropped); read-only table/font checksum computation instead of temporarily zeroing bytes in the
-  source stream; bounded per-table stream slices instead of eagerly duplicating every table into a
-  fresh buffer; cycle- and budget-guarded compound glyph resolution; immutable `CmapTable.CMaps` and
-  `GlyphCompound.Instructions`.
-- **Breaking:** `GlyphCompound.getGlyphIndex(int)` renamed to `GetGlyphIndex(int)` and returns
-  `ushort`; `GlyphCompound.Instructions` is `ReadOnlyMemory<byte>` instead of `byte[]`;
-  `CmapTable.CMaps` is `IReadOnlyList<CMapFormatBase>` instead of an array; several `short`-typed
-  fields widened to `ushort`/`int` (`TrueTypeFont.TablesCount`/`SearchRange`/`EntrySelector`/
-  `RangeShift`, `CmapTable.Version`/`NumberSubtables`, `GlyphBase.Length`).
-- New: `TrueTypeFont.ParseFont`/`ParseFontAsync` overloads taking `TrueTypeFontParsingOptions`;
-  `TrueTypeFont.Diagnostics`; `WriteFont(Stream, TrueTypeFontWritingOptions)`/`WriteFontAsync`.
-- Preview language features disabled and `LangVersion` pinned for the package (was not actually
-  relying on any preview-only feature).
-- See `docs/releasing/MigrationTo2.0.md` and `docs/releasing/AcceptedApiBreaks.md#omy-utils-fonts`.
-
 ## [2.0.0-rc.1] - Release candidate
 
 ### `omy.Utils`
@@ -172,7 +142,7 @@ All notable changes to this project will be documented in this file.
 - Added `omy.Utils.Parser` (v0.1.0): self-describing universal parser framework. Tokenizes and parses any ANTLR4 grammar at runtime without code generation. Includes `LexerEngine`, `ParserEngine`, `Antlr4GrammarConverter`, and `RuleResolver`.
 - Added XML documentation (English) to all `Utils.Parser` public and private members.
 - Added `PackageTags`, `PackageReadmeFile`, `RepositoryUrl`, `RepositoryType`, and `PackageProjectUrl` to `omy.Utils.Parser.csproj`.
-- Added `RepositoryUrl`, `RepositoryType`, and `RepositoryUrl` to all other packable project files.
+- Added `RepositoryUrl`, `RepositoryType`, and `PackageProjectUrl` to all other packable project files.
 - Added consumer-focused documentation, getting started guide, GitHub About proposal, and release process notes.
 - Marked internal projects (`Utils.Expressions.CSyntax`, `Utils.Parser.VisualStudio.Worker`) as non-packable to keep NuGet metadata scope limited to published packages.
 - Documented package family overview and usage in the root README and base package README.
@@ -193,3 +163,8 @@ All notable changes to this project will be documented in this file.
 - **Breaking:** `VariantRule` and `OrdinalVariantRule` now expose immutable signed `Priority` values; trigger tuples were replaced by `TriggerReplacementForm`.
 - Canonical constraint sets, shared specificity/priority ranking, and construction-time `UNTS001`–`UNTS004` diagnostics reject unresolved intersections instead of using declaration order.
 - XML `priority` attributes default to zero and cumulative variants apply in ascending specificity and priority order.
+
+### Changed — `omy.Utils.Net` (BREAKING)
+- Added exclusive protocol exchanges, fail-closed poisoned sessions, structured response exceptions, and bounded streaming POP3/NNTP payload APIs.
+- Added strict SMTP paths/options, strict UTF-8 SASL, exclusive mail transactions, and bounded verified RSET recovery.
+- POP3 and NNTP mandatory numeric responses are strict; NEWNEWS and `INntpArticleStore.ListNewsSinceAsync` use message IDs, and NEXT returns null only for 421.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — `omy.Utils.Net` (BREAKING)
+- Added exclusive protocol exchanges, fail-closed poisoned sessions, structured response exceptions, and bounded streaming POP3/NNTP payload APIs.
+- Added strict SMTP paths/options, strict UTF-8 SASL, exclusive mail transactions, and bounded verified RSET recovery.
+- POP3 and NNTP mandatory numeric responses are strict; NEWNEWS returns message IDs and NEXT returns null only for 421.
+
 ## [2.0.0-rc.1] - Release candidate
 
 ### `omy.Utils`

--- a/Utils.Net/DONE-2026-08-04.md
+++ b/Utils.Net/DONE-2026-08-04.md
@@ -14,7 +14,7 @@ This pass complements the earlier `Utils.Net` audit files. It focuses on SMTP, P
 
 **Priority: P1 protocol correctness.**
 
-### 60. SMTP envelope arguments can escape the generated angle-bracket syntax
+### 60. ✅ SMTP envelope arguments can escape the generated angle-bracket syntax
 
 `SendMailAsync` validates only CR, LF, and NUL before interpolating sender and recipient strings into `MAIL FROM:<...>` and `RCPT TO:<...>`. An argument containing `>` can terminate the mailbox path and append SMTP parameters or other malformed syntax on the same line.
 
@@ -24,7 +24,7 @@ This pass complements the earlier `Utils.Net` audit files. It focuses on SMTP, P
 
 **Priority: P1 command construction safety.**
 
-### 61. SMTP mail transactions are not recovered after a partial recipient or DATA failure
+### 61. ✅ SMTP mail transactions are not recovered after a partial recipient or DATA failure
 
 `SendMailAsync` sends `MAIL FROM`, then each `RCPT TO`, then `DATA`. If one recipient is rejected, cancellation occurs, message generation fails, or the final DATA response is negative, no `RSET` is issued and no transaction-state object records the uncertain server state.
 
@@ -44,7 +44,7 @@ The recipient enumerable is not validated for nullness or emptiness and is consu
 
 **Priority: P1 transaction validation.**
 
-### 63. SMTP AUTH PLAIN and LOGIN force credentials through ASCII
+### 63. ✅ SMTP AUTH PLAIN and LOGIN force credentials through ASCII
 
 User names and passwords are converted with `Encoding.ASCII`, replacing non-ASCII characters with `?`. SASL PLAIN uses UTF-8 representations under its modern specification, subject to mechanism/profile rules.
 
@@ -74,7 +74,7 @@ Both multi-line readers use `line.TrimEnd() == "."`. The protocol terminator is 
 
 **Priority: P1 data fidelity.**
 
-### 66. POP3 numeric response parsing silently manufactures zero values or throws incidental format exceptions
+### 66. ✅ POP3 numeric response parsing silently manufactures zero values or throws incidental format exceptions
 
 `GetStatAsync` returns zero for missing fields but uses `int.Parse` for present malformed or oversized values. Similar methods silently ignore malformed LIST/UIDL rows.
 
@@ -104,7 +104,7 @@ Article, header, and body methods remove the first dot from every non-terminator
 
 **Priority: P1 data validation.**
 
-### 69. Multi-line limit failures do not recover or retire the connection
+### 69. ✅ Multi-line limit failures do not recover or retire the connection
 
 When POP3 or NNTP line/character limits are exceeded, the reader throws immediately but unread lines through the terminating dot remain queued or continue arriving on the connection.
 
@@ -114,7 +114,7 @@ When POP3 or NNTP line/character limits are exceeded, the reader throws immediat
 
 **Priority: P1 session synchronization.**
 
-### 70. Generic response-count limits can split legitimate protocol multi-line replies from their payload phase
+### 70. ✅ Generic response-count limits can split legitimate protocol multi-line replies from their payload phase
 
 `SendCommandAsync` limits only status responses collected before a completion/unknown severity line. POP3 and NNTP then read their dot-terminated payload through a separate API with separate limits. The two-stage contract is implicit and shared-queue based.
 
@@ -126,7 +126,7 @@ When POP3 or NNTP line/character limits are exceeded, the reader throws immediat
 
 ## Medium-priority findings
 
-### 71. NNTP `NextAsync` converts every negative response into “no next article”
+### 71. ✅ NNTP `NextAsync` converts every negative response into “no next article”
 
 Authentication failures, missing group selection, temporary server errors, and protocol failures all return `null`, identical to the normal no-next-article case.
 
@@ -134,7 +134,7 @@ Authentication failures, missing group selection, temporary server errors, and p
 
 **Priority: P2 error semantics.**
 
-### 72. Protocol methods expose generic `IOException` without preserving response codes
+### 72. ✅ Protocol methods expose generic `IOException` without preserving response codes
 
 SMTP, POP3, and NNTP success guards throw `IOException` containing only the final message. The numeric/symbolic response code, severity, full response sequence, and command context are not retained structurally.
 
@@ -142,7 +142,7 @@ SMTP, POP3, and NNTP success guards throw `IOException` containing only the fina
 
 **Priority: P2 diagnostics and caller control.**
 
-### 73. SMTP/POP3/NNTP payloads are fully materialized as strings and line lists
+### 73. ✅ SMTP/POP3/NNTP payloads are fully materialized as strings and line lists
 
 Mail DATA, retrieved messages, articles, headers, bodies, and large LIST/CAPA results are accumulated in memory. Existing line/character limits reduce but do not remove large allocation and duplication costs.
 
@@ -185,3 +185,16 @@ Mail DATA, retrieved messages, articles, headers, bodies, and large LIST/CAPA re
 ## Deployment warning
 
 Until items 59–70 are addressed, do not use the SMTP capability list as an authoritative security-feature inventory, do not pass untrusted mailbox strings to envelope methods, and do not reuse a POP3/NNTP connection after cancellation or a multiline-limit failure. Retrieved POP3 message text is not currently platform-independent, and protocol failures are not reliably distinguishable from ordinary empty/no-result conditions.
+## Pass-seven resolution record (2026-08-04)
+
+| Item | Status | Resolution | Files changed | Tests | API breaks | Remaining limitations |
+|---:|---|---|---|---|---|---|
+| 60 | Resolved | Added typed strict `SmtpPath` plus separately typed ESMTP options and explicit SMTPUTF8 opt-in. | `SmtpModels.cs`, `SmtpClient.cs` | `ProtocolHardeningTests` path matrix and pre-existing no-write validation test. | Historically permissive strings now fail before I/O. | Quoted local-parts and source routes are intentionally unsupported. |
+| 61 | Resolved | One lease owns MAIL/RCPT/DATA; verified bounded RSET recovery preserves the primary and recovery errors. | `SmtpClient.cs` | In-memory protocol tests and Net-filter suite. | Transaction failures are structured and sessions can become permanently poisoned. | Partial recipient success is not enabled. |
+| 63 | Resolved | PLAIN and LOGIN use strict UTF-8, validate each NUL-free field, redact payloads, and LOGIN is exclusive. | `SmtpModels.cs`, `SmtpClient.cs` | Credential NUL and UTF-8 model tests. | Invalid credentials fail locally. | AUTH remains caller-controlled and must be used over TLS. |
+| 66 | Resolved | STAT/LIST/UIDL and GROUP/LIST/STAT use invariant exact parsers; malformed rows invalidate the operation; NEWNEWS returns message IDs. | `Pop3Client.cs`, `NntpClient.cs` | Net-filter protocol suite. | POP3 sizes use `long`; NEWNEWS returns strings; strict failures replace defaults. | NNTP LIST accepts the standard optional fourth posting-status field. |
+| 69 | Resolved | Line, character, and byte overruns poison and close an incomplete session rather than draining it. | `ProtocolPayloadLimits.cs`, `CommandResponseClient.cs` | Limits validation and Net-filter framing suite. | New byte limit and fail-closed behavior. | Bytes are counted after UTF-8 encoding of decoded protocol text. |
+| 70 | Resolved | PR #520 established nominal `SendMultilineCommandAsync` ownership; this pass consolidates it with a reusable exclusive exchange and completes cancellation, limits, streaming, EOF, and poison paths. No incomplete body can contaminate the next exchange. | `CommandResponseClient.cs` | Existing exact-terminator/dot tests plus Net-filter suite. | Failed framing permanently retires the client. | The legacy protected materializing helper remains as a bounded wrapper. |
+| 71 | Resolved | NEXT maps 223 to a strict parsed article, 421 to null, and every other response to `ProtocolResponseException`. | `NntpClient.cs` | Net-filter NNTP tests. | Negative responses no longer all map to null. | None. |
+| 72 | Resolved | Added immutable structured response diagnostics and a poisoned-session exception with a retained root cause. | `ProtocolExceptions.cs` | Redaction and defensive-copy test. | Generic response errors are replaced by typed failures. | No protocol secrets are included in exception messages. |
+| 73 | Resolved | Added progressive SMTP `TextReader`/`Stream` input and POP3/NNTP `TextWriter` output; materialized wrappers remain bounded. | `SmtpClient.cs`, `Pop3Client.cs`, `NntpClient.cs` | Existing in-memory payload tests and Net-filter suite. | New overloads; NEWNEWS semantic correction. | Stream SMTP input is decoded through the caller-provided encoding rather than transferred as opaque bytes. |

--- a/Utils.Net/Net/CommandResponseClient.cs
+++ b/Utils.Net/Net/CommandResponseClient.cs
@@ -57,7 +57,9 @@ public class CommandResponseClient : IDisposable
     private const int StateConnecting = 1;
     private const int StateConnected = 2;
     private const int StateDisposed = 3;
+    private const int StatePoisoned = 4;
     private int _state = StateNotConnected;
+    private Exception? _poisonCause;
 
     private int _maxLineLength = 8192;
 
@@ -208,6 +210,11 @@ public class CommandResponseClient : IDisposable
     /// rely on the property to reflect the fully-initialised connection state.
     /// </remarks>
     public bool IsConnected => _state == StateConnected;
+
+    /// <summary>
+    /// Gets the first error that made the protocol session unusable, or <see langword="null"/>.
+    /// </summary>
+    public Exception? SessionFailure => Volatile.Read(ref _poisonCause);
 
     /// <summary>
     /// Default port used by the protocol.
@@ -367,6 +374,121 @@ public class CommandResponseClient : IDisposable
     }
 
     /// <summary>
+    /// Executes one complete protocol exchange while exclusively owning the connection.
+    /// </summary>
+    /// <typeparam name="TResult">Result produced by the exchange.</typeparam>
+    /// <param name="command">Sanitized command name used for diagnostics.</param>
+    /// <param name="exchange">Exchange implementation.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The exchange result.</returns>
+    protected async Task<TResult> ExecuteExclusiveExchangeAsync<TResult>(
+        string command,
+        Func<ProtocolExchangeContext, CancellationToken, ValueTask<TResult>> exchange,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(exchange);
+        ThrowIfUnavailable();
+        CancellationToken sessionToken = _listenTokenSource?.Token ?? CancellationToken.None;
+        using CancellationTokenSource linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, sessionToken);
+        await _sendLock.WaitAsync(linked.Token).ConfigureAwait(false);
+        try
+        {
+            ThrowIfUnavailable();
+            DrainPendingResponses();
+            Interlocked.Increment(ref _activeCommandWaiters);
+            try
+            {
+                return await exchange(new ProtocolExchangeContext(this, command), linked.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _activeCommandWaiters);
+            }
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Marks this session unusable after protocol framing is lost.
+    /// </summary>
+    /// <param name="cause">The primary failure.</param>
+    protected void PoisonSession(Exception cause)
+    {
+        ArgumentNullException.ThrowIfNull(cause);
+        if (Interlocked.CompareExchange(ref _poisonCause, cause, null) is not null)
+            return;
+        Interlocked.Exchange(ref _state, StatePoisoned);
+        _disconnected = true;
+        try { _listenTokenSource?.Cancel(); } catch (ObjectDisposedException) { }
+        try { _reader?.Dispose(); } catch (Exception ex) { Logger?.LogDebug(ex, "Error closing poisoned session reader"); }
+        try { _writer?.Dispose(); } catch (Exception ex) { Logger?.LogDebug(ex, "Error closing poisoned session writer"); }
+        try { if (!_leaveOpen) _stream?.Dispose(); } catch (Exception ex) { Logger?.LogDebug(ex, "Error closing poisoned session transport"); }
+        _responseSignal.Release();
+    }
+
+    /// <summary>
+    /// Throws when this client cannot start another protocol operation.
+    /// </summary>
+    private void ThrowIfUnavailable()
+    {
+        if (_disposed != 0 || _state == StateDisposed)
+            throw new ObjectDisposedException(GetType().Name);
+        if (_state == StatePoisoned)
+            throw new ProtocolSessionPoisonedException("The protocol session is unusable.", _poisonCause);
+        if (_disconnected)
+            throw new IOException("Connection closed.");
+        if (_state != StateConnected)
+            throw new InvalidOperationException("Client is not connected.");
+    }
+
+    /// <summary>
+    /// Provides controlled access to a connection during an exclusive protocol exchange.
+    /// </summary>
+    protected sealed class ProtocolExchangeContext
+    {
+        private readonly CommandResponseClient _owner;
+
+        /// <summary>
+        /// Initializes a context owned by one client exchange.
+        /// </summary>
+        internal ProtocolExchangeContext(CommandResponseClient owner, string command)
+        {
+            _owner = owner;
+            Command = command;
+        }
+
+        /// <summary>Gets the sanitized command verb.</summary>
+        public string Command { get; }
+
+        /// <summary>Writes one validated protocol line.</summary>
+        public async ValueTask WriteLineAsync(string line, CancellationToken cancellationToken)
+        {
+            ValidateCommandArgument(line, nameof(line));
+            _owner.Logger?.LogDebug("Sending: {Command}", _owner.RedactCommandForLog(line));
+            await _owner._writer!.WriteLineAsync(line.AsMemory(), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>Reads the next framed response line.</summary>
+        public async ValueTask<ServerResponse> ReadLineAsync(CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                await _owner._responseSignal.WaitAsync(cancellationToken).ConfigureAwait(false);
+                if (_owner._responseQueue.TryDequeue(out ServerResponse response))
+                    return response;
+                if (_owner._disconnected)
+                    throw new IOException("Connection closed before the response completed.");
+            }
+        }
+
+        /// <summary>Marks the session unusable.</summary>
+        public void Poison(Exception cause) => _owner.PoisonSession(cause);
+    }
+
+    /// <summary>
     /// Sends a command and collects responses until a response with at least completion severity is received.
     /// </summary>
     /// <param name="command">Command to send.</param>
@@ -398,9 +520,12 @@ public class CommandResponseClient : IDisposable
             // the command so that a response arriving immediately after (or during) the write
             // is routed to the queue rather than raised as unsolicited.
             Interlocked.Increment(ref _activeCommandWaiters);
+            bool commandWritten = false;
+            bool responseComplete = false;
             try
             {
                 await _writer.WriteLineAsync(command.AsMemory(), cancellationToken).ConfigureAwait(false);
+                commandWritten = true;
                 List<ServerResponse> responses = new();
                 while (true)
                 {
@@ -416,15 +541,23 @@ public class CommandResponseClient : IDisposable
                     responses.Add(response);
                     if (MaxResponseCount > 0 && responses.Count > MaxResponseCount)
                     {
-                        throw new InvalidDataException($"Server sent more than {MaxResponseCount} response lines for a single command.");
+                        InvalidDataException error = new($"Server sent more than {MaxResponseCount} response lines for a single command.");
+                        PoisonSession(error);
+                        throw error;
                     }
                     if (response.Severity >= ResponseSeverity.Completion || response.Severity == ResponseSeverity.Unknown)
                     {
                         break;
                     }
                 }
+                responseComplete = true;
                 ResetKeepAlive();
                 return responses;
+            }
+            catch (Exception ex) when (commandWritten && !responseComplete && ex is OperationCanceledException or IOException)
+            {
+                PoisonSession(ex);
+                throw;
             }
             finally
             {
@@ -450,6 +583,75 @@ public class CommandResponseClient : IDisposable
     /// </returns>
     protected static string BodyLineToString(ServerResponse response) =>
         response.Message is null ? response.Code : $"{response.Code} {response.Message}";
+
+    /// <summary>Removes one dot from a correctly dot-stuffed payload line.</summary>
+    internal static ReadOnlyMemory<char> UnstuffDotLine(ReadOnlyMemory<char> line) =>
+        line.Span.StartsWith("..".AsSpan(), StringComparison.Ordinal) ? line[1..] : line;
+
+    /// <summary>
+    /// Streams a complete dot-terminated exchange while retaining exclusive connection ownership.
+    /// </summary>
+    protected Task<IReadOnlyList<ServerResponse>> StreamMultilineCommandAsync(
+        string command,
+        Func<ReadOnlyMemory<char>, CancellationToken, ValueTask> consumeLine,
+        ProtocolPayloadLimits limits,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(consumeLine);
+        ArgumentNullException.ThrowIfNull(limits);
+        ValidateCommandArgument(command, nameof(command));
+        return ExecuteExclusiveExchangeAsync<IReadOnlyList<ServerResponse>>(command, async (context, token) =>
+        {
+            bool payloadStarted = false;
+            bool terminated = false;
+            try
+            {
+                await context.WriteLineAsync(command, token).ConfigureAwait(false);
+                List<ServerResponse> status = [];
+                while (true)
+                {
+                    ServerResponse response = await context.ReadLineAsync(token).ConfigureAwait(false);
+                    status.Add(response);
+                    if (MaxResponseCount > 0 && status.Count > MaxResponseCount)
+                        throw new InvalidDataException($"Server sent more than {MaxResponseCount} status lines.");
+                    if (response.Severity >= ResponseSeverity.Completion || response.Severity == ResponseSeverity.Unknown)
+                        break;
+                }
+                if (status[^1].Severity is ResponseSeverity.TransientNegative or ResponseSeverity.PermanentNegative)
+                    return status;
+
+                payloadStarted = true;
+                int lines = 0;
+                long characters = 0;
+                long bytes = 0;
+                while (true)
+                {
+                    ServerResponse response = await context.ReadLineAsync(token).ConfigureAwait(false);
+                    string raw = BodyLineToString(response);
+                    if (raw == ".")
+                    {
+                        terminated = true;
+                        break;
+                    }
+                    lines = checked(lines + 1);
+                    characters = checked(characters + raw.Length);
+                    bytes = checked(bytes + Encoding.UTF8.GetByteCount(raw));
+                    if ((limits.MaximumLines > 0 && lines > limits.MaximumLines) ||
+                        (limits.MaximumCharacters > 0 && characters > limits.MaximumCharacters) ||
+                        (limits.MaximumBytes > 0 && bytes > limits.MaximumBytes))
+                        throw new InvalidDataException("The dot-terminated payload exceeded its configured limit.");
+                    await consumeLine(UnstuffDotLine(raw.AsMemory()), token).ConfigureAwait(false);
+                }
+                ResetKeepAlive();
+                return status;
+            }
+            catch (Exception ex) when (payloadStarted && !terminated)
+            {
+                context.Poison(ex);
+                throw;
+            }
+        }, cancellationToken);
+    }
 
     /// <summary>
     /// Sends a command, receives the opening status response(s), then reads all body lines
@@ -490,91 +692,24 @@ public class CommandResponseClient : IDisposable
         int maxBodyChars = 0,
         CancellationToken cancellationToken = default)
     {
-        if (_disposed != 0) throw new ObjectDisposedException(GetType().Name);
-        if (_state == StateDisposed || _disconnected) throw new IOException("Connection closed.");
-        if (_state != StateConnected) throw new InvalidOperationException("Client is not connected.");
-
-        await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        ArgumentNullException.ThrowIfNull(isBodyTerminator);
+        List<ServerResponse> body = [];
+        ProtocolPayloadLimits limits = new()
         {
-            if (_disconnected) throw new IOException("Connection closed.");
-            DrainPendingResponses();
-            Logger?.LogDebug("Sending: {Command}", RedactCommandForLog(command));
-
-            Interlocked.Increment(ref _activeCommandWaiters);
-            try
+            MaximumLines = maxBodyLines,
+            MaximumCharacters = maxBodyChars,
+            MaximumBytes = 0
+        };
+        IReadOnlyList<ServerResponse> status = await StreamMultilineCommandAsync(
+            command,
+            (line, _) =>
             {
-                await _writer.WriteLineAsync(command.AsMemory(), cancellationToken).ConfigureAwait(false);
-
-                // Phase 1: status line(s) — same break condition as SendCommandAsync.
-                var statusLines = new List<ServerResponse>();
-                while (true)
-                {
-                    await _responseSignal.WaitAsync(cancellationToken).ConfigureAwait(false);
-                    if (!_responseQueue.TryDequeue(out ServerResponse response))
-                    {
-                        if (_disconnected) throw new IOException("Connection closed.");
-                        continue;
-                    }
-                    statusLines.Add(response);
-                    if (MaxResponseCount > 0 && statusLines.Count > MaxResponseCount)
-                        throw new InvalidDataException($"Server sent more than {MaxResponseCount} response lines for a single command.");
-                    if (response.Severity >= ResponseSeverity.Completion || response.Severity == ResponseSeverity.Unknown)
-                        break;
-                }
-
-                // Phase 2: body lines. _activeCommandWaiters remains > 0 so the listener
-                // routes all body lines to the queue rather than raising them as unsolicited.
-                // Skip body when the last status is a negative response (4xx/5xx).
-                List<ServerResponse> bodyLines;
-                ServerResponse lastStatus = statusLines[^1];
-                if (lastStatus.Severity == ResponseSeverity.TransientNegative ||
-                    lastStatus.Severity == ResponseSeverity.PermanentNegative)
-                {
-                    bodyLines = [];
-                }
-                else
-                {
-                    int totalBodyChars = 0;
-                    bodyLines = new List<ServerResponse>();
-                    while (true)
-                    {
-                        await _responseSignal.WaitAsync(cancellationToken).ConfigureAwait(false);
-                        if (!_responseQueue.TryDequeue(out ServerResponse response))
-                        {
-                            if (_disconnected) throw new IOException("Connection closed.");
-                            continue;
-                        }
-                        if (isBodyTerminator(response))
-                            break;
-                        bodyLines.Add(response);
-                        if (MaxResponseCount > 0 && bodyLines.Count > MaxResponseCount)
-                            throw new InvalidDataException($"Server sent more than {MaxResponseCount} body lines for a single command.");
-                        if (maxBodyLines > 0 && bodyLines.Count > maxBodyLines)
-                            throw new InvalidDataException($"Multi-line response exceeded the line limit of {maxBodyLines}.");
-                        if (maxBodyChars > 0)
-                        {
-                            totalBodyChars += response.Message is null
-                                ? response.Code.Length
-                                : response.Code.Length + 1 + response.Message.Length;
-                            if (totalBodyChars > maxBodyChars)
-                                throw new InvalidDataException($"Multi-line response exceeded the character limit of {maxBodyChars}.");
-                        }
-                    }
-                }
-
-                ResetKeepAlive();
-                return (statusLines, bodyLines);
-            }
-            finally
-            {
-                Interlocked.Decrement(ref _activeCommandWaiters);
-            }
-        }
-        finally
-        {
-            _sendLock.Release();
-        }
+                body.Add(ParseResponseLine(line.ToString()));
+                return ValueTask.CompletedTask;
+            },
+            limits,
+            cancellationToken).ConfigureAwait(false);
+        return (status, body);
     }
 
     /// <summary>
@@ -1257,4 +1392,3 @@ public class CommandResponseClient : IDisposable
     // Item 50: no finalizer — all resources are managed. A finalizer that joins threads or
     // disposes managed semaphores from the finalizer thread can deadlock the GC.
 }
-

--- a/Utils.Net/Net/CommandResponseClient.cs
+++ b/Utils.Net/Net/CommandResponseClient.cs
@@ -463,16 +463,36 @@ public class CommandResponseClient : IDisposable
         /// <summary>Gets the sanitized command verb.</summary>
         public string Command { get; }
 
+        /// <summary>Gets a value indicating whether a command line write has begun and has not yet completed.</summary>
+        public bool WriteStarted { get; private set; }
+
         /// <summary>Gets a value indicating whether the last written command is waiting for its status response.</summary>
         public bool AwaitingResponse { get; private set; }
+
+        /// <summary>Gets a value indicating whether a write failure already made this exchange unrecoverable.</summary>
+        private bool WriteFailedAmbiguously { get; set; }
 
         /// <summary>Writes one validated protocol line and marks the following status response as owned by this exchange.</summary>
         public async ValueTask WriteLineAsync(string line, CancellationToken cancellationToken)
         {
             ValidateCommandArgument(line, nameof(line));
             _owner.Logger?.LogDebug("Sending: {Command}", _owner.RedactCommandForLog(line));
-            await _owner._writer!.WriteLineAsync(line.AsMemory(), cancellationToken).ConfigureAwait(false);
-            AwaitingResponse = true;
+            WriteStarted = true;
+            try
+            {
+                await _owner._writer!.WriteLineAsync(line.AsMemory(), cancellationToken).ConfigureAwait(false);
+                AwaitingResponse = true;
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or IOException)
+            {
+                WriteFailedAmbiguously = true;
+                Poison(ex);
+                throw;
+            }
+            finally
+            {
+                WriteStarted = false;
+            }
         }
 
         /// <summary>Reads the next framed response line.</summary>
@@ -520,7 +540,9 @@ public class CommandResponseClient : IDisposable
         /// <summary>Marks the session unusable when an exchange ended before the owned response was fully consumed.</summary>
         public bool PoisonIfResponseAmbiguous(Exception cause)
         {
-            if (!AwaitingResponse || cause is ProtocolResponseException)
+            if (cause is ProtocolResponseException)
+                return false;
+            if (!WriteFailedAmbiguously && !WriteStarted && !AwaitingResponse)
                 return false;
             Poison(cause);
             return true;

--- a/Utils.Net/Net/CommandResponseClient.cs
+++ b/Utils.Net/Net/CommandResponseClient.cs
@@ -463,12 +463,16 @@ public class CommandResponseClient : IDisposable
         /// <summary>Gets the sanitized command verb.</summary>
         public string Command { get; }
 
-        /// <summary>Writes one validated protocol line.</summary>
+        /// <summary>Gets a value indicating whether the last written command is waiting for its status response.</summary>
+        public bool AwaitingResponse { get; private set; }
+
+        /// <summary>Writes one validated protocol line and marks the following status response as owned by this exchange.</summary>
         public async ValueTask WriteLineAsync(string line, CancellationToken cancellationToken)
         {
             ValidateCommandArgument(line, nameof(line));
             _owner.Logger?.LogDebug("Sending: {Command}", _owner.RedactCommandForLog(line));
             await _owner._writer!.WriteLineAsync(line.AsMemory(), cancellationToken).ConfigureAwait(false);
+            AwaitingResponse = true;
         }
 
         /// <summary>Reads the next framed response line.</summary>
@@ -503,12 +507,24 @@ public class CommandResponseClient : IDisposable
                     throw error;
                 }
                 if (response.Severity >= ResponseSeverity.Completion || response.Severity == ResponseSeverity.Unknown)
+                {
+                    AwaitingResponse = false;
                     return responses.AsReadOnly();
+                }
             }
         }
 
         /// <summary>Marks the session unusable.</summary>
         public void Poison(Exception cause) => _owner.PoisonSession(cause);
+
+        /// <summary>Marks the session unusable when an exchange ended before the owned response was fully consumed.</summary>
+        public bool PoisonIfResponseAmbiguous(Exception cause)
+        {
+            if (!AwaitingResponse || cause is ProtocolResponseException)
+                return false;
+            Poison(cause);
+            return true;
+        }
     }
 
     /// <summary>
@@ -619,7 +635,8 @@ public class CommandResponseClient : IDisposable
         Func<ReadOnlyMemory<char>, CancellationToken, ValueTask> consumeLine,
         ProtocolPayloadLimits limits,
         CancellationToken cancellationToken = default,
-        Func<ServerResponse, bool>? isBodyTerminator = null)
+        Func<ServerResponse, bool>? isBodyTerminator = null,
+        Action<IReadOnlyList<ServerResponse>>? validateOpeningResponse = null)
     {
         ArgumentNullException.ThrowIfNull(consumeLine);
         ArgumentNullException.ThrowIfNull(limits);
@@ -632,6 +649,7 @@ public class CommandResponseClient : IDisposable
             {
                 await context.WriteLineAsync(command, token).ConfigureAwait(false);
                 IReadOnlyList<ServerResponse> status = await context.ReadResponsesAsync(token).ConfigureAwait(false);
+                validateOpeningResponse?.Invoke(status);
                 if (status[^1].Severity is ResponseSeverity.TransientNegative or ResponseSeverity.PermanentNegative)
                     return status;
 

--- a/Utils.Net/Net/CommandResponseClient.cs
+++ b/Utils.Net/Net/CommandResponseClient.cs
@@ -484,6 +484,29 @@ public class CommandResponseClient : IDisposable
             }
         }
 
+        /// <summary>
+        /// Reads one complete status response and enforces the client's response-count limit.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>An immutable snapshot of the status response lines.</returns>
+        public async ValueTask<IReadOnlyList<ServerResponse>> ReadResponsesAsync(CancellationToken cancellationToken)
+        {
+            List<ServerResponse> responses = [];
+            while (true)
+            {
+                ServerResponse response = await ReadLineAsync(cancellationToken).ConfigureAwait(false);
+                responses.Add(response);
+                if (_owner.MaxResponseCount > 0 && responses.Count > _owner.MaxResponseCount)
+                {
+                    InvalidDataException error = new($"Server sent more than {_owner.MaxResponseCount} status lines for one exchange.");
+                    Poison(error);
+                    throw error;
+                }
+                if (response.Severity >= ResponseSeverity.Completion || response.Severity == ResponseSeverity.Unknown)
+                    return responses.AsReadOnly();
+            }
+        }
+
         /// <summary>Marks the session unusable.</summary>
         public void Poison(Exception cause) => _owner.PoisonSession(cause);
     }
@@ -595,7 +618,8 @@ public class CommandResponseClient : IDisposable
         string command,
         Func<ReadOnlyMemory<char>, CancellationToken, ValueTask> consumeLine,
         ProtocolPayloadLimits limits,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        Func<ServerResponse, bool>? isBodyTerminator = null)
     {
         ArgumentNullException.ThrowIfNull(consumeLine);
         ArgumentNullException.ThrowIfNull(limits);
@@ -607,16 +631,7 @@ public class CommandResponseClient : IDisposable
             try
             {
                 await context.WriteLineAsync(command, token).ConfigureAwait(false);
-                List<ServerResponse> status = [];
-                while (true)
-                {
-                    ServerResponse response = await context.ReadLineAsync(token).ConfigureAwait(false);
-                    status.Add(response);
-                    if (MaxResponseCount > 0 && status.Count > MaxResponseCount)
-                        throw new InvalidDataException($"Server sent more than {MaxResponseCount} status lines.");
-                    if (response.Severity >= ResponseSeverity.Completion || response.Severity == ResponseSeverity.Unknown)
-                        break;
-                }
+                IReadOnlyList<ServerResponse> status = await context.ReadResponsesAsync(token).ConfigureAwait(false);
                 if (status[^1].Severity is ResponseSeverity.TransientNegative or ResponseSeverity.PermanentNegative)
                     return status;
 
@@ -628,7 +643,7 @@ public class CommandResponseClient : IDisposable
                 {
                     ServerResponse response = await context.ReadLineAsync(token).ConfigureAwait(false);
                     string raw = BodyLineToString(response);
-                    if (raw == ".")
+                    if ((isBodyTerminator?.Invoke(response) ?? raw == "."))
                     {
                         terminated = true;
                         break;
@@ -675,6 +690,10 @@ public class CommandResponseClient : IDisposable
     /// Maximum total characters across all body lines. <see cref="InvalidDataException"/> is
     /// thrown when the limit is exceeded. Set to 0 to disable.
     /// </param>
+    /// <param name="maxBodyBytes">
+    /// Maximum total UTF-8 bytes across all body lines. <see cref="InvalidDataException"/> is
+    /// thrown when the limit is exceeded. Set to 0 to disable.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
     /// A tuple of <c>StatusLines</c> (the opening response line(s), including the final
@@ -690,6 +709,7 @@ public class CommandResponseClient : IDisposable
         Func<ServerResponse, bool> isBodyTerminator,
         int maxBodyLines = 0,
         int maxBodyChars = 0,
+        long maxBodyBytes = 0,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(isBodyTerminator);
@@ -698,7 +718,7 @@ public class CommandResponseClient : IDisposable
         {
             MaximumLines = maxBodyLines,
             MaximumCharacters = maxBodyChars,
-            MaximumBytes = 0
+            MaximumBytes = maxBodyBytes
         };
         IReadOnlyList<ServerResponse> status = await StreamMultilineCommandAsync(
             command,
@@ -708,7 +728,8 @@ public class CommandResponseClient : IDisposable
                 return ValueTask.CompletedTask;
             },
             limits,
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken,
+            isBodyTerminator).ConfigureAwait(false);
         return (status, body);
     }
 

--- a/Utils.Net/Net/INntpArticleStore.cs
+++ b/Utils.Net/Net/INntpArticleStore.cs
@@ -34,13 +34,13 @@ public interface INntpArticleStore
     Task<IReadOnlyDictionary<int, string>> ListAsync(string group, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves article numbers newer than the given time from the specified group.
+    /// Retrieves message identifiers newer than the given time from the specified group.
     /// </summary>
     /// <param name="group">Name of the newsgroup.</param>
     /// <param name="sinceUtc">Lower bound in UTC. Articles newer than this time are returned.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Collection of article numbers.</returns>
-    Task<IReadOnlyCollection<int>> ListNewsSinceAsync(string group, DateTime sinceUtc, CancellationToken cancellationToken = default);
+    /// <returns>Collection of RFC-style message identifiers.</returns>
+    Task<IReadOnlyCollection<string>> ListNewsSinceAsync(string group, DateTime sinceUtc, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the full text of a single article.
@@ -60,4 +60,3 @@ public interface INntpArticleStore
     /// <returns>Number assigned to the new article.</returns>
     Task<int> AddAsync(string group, string article, CancellationToken cancellationToken = default);
 }
-

--- a/Utils.Net/Net/NntpClient.cs
+++ b/Utils.Net/Net/NntpClient.cs
@@ -290,12 +290,14 @@ public class NntpClient : CommandResponseClient
     {
         ValidateId(id, nameof(id));
         ArgumentNullException.ThrowIfNull(destination);
-        IReadOnlyList<ServerResponse> status = await StreamMultilineCommandAsync($"{command} {id}", async (line, token) =>
+        await StreamMultilineCommandAsync($"{command} {id}", async (line, token) =>
         {
             await destination.WriteAsync(line, token).ConfigureAwait(false);
             await destination.WriteAsync("\r\n".AsMemory(), token).ConfigureAwait(false);
-        }, new ProtocolPayloadLimits { MaximumLines = MaxMultilineLines, MaximumCharacters = MaxMultilineChars, MaximumBytes = MaxMultilineBytes }, cancellationToken).ConfigureAwait(false);
-        ProtocolResponseValidator.RequireCode("NNTP", command, status, expectedCode);
+        },
+        new ProtocolPayloadLimits { MaximumLines = MaxMultilineLines, MaximumCharacters = MaxMultilineChars, MaximumBytes = MaxMultilineBytes },
+        cancellationToken,
+        validateOpeningResponse: status => ProtocolResponseValidator.RequireCode("NNTP", command, status, expectedCode)).ConfigureAwait(false);
     }
 
     /// <summary>Parses a strict NNTP article-number and message-id response.</summary>

--- a/Utils.Net/Net/NntpClient.cs
+++ b/Utils.Net/Net/NntpClient.cs
@@ -79,7 +79,7 @@ public class NntpClient : CommandResponseClient
         ValidateCommandArgument(group, nameof(group));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"GROUP {group}", cancellationToken).ConfigureAwait(false);
         ProtocolResponseValidator.RequireCode("NNTP", "GROUP", responses, "211");
-        string[] parts = ExactFields(responses[0].Message, 3, "GROUP");
+        string[] parts = ExactFields(responses[0].Message, 3, "GROUP", responses);
         if (!TryNonNegative(parts[0], out int count) || !TryNonNegative(parts[1], out int first) || !TryNonNegative(parts[2], out int last) || (count > 0 && first > last))
             throw new ProtocolResponseException("NNTP", "GROUP", responses);
         return (count, first, last);
@@ -110,7 +110,7 @@ public class NntpClient : CommandResponseClient
     public async Task<IReadOnlyList<(string group, int last, int first)>> ListAsync(CancellationToken cancellationToken = default)
     {
         var (status, body) = await SendMultilineCommandAsync(
-            "LIST", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
+            "LIST", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, MaxMultilineBytes, cancellationToken).ConfigureAwait(false);
         ProtocolResponseValidator.RequireCode("NNTP", "LIST", status, "215");
         List<(string group, int last, int first)> result = new();
         foreach (ServerResponse response in body)
@@ -136,7 +136,7 @@ public class NntpClient : CommandResponseClient
         string date = utc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
         string time = utc.ToString("HHmmss", CultureInfo.InvariantCulture);
         var (status, body) = await SendMultilineCommandAsync(
-            $"NEWGROUPS {date} {time} GMT", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
+            $"NEWGROUPS {date} {time} GMT", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, MaxMultilineBytes, cancellationToken).ConfigureAwait(false);
         await EnsureCompletionAsync(status).ConfigureAwait(false);
         List<string> result = new(body.Count);
         foreach (ServerResponse response in body)
@@ -158,7 +158,7 @@ public class NntpClient : CommandResponseClient
         string date = utc.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
         string time = utc.ToString("HHmmss", CultureInfo.InvariantCulture);
         var (status, body) = await SendMultilineCommandAsync(
-            $"NEWNEWS {group} {date} {time} GMT", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
+            $"NEWNEWS {group} {date} {time} GMT", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, MaxMultilineBytes, cancellationToken).ConfigureAwait(false);
         await EnsureCompletionAsync(status).ConfigureAwait(false);
         List<string> ids = new();
         foreach (ServerResponse response in body)
@@ -301,17 +301,17 @@ public class NntpClient : CommandResponseClient
     /// <summary>Parses a strict NNTP article-number and message-id response.</summary>
     private static (int id, string messageId) ParseArticleStatus(string command, IReadOnlyList<ServerResponse> responses)
     {
-        string[] fields = ExactFields(responses[0].Message, 2, command);
+        string[] fields = ExactFields(responses[0].Message, 2, command, responses);
         if (!int.TryParse(fields[0], NumberStyles.None, CultureInfo.InvariantCulture, out int id) || id <= 0 || !IsMessageId(fields[1]))
             throw new ProtocolResponseException("NNTP", command, responses);
         return (id, fields[1]);
     }
 
     /// <summary>Requires an exact number of response fields.</summary>
-    private static string[] ExactFields(string? value, int count, string command)
+    private static string[] ExactFields(string? value, int count, string command, IReadOnlyList<ServerResponse> responses)
     {
         string[] fields = value?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? [];
-        return fields.Length == count ? fields : throw new InvalidDataException($"Malformed NNTP {command} response.");
+        return fields.Length == count ? fields : throw new ProtocolResponseException("NNTP", command, responses);
     }
 
     /// <summary>Parses a non-negative invariant integer.</summary>

--- a/Utils.Net/Net/NntpClient.cs
+++ b/Utils.Net/Net/NntpClient.cs
@@ -25,6 +25,9 @@ public class NntpClient : CommandResponseClient
     /// </summary>
     public int MaxMultilineChars { get; set; } = 10 * 1024 * 1024;
 
+    /// <summary>Gets or sets the maximum UTF-8 byte count for a multiline response.</summary>
+    public long MaxMultilineBytes { get; set; } = 40 * 1024 * 1024;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="NntpClient"/> class.
     /// </summary>
@@ -75,11 +78,10 @@ public class NntpClient : CommandResponseClient
     {
         ValidateCommandArgument(group, nameof(group));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"GROUP {group}", cancellationToken).ConfigureAwait(false);
-        await EnsureCompletionAsync(responses).ConfigureAwait(false);
-        string[] parts = responses[0].Message?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
-        int count = parts.Length > 0 ? int.Parse(parts[0]) : 0;
-        int first = parts.Length > 1 ? int.Parse(parts[1]) : 0;
-        int last = parts.Length > 2 ? int.Parse(parts[2]) : 0;
+        ProtocolResponseValidator.RequireCode("NNTP", "GROUP", responses, "211");
+        string[] parts = ExactFields(responses[0].Message, 3, "GROUP");
+        if (!TryNonNegative(parts[0], out int count) || !TryNonNegative(parts[1], out int first) || !TryNonNegative(parts[2], out int last) || (count > 0 && first > last))
+            throw new ProtocolResponseException("NNTP", "GROUP", responses);
         return (count, first, last);
     }
 
@@ -91,25 +93,14 @@ public class NntpClient : CommandResponseClient
     /// <returns>Article text.</returns>
     public async Task<string> ArticleAsync(int id, CancellationToken cancellationToken = default)
     {
-        var (status, body) = await SendMultilineCommandAsync(
-            $"ARTICLE {id}", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
-        await EnsureCompletionAsync(status).ConfigureAwait(false);
         StringBuilder sb = new();
-        foreach (ServerResponse response in body)
-        {
-            string line = BodyLineToString(response);
-            if (line.StartsWith("..", StringComparison.Ordinal))
-            {
-                sb.Append(line.AsSpan(1));
-            }
-            else
-            {
-                sb.Append(line);
-            }
-            sb.Append("\r\n");
-        }
+        using StringWriter writer = new(sb, CultureInfo.InvariantCulture);
+        await ArticleAsync(id, writer, cancellationToken).ConfigureAwait(false);
         return sb.ToString();
     }
+
+    /// <summary>Streams a complete article while exclusively owning the exchange.</summary>
+    public Task ArticleAsync(int id, TextWriter destination, CancellationToken cancellationToken = default) => StreamArticlePartAsync("ARTICLE", "220", id, destination, cancellationToken);
 
     /// <summary>
     /// Lists available newsgroups.
@@ -120,16 +111,15 @@ public class NntpClient : CommandResponseClient
     {
         var (status, body) = await SendMultilineCommandAsync(
             "LIST", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
-        await EnsureCompletionAsync(status).ConfigureAwait(false);
+        ProtocolResponseValidator.RequireCode("NNTP", "LIST", status, "215");
         List<(string group, int last, int first)> result = new();
         foreach (ServerResponse response in body)
         {
             string line = BodyLineToString(response);
             string[] parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length >= 3)
-            {
-                result.Add((parts[0], int.Parse(parts[1]), int.Parse(parts[2])));
-            }
+            if (parts.Length is < 3 or > 4 || parts[0].Length == 0 || !TryNonNegative(parts[1], out int high) || !TryNonNegative(parts[2], out int low) || high < low)
+                throw new ProtocolResponseException("NNTP", "LIST", status);
+            result.Add((parts[0], high, low));
         }
         return result;
     }
@@ -161,7 +151,7 @@ public class NntpClient : CommandResponseClient
     /// <param name="sinceUtc">Lower bound in UTC.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Collection of article numbers.</returns>
-    public async Task<IReadOnlyList<int>> NewNewsAsync(string group, DateTime sinceUtc, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<string>> NewNewsAsync(string group, DateTime sinceUtc, CancellationToken cancellationToken = default)
     {
         ValidateCommandArgument(group, nameof(group));
         DateTime utc = sinceUtc.Kind == DateTimeKind.Local ? sinceUtc.ToUniversalTime() : DateTime.SpecifyKind(sinceUtc, DateTimeKind.Utc);
@@ -170,13 +160,12 @@ public class NntpClient : CommandResponseClient
         var (status, body) = await SendMultilineCommandAsync(
             $"NEWNEWS {group} {date} {time} GMT", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
         await EnsureCompletionAsync(status).ConfigureAwait(false);
-        List<int> ids = new();
+        List<string> ids = new();
         foreach (ServerResponse response in body)
         {
-            if (int.TryParse(BodyLineToString(response), out int id))
-            {
-                ids.Add(id);
-            }
+            string id = BodyLineToString(response);
+            if (!IsMessageId(id)) throw new ProtocolResponseException("NNTP", "NEWNEWS", status);
+            ids.Add(id);
         }
         return ids;
     }
@@ -189,25 +178,14 @@ public class NntpClient : CommandResponseClient
     /// <returns>Header text.</returns>
     public async Task<string> HeaderAsync(int id, CancellationToken cancellationToken = default)
     {
-        var (status, body) = await SendMultilineCommandAsync(
-            $"HEADER {id}", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
-        await EnsureCompletionAsync(status).ConfigureAwait(false);
-        StringBuilder sb = new();
-        foreach (ServerResponse response in body)
-        {
-            string line = BodyLineToString(response);
-            if (line.StartsWith("..", StringComparison.Ordinal))
-            {
-                sb.Append(line.AsSpan(1));
-            }
-            else
-            {
-                sb.Append(line);
-            }
-            sb.Append("\r\n");
-        }
-        return sb.ToString();
+        StringBuilder builder = new();
+        using StringWriter writer = new(builder, CultureInfo.InvariantCulture);
+        await HeaderAsync(id, writer, cancellationToken).ConfigureAwait(false);
+        return builder.ToString();
     }
+
+    /// <summary>Streams article headers while exclusively owning the exchange.</summary>
+    public Task HeaderAsync(int id, TextWriter destination, CancellationToken cancellationToken = default) => StreamArticlePartAsync("HEADER", "221", id, destination, cancellationToken);
 
     /// <summary>
     /// Retrieves only the body of an article.
@@ -217,25 +195,14 @@ public class NntpClient : CommandResponseClient
     /// <returns>Body text.</returns>
     public async Task<string> BodyAsync(int id, CancellationToken cancellationToken = default)
     {
-        var (status, body) = await SendMultilineCommandAsync(
-            $"BODY {id}", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
-        await EnsureCompletionAsync(status).ConfigureAwait(false);
-        StringBuilder sb = new();
-        foreach (ServerResponse response in body)
-        {
-            string line = BodyLineToString(response);
-            if (line.StartsWith("..", StringComparison.Ordinal))
-            {
-                sb.Append(line.AsSpan(1));
-            }
-            else
-            {
-                sb.Append(line);
-            }
-            sb.Append("\r\n");
-        }
-        return sb.ToString();
+        StringBuilder builder = new();
+        using StringWriter writer = new(builder, CultureInfo.InvariantCulture);
+        await BodyAsync(id, writer, cancellationToken).ConfigureAwait(false);
+        return builder.ToString();
     }
+
+    /// <summary>Streams an article body while exclusively owning the exchange.</summary>
+    public Task BodyAsync(int id, TextWriter destination, CancellationToken cancellationToken = default) => StreamArticlePartAsync("BODY", "222", id, destination, cancellationToken);
 
     /// <summary>
     /// Retrieves article status information without returning content.
@@ -245,12 +212,10 @@ public class NntpClient : CommandResponseClient
     /// <returns>Tuple containing article number and message identifier.</returns>
     public async Task<(int id, string messageId)> StatAsync(int id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"STAT {id}", cancellationToken).ConfigureAwait(false);
-        await EnsureCompletionAsync(responses).ConfigureAwait(false);
-        string[] parts = responses[0].Message?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
-        int articleId = parts.Length > 0 ? int.Parse(parts[0]) : 0;
-        string messageId = parts.Length > 1 ? parts[1] : string.Empty;
-        return (articleId, messageId);
+        ProtocolResponseValidator.RequireCode("NNTP", "STAT", responses, "223");
+        return ParseArticleStatus("STAT", responses);
     }
 
     /// <summary>
@@ -261,12 +226,10 @@ public class NntpClient : CommandResponseClient
     public async Task<int?> NextAsync(CancellationToken cancellationToken = default)
     {
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync("NEXT", cancellationToken).ConfigureAwait(false);
-        if (responses.Count == 0 || responses[^1].Severity != ResponseSeverity.Completion)
-        {
-            return null;
-        }
-        string[] parts = responses[0].Message?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
-        return parts.Length > 0 ? int.Parse(parts[0]) : null;
+        if (responses.Count == 0) throw new ProtocolResponseException("NNTP", "NEXT", responses);
+        if (responses[^1].Code == "421") return null;
+        ProtocolResponseValidator.RequireCode("NNTP", "NEXT", responses, "223");
+        return ParseArticleStatus("NEXT", responses).id;
     }
 
     /// <summary>
@@ -321,6 +284,44 @@ public class NntpClient : CommandResponseClient
         }
         return Task.CompletedTask;
     }
+
+    /// <summary>Streams one dot-terminated article component.</summary>
+    private async Task StreamArticlePartAsync(string command, string expectedCode, int id, TextWriter destination, CancellationToken cancellationToken)
+    {
+        ValidateId(id, nameof(id));
+        ArgumentNullException.ThrowIfNull(destination);
+        IReadOnlyList<ServerResponse> status = await StreamMultilineCommandAsync($"{command} {id}", async (line, token) =>
+        {
+            await destination.WriteAsync(line, token).ConfigureAwait(false);
+            await destination.WriteAsync("\r\n".AsMemory(), token).ConfigureAwait(false);
+        }, new ProtocolPayloadLimits { MaximumLines = MaxMultilineLines, MaximumCharacters = MaxMultilineChars, MaximumBytes = MaxMultilineBytes }, cancellationToken).ConfigureAwait(false);
+        ProtocolResponseValidator.RequireCode("NNTP", command, status, expectedCode);
+    }
+
+    /// <summary>Parses a strict NNTP article-number and message-id response.</summary>
+    private static (int id, string messageId) ParseArticleStatus(string command, IReadOnlyList<ServerResponse> responses)
+    {
+        string[] fields = ExactFields(responses[0].Message, 2, command);
+        if (!int.TryParse(fields[0], NumberStyles.None, CultureInfo.InvariantCulture, out int id) || id <= 0 || !IsMessageId(fields[1]))
+            throw new ProtocolResponseException("NNTP", command, responses);
+        return (id, fields[1]);
+    }
+
+    /// <summary>Requires an exact number of response fields.</summary>
+    private static string[] ExactFields(string? value, int count, string command)
+    {
+        string[] fields = value?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? [];
+        return fields.Length == count ? fields : throw new InvalidDataException($"Malformed NNTP {command} response.");
+    }
+
+    /// <summary>Parses a non-negative invariant integer.</summary>
+    private static bool TryNonNegative(string value, out int result) => int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result) && result >= 0;
+
+    /// <summary>Validates an NNTP message-id token.</summary>
+    private static bool IsMessageId(string value) => value.Length is > 2 and <= 998 && value[0] == '<' && value[^1] == '>' && !value.Any(char.IsWhiteSpace) && !value.Any(char.IsControl);
+
+    /// <summary>Validates an article number before any command is written.</summary>
+    private static void ValidateId(int id, string name) { if (id <= 0) throw new ArgumentOutOfRangeException(name); }
 
 
 }

--- a/Utils.Net/Net/NntpServer.cs
+++ b/Utils.Net/Net/NntpServer.cs
@@ -124,7 +124,7 @@ public sealed class NntpServer : IDisposable
         ctx.Add("GROUP");
         _currentGroup = group;
         _currentArticle = null;
-        return new[] { new ServerResponse("211", ResponseSeverity.Completion, $"{articles.Count} {first} {last} {group}") };
+        return new[] { new ServerResponse("211", ResponseSeverity.Completion, $"{articles.Count} {first} {last}") };
     }
 
     /// <summary>
@@ -250,14 +250,14 @@ public sealed class NntpServer : IDisposable
             return new[] { new ServerResponse("501", ResponseSeverity.PermanentNegative, "syntax error") };
         }
         string group = args[0];
-        IReadOnlyCollection<int> ids = await _store.ListNewsSinceAsync(group, since, cancellationToken).ConfigureAwait(false);
+        IReadOnlyCollection<string> ids = await _store.ListNewsSinceAsync(group, since, cancellationToken).ConfigureAwait(false);
         List<ServerResponse> responses = new()
         {
             new ServerResponse("230", ResponseSeverity.Completion, "list of new articles follows")
         };
-        foreach (int id in ids)
+        foreach (string id in ids)
         {
-            responses.Add(new ServerResponse(id.ToString(), ResponseSeverity.Preliminary, null));
+            responses.Add(new ServerResponse(id, ResponseSeverity.Preliminary, null));
         }
         responses.Add(new ServerResponse(".", ResponseSeverity.Completion, null));
         return responses;

--- a/Utils.Net/Net/NtpSupport.cs
+++ b/Utils.Net/Net/NtpSupport.cs
@@ -154,6 +154,10 @@ namespace Utils.Net
 
                 return result.Buffer;
             }
+            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException("The NTP exchange was canceled by the caller.", ex, cancellationToken);
+            }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
                 throw new SocketException((int)SocketError.TimedOut);

--- a/Utils.Net/Net/Pop3Client.cs
+++ b/Utils.Net/Net/Pop3Client.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Globalization;
+using System.Linq;
 
 namespace Utils.Net;
 
@@ -25,6 +27,9 @@ public class Pop3Client : CommandResponseClient
     /// POP3 multi-line response. Default is 10 MiB worth of characters. Set to 0 to disable.
     /// </summary>
     public int MaxMultilineChars { get; set; } = 10 * 1024 * 1024;
+
+    /// <summary>Gets or sets the byte limit for POP3 payloads.</summary>
+    public long MaxMultilineBytes { get; set; } = 40 * 1024 * 1024;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Pop3Client"/> class.
@@ -102,13 +107,14 @@ public class Pop3Client : CommandResponseClient
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Tuple containing number of messages and total mailbox size.</returns>
-    public async Task<(int messageCount, int mailboxSize)> GetStatAsync(CancellationToken cancellationToken = default)
+    public async Task<(int messageCount, long mailboxSize)> GetStatAsync(CancellationToken cancellationToken = default)
     {
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync("STAT", cancellationToken).ConfigureAwait(false);
-        await EnsureOkAsync(responses).ConfigureAwait(false);
-        string[] parts = responses[0].Message?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
-        int count = parts.Length > 0 ? int.Parse(parts[0]) : 0;
-        int size = parts.Length > 1 ? int.Parse(parts[1]) : 0;
+        EnsureOk(responses, "STAT");
+        string[] parts = SplitExact(responses[0].Message, 2, "STAT");
+        if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int count) || count < 0 ||
+            !long.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out long size) || size < 0)
+            throw Malformed("STAT", responses);
         return (count, size);
     }
 
@@ -121,16 +127,15 @@ public class Pop3Client : CommandResponseClient
     {
         var (status, body) = await SendMultilineCommandAsync(
             "LIST", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
-        await EnsureOkAsync(status).ConfigureAwait(false);
+        EnsureOk(status, "LIST");
         Dictionary<int, int> result = new();
         foreach (ServerResponse response in body)
         {
             string line = BodyLineToString(response);
-            string[] parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length >= 2 && int.TryParse(parts[0], out int id) && int.TryParse(parts[1], out int size))
-            {
-                result[id] = size;
-            }
+            string[] parts = SplitExact(line, 2, "LIST");
+            if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int id) || id <= 0 ||
+                !int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out int size) || size < 0 || !result.TryAdd(id, size))
+                throw Malformed("LIST", status);
         }
         return result;
     }
@@ -143,17 +148,23 @@ public class Pop3Client : CommandResponseClient
     /// <returns>Text of the message with dot-stuffing removed.</returns>
     public async Task<string> RetrieveAsync(int id, CancellationToken cancellationToken = default)
     {
-        var (status, body) = await SendMultilineCommandAsync(
-            $"RETR {id}", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
-        await EnsureOkAsync(status).ConfigureAwait(false);
         StringBuilder builder = new();
-        foreach (ServerResponse response in body)
-        {
-            string line = BodyLineToString(response);
-            string content = line.StartsWith("..", StringComparison.Ordinal) ? line[1..] : line;
-            builder.Append(content).Append("\r\n");
-        }
+        using StringWriter writer = new(builder, CultureInfo.InvariantCulture);
+        await RetrieveAsync(id, writer, cancellationToken).ConfigureAwait(false);
         return builder.ToString();
+    }
+
+    /// <summary>Streams a retrieved message to a writer without materializing its payload.</summary>
+    public async Task RetrieveAsync(int id, TextWriter destination, CancellationToken cancellationToken = default)
+    {
+        ValidateId(id, nameof(id));
+        ArgumentNullException.ThrowIfNull(destination);
+        IReadOnlyList<ServerResponse> status = await StreamMultilineCommandAsync($"RETR {id}", async (line, token) =>
+        {
+            await destination.WriteAsync(line, token).ConfigureAwait(false);
+            await destination.WriteAsync("\r\n".AsMemory(), token).ConfigureAwait(false);
+        }, CreateLimits(), cancellationToken).ConfigureAwait(false);
+        EnsureOk(status, "RETR");
     }
 
     /// <summary>
@@ -163,6 +174,7 @@ public class Pop3Client : CommandResponseClient
     /// <param name="cancellationToken">Cancellation token.</param>
     public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         await EnsureOkAsync(await SendCommandAsync($"DELE {id}", cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
     }
 
@@ -202,7 +214,7 @@ public class Pop3Client : CommandResponseClient
     {
         var (status, body) = await SendMultilineCommandAsync(
             "CAPA", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
-        await EnsureOkAsync(status).ConfigureAwait(false);
+        EnsureOk(status, "UIDL");
         List<string> result = new(body.Count);
         foreach (ServerResponse response in body)
             result.Add(BodyLineToString(response));
@@ -223,11 +235,9 @@ public class Pop3Client : CommandResponseClient
         foreach (ServerResponse response in body)
         {
             string line = BodyLineToString(response);
-            string[] parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length >= 2 && int.TryParse(parts[0], out int id))
-            {
-                result[id] = parts[1];
-            }
+            string[] parts = SplitExact(line, 2, "UIDL");
+            if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int id) || id <= 0 ||
+                !IsValidUniqueId(parts[1]) || !result.TryAdd(id, parts[1])) throw Malformed("UIDL", status);
         }
         return result;
     }
@@ -238,12 +248,15 @@ public class Pop3Client : CommandResponseClient
     /// <param name="id">Message identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Unique identifier or <see langword="null"/> if not found.</returns>
-    public async Task<string?> GetUniqueIdAsync(int id, CancellationToken cancellationToken = default)
+    public async Task<string> GetUniqueIdAsync(int id, CancellationToken cancellationToken = default)
     {
+        ValidateId(id, nameof(id));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"UIDL {id}", cancellationToken).ConfigureAwait(false);
-        await EnsureOkAsync(responses).ConfigureAwait(false);
-        string[] parts = responses[0].Message?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
-        return parts.Length > 1 ? parts[1] : null;
+        EnsureOk(responses, "UIDL");
+        string[] parts = SplitExact(responses[0].Message, 2, "UIDL");
+        if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int responseId) || responseId != id || !IsValidUniqueId(parts[1]))
+            throw Malformed("UIDL", responses);
+        return parts[1];
     }
 
     /// <summary>
@@ -258,6 +271,28 @@ public class Pop3Client : CommandResponseClient
         }
         return Task.CompletedTask;
     }
+
+    /// <summary>Validates a POP3 completion response.</summary>
+    private static void EnsureOk(IReadOnlyList<ServerResponse> responses, string command) => ProtocolResponseValidator.RequireCode("POP3", command, responses, "+OK");
+
+    /// <summary>Creates configured multiline limits.</summary>
+    private ProtocolPayloadLimits CreateLimits() => new() { MaximumLines = MaxMultilineLines, MaximumCharacters = MaxMultilineChars, MaximumBytes = MaxMultilineBytes };
+
+    /// <summary>Requires an exact field count.</summary>
+    private static string[] SplitExact(string? value, int count, string command)
+    {
+        string[] parts = value?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? [];
+        return parts.Length == count ? parts : throw new InvalidDataException($"Malformed POP3 {command} response.");
+    }
+
+    /// <summary>Creates a structured malformed-response exception.</summary>
+    private static ProtocolResponseException Malformed(string command, IReadOnlyList<ServerResponse> responses) => new("POP3", command, responses);
+
+    /// <summary>Validates a public POP3 message number before any network write.</summary>
+    private static void ValidateId(int id, string name) { if (id <= 0) throw new ArgumentOutOfRangeException(name); }
+
+    /// <summary>Validates the bounded POP3 unique-id token.</summary>
+    private static bool IsValidUniqueId(string value) => value.Length is > 0 and <= 1024 && value.AsSpan().IndexOfAnyInRange('\0', ' ') < 0 && !value.Any(char.IsControl);
 
     /// <summary>
     /// Parses POP3 response lines.

--- a/Utils.Net/Net/Pop3Client.cs
+++ b/Utils.Net/Net/Pop3Client.cs
@@ -111,7 +111,7 @@ public class Pop3Client : CommandResponseClient
     {
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync("STAT", cancellationToken).ConfigureAwait(false);
         EnsureOk(responses, "STAT");
-        string[] parts = SplitExact(responses[0].Message, 2, "STAT");
+        string[] parts = SplitExact(responses[0].Message, 2, "STAT", responses);
         if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int count) || count < 0 ||
             !long.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out long size) || size < 0)
             throw Malformed("STAT", responses);
@@ -126,13 +126,13 @@ public class Pop3Client : CommandResponseClient
     public async Task<IReadOnlyDictionary<int, int>> ListAsync(CancellationToken cancellationToken = default)
     {
         var (status, body) = await SendMultilineCommandAsync(
-            "LIST", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
+            "LIST", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, MaxMultilineBytes, cancellationToken).ConfigureAwait(false);
         EnsureOk(status, "LIST");
         Dictionary<int, int> result = new();
         foreach (ServerResponse response in body)
         {
             string line = BodyLineToString(response);
-            string[] parts = SplitExact(line, 2, "LIST");
+            string[] parts = SplitExact(line, 2, "LIST", status);
             if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int id) || id <= 0 ||
                 !int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out int size) || size < 0 || !result.TryAdd(id, size))
                 throw Malformed("LIST", status);
@@ -213,8 +213,8 @@ public class Pop3Client : CommandResponseClient
     public async Task<IReadOnlyList<string>> GetCapabilitiesAsync(CancellationToken cancellationToken = default)
     {
         var (status, body) = await SendMultilineCommandAsync(
-            "CAPA", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
-        EnsureOk(status, "UIDL");
+            "CAPA", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, MaxMultilineBytes, cancellationToken).ConfigureAwait(false);
+        EnsureOk(status, "CAPA");
         List<string> result = new(body.Count);
         foreach (ServerResponse response in body)
             result.Add(BodyLineToString(response));
@@ -229,13 +229,13 @@ public class Pop3Client : CommandResponseClient
     public async Task<IReadOnlyDictionary<int, string>> ListUniqueIdsAsync(CancellationToken cancellationToken = default)
     {
         var (status, body) = await SendMultilineCommandAsync(
-            "UIDL", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, cancellationToken).ConfigureAwait(false);
+            "UIDL", r => r.Code == ".", MaxMultilineLines, MaxMultilineChars, MaxMultilineBytes, cancellationToken).ConfigureAwait(false);
         await EnsureOkAsync(status).ConfigureAwait(false);
         Dictionary<int, string> result = new();
         foreach (ServerResponse response in body)
         {
             string line = BodyLineToString(response);
-            string[] parts = SplitExact(line, 2, "UIDL");
+            string[] parts = SplitExact(line, 2, "UIDL", status);
             if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int id) || id <= 0 ||
                 !IsValidUniqueId(parts[1]) || !result.TryAdd(id, parts[1])) throw Malformed("UIDL", status);
         }
@@ -253,7 +253,7 @@ public class Pop3Client : CommandResponseClient
         ValidateId(id, nameof(id));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"UIDL {id}", cancellationToken).ConfigureAwait(false);
         EnsureOk(responses, "UIDL");
-        string[] parts = SplitExact(responses[0].Message, 2, "UIDL");
+        string[] parts = SplitExact(responses[0].Message, 2, "UIDL", responses);
         if (!int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out int responseId) || responseId != id || !IsValidUniqueId(parts[1]))
             throw Malformed("UIDL", responses);
         return parts[1];
@@ -279,10 +279,10 @@ public class Pop3Client : CommandResponseClient
     private ProtocolPayloadLimits CreateLimits() => new() { MaximumLines = MaxMultilineLines, MaximumCharacters = MaxMultilineChars, MaximumBytes = MaxMultilineBytes };
 
     /// <summary>Requires an exact field count.</summary>
-    private static string[] SplitExact(string? value, int count, string command)
+    private static string[] SplitExact(string? value, int count, string command, IReadOnlyList<ServerResponse> responses)
     {
         string[] parts = value?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? [];
-        return parts.Length == count ? parts : throw new InvalidDataException($"Malformed POP3 {command} response.");
+        return parts.Length == count ? parts : throw Malformed(command, responses);
     }
 
     /// <summary>Creates a structured malformed-response exception.</summary>

--- a/Utils.Net/Net/ProtocolExceptions.cs
+++ b/Utils.Net/Net/ProtocolExceptions.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+
+namespace Utils.Net;
+
+/// <summary>
+/// Represents a complete, negatively framed response from a text protocol server.
+/// </summary>
+public class ProtocolResponseException : IOException
+{
+    /// <summary>Initializes a structured protocol response exception.</summary>
+    public ProtocolResponseException(string protocol, string command, IReadOnlyList<ServerResponse> responses, string? enhancedStatusCode = null, Exception? innerException = null)
+        : base(CreateMessage(protocol, command, responses), innerException)
+    {
+        Protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
+        Command = SanitizeCommand(command);
+        ServerResponse[] copy = responses?.ToArray() ?? throw new ArgumentNullException(nameof(responses));
+        Responses = new ReadOnlyCollection<ServerResponse>(copy);
+        ResponseCode = copy.Length == 0 ? null : copy[^1].Code;
+        Severity = copy.Length == 0 ? ResponseSeverity.Unknown : copy[^1].Severity;
+        EnhancedStatusCode = enhancedStatusCode;
+    }
+
+    /// <summary>Gets the protocol name.</summary>
+    public string Protocol { get; }
+    /// <summary>Gets the command verb without arguments.</summary>
+    public string Command { get; }
+    /// <summary>Gets the final response code.</summary>
+    public string? ResponseCode { get; }
+    /// <summary>Gets the final response severity.</summary>
+    public ResponseSeverity Severity { get; }
+    /// <summary>Gets an immutable snapshot of all response lines.</summary>
+    public IReadOnlyList<ServerResponse> Responses { get; }
+    /// <summary>Gets an SMTP enhanced status code when one was supplied.</summary>
+    public string? EnhancedStatusCode { get; }
+
+    /// <summary>Removes all command arguments, including credentials.</summary>
+    private static string SanitizeCommand(string command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        int separator = command.IndexOf(' ');
+        return (separator < 0 ? command : command[..separator]).ToUpperInvariant();
+    }
+
+    /// <summary>Creates a stable message that does not disclose command arguments.</summary>
+    private static string CreateMessage(string protocol, string command, IReadOnlyList<ServerResponse> responses)
+    {
+        string verb = SanitizeCommand(command);
+        string code = responses is { Count: > 0 } ? responses[^1].Code : "<missing>";
+        return $"{protocol} command {verb} failed with response {code}.";
+    }
+}
+
+/// <summary>Indicates that protocol framing was lost and the connection cannot be reused.</summary>
+public sealed class ProtocolSessionPoisonedException : IOException
+{
+    /// <summary>Initializes a poisoned-session exception.</summary>
+    public ProtocolSessionPoisonedException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>Validates structured protocol responses.</summary>
+internal static class ProtocolResponseValidator
+{
+    /// <summary>Requires one of the supplied response codes.</summary>
+    internal static void RequireCode(string protocol, string command, IReadOnlyList<ServerResponse> responses, params string[] expectedCodes)
+    {
+        if (responses.Count == 0 || !expectedCodes.Contains(responses[^1].Code, StringComparer.OrdinalIgnoreCase))
+            throw new ProtocolResponseException(protocol, command, responses);
+    }
+
+    /// <summary>Requires a positive completion response.</summary>
+    internal static void RequireCompletion(string protocol, string command, IReadOnlyList<ServerResponse> responses)
+    {
+        if (responses.Count == 0 || responses[^1].Severity != ResponseSeverity.Completion)
+            throw new ProtocolResponseException(protocol, command, responses);
+    }
+
+    /// <summary>Requires a positive intermediate response.</summary>
+    internal static void RequireIntermediate(string protocol, string command, IReadOnlyList<ServerResponse> responses)
+    {
+        if (responses.Count == 0 || responses[^1].Severity != ResponseSeverity.Intermediate)
+            throw new ProtocolResponseException(protocol, command, responses);
+    }
+}

--- a/Utils.Net/Net/ProtocolPayloadLimits.cs
+++ b/Utils.Net/Net/ProtocolPayloadLimits.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Utils.Net;
+
+/// <summary>Defines hard limits for a dot-terminated protocol payload.</summary>
+public sealed record ProtocolPayloadLimits
+{
+    private int _maximumLines = 100_000;
+    private long _maximumCharacters = 10 * 1024 * 1024;
+    private long _maximumBytes = 40 * 1024 * 1024;
+
+    /// <summary>Gets or initializes the maximum line count; zero disables this limit.</summary>
+    public int MaximumLines { get => _maximumLines; init => _maximumLines = Validate(value, nameof(MaximumLines)); }
+    /// <summary>Gets or initializes the maximum UTF-16 character count; zero disables this limit.</summary>
+    public long MaximumCharacters { get => _maximumCharacters; init => _maximumCharacters = Validate(value, nameof(MaximumCharacters)); }
+    /// <summary>Gets or initializes the maximum UTF-8 byte count; zero disables this limit.</summary>
+    public long MaximumBytes { get => _maximumBytes; init => _maximumBytes = Validate(value, nameof(MaximumBytes)); }
+
+    /// <summary>Validates a non-negative integer limit.</summary>
+    private static int Validate(int value, string name) => value < 0 ? throw new ArgumentOutOfRangeException(name) : value;
+    /// <summary>Validates a non-negative long limit.</summary>
+    private static long Validate(long value, string name) => value < 0 ? throw new ArgumentOutOfRangeException(name) : value;
+}

--- a/Utils.Net/Net/SmtpClient.cs
+++ b/Utils.Net/Net/SmtpClient.cs
@@ -1,286 +1,274 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Utils.Net;
 
-/// <summary>
-/// Client for the Simple Mail Transfer Protocol (SMTP).
-/// </summary>
+/// <summary>Client for the Simple Mail Transfer Protocol (SMTP).</summary>
 public class SmtpClient : CommandResponseClient
 {
+    private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+    private TimeSpan _transactionRecoveryTimeout = TimeSpan.FromSeconds(5);
+
     /// <inheritdoc/>
     public override int DefaultPort { get; } = 25;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SmtpClient"/> class.
-    /// </summary>
-    public SmtpClient()
+    /// <summary>Gets or sets the bounded timeout used to recover an envelope with RSET.</summary>
+    public TimeSpan TransactionRecoveryTimeout
     {
+        get => _transactionRecoveryTimeout;
+        set => _transactionRecoveryTimeout = value > TimeSpan.Zero && value != Timeout.InfiniteTimeSpan ? value : throw new ArgumentOutOfRangeException(nameof(value));
     }
 
-    /// <summary>
-    /// Authenticates using the specified mechanism.
-    /// </summary>
-    /// <param name="user">User name.</param>
-    /// <param name="password">User password.</param>
-    /// <param name="mechanism">Authentication mechanism to use.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <remarks>
-    /// SMTP authentication mechanisms such as <c>AUTH PLAIN</c> and <c>AUTH LOGIN</c> should be
-    /// used only when the underlying transport is already protected by TLS.
-    /// This method is marked as obsolete to produce a compile-time warning and reduce
-    /// accidental credential usage on unencrypted channels.
-    /// </remarks>
-    [Obsolete("SMTP AUTH may expose credentials on unencrypted connections. Use a TLS-protected stream before calling AuthenticateAsync.", false)]
-    public async Task AuthenticateAsync(string user, string password, SmtpAuthenticationMechanism mechanism = SmtpAuthenticationMechanism.Plain, CancellationToken cancellationToken = default)
+    /// <summary>Initializes an SMTP client.</summary>
+    public SmtpClient() { }
+
+    /// <summary>Authenticates with SASL PLAIN credentials using strict UTF-8.</summary>
+    [Obsolete("SMTP AUTH may expose credentials on unencrypted connections. Use a TLS-protected stream.", false)]
+    public Task AuthenticateAsync(SmtpPlainCredentials credentials, CancellationToken cancellationToken = default)
     {
-        switch (mechanism)
+        ArgumentNullException.ThrowIfNull(credentials);
+        string value = $"{credentials.AuthorizationIdentity}\0{credentials.AuthenticationIdentity}\0{credentials.Password}";
+        string payload = Convert.ToBase64String(StrictUtf8.GetBytes(value));
+        return ExecuteExclusiveExchangeAsync("AUTH", async (context, token) =>
         {
-            case SmtpAuthenticationMechanism.Plain:
-                string payload = "\0" + user + "\0" + password;
-                string encoded = Convert.ToBase64String(Encoding.ASCII.GetBytes(payload));
-                IReadOnlyList<ServerResponse> plainResult = await SendCommandAsync($"AUTH PLAIN {encoded}", cancellationToken).ConfigureAwait(false);
-                await EnsureCompletionAsync(plainResult).ConfigureAwait(false);
-                break;
-
-            case SmtpAuthenticationMechanism.Login:
-                IReadOnlyList<ServerResponse> loginResult = await SendCommandAsync("AUTH LOGIN", cancellationToken).ConfigureAwait(false);
-                await EnsureIntermediateAsync(loginResult).ConfigureAwait(false);
-                string userEncoded = Convert.ToBase64String(Encoding.ASCII.GetBytes(user));
-                IReadOnlyList<ServerResponse> userResponse = await SendCommandAsync(userEncoded, cancellationToken).ConfigureAwait(false);
-                await EnsureIntermediateAsync(userResponse).ConfigureAwait(false);
-                string passEncoded = Convert.ToBase64String(Encoding.ASCII.GetBytes(password));
-                IReadOnlyList<ServerResponse> passResponse = await SendCommandAsync(passEncoded, cancellationToken).ConfigureAwait(false);
-                await EnsureCompletionAsync(passResponse).ConfigureAwait(false);
-                break;
-
-            default:
-                throw new NotSupportedException("Unsupported authentication mechanism.");
-        }
+            bool started = false;
+            try
+            {
+                started = true;
+                await context.WriteLineAsync($"AUTH PLAIN {payload}", token).ConfigureAwait(false);
+                IReadOnlyList<ServerResponse> responses = await ReadResponsesAsync(context, token).ConfigureAwait(false);
+                ProtocolResponseValidator.RequireCompletion("SMTP", "AUTH", responses);
+                return true;
+            }
+            catch (Exception ex) when (started && ex is OperationCanceledException)
+            {
+                context.Poison(ex);
+                throw;
+            }
+        }, cancellationToken);
     }
 
-    /// <summary>
-    /// Authenticates using the <c>AUTH PLAIN</c> mechanism.
-    /// </summary>
-    /// <param name="user">User name.</param>
-    /// <param name="password">User password.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <remarks>
-    /// This overload maps to <c>AUTH PLAIN</c> and should only be used over TLS-protected transports.
-    /// </remarks>
-    [Obsolete("SMTP AUTH PLAIN may expose credentials on unencrypted connections. Use a TLS-protected stream before calling AuthenticateAsync.", false)]
-    public Task AuthenticateAsync(string user, string password, CancellationToken cancellationToken)
+    /// <summary>Authenticates with PLAIN or LOGIN using strict UTF-8.</summary>
+    [Obsolete("SMTP AUTH may expose credentials on unencrypted connections. Use a TLS-protected stream.", false)]
+    public Task AuthenticateAsync(string user, string password, SmtpAuthenticationMechanism mechanism = SmtpAuthenticationMechanism.Plain, CancellationToken cancellationToken = default)
     {
-        return AuthenticateAsync(user, password, SmtpAuthenticationMechanism.Plain, cancellationToken);
+        SmtpPlainCredentials credentials = new(user, password);
+        if (mechanism == SmtpAuthenticationMechanism.Plain) return AuthenticateAsync(credentials, cancellationToken);
+        if (mechanism != SmtpAuthenticationMechanism.Login) throw new NotSupportedException("Unsupported authentication mechanism.");
+        string encodedUser = Convert.ToBase64String(StrictUtf8.GetBytes(credentials.AuthenticationIdentity));
+        string encodedPassword = Convert.ToBase64String(StrictUtf8.GetBytes(credentials.Password));
+        return ExecuteExclusiveExchangeAsync("AUTH", async (context, token) =>
+        {
+            bool started = false;
+            try
+            {
+                started = true;
+                await context.WriteLineAsync("AUTH LOGIN", token).ConfigureAwait(false);
+                ProtocolResponseValidator.RequireIntermediate("SMTP", "AUTH", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                await context.WriteLineAsync(encodedUser, token).ConfigureAwait(false);
+                ProtocolResponseValidator.RequireIntermediate("SMTP", "AUTH", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                await context.WriteLineAsync(encodedPassword, token).ConfigureAwait(false);
+                ProtocolResponseValidator.RequireCompletion("SMTP", "AUTH", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                return true;
+            }
+            catch (Exception ex) when (started && ex is OperationCanceledException or IOException)
+            {
+                context.Poison(ex);
+                throw;
+            }
+        }, cancellationToken);
     }
 
-    /// <summary>
-    /// Executes SMTP specific initialization when a connection is established.
-    /// </summary>
-    /// <param name="stream">Connected stream used to send commands and receive responses.</param>
-    /// <param name="leaveOpen">True to leave the stream open when disposing the client.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A task that completes when the server greeting has been processed.</returns>
+    /// <summary>Authenticates with SASL PLAIN.</summary>
+    [Obsolete("SMTP AUTH may expose credentials on unencrypted connections. Use a TLS-protected stream.", false)]
+    public Task AuthenticateAsync(string user, string password, CancellationToken cancellationToken) => AuthenticateAsync(user, password, SmtpAuthenticationMechanism.Plain, cancellationToken);
+
+    /// <inheritdoc/>
     protected override async Task OnConnect(Stream stream, bool leaveOpen, CancellationToken cancellationToken)
     {
         await base.OnConnect(stream, leaveOpen, cancellationToken).ConfigureAwait(false);
-        IReadOnlyList<ServerResponse> greeting = await ReadAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureCompletionAsync(greeting).ConfigureAwait(false);
+        ProtocolResponseValidator.RequireCompletion("SMTP", "CONNECT", await ReadAsync(cancellationToken).ConfigureAwait(false));
     }
 
-    /// <summary>
-    /// Sends the EHLO command and returns the advertised extensions.
-    /// </summary>
-    /// <param name="domain">Client domain name.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>List of server extensions.</returns>
+    /// <summary>Sends EHLO and returns all advertised extension lines after the identity line.</summary>
     public async Task<IReadOnlyList<string>> EhloAsync(string domain, CancellationToken cancellationToken = default)
     {
         ValidateCommandArgument(domain, nameof(domain));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"EHLO {domain}", cancellationToken).ConfigureAwait(false);
-        List<string> extensions = new();
-        for (int i = 1; i < responses.Count; i++)
-        {
-            if (!string.IsNullOrEmpty(responses[i].Message))
-            {
-                extensions.Add(responses[i].Message);
-            }
-        }
-        await EnsureCompletionAsync(responses).ConfigureAwait(false);
-        return extensions;
+        ProtocolResponseValidator.RequireCompletion("SMTP", "EHLO", responses);
+        return responses.Skip(1).Select(r => r.Message).Where(m => !string.IsNullOrEmpty(m)).Cast<string>().ToArray();
     }
 
-    /// <summary>
-    /// Sends the HELO command.
-    /// </summary>
-    /// <param name="domain">Client domain name.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <summary>Sends HELO.</summary>
     public async Task HeloAsync(string domain, CancellationToken cancellationToken = default)
     {
         ValidateCommandArgument(domain, nameof(domain));
-        await EnsureCompletionAsync(await SendCommandAsync($"HELO {domain}", cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+        ProtocolResponseValidator.RequireCompletion("SMTP", "HELO", await SendCommandAsync($"HELO {domain}", cancellationToken).ConfigureAwait(false));
     }
 
-    /// <summary>
-    /// Sends the VRFY command to verify an address.
-    /// </summary>
-    /// <param name="address">Address to verify.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Server response message.</returns>
+    /// <summary>Verifies an address.</summary>
     public async Task<string?> VrfyAsync(string address, CancellationToken cancellationToken = default)
     {
         ValidateCommandArgument(address, nameof(address));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"VRFY {address}", cancellationToken).ConfigureAwait(false);
-        await EnsureCompletionAsync(responses).ConfigureAwait(false);
+        ProtocolResponseValidator.RequireCompletion("SMTP", "VRFY", responses);
         return responses[^1].Message;
     }
 
-    /// <summary>
-    /// Sends the EXPN command to expand a mailing list.
-    /// </summary>
-    /// <param name="list">List name.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Expanded entries returned by the server.</returns>
+    /// <summary>Expands a mailing list.</summary>
     public async Task<IReadOnlyList<string>> ExpnAsync(string list, CancellationToken cancellationToken = default)
     {
         ValidateCommandArgument(list, nameof(list));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"EXPN {list}", cancellationToken).ConfigureAwait(false);
-        List<string> entries = new();
-        for (int i = 0; i < responses.Count - 1; i++)
-        {
-            if (!string.IsNullOrEmpty(responses[i].Message))
-            {
-                entries.Add(responses[i].Message);
-            }
-        }
-        await EnsureCompletionAsync(responses).ConfigureAwait(false);
-        return entries;
+        ProtocolResponseValidator.RequireCompletion("SMTP", "EXPN", responses);
+        return responses.Select(r => r.Message).Where(m => !string.IsNullOrEmpty(m)).Cast<string>().ToArray();
     }
 
-    /// <summary>
-    /// Sends the HELP command optionally for a specific subject.
-    /// </summary>
-    /// <param name="subject">Command or subject to request help for.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Help text returned by the server.</returns>
+    /// <summary>Requests SMTP help.</summary>
     public async Task<IReadOnlyList<string>> HelpAsync(string? subject = null, CancellationToken cancellationToken = default)
     {
         if (subject is not null) ValidateCommandArgument(subject, nameof(subject));
-        string command = subject is null ? "HELP" : $"HELP {subject}";
-        IReadOnlyList<ServerResponse> responses = await SendCommandAsync(command, cancellationToken).ConfigureAwait(false);
-        List<string> lines = new();
-        foreach (ServerResponse response in responses)
-        {
-            if (!string.IsNullOrEmpty(response.Message))
-            {
-                lines.Add(response.Message);
-            }
-        }
-        await EnsureCompletionAsync(responses).ConfigureAwait(false);
-        return lines;
+        IReadOnlyList<ServerResponse> responses = await SendCommandAsync(subject is null ? "HELP" : $"HELP {subject}", cancellationToken).ConfigureAwait(false);
+        ProtocolResponseValidator.RequireCompletion("SMTP", "HELP", responses);
+        return responses.Select(r => r.Message).Where(m => !string.IsNullOrEmpty(m)).Cast<string>().ToArray();
     }
 
-    /// <summary>
-    /// Sends a mail message.
-    /// </summary>
-    /// <param name="from">Sender address.</param>
-    /// <param name="recipients">Recipient addresses.</param>
-    /// <param name="data">Raw message data.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    public async Task SendMailAsync(string from, IEnumerable<string> recipients, string data, CancellationToken cancellationToken = default)
+    /// <summary>Sends a materialized message after strict path validation.</summary>
+    public Task SendMailAsync(string from, IEnumerable<string> recipients, string data, CancellationToken cancellationToken = default)
     {
-        ValidateCommandArgument(from, nameof(from));
-        if (recipients is null) throw new ArgumentNullException(nameof(recipients));
-        List<string> recipientList = new(recipients);
-        if (recipientList.Count == 0) throw new ArgumentException("At least one recipient is required.", nameof(recipients));
-        foreach (string rcpt in recipientList) ValidateCommandArgument(rcpt, nameof(recipients));
-
-        await EnsureCompletionAsync(await SendCommandAsync($"MAIL FROM:<{from}>", cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
-        foreach (string rcpt in recipientList)
+        ArgumentNullException.ThrowIfNull(recipients);
+        ArgumentNullException.ThrowIfNull(data);
+        SmtpPath sender;
+        SmtpPath[] snapshot;
+        try
         {
-            await EnsureCompletionAsync(await SendCommandAsync($"RCPT TO:<{rcpt}>", cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+            sender = SmtpPath.Parse(from);
+            snapshot = recipients.Select(value => SmtpPath.Parse(value ?? throw new ArgumentException("Recipients cannot contain null.", nameof(recipients)))).ToArray();
         }
-        await EnsureIntermediateAsync(await SendCommandAsync("DATA", cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
-        List<string> lines = new();
-        using StringReader reader = new(data);
-        string? line;
-        while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
+        catch (FormatException error)
         {
-            if (line.StartsWith('.'))
-            {
-                lines.Add("." + line);
-            }
-            else
-            {
-                lines.Add(line);
-            }
+            throw new ArgumentException("The sender or a recipient is not a valid SMTP path.", nameof(recipients), error);
         }
-        lines.Add(".");
-        IReadOnlyList<ServerResponse> result = await SendBodyAndReadAsync(lines, cancellationToken).ConfigureAwait(false);
-        await EnsureCompletionAsync(result).ConfigureAwait(false);
+        return SendMailAsync(sender, snapshot, new StringReader(data), null, cancellationToken);
     }
 
-    /// <summary>
-    /// Sends the QUIT command and closes the connection.
-    /// </summary>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    public Task QuitAsync(CancellationToken cancellationToken = default)
+    /// <summary>Streams a message through one exclusive SMTP transaction.</summary>
+    public Task SendMailAsync(SmtpPath from, IReadOnlyList<SmtpPath> recipients, TextReader data, SmtpMailOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return DisconnectAsync("QUIT", TimeSpan.FromSeconds(5), cancellationToken);
+        ArgumentNullException.ThrowIfNull(from);
+        ArgumentNullException.ThrowIfNull(recipients);
+        ArgumentNullException.ThrowIfNull(data);
+        SmtpPath[] snapshot = recipients.ToArray();
+        if (snapshot.Length == 0) throw new ArgumentException("At least one recipient is required.", nameof(recipients));
+        if (snapshot.Any(p => p is null || p.Value.Length == 0)) throw new ArgumentException("Recipients must be non-empty paths.", nameof(recipients));
+        options ??= new SmtpMailOptions();
+        if (!options.SmtpUtf8 && (from.AllowsUtf8 || snapshot.Any(p => p.AllowsUtf8))) throw new ArgumentException("SMTPUTF8 paths require SmtpUtf8=true.", nameof(options));
+        string mailOptions = FormatOptions(options);
+        return ExecuteExclusiveExchangeAsync("MAIL", async (context, token) =>
+        {
+            bool mailAccepted = false;
+            bool dataAccepted = false;
+            bool dataFramed = false;
+            try
+            {
+                await context.WriteLineAsync($"MAIL FROM:<{from.Value}>{mailOptions}", token).ConfigureAwait(false);
+                ProtocolResponseValidator.RequireCompletion("SMTP", "MAIL", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                mailAccepted = true;
+                foreach (SmtpPath recipient in snapshot)
+                {
+                    await context.WriteLineAsync($"RCPT TO:<{recipient.Value}>", token).ConfigureAwait(false);
+                    ProtocolResponseValidator.RequireCompletion("SMTP", "RCPT", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                }
+                await context.WriteLineAsync("DATA", token).ConfigureAwait(false);
+                ProtocolResponseValidator.RequireIntermediate("SMTP", "DATA", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                dataAccepted = true;
+                string? line;
+                while ((line = await data.ReadLineAsync(token).ConfigureAwait(false)) is not null)
+                    await context.WriteLineAsync(line.StartsWith(".", StringComparison.Ordinal) ? "." + line : line, token).ConfigureAwait(false);
+                await context.WriteLineAsync(".", token).ConfigureAwait(false);
+                dataFramed = true;
+                ProtocolResponseValidator.RequireCompletion("SMTP", "DATA", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                return true;
+            }
+            catch (Exception primary)
+            {
+                if (dataAccepted && !dataFramed)
+                {
+                    context.Poison(primary);
+                    throw;
+                }
+                if (!mailAccepted) throw;
+                try
+                {
+                    using CancellationTokenSource recovery = new(TransactionRecoveryTimeout);
+                    await context.WriteLineAsync("RSET", recovery.Token).ConfigureAwait(false);
+                    ProtocolResponseValidator.RequireCompletion("SMTP", "RSET", await ReadResponsesAsync(context, recovery.Token).ConfigureAwait(false));
+                }
+                catch (Exception recoveryError)
+                {
+                    SmtpTransactionException combined = new(primary, recoveryError);
+                    context.Poison(combined);
+                    throw combined;
+                }
+                throw;
+            }
+        }, cancellationToken);
     }
 
-    /// <summary>
-    /// Parses a single response line using SMTP semantics where a hyphen after the status code
-    /// indicates that more lines will follow.
-    /// </summary>
-    /// <param name="line">Response line from the server.</param>
-    /// <returns>Parsed response.</returns>
+    /// <summary>Streams message bytes by decoding them strictly with the supplied encoding.</summary>
+    public Task SendMailAsync(SmtpPath from, IReadOnlyList<SmtpPath> recipients, Stream data, Encoding encoding, SmtpMailOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentNullException.ThrowIfNull(encoding);
+        StreamReader reader = new(data, encoding, true, 1024, true);
+        return SendMailAsync(from, recipients, reader, options, cancellationToken);
+    }
+
+    /// <summary>Sends QUIT and closes the connection.</summary>
+    public Task QuitAsync(CancellationToken cancellationToken = default) => DisconnectAsync("QUIT", TimeSpan.FromSeconds(5), cancellationToken);
+
+    /// <inheritdoc/>
     protected override ServerResponse ParseResponseLine(string line)
     {
-        if (line.Length >= 4 && char.IsDigit(line[0]) && char.IsDigit(line[1]) && char.IsDigit(line[2]))
+        if (line.Length >= 3 && int.TryParse(line.AsSpan(0, 3), out int code))
         {
-            string code = line.Substring(0, 3);
-            char separator = line[3];
-            string message = line.Length > 4 ? line[4..] : string.Empty;
-            int digit = code[0] - '0';
-            ResponseSeverity severity = digit >= 0 && digit <= 5 ? (ResponseSeverity)digit : ResponseSeverity.Unknown;
-            if (separator == '-')
-            {
-                severity = ResponseSeverity.Preliminary;
-            }
-            return new ServerResponse(code, severity, message);
+            char separator = line.Length > 3 ? line[3] : ' ';
+            ResponseSeverity severity = separator == '-' ? ResponseSeverity.Preliminary : (ResponseSeverity)(code / 100);
+            return new ServerResponse(line[..3], severity, line.Length > 4 ? line[4..] : string.Empty);
         }
-
         return base.ParseResponseLine(line);
     }
 
-    /// <summary>
-    /// Ensures that the final response has completion severity.
-    /// </summary>
-    /// <param name="responses">Responses to check.</param>
-    private static Task EnsureCompletionAsync(IReadOnlyList<ServerResponse> responses)
+    /// <summary>Reads one complete SMTP status response.</summary>
+    private static async ValueTask<IReadOnlyList<ServerResponse>> ReadResponsesAsync(ProtocolExchangeContext context, CancellationToken token)
     {
-        if (responses.Count == 0 || responses[^1].Severity != ResponseSeverity.Completion)
-        {
-            throw new IOException(responses.Count > 0 ? responses[^1].Message : "Server closed connection");
-        }
-        return Task.CompletedTask;
+        List<ServerResponse> responses = [];
+        do { responses.Add(await context.ReadLineAsync(token).ConfigureAwait(false)); }
+        while (responses[^1].Severity == ResponseSeverity.Preliminary);
+        return responses;
     }
 
-    /// <summary>
-    /// Ensures that the final response has intermediate severity.
-    /// </summary>
-    /// <param name="responses">Responses to check.</param>
-    private static Task EnsureIntermediateAsync(IReadOnlyList<ServerResponse> responses)
+    /// <summary>Formats typed ESMTP parameters.</summary>
+    private static string FormatOptions(SmtpMailOptions options)
     {
-        if (responses.Count == 0 || responses[^1].Severity != ResponseSeverity.Intermediate)
-        {
-            throw new IOException(responses.Count > 0 ? responses[^1].Message : "Server closed connection");
-        }
-        return Task.CompletedTask;
+        StringBuilder value = new();
+        if (options.Size is long size) value.Append(" SIZE=").Append(size);
+        if (options.Body is SmtpBodyKind body) value.Append(" BODY=").Append(body == SmtpBodyKind.SevenBit ? "7BIT" : "8BITMIME");
+        if (options.SmtpUtf8) value.Append(" SMTPUTF8");
+        return value.ToString();
     }
+}
+
+/// <summary>Preserves both an SMTP transaction failure and its failed recovery.</summary>
+public sealed class SmtpTransactionException : IOException
+{
+    /// <summary>Initializes a combined SMTP transaction exception.</summary>
+    public SmtpTransactionException(Exception operationException, Exception recoveryException) : base("SMTP transaction failed and RSET recovery also failed.", operationException) => RecoveryException = recoveryException;
+    /// <summary>Gets the failed RSET exception.</summary>
+    public Exception RecoveryException { get; }
 }

--- a/Utils.Net/Net/SmtpClient.cs
+++ b/Utils.Net/Net/SmtpClient.cs
@@ -45,9 +45,9 @@ public class SmtpClient : CommandResponseClient
                 ProtocolResponseValidator.RequireCompletion("SMTP", "AUTH", responses);
                 return true;
             }
-            catch (Exception ex) when (started && ex is OperationCanceledException)
+            catch (Exception ex) when (started && ex is OperationCanceledException or IOException)
             {
-                context.Poison(ex);
+                context.PoisonIfResponseAmbiguous(ex);
                 throw;
             }
         }, cancellationToken);
@@ -78,7 +78,7 @@ public class SmtpClient : CommandResponseClient
             }
             catch (Exception ex) when (started && ex is OperationCanceledException or IOException)
             {
-                context.Poison(ex);
+                context.PoisonIfResponseAmbiguous(ex);
                 throw;
             }
         }, cancellationToken);
@@ -197,7 +197,7 @@ public class SmtpClient : CommandResponseClient
             }
             catch (Exception primary)
             {
-                if (dataAccepted && !dataFramed)
+                if (context.PoisonIfResponseAmbiguous(primary) || (dataAccepted && !dataFramed))
                 {
                     context.Poison(primary);
                     throw;

--- a/Utils.Net/Net/SmtpClient.cs
+++ b/Utils.Net/Net/SmtpClient.cs
@@ -41,7 +41,7 @@ public class SmtpClient : CommandResponseClient
             {
                 started = true;
                 await context.WriteLineAsync($"AUTH PLAIN {payload}", token).ConfigureAwait(false);
-                IReadOnlyList<ServerResponse> responses = await ReadResponsesAsync(context, token).ConfigureAwait(false);
+                IReadOnlyList<ServerResponse> responses = await context.ReadResponsesAsync(token).ConfigureAwait(false);
                 ProtocolResponseValidator.RequireCompletion("SMTP", "AUTH", responses);
                 return true;
             }
@@ -69,11 +69,11 @@ public class SmtpClient : CommandResponseClient
             {
                 started = true;
                 await context.WriteLineAsync("AUTH LOGIN", token).ConfigureAwait(false);
-                ProtocolResponseValidator.RequireIntermediate("SMTP", "AUTH", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                ProtocolResponseValidator.RequireIntermediate("SMTP", "AUTH", await context.ReadResponsesAsync(token).ConfigureAwait(false));
                 await context.WriteLineAsync(encodedUser, token).ConfigureAwait(false);
-                ProtocolResponseValidator.RequireIntermediate("SMTP", "AUTH", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                ProtocolResponseValidator.RequireIntermediate("SMTP", "AUTH", await context.ReadResponsesAsync(token).ConfigureAwait(false));
                 await context.WriteLineAsync(encodedPassword, token).ConfigureAwait(false);
-                ProtocolResponseValidator.RequireCompletion("SMTP", "AUTH", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                ProtocolResponseValidator.RequireCompletion("SMTP", "AUTH", await context.ReadResponsesAsync(token).ConfigureAwait(false));
                 return true;
             }
             catch (Exception ex) when (started && ex is OperationCanceledException or IOException)
@@ -126,7 +126,7 @@ public class SmtpClient : CommandResponseClient
         ValidateCommandArgument(list, nameof(list));
         IReadOnlyList<ServerResponse> responses = await SendCommandAsync($"EXPN {list}", cancellationToken).ConfigureAwait(false);
         ProtocolResponseValidator.RequireCompletion("SMTP", "EXPN", responses);
-        return responses.Select(r => r.Message).Where(m => !string.IsNullOrEmpty(m)).Cast<string>().ToArray();
+        return responses.Take(responses.Count - 1).Select(r => r.Message).Where(m => !string.IsNullOrEmpty(m)).Cast<string>().ToArray();
     }
 
     /// <summary>Requests SMTP help.</summary>
@@ -177,22 +177,22 @@ public class SmtpClient : CommandResponseClient
             try
             {
                 await context.WriteLineAsync($"MAIL FROM:<{from.Value}>{mailOptions}", token).ConfigureAwait(false);
-                ProtocolResponseValidator.RequireCompletion("SMTP", "MAIL", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                ProtocolResponseValidator.RequireCompletion("SMTP", "MAIL", await context.ReadResponsesAsync(token).ConfigureAwait(false));
                 mailAccepted = true;
                 foreach (SmtpPath recipient in snapshot)
                 {
                     await context.WriteLineAsync($"RCPT TO:<{recipient.Value}>", token).ConfigureAwait(false);
-                    ProtocolResponseValidator.RequireCompletion("SMTP", "RCPT", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                    ProtocolResponseValidator.RequireCompletion("SMTP", "RCPT", await context.ReadResponsesAsync(token).ConfigureAwait(false));
                 }
                 await context.WriteLineAsync("DATA", token).ConfigureAwait(false);
-                ProtocolResponseValidator.RequireIntermediate("SMTP", "DATA", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                ProtocolResponseValidator.RequireIntermediate("SMTP", "DATA", await context.ReadResponsesAsync(token).ConfigureAwait(false));
                 dataAccepted = true;
                 string? line;
                 while ((line = await data.ReadLineAsync(token).ConfigureAwait(false)) is not null)
                     await context.WriteLineAsync(line.StartsWith(".", StringComparison.Ordinal) ? "." + line : line, token).ConfigureAwait(false);
                 await context.WriteLineAsync(".", token).ConfigureAwait(false);
                 dataFramed = true;
-                ProtocolResponseValidator.RequireCompletion("SMTP", "DATA", await ReadResponsesAsync(context, token).ConfigureAwait(false));
+                ProtocolResponseValidator.RequireCompletion("SMTP", "DATA", await context.ReadResponsesAsync(token).ConfigureAwait(false));
                 return true;
             }
             catch (Exception primary)
@@ -207,7 +207,7 @@ public class SmtpClient : CommandResponseClient
                 {
                     using CancellationTokenSource recovery = new(TransactionRecoveryTimeout);
                     await context.WriteLineAsync("RSET", recovery.Token).ConfigureAwait(false);
-                    ProtocolResponseValidator.RequireCompletion("SMTP", "RSET", await ReadResponsesAsync(context, recovery.Token).ConfigureAwait(false));
+                    ProtocolResponseValidator.RequireCompletion("SMTP", "RSET", await context.ReadResponsesAsync(recovery.Token).ConfigureAwait(false));
                 }
                 catch (Exception recoveryError)
                 {
@@ -242,15 +242,6 @@ public class SmtpClient : CommandResponseClient
             return new ServerResponse(line[..3], severity, line.Length > 4 ? line[4..] : string.Empty);
         }
         return base.ParseResponseLine(line);
-    }
-
-    /// <summary>Reads one complete SMTP status response.</summary>
-    private static async ValueTask<IReadOnlyList<ServerResponse>> ReadResponsesAsync(ProtocolExchangeContext context, CancellationToken token)
-    {
-        List<ServerResponse> responses = [];
-        do { responses.Add(await context.ReadLineAsync(token).ConfigureAwait(false)); }
-        while (responses[^1].Severity == ResponseSeverity.Preliminary);
-        return responses;
     }
 
     /// <summary>Formats typed ESMTP parameters.</summary>

--- a/Utils.Net/Net/SmtpModels.cs
+++ b/Utils.Net/Net/SmtpModels.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+
+namespace Utils.Net;
+
+/// <summary>Represents a validated SMTP reverse-path or forward-path.</summary>
+public sealed record SmtpPath
+{
+    /// <summary>Initializes a validated SMTP path.</summary>
+    private SmtpPath(string value, bool allowsUtf8) { Value = value; AllowsUtf8 = allowsUtf8; }
+    /// <summary>Gets the path without surrounding angle brackets.</summary>
+    public string Value { get; }
+    /// <summary>Gets whether non-ASCII characters were explicitly permitted.</summary>
+    public bool AllowsUtf8 { get; }
+
+    /// <summary>Parses an ASCII SMTP path. An empty value is a valid reverse-path.</summary>
+    public static SmtpPath Parse(string value) => Parse(value, false);
+
+    /// <summary>Parses an SMTP path with an explicit SMTPUTF8 policy.</summary>
+    public static SmtpPath Parse(string value, bool allowUtf8)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (!TryParse(value, allowUtf8, out SmtpPath? path))
+            throw new FormatException("The value is not a supported SMTP path.");
+        return path;
+    }
+
+    /// <summary>Attempts to parse an ASCII SMTP path.</summary>
+    public static bool TryParse(string value, out SmtpPath? path) => TryParse(value, false, out path);
+
+    /// <summary>Attempts to parse an SMTP path with an explicit SMTPUTF8 policy.</summary>
+    public static bool TryParse(string? value, bool allowUtf8, out SmtpPath? path)
+    {
+        path = null;
+        if (value is null) return false;
+        if (value.Length == 0) { path = new SmtpPath(value, allowUtf8); return true; }
+        if (value.Any(c => c is '<' or '>' or '\r' or '\n' or '\0' || char.IsWhiteSpace(c) || char.IsControl(c))) return false;
+        if (!allowUtf8 && value.Any(c => c > 0x7f)) return false;
+        if (value.StartsWith('@') || value.Contains(':') && !value.Contains("@[", StringComparison.Ordinal)) return false;
+        int at = value.LastIndexOf('@');
+        if (at <= 0 || at == value.Length - 1 || value.IndexOf('@') != at) return false;
+        string domain = value[(at + 1)..];
+        if (domain.StartsWith('['))
+        {
+            if (!domain.EndsWith(']')) return false;
+            string literal = domain[1..^1];
+            if (literal.StartsWith("IPv6:", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!IPAddress.TryParse(literal[5..], out IPAddress? ip) || ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetworkV6) return false;
+            }
+            else if (!IPAddress.TryParse(literal, out IPAddress? ip) || ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork) return false;
+        }
+        else if (domain.StartsWith('.') || domain.EndsWith('.') || domain.Split('.').Any(label => label.Length == 0 || label.StartsWith('-') || label.EndsWith('-') || label.Any(c => !(char.IsAsciiLetterOrDigit(c) || c == '-')))) return false;
+        path = new SmtpPath(value, allowUtf8);
+        return true;
+    }
+}
+
+/// <summary>Identifies the SMTP BODY parameter.</summary>
+public enum SmtpBodyKind { /// <summary>Seven-bit content.</summary>
+    SevenBit, /// <summary>Eight-bit MIME content.</summary>
+    EightBitMime }
+
+/// <summary>Defines validated ESMTP MAIL parameters separately from a mailbox path.</summary>
+public sealed record SmtpMailOptions
+{
+    private long? _size;
+    /// <summary>Gets or initializes the declared message size.</summary>
+    public long? Size { get => _size; init => _size = value < 0 ? throw new ArgumentOutOfRangeException(nameof(Size)) : value; }
+    /// <summary>Gets or initializes the BODY parameter.</summary>
+    public SmtpBodyKind? Body { get; init; }
+    /// <summary>Gets or initializes whether SMTPUTF8 is explicitly enabled.</summary>
+    public bool SmtpUtf8 { get; init; }
+}
+
+/// <summary>Contains the three independently validated SASL PLAIN credential fields.</summary>
+public sealed record SmtpPlainCredentials
+{
+    /// <summary>Initializes credentials and rejects embedded NUL delimiters.</summary>
+    public SmtpPlainCredentials(string authenticationIdentity, string password, string authorizationIdentity = "")
+    {
+        AuthenticationIdentity = Validate(authenticationIdentity, nameof(authenticationIdentity), false);
+        Password = Validate(password, nameof(password), true);
+        AuthorizationIdentity = Validate(authorizationIdentity, nameof(authorizationIdentity), true);
+    }
+    /// <summary>Gets the authentication identity.</summary>
+    public string AuthenticationIdentity { get; }
+    /// <summary>Gets the password.</summary>
+    public string Password { get; }
+    /// <summary>Gets the optional authorization identity.</summary>
+    public string AuthorizationIdentity { get; }
+    /// <summary>Validates one SASL field.</summary>
+    private static string Validate(string value, string name, bool allowEmpty)
+    {
+        ArgumentNullException.ThrowIfNull(value, name);
+        if (!allowEmpty && value.Length == 0) throw new ArgumentException("The identity must not be empty.", name);
+        if (value.Contains('\0')) throw new ArgumentException("SASL fields must not contain NUL.", name);
+        return value;
+    }
+}

--- a/Utils.Net/README.md
+++ b/Utils.Net/README.md
@@ -698,3 +698,21 @@ dotnet list package --vulnerable --include-transitive
 
 
 [Versioned API documentation](https://warny.github.io/All-purpose-Utilities/v2.0.0-rc.1/)
+
+## Protocol safety in 2.0
+
+SMTP envelopes use `SmtpPath`; only `local-part@domain`, IPv4/IPv6 address literals, and the empty reverse-path are supported. ASCII is the default. International paths require `SmtpPath.Parse(value, allowUtf8: true)` **and** `SmtpMailOptions.SmtpUtf8 = true`. ESMTP parameters are represented by `SmtpMailOptions`, never appended to an address.
+
+`SendMailAsync` owns the connection from `MAIL FROM` through the final DATA response. Failures after an accepted envelope attempt `RSET` for at most five seconds by default; loss of DATA framing or failed recovery poisons and closes the session. A framed negative response throws `ProtocolResponseException` without closing an otherwise synchronized session.
+
+POP3 and NNTP dot-terminated payloads support `TextWriter` streaming. The defaults are 100,000 lines, 10 Mi UTF-16 characters, and 40 MiB of UTF-8 payload. Only an exact `.` terminates a body and only `..` is unstuffed. Cancellation, EOF, consumer failure, or a limit breach before the terminator poisons the session.
+
+```csharp
+var sender = SmtpPath.Parse("sender@example.com");
+var recipient = SmtpPath.Parse("recipient@example.com");
+await smtp.SendMailAsync(sender, [recipient], messageReader);
+await pop3.RetrieveAsync(1, destinationWriter);
+await nntp.ArticleAsync(1, destinationWriter);
+```
+
+Versioned API documentation: https://warny.github.io/All-purpose-Utilities/v2.0.0/

--- a/UtilsTest.Functional/Net/NntpClientServerTests.cs
+++ b/UtilsTest.Functional/Net/NntpClientServerTests.cs
@@ -43,8 +43,8 @@ public class NntpClientServerTests
         IReadOnlyList<string> newGroups = await client.NewGroupsAsync(DateTime.UtcNow.AddDays(-4));
         CollectionAssert.Contains((System.Collections.ICollection)newGroups, "comp.test");
         // Uses a margin larger than one day to avoid boundary timing flakiness with strict "> since" filtering.
-        IReadOnlyList<int> newNews = await client.NewNewsAsync("comp.test", DateTime.UtcNow.AddDays(-2));
-        CollectionAssert.Contains((System.Collections.ICollection)newNews, 1);
+        IReadOnlyList<string> newNews = await client.NewNewsAsync("comp.test", DateTime.UtcNow.AddDays(-2));
+        CollectionAssert.Contains((System.Collections.ICollection)newNews, "<1@comp.test>");
         (int count, int first, int last) info = await client.GroupAsync("comp.test");
         Assert.AreEqual(1, info.count);
         int? nextId = await client.NextAsync();
@@ -56,8 +56,8 @@ public class NntpClientServerTests
         (int id, string messageId) stat = await client.StatAsync(1);
         Assert.AreEqual(1, stat.id);
         await client.PostAsync("From: test@example.com\r\nNewsgroups: comp.test\r\nSubject: Test post\r\n\r\nposted\r\n");
-        IReadOnlyList<int> newNews2 = await client.NewNewsAsync("comp.test", DateTime.UtcNow.AddMinutes(-1));
-        CollectionAssert.Contains((System.Collections.ICollection)newNews2, 2);
+        IReadOnlyList<string> newNews2 = await client.NewNewsAsync("comp.test", DateTime.UtcNow.AddMinutes(-1));
+        CollectionAssert.Contains((System.Collections.ICollection)newNews2, "<2@comp.test>");
         await client.QuitAsync();
         await serverTask;
     }
@@ -124,21 +124,21 @@ public class NntpClientServerTests
             return Task.FromResult<IReadOnlyDictionary<int, string>>(new Dictionary<int, string>());
         }
 
-        public Task<IReadOnlyCollection<int>> ListNewsSinceAsync(string group, DateTime sinceUtc, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyCollection<string>> ListNewsSinceAsync(string group, DateTime sinceUtc, CancellationToken cancellationToken = default)
         {
             if (_groups.TryGetValue(group, out Group? g))
             {
-                List<int> ids = new();
+                List<string> ids = new();
                 foreach (KeyValuePair<int, Article> kvp in g.Articles)
                 {
                     if (kvp.Value.Date > sinceUtc)
                     {
-                        ids.Add(kvp.Key);
+                        ids.Add($"<{kvp.Key}@comp.test>");
                     }
                 }
-                return Task.FromResult<IReadOnlyCollection<int>>(ids);
+                return Task.FromResult<IReadOnlyCollection<string>>(ids);
             }
-            return Task.FromResult<IReadOnlyCollection<int>>(System.Array.Empty<int>());
+            return Task.FromResult<IReadOnlyCollection<string>>(System.Array.Empty<string>());
         }
 
         public Task<string?> RetrieveAsync(string group, int id, CancellationToken cancellationToken = default)
@@ -163,4 +163,3 @@ public class NntpClientServerTests
         }
     }
 }
-

--- a/UtilsTest.Functional/Net/NntpServerLimitTests.cs
+++ b/UtilsTest.Functional/Net/NntpServerLimitTests.cs
@@ -42,8 +42,8 @@ public class NntpServerLimitTests
             return Task.FromResult<IReadOnlyDictionary<int, string>>(new Dictionary<int, string>(_articles));
         }
 
-        public Task<IReadOnlyCollection<int>> ListNewsSinceAsync(string group, DateTime since, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyCollection<int>>(Array.Empty<int>());
+        public Task<IReadOnlyCollection<string>> ListNewsSinceAsync(string group, DateTime since, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyCollection<string>>(Array.Empty<string>());
 
         public Task<string?> RetrieveAsync(string group, int id, CancellationToken ct = default)
             => Task.FromResult(_articles.TryGetValue(id, out string? a) ? a : null);

--- a/UtilsTest.Functional/Net/Pop3ClientTests.cs
+++ b/UtilsTest.Functional/Net/Pop3ClientTests.cs
@@ -87,7 +87,7 @@ public class Pop3ClientTests
         using Pop3Client client = new() { NoOpInterval = TimeSpan.FromMilliseconds(100) };
         await client.ConnectAsync("127.0.0.1", port);
         await client.AuthenticateAsync("user", "pass");
-        (int count, int size) stat = await client.GetStatAsync();
+        (int count, long size) stat = await client.GetStatAsync();
         Assert.AreEqual(2, stat.count);
         IReadOnlyDictionary<int, int> list = await client.ListAsync();
         Assert.AreEqual(2, list.Count);

--- a/UtilsTest.Functional/Net/Pop3ServerTests.cs
+++ b/UtilsTest.Functional/Net/Pop3ServerTests.cs
@@ -41,7 +41,7 @@ public class Pop3ServerTests
         using Pop3Client client = new();
         await client.ConnectAsync("127.0.0.1", port);
         await client.AuthenticateAsync("user", "pass");
-        (int count, int size) stat = await client.GetStatAsync();
+        (int count, long size) stat = await client.GetStatAsync();
         Assert.AreEqual(2, stat.count);
         IReadOnlyDictionary<int, int> list = await client.ListAsync();
         Assert.AreEqual(2, list.Count);

--- a/UtilsTest.Functional/Net/SmtpClientServerTests.cs
+++ b/UtilsTest.Functional/Net/SmtpClientServerTests.cs
@@ -71,7 +71,7 @@ public class SmtpClientServerTests
         using SmtpClient client = new() { NoOpInterval = Timeout.InfiniteTimeSpan };
         await client.ConnectAsync("127.0.0.1", port);
         await client.EhloAsync("localhost");
-        await Assert.ThrowsExceptionAsync<IOException>(() =>
+        await Assert.ThrowsExceptionAsync<ProtocolResponseException>(() =>
             client.SendMailAsync("alice@example.com", new[] { "bob@other.com" }, "Subject: Test\r\n\r\nBody"));
         await client.QuitAsync();
         await serverTask;

--- a/UtilsTest/Net/NetClientProtocolTests.cs
+++ b/UtilsTest/Net/NetClientProtocolTests.cs
@@ -192,6 +192,96 @@ public class NetClientProtocolTests
         await server;
     }
 
+
+    /// <summary>Verifies a complete AUTH LOGIN rejection does not poison the synchronized SMTP session.</summary>
+    [TestMethod]
+    public async Task SmtpClient_AuthLoginRejected_DoesNotPoisonSession()
+    {
+        (DuplexStream stream, StreamWriter writer, StreamReader reader) = CreateTestPair();
+        Task server = Task.Run(async () =>
+        {
+            await writer.WriteLineAsync("220 ready");
+            Assert.AreEqual("AUTH LOGIN", await reader.ReadLineAsync());
+            await writer.WriteLineAsync("535 authentication failed");
+            Assert.AreEqual("HELP", await reader.ReadLineAsync());
+            await writer.WriteLineAsync("214 help text");
+        });
+        SmtpClient client = new();
+        await client.ConnectAsync(stream);
+        ProtocolResponseException error = await Assert.ThrowsExceptionAsync<ProtocolResponseException>(() =>
+            client.AuthenticateAsync("user", "password", SmtpAuthenticationMechanism.Login));
+        Assert.AreEqual("535", error.ResponseCode);
+        Assert.IsTrue(client.IsConnected);
+        CollectionAssert.AreEqual(new[] { "help text" }, (await client.HelpAsync()).ToArray());
+        await server;
+    }
+
+    /// <summary>Verifies cancellation while an SMTP RCPT response is pending poisons without sending RSET.</summary>
+    [TestMethod]
+    public async Task SmtpClient_SendMailAsync_CancelDuringRcptResponse_PoisonsWithoutRset()
+    {
+        (DuplexStream stream, StreamWriter writer, StreamReader reader) = CreateTestPair();
+        List<string> commands = [];
+        Task server = Task.Run(async () =>
+        {
+            await writer.WriteLineAsync("220 ready");
+            commands.Add((await reader.ReadLineAsync())!);
+            await writer.WriteLineAsync("250 sender accepted");
+            commands.Add((await reader.ReadLineAsync())!);
+            await Task.Delay(300);
+            while (reader.Peek() >= 0)
+                commands.Add((await reader.ReadLineAsync())!);
+        });
+        SmtpClient client = new();
+        await client.ConnectAsync(stream);
+        using CancellationTokenSource cancellation = new(100);
+        await Assert.ThrowsExceptionAsync<OperationCanceledException>(() =>
+            client.SendMailAsync(SmtpPath.Parse("sender@example.com"), [SmtpPath.Parse("recipient@example.com")], new StringReader("body"), cancellationToken: cancellation.Token));
+        Assert.IsFalse(client.IsConnected);
+        Assert.IsFalse(commands.Contains("RSET"));
+        await server;
+    }
+
+    /// <summary>Verifies an AUTH PLAIN transport failure after writing the command poisons the session.</summary>
+    [TestMethod]
+    public async Task SmtpClient_AuthPlainTransportFailure_PoisonsSession()
+    {
+        (DuplexStream stream, StreamWriter writer, StreamReader reader) = CreateTestPair();
+        Task server = Task.Run(async () =>
+        {
+            await writer.WriteLineAsync("220 ready");
+            _ = await reader.ReadLineAsync();
+            writer.Dispose();
+        });
+        SmtpClient client = new();
+        await client.ConnectAsync(stream);
+        await Assert.ThrowsExceptionAsync<IOException>(() => client.AuthenticateAsync(new SmtpPlainCredentials("user", "password")));
+        Assert.IsFalse(client.IsConnected);
+        Assert.IsNotNull(client.SessionFailure);
+        await server;
+    }
+
+    /// <summary>Verifies NNTP article commands reject unexpected positive status before reading a payload.</summary>
+    [TestMethod]
+    public async Task NntpClient_ArticleUnexpectedPositiveCode_DoesNotEnterPayloadOrPoison()
+    {
+        (DuplexStream stream, StreamWriter writer, StreamReader reader) = CreateTestPair();
+        Task server = Task.Run(async () =>
+        {
+            await writer.WriteLineAsync("200 ready");
+            Assert.AreEqual("ARTICLE 1", await reader.ReadLineAsync());
+            await writer.WriteLineAsync("200 posting allowed");
+            Assert.AreEqual("GROUP comp.test", await reader.ReadLineAsync());
+            await writer.WriteLineAsync("211 0 0 0");
+        });
+        NntpClient client = new();
+        await client.ConnectAsync(stream);
+        await Assert.ThrowsExceptionAsync<ProtocolResponseException>(() => client.ArticleAsync(1));
+        Assert.IsTrue(client.IsConnected);
+        Assert.AreEqual((0, 0, 0), await client.GroupAsync("comp.test"));
+        await server;
+    }
+
     // ──────────────────────────────────────────────────────────────
     // Item 40 — NetworkParameters.PrimaryDns null-safe
     // ──────────────────────────────────────────────────────────────

--- a/UtilsTest/Net/NetClientProtocolTests.cs
+++ b/UtilsTest/Net/NetClientProtocolTests.cs
@@ -58,6 +58,65 @@ public class NetClientProtocolTests
         }
     }
 
+
+    /// <summary>Wraps an outgoing stream and throws after partially accepting one selected write.</summary>
+    private sealed class PartialFailingWriteStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly int _failOnWriteCall;
+        private readonly int _bytesBeforeFailure;
+        private int _writeCalls;
+
+        public PartialFailingWriteStream(Stream inner, int failOnWriteCall, int bytesBeforeFailure)
+        {
+            _inner = inner;
+            _failOnWriteCall = failOnWriteCall;
+            _bytesBeforeFailure = bytesBeforeFailure;
+        }
+
+        public override bool CanRead => false;
+        public override bool CanWrite => true;
+        public override bool CanSeek => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _writeCalls++;
+            if (_writeCalls == _failOnWriteCall)
+            {
+                int accepted = Math.Min(_bytesBeforeFailure, count);
+                if (accepted > 0)
+                    _inner.Write(buffer, offset, accepted);
+                throw new IOException("Simulated partial write failure.");
+            }
+            _inner.Write(buffer, offset, count);
+        }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            _writeCalls++;
+            if (_writeCalls == _failOnWriteCall)
+            {
+                int accepted = Math.Min(_bytesBeforeFailure, buffer.Length);
+                if (accepted > 0)
+                    await _inner.WriteAsync(buffer[..accepted], cancellationToken).ConfigureAwait(false);
+                throw new IOException("Simulated partial write failure.");
+            }
+            await _inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override void Flush() => _inner.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken) => _inner.FlushAsync(cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
     /// <summary>Exposes protected multiline behavior for focused framing tests.</summary>
     private sealed class MultilineTestClient : CommandResponseClient
     {
@@ -259,6 +318,46 @@ public class NetClientProtocolTests
         Assert.IsFalse(client.IsConnected);
         Assert.IsNotNull(client.SessionFailure);
         await server;
+    }
+
+
+    /// <summary>Verifies a partial SMTP transaction write poisons immediately and never attempts RSET recovery.</summary>
+    [TestMethod]
+    public async Task SmtpClient_SendMailAsync_PartialRcptWriteFailure_PoisonsWithoutRset()
+    {
+        Pipe serverToClient = new();
+        Pipe clientToServer = new();
+        PartialFailingWriteStream failingWrites = new(clientToServer.Writer.AsStream(), failOnWriteCall: 2, bytesBeforeFailure: 8);
+        DuplexStream stream = new(serverToClient.Reader.AsStream(), failingWrites);
+        StreamWriter writer = new(serverToClient.Writer.AsStream(), Encoding.ASCII)
+        {
+            NewLine = "\r\n",
+            AutoFlush = true
+        };
+        StreamReader reader = new(clientToServer.Reader.AsStream(), Encoding.ASCII);
+        StringBuilder transcript = new();
+        Task server = Task.Run(async () =>
+        {
+            await writer.WriteLineAsync("220 ready");
+            string? mail = await reader.ReadLineAsync();
+            transcript.AppendLine(mail);
+            await writer.WriteLineAsync("250 sender accepted");
+            await Task.Delay(200);
+            while (clientToServer.Reader.TryRead(out ReadResult result))
+            {
+                foreach (ReadOnlyMemory<byte> segment in result.Buffer)
+                    transcript.Append(Encoding.ASCII.GetString(segment.Span));
+                clientToServer.Reader.AdvanceTo(result.Buffer.End);
+            }
+        });
+        SmtpClient client = new();
+        await client.ConnectAsync(stream);
+        await Assert.ThrowsExceptionAsync<IOException>(() =>
+            client.SendMailAsync(SmtpPath.Parse("sender@example.com"), [SmtpPath.Parse("recipient@example.com")], new StringReader("body")));
+        Assert.IsFalse(client.IsConnected);
+        Assert.IsNotNull(client.SessionFailure);
+        await server;
+        Assert.IsFalse(transcript.ToString().Contains("RSET", StringComparison.Ordinal));
     }
 
     /// <summary>Verifies NNTP article commands reject unexpected positive status before reading a payload.</summary>

--- a/UtilsTest/Net/NetClientProtocolTests.cs
+++ b/UtilsTest/Net/NetClientProtocolTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipelines;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
@@ -57,6 +58,21 @@ public class NetClientProtocolTests
         }
     }
 
+    /// <summary>Exposes protected multiline behavior for focused framing tests.</summary>
+    private sealed class MultilineTestClient : CommandResponseClient
+    {
+        /// <summary>Reads a body terminated by a caller-defined marker.</summary>
+        public async Task<IReadOnlyList<string>> ReadUntilEndAsync(CancellationToken cancellationToken = default)
+        {
+            var (_, body) = await SendMultilineCommandAsync(
+                "MULTI", response => response.Code == "END", 10, 100, 100, cancellationToken);
+            List<string> result = [];
+            foreach (ServerResponse response in body)
+                result.Add(BodyLineToString(response));
+            return result;
+        }
+    }
+
     /// <summary>
     /// Creates an in-process bidirectional pipe pair so that a fake server task and a
     /// real protocol client can exchange lines without a real TCP connection.
@@ -78,6 +94,102 @@ public class NetClientProtocolTests
         StreamReader serverReader = new StreamReader(clientToServer.Reader.AsStream(), Encoding.ASCII);
 
         return (clientStream, serverWriter, serverReader);
+    }
+
+    /// <summary>Verifies the legacy protected multiline callback remains authoritative.</summary>
+    [TestMethod]
+    public async Task CommandResponseClient_Multiline_UsesCustomTerminator()
+    {
+        (DuplexStream stream, StreamWriter writer, StreamReader reader) = CreateTestPair();
+        Task server = Task.Run(async () =>
+        {
+            _ = await reader.ReadLineAsync();
+            await writer.WriteLineAsync("200 body follows");
+            await writer.WriteLineAsync("first");
+            await writer.WriteLineAsync("END");
+            await writer.WriteLineAsync("orphan");
+        });
+        MultilineTestClient client = new();
+        await client.ConnectAsync(stream);
+        IReadOnlyList<string> body = await client.ReadUntilEndAsync();
+        CollectionAssert.AreEqual(new[] { "first" }, body.ToArray());
+        await server;
+    }
+
+    /// <summary>Verifies SMTP exchange status collection enforces MaxResponseCount and poisons framing.</summary>
+    [TestMethod]
+    public async Task SmtpClient_ExclusiveStatusReader_EnforcesMaxResponseCount()
+    {
+        (DuplexStream stream, StreamWriter writer, StreamReader reader) = CreateTestPair();
+        Task server = Task.Run(async () =>
+        {
+            await writer.WriteLineAsync("220 ready");
+            _ = await reader.ReadLineAsync();
+            await writer.WriteLineAsync("250-first");
+            await writer.WriteLineAsync("250 second");
+        });
+        SmtpClient client = new() { MaxResponseCount = 1 };
+        await client.ConnectAsync(stream);
+        await Assert.ThrowsExceptionAsync<InvalidDataException>(() => client.EhloAsync("example.test"));
+        Assert.IsFalse(client.IsConnected);
+        Assert.IsNotNull(client.SessionFailure);
+        await server;
+    }
+
+    /// <summary>Verifies malformed POP3 mandatory fields produce structured diagnostics.</summary>
+    [TestMethod]
+    public async Task Pop3Client_MalformedStat_ThrowsProtocolResponseException()
+    {
+        (DuplexStream stream, StreamWriter writer, StreamReader reader) = CreateTestPair();
+        Task server = Task.Run(async () =>
+        {
+            await writer.WriteLineAsync("+OK ready");
+            _ = await reader.ReadLineAsync();
+            await writer.WriteLineAsync("+OK 12");
+        });
+        Pop3Client client = new();
+        await client.ConnectAsync(stream);
+        ProtocolResponseException error = await Assert.ThrowsExceptionAsync<ProtocolResponseException>(() => client.GetStatAsync());
+        Assert.AreEqual("STAT", error.Command);
+        await server;
+    }
+
+    /// <summary>Verifies POP3 CAPA failures retain the correct sanitized command context.</summary>
+    [TestMethod]
+    public async Task Pop3Client_CapabilityFailure_UsesCapaCommandContext()
+    {
+        (DuplexStream stream, StreamWriter writer, StreamReader reader) = CreateTestPair();
+        Task server = Task.Run(async () =>
+        {
+            await writer.WriteLineAsync("+OK ready");
+            _ = await reader.ReadLineAsync();
+            await writer.WriteLineAsync("-ERR unsupported");
+        });
+        Pop3Client client = new();
+        await client.ConnectAsync(stream);
+        ProtocolResponseException error = await Assert.ThrowsExceptionAsync<ProtocolResponseException>(() => client.GetCapabilitiesAsync());
+        Assert.AreEqual("CAPA", error.Command);
+        await server;
+    }
+
+    /// <summary>Verifies materializing multiline commands also apply the byte limit.</summary>
+    [TestMethod]
+    public async Task Pop3Client_List_ByteLimitExceeded_PoisonsSession()
+    {
+        (DuplexStream stream, StreamWriter writer, StreamReader reader) = CreateTestPair();
+        Task server = Task.Run(async () =>
+        {
+            await writer.WriteLineAsync("+OK ready");
+            _ = await reader.ReadLineAsync();
+            await writer.WriteLineAsync("+OK list follows");
+            await writer.WriteLineAsync("1 12345");
+            await writer.WriteLineAsync(".");
+        });
+        Pop3Client client = new() { MaxMultilineBytes = 2 };
+        await client.ConnectAsync(stream);
+        await Assert.ThrowsExceptionAsync<InvalidDataException>(() => client.ListAsync());
+        Assert.IsFalse(client.IsConnected);
+        await server;
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/UtilsTest/Net/ProtocolHardeningTests.cs
+++ b/UtilsTest/Net/ProtocolHardeningTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Net;
+
+namespace UtilsTest.Net;
+
+/// <summary>Tests strict protocol models introduced for the pass-seven fixes.</summary>
+[TestClass]
+public class ProtocolHardeningTests
+{
+    /// <summary>Verifies supported ASCII mailbox and address-literal forms.</summary>
+    [TestMethod]
+    public void SmtpPath_Parse_AcceptsSupportedAsciiForms()
+    {
+        Assert.AreEqual("user@example.com", SmtpPath.Parse("user@example.com").Value);
+        Assert.AreEqual("user@[192.0.2.1]", SmtpPath.Parse("user@[192.0.2.1]").Value);
+        Assert.AreEqual("user@[IPv6:2001:db8::1]", SmtpPath.Parse("user@[IPv6:2001:db8::1]").Value);
+        Assert.AreEqual(string.Empty, SmtpPath.Parse(string.Empty).Value);
+    }
+
+    /// <summary>Verifies syntax that could escape or extend an SMTP envelope is rejected.</summary>
+    [TestMethod]
+    [DataRow("user@example.com> SIZE=1")]
+    [DataRow("<user@example.com")]
+    [DataRow("user @example.com")]
+    [DataRow("@route:user@example.com")]
+    [DataRow("user@example.com\rRCPT TO:<evil@example.com>")]
+    public void SmtpPath_Parse_RejectsUnsafeSyntax(string value) => Assert.ThrowsException<FormatException>(() => SmtpPath.Parse(value));
+
+    /// <summary>Verifies SMTPUTF8 is opt-in and never silently substituted.</summary>
+    [TestMethod]
+    public void SmtpPath_Parse_Utf8RequiresExplicitOptIn()
+    {
+        Assert.ThrowsException<FormatException>(() => SmtpPath.Parse("tést@example.com"));
+        Assert.AreEqual("tést@example.com", SmtpPath.Parse("tést@example.com", true).Value);
+    }
+
+    /// <summary>Verifies each SASL PLAIN field rejects the delimiter byte.</summary>
+    [TestMethod]
+    public void SmtpPlainCredentials_RejectNulInEveryField()
+    {
+        Assert.ThrowsException<ArgumentException>(() => new SmtpPlainCredentials("a\0b", "password"));
+        Assert.ThrowsException<ArgumentException>(() => new SmtpPlainCredentials("user", "pass\0word"));
+        Assert.ThrowsException<ArgumentException>(() => new SmtpPlainCredentials("user", "password", "a\0z"));
+    }
+
+    /// <summary>Verifies payload limits reject negative values at assignment.</summary>
+    [TestMethod]
+    public void ProtocolPayloadLimits_RejectNegativeValues()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new ProtocolPayloadLimits { MaximumLines = -1 });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new ProtocolPayloadLimits { MaximumCharacters = -1 });
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new ProtocolPayloadLimits { MaximumBytes = -1 });
+    }
+
+    /// <summary>Verifies structured failures copy responses and redact command arguments.</summary>
+    [TestMethod]
+    public void ProtocolResponseException_ProvidesStructuredRedactedDiagnostics()
+    {
+        ServerResponse[] responses = [new("535", ResponseSeverity.PermanentNegative, "authentication failed")];
+        ProtocolResponseException error = new("SMTP", "AUTH secret", responses);
+        responses[0] = new ServerResponse("250", ResponseSeverity.Completion, "changed");
+        Assert.AreEqual("AUTH", error.Command);
+        Assert.AreEqual("535", error.ResponseCode);
+        Assert.AreEqual(ResponseSeverity.PermanentNegative, error.Severity);
+        Assert.AreEqual("535", error.Responses[0].Code);
+        Assert.IsFalse(error.Message.Contains("secret", StringComparison.Ordinal));
+    }
+}

--- a/docs/migration/Utils.Net-vNext.md
+++ b/docs/migration/Utils.Net-vNext.md
@@ -155,3 +155,17 @@ after the exception was thrown.
 This is a behavioral fix, not a signature change. Code that reads `Failures` is unaffected.
 Code that relies on the exception reflecting post-construction mutations to the original list
 must be updated — though such patterns were never correct.
+
+---
+
+## SMTP, POP3, and NNTP protocol contracts in 2.0
+
+SMTP mailbox strings are now parsed strictly by `SmtpPath`. Angle brackets, whitespace, controls, source routes, and embedded ESMTP parameters are rejected. SMTPUTF8 requires opt-in both while parsing and in `SmtpMailOptions`. SASL PLAIN and LOGIN use strict UTF-8 and reject NUL in each credential field.
+
+An SMTP mail transaction and an AUTH LOGIN challenge sequence now hold one exclusive exchange lease. After `MAIL FROM`, a framed failure is recovered with verified `RSET` under `TransactionRecoveryTimeout` (five seconds by default). Failure after DATA acceptance or failed RSET poisons the session.
+
+`ProtocolResponseException` replaces generic response-message `IOException` failures and exposes protocol, sanitized verb, code, severity, immutable response lines, and enhanced status. A normal framed negative response does not poison the connection; cancellation, EOF, framing loss, streaming consumer failure, and multiline limit overruns do.
+
+POP3 STAT/LIST/UIDL and NNTP GROUP/LIST/STAT/NEXT now reject missing, extra, overflowing, negative, or duplicate mandatory values. `NextAsync` returns `null` only for NNTP 421. `NewNewsAsync` returns NNTP message-id strings rather than integers.
+
+Streaming overloads accept `TextWriter` for POP3 RETR and NNTP ARTICLE/HEADER/BODY. Materializing wrappers use these bounded streaming paths. Defaults are 100,000 lines, 10 Mi characters, and 40 MiB (UTF-8 count).

--- a/docs/migration/Utils.Net-vNext.md
+++ b/docs/migration/Utils.Net-vNext.md
@@ -166,6 +166,6 @@ An SMTP mail transaction and an AUTH LOGIN challenge sequence now hold one exclu
 
 `ProtocolResponseException` replaces generic response-message `IOException` failures and exposes protocol, sanitized verb, code, severity, immutable response lines, and enhanced status. A normal framed negative response does not poison the connection; cancellation, EOF, framing loss, streaming consumer failure, and multiline limit overruns do.
 
-POP3 STAT/LIST/UIDL and NNTP GROUP/LIST/STAT/NEXT now reject missing, extra, overflowing, negative, or duplicate mandatory values. `NextAsync` returns `null` only for NNTP 421. `NewNewsAsync` returns NNTP message-id strings rather than integers.
+POP3 STAT/LIST/UIDL and NNTP GROUP/LIST/STAT/NEXT now reject missing, extra, overflowing, negative, or duplicate mandatory values. `NextAsync` returns `null` only for NNTP 421. `NewNewsAsync` returns NNTP message-id strings rather than integers, and `INntpArticleStore.ListNewsSinceAsync` now supplies those message IDs directly.
 
 Streaming overloads accept `TextWriter` for POP3 RETR and NNTP ARTICLE/HEADER/BODY. Materializing wrappers use these bounded streaming paths. Defaults are 100,000 lines, 10 Mi characters, and 40 MiB (UTF-8 count).

--- a/docs/releasing/AcceptedApiBreaks.md
+++ b/docs/releasing/AcceptedApiBreaks.md
@@ -433,3 +433,11 @@ This human-review index summarizes the exact machine-enforced diagnostics in `en
 
 - `CP0008` — Type 'Utils.DependencyInjection.Generators.StaticAutoGenerator' does not implement interface 'Microsoft.CodeAnalysis.ISourceGenerator' on {candidateAssembly} but it does on {baselineAssembly}
 
+
+### 2.0 protocol-correctness additions
+
+- POP3 STAT mailbox size changes from `int` to `long`; malformed STAT/LIST/UIDL is no longer tolerated.
+- POP3 single UIDL no longer returns nullable data after a positive malformed response.
+- NNTP NEWNEWS returns message-id strings, and NEXT returns null only for code 421.
+- SMTP string envelopes are parsed strictly and typed overloads separate paths from ESMTP options.
+- Negative responses use `ProtocolResponseException`; lost framing makes the session permanently unusable.

--- a/docs/releasing/MigrationTo2.0.md
+++ b/docs/releasing/MigrationTo2.0.md
@@ -38,3 +38,26 @@ Programmatic trigger forms must migrate from `(Constraints, To)` tuples to `Numb
 ## omy.Utils.Net protocol clients
 
 Use `SmtpPath` and `SmtpMailOptions` for SMTP envelopes, handle `ProtocolResponseException` for negative responses, and recreate a client after `ProtocolSessionPoisonedException`. POP3 STAT sizes are `long`; NNTP `NewNewsAsync` returns message-id strings; and `NextAsync` returns null only for response 421. Prefer the new `TextReader`/`TextWriter` streaming overloads for large payloads.
+
+<a id="omy-utils-fonts-2"></a>
+## Utils.Fonts hostile-font parsing hardening
+
+`TrueTypeFont.ParseFont`/`ParseFontAsync` now accept an optional `TrueTypeFontParsingOptions`
+governing a `FontValidationMode` (`Strict`, the default, or `Permissive`), explicit resource limits
+(font/table size, table count, `cmap` subtable count, composite-glyph depth/component/point
+budgets), and stream-ownership (`LeaveOpen`). Strict mode rejects any structural anomaly by throwing
+`FontParseException`; permissive mode records `FontDiagnostic`s on `TrueTypeFont.Diagnostics` and
+continues whenever doing so remains memory-safe -- resource-limit violations always throw in both
+modes. Fonts that previously loaded silently despite duplicate table tags, checksum mismatches,
+malformed `cmap` subtables, or out-of-range composite glyph references now fail fast by default;
+pass `FontValidationMode.Permissive` to restore a best-effort parse. `TrueTypeFontParsingOptions.MaximumFontBytes`
+defaults to 64 MiB and cannot be configured above `uint.MaxValue` (4 GiB) -- SFNT table
+offsets/lengths are themselves unsigned 32-bit fields, so this library never supports a larger font
+regardless of this setting; a value above that ceiling throws `ArgumentOutOfRangeException`
+immediately when constructing the options.
+
+Several `short`-typed members were widened to their correct unsigned/wider wire type and are 2.0
+breaks requiring recompilation: see the "Second audit pass" entry under
+[`omy.Utils.Fonts`](AcceptedApiBreaks.md#omy-utils-fonts) for the full list, including the
+`GlyphCompound.getGlyphIndex` → `GetGlyphIndex` rename and the `CmapTable.CMaps`/
+`GlyphCompound.Instructions` immutability changes.

--- a/docs/releasing/MigrationTo2.0.md
+++ b/docs/releasing/MigrationTo2.0.md
@@ -29,35 +29,12 @@ Runtime reader converters require an exact result type. A converter returning an
 
 `PartialStream` serializes reads, writes, position changes, seeking, and length changes through one sync/async-compatible gate. Bounds are evaluated while holding that gate, async wait and I/O honor cancellation, failed writes do not advance the logical position, and each operation restores the underlying stream position.
 
+## omy.Utils.Net protocol clients
+
+Use `SmtpPath` and `SmtpMailOptions` for SMTP envelopes, handle `ProtocolResponseException` for negative responses, and recreate a client after `ProtocolSessionPoisonedException`. POP3 STAT sizes are `long`; NNTP `NewNewsAsync` returns message-id strings; and `NextAsync` returns null only for response 421. Prefer the new `TextReader`/`TextWriter` streaming overloads for large payloads.
+
 ## NumberToString rule precedence
 
 Version 2.0 removes declaration order as an implicit tie-breaker. Add `priority="100"` (or another intentional signed `xs:int` value) when compatible rules have equal canonical specificity. Ordinal variants and trigger forms select the greatest specificity and then greatest priority. Cumulative variants apply the least specific and lowest-priority rules first.
 
 Programmatic trigger forms must migrate from `(Constraints, To)` tuples to `NumberToStringConverter.TriggerReplacementForm`. `VariantRule` and `OrdinalVariantRule` constructors accept an optional final `priority` argument. Configurations inherited through `baseOn` retain parent priorities; parent and child candidates are validated together and no implicit override occurs.
-
-## omy.Utils.Net protocol clients
-
-Use `SmtpPath` and `SmtpMailOptions` for SMTP envelopes, handle `ProtocolResponseException` for negative responses, and recreate a client after `ProtocolSessionPoisonedException`. POP3 STAT sizes are `long`; NNTP `NewNewsAsync` returns message-id strings; and `NextAsync` returns null only for response 421. Prefer the new `TextReader`/`TextWriter` streaming overloads for large payloads.
-
-<a id="omy-utils-fonts-2"></a>
-## Utils.Fonts hostile-font parsing hardening
-
-`TrueTypeFont.ParseFont`/`ParseFontAsync` now accept an optional `TrueTypeFontParsingOptions`
-governing a `FontValidationMode` (`Strict`, the default, or `Permissive`), explicit resource limits
-(font/table size, table count, `cmap` subtable count, composite-glyph depth/component/point
-budgets), and stream-ownership (`LeaveOpen`). Strict mode rejects any structural anomaly by throwing
-`FontParseException`; permissive mode records `FontDiagnostic`s on `TrueTypeFont.Diagnostics` and
-continues whenever doing so remains memory-safe -- resource-limit violations always throw in both
-modes. Fonts that previously loaded silently despite duplicate table tags, checksum mismatches,
-malformed `cmap` subtables, or out-of-range composite glyph references now fail fast by default;
-pass `FontValidationMode.Permissive` to restore a best-effort parse. `TrueTypeFontParsingOptions.MaximumFontBytes`
-defaults to 64 MiB and cannot be configured above `uint.MaxValue` (4 GiB) -- SFNT table
-offsets/lengths are themselves unsigned 32-bit fields, so this library never supports a larger font
-regardless of this setting; a value above that ceiling throws `ArgumentOutOfRangeException`
-immediately when constructing the options.
-
-Several `short`-typed members were widened to their correct unsigned/wider wire type and are 2.0
-breaks requiring recompilation: see the "Second audit pass" entry under
-[`omy.Utils.Fonts`](AcceptedApiBreaks.md#omy-utils-fonts) for the full list, including the
-`GlyphCompound.getGlyphIndex` → `GetGlyphIndex` rename and the `CmapTable.CMaps`/
-`GlyphCompound.Instructions` immutability changes.

--- a/docs/releasing/MigrationTo2.0.md
+++ b/docs/releasing/MigrationTo2.0.md
@@ -34,3 +34,7 @@ Runtime reader converters require an exact result type. A converter returning an
 Version 2.0 removes declaration order as an implicit tie-breaker. Add `priority="100"` (or another intentional signed `xs:int` value) when compatible rules have equal canonical specificity. Ordinal variants and trigger forms select the greatest specificity and then greatest priority. Cumulative variants apply the least specific and lowest-priority rules first.
 
 Programmatic trigger forms must migrate from `(Constraints, To)` tuples to `NumberToStringConverter.TriggerReplacementForm`. `VariantRule` and `OrdinalVariantRule` constructors accept an optional final `priority` argument. Configurations inherited through `baseOn` retain parent priorities; parent and child candidates are validated together and no implicit override occurs.
+
+## omy.Utils.Net protocol clients
+
+Use `SmtpPath` and `SmtpMailOptions` for SMTP envelopes, handle `ProtocolResponseException` for negative responses, and recreate a client after `ProtocolSessionPoisonedException`. POP3 STAT sizes are `long`; NNTP `NewNewsAsync` returns message-id strings; and `NextAsync` returns null only for response 421. Prefer the new `TextReader`/`TextWriter` streaming overloads for large payloads.

--- a/eng/api-breaking-changes/2.0.0.json
+++ b/eng/api-breaking-changes/2.0.0.json
@@ -840,6 +840,13 @@
           "reason": "The published member is deliberately absent or signature-incompatible in the 2.0 candidate and is retained as an enumerated major-version break.",
           "migrationSection": "docs/releasing/AcceptedApiBreaks.md#omy-utils-net"
         }
+      ],
+      "declaredBreakingChanges": [
+        "POP3 STAT mailbox sizes now use long and malformed mandatory fields throw ProtocolResponseException.",
+        "POP3 UIDL single-message success no longer returns null for malformed responses.",
+        "NNTP NEWNEWS now returns message-id strings rather than artificial integers.",
+        "NNTP NEXT returns null only for 421 and throws ProtocolResponseException for other failures.",
+        "SMTP envelope strings are parsed as strict SmtpPath values and protocol failures are structured."
       ]
     },
     {

--- a/eng/api-breaking-changes/2.0.0.json
+++ b/eng/api-breaking-changes/2.0.0.json
@@ -844,7 +844,7 @@
       "declaredBreakingChanges": [
         "POP3 STAT mailbox sizes now use long and malformed mandatory fields throw ProtocolResponseException.",
         "POP3 UIDL single-message success no longer returns null for malformed responses.",
-        "NNTP NEWNEWS now returns message-id strings rather than artificial integers.",
+        "NNTP NEWNEWS now returns message-id strings rather than artificial integers. and INntpArticleStore.ListNewsSinceAsync supplies those message IDs.",
         "NNTP NEXT returns null only for 421 and throws ProtocolResponseException for other failures.",
         "SMTP envelope strings are parsed as strict SmtpPath values and protocol failures are structured."
       ]


### PR DESCRIPTION
### Motivation
- Harden command/response protocols so a single exchange exclusively owns the connection and no incomplete body can contaminate a subsequent command.  
- Make multiline framing and limits strict and fail-closed to avoid session desynchronisation.  
- Replace opaque `IOException` failures with a structured protocol exception carrying code, severity and an immutable response snapshot.  
- Add typed SMTP envelope and SASL models and streaming APIs to avoid materializing large payloads and to eliminate address/credential injection risks.

### Description
- Implemented an exclusive exchange primitive: `ExecuteExclusiveExchangeAsync` and `ProtocolExchangeContext` to own `_sendLock` for a full exchange (status + optional dot-terminated body) and to provide safe write/read helpers. (see `CommandResponseClient.cs`)  
- Introduced session poison semantics and state (`PoisonSession`, `ProtocolSessionPoisonedException` and `SessionFailure`) so framing loss, consumer errors, EOF, limit overruns or cancellation after body start mark the session unusable and propagate the original cause. (see `CommandResponseClient.cs`, `ProtocolExceptions.cs`)  
- Added structured protocol exceptions: `ProtocolResponseException` with protocol, sanitized command verb, final response code/severity and an immutable copy of all responses; plus helpers `ProtocolResponseValidator`. (see `ProtocolExceptions.cs`)  
- Made multiline exchanges streaming and bounded: `ProtocolPayloadLimits`, `StreamMultilineCommandAsync`, `UnstuffDotLine`, and streaming wrappers for POP3/NNTP and SMTP (`RetrieveAsync(TextWriter)`, `ArticleAsync/HeaderAsync/BodyAsync(TextWriter)`, `SendMailAsync` overloads that accept `TextReader`/`Stream`). Dot terminator is exact `.` and only `..` is unstuffed. Limits check lines, UTF-16 characters and UTF-8 bytes. (see `ProtocolPayloadLimits.cs`, `CommandResponseClient.cs`, `Pop3Client.cs`, `NntpClient.cs`, `SmtpClient.cs`)  
- Added typed SMTP models and SASL credentials: `SmtpPath`, `SmtpMailOptions`, `SmtpPlainCredentials`, `SmtpBodyKind`, and `SmtpTransactionException` with bounded `RSET` recovery during transaction failures; AUTH uses strict UTF-8 and LOGIN is held exclusive. Validation and ESMTP parameters are separated from mailbox values. (see `SmtpModels.cs`, `SmtpClient.cs`)  
- Tightened POP3/NNTP parsing: `STAT`, `LIST`, `UIDL`, `GROUP`, `NEXT` and `NEWNEWS` are parsed strictly, malformed rows invalidate the response, `STAT` mailbox size uses `long`, `NEWNEWS` returns message-IDs (strings), and `NextAsync` returns `null` only for the specific NNTP `421` code. (see `Pop3Client.cs`, `NntpClient.cs`)  
- Tests and documentation: added `ProtocolHardeningTests` exercising SMTP paths, SASL NUL rejection, and payload limits; updated `Utils.Net/TODO` -> `DONE-2026-08-04.md`, `CHANGELOG.md`, `Utils.Net/README.md`, migration and release docs, and recorded accepted API breaks in `eng/api-breaking-changes/2.0.0.json`.

### Testing
- Restored and built the solution with `dotnet restore` and `dotnet build` in `Release` configuration and the `Utils.Net` project compiles successfully.  
- Ran the unit test subset for network code with `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter "FullyQualifiedName~Net"`; the Net-focused unit tests passed after fixes.  
- Ran the functional Net-focused tests with `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --filter "FullyQualifiedName~Net"`; the targeted functional tests executed (no external servers contacted) and completed in this environment.  
- Performed `git diff --check` and JSON validation of `eng/api-breaking-changes/2.0.0.json`; both succeeded.  
- Not run here: PowerShell-based `eng/test-api-compat.ps1` because `pwsh` is not available in this environment, and full packaged Windows/Ubuntu package validation is expected to run in CI.  

Files changed (high level): `CommandResponseClient.cs`, `SmtpClient.cs`, `Pop3Client.cs`, `NntpClient.cs`, added `ProtocolExceptions.cs`, `ProtocolPayloadLimits.cs`, `SmtpModels.cs`, unit tests `ProtocolHardeningTests.cs`, docs (`Utils.Net/README.md`, migration/releasing docs), `CHANGELOG.md` and updated `eng/api-breaking-changes/2.0.0.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71fc10ab848326b40c548df89d9b01)