### PR TITLE
Enforce immutability for public Parser models (defensive snapshots)

### DIFF
--- a/Utils.Parser.Antlr4.Common/Antlr4OptionSet.cs
+++ b/Utils.Parser.Antlr4.Common/Antlr4OptionSet.cs
@@ -1,7 +1,19 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Antlr4.Common;
 
 /// <summary>
 /// Represents ANTLR4 grammar options declared in an <c>options { ... }</c> prequel block.
 /// </summary>
-/// <param name="Values">Option key/value pairs using ANTLR identifier keys.</param>
-public sealed record Antlr4OptionSet(IReadOnlyDictionary<string, string> Values);
+/// <param name="Values">Option key/value pairs using ordinal ANTLR identifier keys.</param>
+public sealed record Antlr4OptionSet(IReadOnlyDictionary<string, string> Values)
+{
+    private IReadOnlyDictionary<string, string> _values = Values.ToImmutableDictionary(StringComparer.Ordinal);
+
+    /// <summary>Gets an immutable ordinal snapshot of option key/value pairs.</summary>
+    public IReadOnlyDictionary<string, string> Values
+    {
+        get => _values;
+        init => _values = value.ToImmutableDictionary(StringComparer.Ordinal);
+    }
+}

--- a/Utils.Parser.Antlr4.Common/Antlr4PrequelModel.cs
+++ b/Utils.Parser.Antlr4.Common/Antlr4PrequelModel.cs
@@ -1,15 +1,8 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Antlr4.Common;
 
-/// <summary>
-/// Shared model for ANTLR4 grammar prequel metadata.
-/// </summary>
-/// <param name="Options">Optional grammar options block metadata.</param>
-/// <param name="Imports">Imported grammar metadata entries in source order.</param>
-/// <param name="Actions">Grammar actions in source order.</param>
-/// <param name="DeclaredTokens">Declared tokens from <c>tokens { ... }</c> blocks.</param>
-/// <param name="DeclaredChannels">Declared channels from <c>channels { ... }</c> blocks.</param>
-/// <param name="HasTokensBlock"><c>true</c> when a <c>tokens { ... }</c> block was parsed, including empty blocks.</param>
-/// <param name="HasChannelsBlock"><c>true</c> when a <c>channels { ... }</c> block was parsed, including default-only blocks.</param>
+/// <summary>Shared model for ANTLR4 grammar prequel metadata.</summary>
 public sealed record Antlr4PrequelModel(
     Antlr4OptionSet? Options,
     IReadOnlyList<Antlr4ImportInfo> Imports,
@@ -17,4 +10,38 @@ public sealed record Antlr4PrequelModel(
     IReadOnlyCollection<string> DeclaredTokens,
     IReadOnlyCollection<string> DeclaredChannels,
     bool HasTokensBlock = false,
-    bool HasChannelsBlock = false);
+    bool HasChannelsBlock = false)
+{
+    private IReadOnlyList<Antlr4ImportInfo> _imports = Imports.ToImmutableArray();
+    private IReadOnlyList<Antlr4ActionInfo> _actions = Actions.ToImmutableArray();
+    private IReadOnlyCollection<string> _declaredTokens = DeclaredTokens.ToImmutableHashSet(StringComparer.Ordinal);
+    private IReadOnlyCollection<string> _declaredChannels = DeclaredChannels.ToImmutableHashSet(StringComparer.Ordinal);
+
+    /// <summary>Gets an immutable snapshot of imports in source order.</summary>
+    public IReadOnlyList<Antlr4ImportInfo> Imports
+    {
+        get => _imports;
+        init => _imports = value.ToImmutableArray();
+    }
+
+    /// <summary>Gets an immutable snapshot of actions in source order.</summary>
+    public IReadOnlyList<Antlr4ActionInfo> Actions
+    {
+        get => _actions;
+        init => _actions = value.ToImmutableArray();
+    }
+
+    /// <summary>Gets the immutable ordinal set of declared tokens.</summary>
+    public IReadOnlyCollection<string> DeclaredTokens
+    {
+        get => _declaredTokens;
+        init => _declaredTokens = value.ToImmutableHashSet(StringComparer.Ordinal);
+    }
+
+    /// <summary>Gets the immutable ordinal set of declared channels.</summary>
+    public IReadOnlyCollection<string> DeclaredChannels
+    {
+        get => _declaredChannels;
+        init => _declaredChannels = value.ToImmutableHashSet(StringComparer.Ordinal);
+    }
+}

--- a/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelValidationResult.cs
+++ b/Utils.Parser.Antlr4.Common/Diagnostics/Antlr4PrequelValidationResult.cs
@@ -1,8 +1,16 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Antlr4.Common.Diagnostics;
 
-/// <summary>
-/// Holds neutral validation facts derived from an ANTLR4 prequel model.
-/// </summary>
-/// <param name="Diagnostics">Validation facts in deterministic emission order.</param>
-public sealed record Antlr4PrequelValidationResult(
-    IReadOnlyList<Antlr4PrequelDiagnostic> Diagnostics);
+/// <summary>Holds neutral validation facts derived from an ANTLR4 prequel model.</summary>
+public sealed record Antlr4PrequelValidationResult(IReadOnlyList<Antlr4PrequelDiagnostic> Diagnostics)
+{
+    private IReadOnlyList<Antlr4PrequelDiagnostic> _diagnostics = Diagnostics.ToImmutableArray();
+
+    /// <summary>Gets an immutable snapshot of diagnostics in deterministic emission order.</summary>
+    public IReadOnlyList<Antlr4PrequelDiagnostic> Diagnostics
+    {
+        get => _diagnostics;
+        init => _diagnostics = value.ToImmutableArray();
+    }
+}

--- a/Utils.Parser.Antlr4.Common/Utils.Parser.Antlr4.Common.csproj
+++ b/Utils.Parser.Antlr4.Common/Utils.Parser.Antlr4.Common.csproj
@@ -21,6 +21,10 @@
         <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
+    <ItemGroup>
+        <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    </ItemGroup>
+
 
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/Utils.Parser/Model/GrammarExtensionBinding.cs
+++ b/Utils.Parser/Model/GrammarExtensionBinding.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Model;
 
 /// <summary>
@@ -5,6 +7,10 @@ namespace Utils.Parser.Model;
 /// </summary>
 public sealed record GrammarExtensionBinding
 {
+    private IReadOnlySet<string> _lexerRuleNames = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.Ordinal);
+    private IReadOnlySet<string> _declaredTokens = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.Ordinal);
+    private IReadOnlySet<string> _declaredChannels = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.Ordinal);
+
     /// <summary>Grammar name declaring the binding.</summary>
     public string GrammarName { get; init; } = string.Empty;
 
@@ -14,12 +20,24 @@ public sealed record GrammarExtensionBinding
     /// <summary>Name of the declared ANTLR <c>superClass</c>.</summary>
     public string SuperClassName { get; init; } = string.Empty;
 
-    /// <summary>Lexer rules declared by the grammar owning the binding.</summary>
-    public IReadOnlySet<string> LexerRuleNames { get; init; } = new HashSet<string>(StringComparer.Ordinal);
+    /// <summary>Gets an immutable ordinal set of lexer rules declared by the grammar.</summary>
+    public IReadOnlySet<string> LexerRuleNames
+    {
+        get => _lexerRuleNames;
+        init => _lexerRuleNames = value.ToImmutableHashSet(StringComparer.Ordinal);
+    }
 
-    /// <summary>Tokens declared in <c>tokens { ... }</c>.</summary>
-    public IReadOnlySet<string> DeclaredTokens { get; init; } = new HashSet<string>(StringComparer.Ordinal);
+    /// <summary>Gets an immutable ordinal set of declared tokens.</summary>
+    public IReadOnlySet<string> DeclaredTokens
+    {
+        get => _declaredTokens;
+        init => _declaredTokens = value.ToImmutableHashSet(StringComparer.Ordinal);
+    }
 
-    /// <summary>Channels declared in <c>channels { ... }</c>.</summary>
-    public IReadOnlySet<string> DeclaredChannels { get; init; } = new HashSet<string>(StringComparer.Ordinal);
+    /// <summary>Gets an immutable ordinal set of declared channels.</summary>
+    public IReadOnlySet<string> DeclaredChannels
+    {
+        get => _declaredChannels;
+        init => _declaredChannels = value.ToImmutableHashSet(StringComparer.Ordinal);
+    }
 }

--- a/Utils.Parser/Model/GrammarMeta.cs
+++ b/Utils.Parser/Model/GrammarMeta.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Model;
 
 /// <summary>
@@ -17,7 +19,17 @@ public enum GrammarType
 /// Represents the key/value pairs declared in an <c>options { ... }</c> block,
 /// such as <c>tokenVocab=MyLexer</c> or <c>superClass=MyBase</c>.
 /// </summary>
-public record GrammarOptions(IReadOnlyDictionary<string, string> Values);
+public record GrammarOptions(IReadOnlyDictionary<string, string> Values)
+{
+    private IReadOnlyDictionary<string, string> _values = Values.ToImmutableDictionary(StringComparer.Ordinal);
+
+    /// <summary>Gets an immutable ordinal snapshot of grammar option values.</summary>
+    public IReadOnlyDictionary<string, string> Values
+    {
+        get => _values;
+        init => _values = value.ToImmutableDictionary(StringComparer.Ordinal);
+    }
+}
 
 /// <summary>
 /// Represents normalized and runtime-consumable grammar options.

--- a/Utils.Parser/Model/LeftRecursiveRuleInfo.cs
+++ b/Utils.Parser/Model/LeftRecursiveRuleInfo.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Model;
 
 /// <summary>
@@ -6,17 +8,23 @@ namespace Utils.Parser.Model;
 /// </summary>
 public sealed record LeftRecursiveRuleInfo
 {
+    private IReadOnlyList<Alternative> _baseAlternatives = ImmutableArray<Alternative>.Empty;
+    private IReadOnlyList<Alternative> _recursiveAlternatives = ImmutableArray<Alternative>.Empty;
+
     /// <summary>Gets the parser rule described by this entry.</summary>
     public required Rule Rule { get; init; }
 
-    /// <summary>
-    /// Gets alternatives that do not start with the rule itself and can be used
-    /// as initial seed nodes.
-    /// </summary>
-    public required IReadOnlyList<Alternative> BaseAlternatives { get; init; }
+    /// <summary>Gets an immutable snapshot of alternatives usable as initial seed nodes.</summary>
+    public required IReadOnlyList<Alternative> BaseAlternatives
+    {
+        get => _baseAlternatives;
+        init => _baseAlternatives = value.ToImmutableArray();
+    }
 
-    /// <summary>
-    /// Gets direct left-recursive alternatives that start with the rule itself.
-    /// </summary>
-    public required IReadOnlyList<Alternative> RecursiveAlternatives { get; init; }
+    /// <summary>Gets an immutable snapshot of direct left-recursive alternatives.</summary>
+    public required IReadOnlyList<Alternative> RecursiveAlternatives
+    {
+        get => _recursiveAlternatives;
+        init => _recursiveAlternatives = value.ToImmutableArray();
+    }
 }

--- a/Utils.Parser/Model/LexerMode.cs
+++ b/Utils.Parser/Model/LexerMode.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Model;
 
 /// <summary>
@@ -12,4 +14,15 @@ public record LexerMode(
     string Name,
     /// <summary>Lexer rules belonging to this mode, ordered by declaration order.</summary>
     IReadOnlyList<Rule> Rules
-);
+)
+{
+    /// <summary>Stores the immutable ordered snapshot of lexer rules.</summary>
+    private IReadOnlyList<Rule> _rules = Rules.ToImmutableArray();
+
+    /// <summary>Gets the immutable ordered snapshot of lexer rules.</summary>
+    public IReadOnlyList<Rule> Rules
+    {
+        get => _rules;
+        init => _rules = value.ToImmutableArray();
+    }
+}

--- a/Utils.Parser/Model/ParserDefinition.cs
+++ b/Utils.Parser/Model/ParserDefinition.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 
 namespace Utils.Parser.Model;
 
@@ -45,6 +47,46 @@ public record ParserDefinition(
     Rule? RootRule
 )
 {
+    /// <summary>Top-level action blocks captured as an immutable snapshot.</summary>
+    private IReadOnlyList<GrammarAction> _actions = Actions.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of top-level action blocks.</summary>
+    public IReadOnlyList<GrammarAction> Actions
+    {
+        get => _actions;
+        init => _actions = value.ToImmutableArray();
+    }
+
+    /// <summary>Grammar imports captured as an immutable snapshot.</summary>
+    private IReadOnlyList<GrammarImport> _imports = Imports.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of grammar imports.</summary>
+    public IReadOnlyList<GrammarImport> Imports
+    {
+        get => _imports;
+        init => _imports = value.ToImmutableArray();
+    }
+
+    /// <summary>Lexer modes captured as an immutable snapshot.</summary>
+    private IReadOnlyList<LexerMode> _modes = Modes.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of lexer modes.</summary>
+    public IReadOnlyList<LexerMode> Modes
+    {
+        get => _modes;
+        init => _modes = value.ToImmutableArray();
+    }
+
+    /// <summary>Parser rules captured as an immutable snapshot.</summary>
+    private IReadOnlyList<Rule> _parserRules = ParserRules.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of parser rules.</summary>
+    public IReadOnlyList<Rule> ParserRules
+    {
+        get => _parserRules;
+        init => _parserRules = value.ToImmutableArray();
+    }
+
     /// <summary>
     /// Backward-compatible constructor used by generated code that does not provide extension metadata.
     /// </summary>
@@ -73,16 +115,37 @@ public record ParserDefinition(
     }
 
     /// <summary>Token names declared in optional <c>tokens { ... }</c> blocks.</summary>
-    public IReadOnlySet<string> DeclaredTokens { get; init; } =
-        DeclaredTokens ?? new HashSet<string>(StringComparer.Ordinal);
+    private IReadOnlySet<string> _declaredTokens =
+        (DeclaredTokens ?? Enumerable.Empty<string>()).ToImmutableHashSet(StringComparer.Ordinal);
+
+    /// <summary>Gets the immutable ordinal set of declared tokens.</summary>
+    public IReadOnlySet<string> DeclaredTokens
+    {
+        get => _declaredTokens;
+        init => _declaredTokens = (value ?? Enumerable.Empty<string>()).ToImmutableHashSet(StringComparer.Ordinal);
+    }
 
     /// <summary>Channel names declared in optional <c>channels { ... }</c> blocks.</summary>
-    public IReadOnlySet<string> DeclaredChannels { get; init; } =
-        DeclaredChannels ?? new HashSet<string>(StringComparer.Ordinal);
+    private IReadOnlySet<string> _declaredChannels =
+        (DeclaredChannels ?? Enumerable.Empty<string>()).ToImmutableHashSet(StringComparer.Ordinal);
+
+    /// <summary>Gets the immutable ordinal set of declared channels.</summary>
+    public IReadOnlySet<string> DeclaredChannels
+    {
+        get => _declaredChannels;
+        init => _declaredChannels = (value ?? Enumerable.Empty<string>()).ToImmutableHashSet(StringComparer.Ordinal);
+    }
 
     /// <summary>Grammar-superClass extension bindings discovered during compilation.</summary>
-    public IReadOnlyList<GrammarExtensionBinding> ExtensionBindings { get; init; } =
-        ExtensionBindings ?? [];
+    private IReadOnlyList<GrammarExtensionBinding> _extensionBindings =
+        (ExtensionBindings ?? []).ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of extension bindings.</summary>
+    public IReadOnlyList<GrammarExtensionBinding> ExtensionBindings
+    {
+        get => _extensionBindings;
+        init => _extensionBindings = (value ?? []).ToImmutableArray();
+    }
 
     /// <summary>
     /// Normalized effective options derived from <see cref="Options"/> and <see cref="Type"/>.
@@ -99,13 +162,27 @@ public record ParserDefinition(
     /// Flat lookup of all rules (both lexer and parser) by name.
     /// Populated during the resolution pass by <c>RuleResolver.Resolve</c>.
     /// </summary>
-    public IReadOnlyDictionary<string, Rule> AllRules { get; init; }
-        = new Dictionary<string, Rule>();
+    private IReadOnlyDictionary<string, Rule> _allRules =
+        ImmutableDictionary<string, Rule>.Empty.WithComparers(StringComparer.Ordinal);
+
+    /// <summary>Gets the immutable ordinal lookup of all rules.</summary>
+    public IReadOnlyDictionary<string, Rule> AllRules
+    {
+        get => _allRules;
+        init => _allRules = value.ToImmutableDictionary(StringComparer.Ordinal);
+    }
 
     /// <summary>
     /// Lookup table of direct left-recursive parser rules computed during
     /// resolution.
     /// </summary>
-    public IReadOnlyDictionary<string, LeftRecursiveRuleInfo> LeftRecursiveRules { get; init; }
-        = new Dictionary<string, LeftRecursiveRuleInfo>();
+    private IReadOnlyDictionary<string, LeftRecursiveRuleInfo> _leftRecursiveRules =
+        ImmutableDictionary<string, LeftRecursiveRuleInfo>.Empty.WithComparers(StringComparer.Ordinal);
+
+    /// <summary>Gets the immutable ordinal lookup of left-recursive rules.</summary>
+    public IReadOnlyDictionary<string, LeftRecursiveRuleInfo> LeftRecursiveRules
+    {
+        get => _leftRecursiveRules;
+        init => _leftRecursiveRules = value.ToImmutableDictionary(StringComparer.Ordinal);
+    }
 }

--- a/Utils.Parser/Model/Rule.cs
+++ b/Utils.Parser/Model/Rule.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Model;
 
 /// <summary>
@@ -20,7 +22,18 @@ public enum RuleKind
 /// Key/value options attached to an individual rule:
 /// <c>options { greedy=false; }</c>.
 /// </summary>
-public record RuleOptions(IReadOnlyDictionary<string, string> Values);
+public record RuleOptions(IReadOnlyDictionary<string, string> Values)
+{
+    /// <summary>Gets an immutable snapshot of the rule option values.</summary>
+    private IReadOnlyDictionary<string, string> _values = Values.ToImmutableDictionary(StringComparer.Ordinal);
+
+    /// <summary>Gets an immutable snapshot of the rule option values.</summary>
+    public IReadOnlyDictionary<string, string> Values
+    {
+        get => _values;
+        init => _values = value.ToImmutableDictionary(StringComparer.Ordinal);
+    }
+}
 
 /// <summary>
 /// A typed parameter declared on a parser rule:
@@ -72,7 +85,28 @@ public record RuleExceptionMetadata(
     IReadOnlyList<RuleCatchClause> CatchClauses,
     /// <summary>Raw finally action body, or <c>null</c> when absent.</summary>
     string? FinallyAction
-);
+)
+{
+    /// <summary>Stores the immutable snapshot of declared exception names.</summary>
+    private IReadOnlyList<string> _throws = Throws.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of declared exception names.</summary>
+    public IReadOnlyList<string> Throws
+    {
+        get => _throws;
+        init => _throws = value.ToImmutableArray();
+    }
+
+    /// <summary>Stores the immutable snapshot of declared catch clauses.</summary>
+    private IReadOnlyList<RuleCatchClause> _catchClauses = CatchClauses.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of declared catch clauses.</summary>
+    public IReadOnlyList<RuleCatchClause> CatchClauses
+    {
+        get => _catchClauses;
+        init => _catchClauses = value.ToImmutableArray();
+    }
+}
 
 /// <summary>
 /// A single grammar rule — either a lexer rule (upper-case name by convention)
@@ -113,4 +147,35 @@ public record Rule(
     IReadOnlyList<RuleLocal>? Locals = null,
     /// <summary>Rule-level exception metadata preserved as passive metadata, or <c>null</c> when absent.</summary>
     RuleExceptionMetadata? ExceptionMetadata = null
-);
+)
+{
+    /// <summary>Stores the immutable snapshot of parameters, or <c>null</c> when absent.</summary>
+    private IReadOnlyList<RuleParameter>? _parameters = Parameters?.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of parameters, or <c>null</c> when absent.</summary>
+    public IReadOnlyList<RuleParameter>? Parameters
+    {
+        get => _parameters;
+        init => _parameters = value?.ToImmutableArray();
+    }
+
+    /// <summary>Stores the immutable snapshot of returns, or <c>null</c> when absent.</summary>
+    private IReadOnlyList<RuleReturn>? _returns = Returns?.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of returns, or <c>null</c> when absent.</summary>
+    public IReadOnlyList<RuleReturn>? Returns
+    {
+        get => _returns;
+        init => _returns = value?.ToImmutableArray();
+    }
+
+    /// <summary>Stores the immutable snapshot of locals, or <c>null</c> when absent.</summary>
+    private IReadOnlyList<RuleLocal>? _locals = Locals?.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of locals, or <c>null</c> when absent.</summary>
+    public IReadOnlyList<RuleLocal>? Locals
+    {
+        get => _locals;
+        init => _locals = value?.ToImmutableArray();
+    }
+}

--- a/Utils.Parser/Model/RuleContent.cs
+++ b/Utils.Parser/Model/RuleContent.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Model;
 
 /// <summary>
@@ -43,7 +45,18 @@ public record CharSetMatch(
     IReadOnlySet<char> Chars,
     /// <summary><c>true</c> when the <c>^</c> negation prefix is present.</summary>
     bool Negated
-) : TokenizerContent;
+) : TokenizerContent
+{
+    /// <summary>Stores the immutable character set captured at construction time.</summary>
+    private IReadOnlySet<char> _chars = Chars.ToImmutableHashSet();
+
+    /// <summary>Gets the immutable character set captured at construction time.</summary>
+    public IReadOnlySet<char> Chars
+    {
+        get => _chars;
+        init => _chars = value.ToImmutableHashSet();
+    }
+}
 
 /// <summary>
 /// Matches any single character (the <c>.</c> wildcard in lexer rules).
@@ -200,7 +213,18 @@ public record EmbeddedAction(
     ActionPosition Position,
     /// <summary>Label references extracted from <see cref="RawCode"/>.</summary>
     IReadOnlyList<LabelRef> Labels
-) : RuleContent;
+) : RuleContent
+{
+    /// <summary>Stores the immutable snapshot of label references.</summary>
+    private IReadOnlyList<LabelRef> _labels = Labels.ToImmutableArray();
+
+    /// <summary>Gets the immutable snapshot of label references.</summary>
+    public IReadOnlyList<LabelRef> Labels
+    {
+        get => _labels;
+        init => _labels = value.ToImmutableArray();
+    }
+}
 
 /// <summary>
 /// A structured lexer command such as <c>-> skip</c>, <c>-> channel(HIDDEN)</c>,
@@ -241,7 +265,18 @@ public enum LexerCommandType
 /// <summary>
 /// An ordered sequence of grammar elements that must all match in order: <c>A B C</c>.
 /// </summary>
-public record Sequence(IReadOnlyList<RuleContent> Items) : RuleContent;
+public record Sequence(IReadOnlyList<RuleContent> Items) : RuleContent
+{
+    /// <summary>Stores the immutable ordered snapshot of sequence items.</summary>
+    private IReadOnlyList<RuleContent> _items = Items.ToImmutableArray();
+
+    /// <summary>Gets the immutable ordered snapshot of sequence items.</summary>
+    public IReadOnlyList<RuleContent> Items
+    {
+        get => _items;
+        init => _items = value.ToImmutableArray();
+    }
+}
 
 /// <summary>
 /// A quantified repetition: <c>*</c>, <c>+</c>, <c>?</c>, or <c>{n,m}</c>.
@@ -284,7 +319,18 @@ public record Alternative(
 /// A set of mutually exclusive alternatives: <c>A | B | C</c>.
 /// This is the top-level content of every <see cref="Rule"/>.
 /// </summary>
-public record Alternation(IReadOnlyList<Alternative> Alternatives) : RuleContent;
+public record Alternation(IReadOnlyList<Alternative> Alternatives) : RuleContent
+{
+    /// <summary>Stores the immutable ordered snapshot of alternatives.</summary>
+    private IReadOnlyList<Alternative> _alternatives = Alternatives.ToImmutableArray();
+
+    /// <summary>Gets the immutable ordered snapshot of alternatives.</summary>
+    public IReadOnlyList<Alternative> Alternatives
+    {
+        get => _alternatives;
+        init => _alternatives = value.ToImmutableArray();
+    }
+}
 
 /// <summary>
 /// Left/right/no associativity for an alternative, used when resolving

--- a/Utils.Parser/ROADMAP.md
+++ b/Utils.Parser/ROADMAP.md
@@ -81,6 +81,7 @@ Current capabilities and responsibilities:
 - ANTLR4 grammar bootstrap/conversion support is present.
 - Syntax colorisation descriptor DTO public contracts are hardened to read-only collection exposure (`IReadOnlyList<T>`), with mutation remaining internal to parser conversion flow.
 - Visual Studio syntax colorization descriptor DTO public contracts are hardened to read-only collection exposure (`IReadOnlyList<T>`), with descriptor-population mutation remaining internal to conversion flow.
+- Public structural grammar, parse-tree, and ANTLR prequel model collections capture immutable construction-time snapshots while preserving their existing read-only interface contracts, ordering, null normalization, and ordinal name comparison.
 - `Rule.Kind` is now an immutable part of the public `Rule` record; mutable resolution state is kept inside internal `RuleResolutionBuilder` instances so `RuleResolver` produces final resolved rule projections without mutating public rule objects in place.
 - Runtime invariant documentation exists.
 - Branch outcome documentation exists.

--- a/Utils.Parser/Runtime/ParseNode.cs
+++ b/Utils.Parser/Runtime/ParseNode.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Utils.Parser.Model;
 using Utils.Parser.Source;
 
@@ -43,7 +44,18 @@ public record ParserNode(
     Rule Rule,
     /// <summary>Ordered list of child nodes matched by this rule's alternative.</summary>
     IReadOnlyList<ParseNode> Children
-) : ParseNode(Span, ModeName, Rule);
+) : ParseNode(Span, ModeName, Rule)
+{
+    /// <summary>Stores the immutable child snapshot.</summary>
+    private IReadOnlyList<ParseNode> _children = Children.ToImmutableArray();
+
+    /// <summary>Gets the immutable ordered snapshot of child nodes.</summary>
+    public virtual IReadOnlyList<ParseNode> Children
+    {
+        get => _children;
+        init => _children = value.ToImmutableArray();
+    }
+}
 
 /// <summary>
 /// A synthetic wrapper node produced by a quantifier (<c>?</c>, <c>*</c>, <c>+</c>)
@@ -67,7 +79,18 @@ public record QuantifierNode(
     Rule Rule,
     /// <summary>One child per matched repetition of the quantifier body.</summary>
     IReadOnlyList<ParseNode> Children
-) : ParserNode(Span, ModeName, Rule, Children);
+) : ParserNode(Span, ModeName, Rule, Children)
+{
+    /// <summary>Stores the immutable repetition child snapshot.</summary>
+    private IReadOnlyList<ParseNode> _children = Children.ToImmutableArray();
+
+    /// <summary>Gets the immutable ordered snapshot of repetition children.</summary>
+    public override IReadOnlyList<ParseNode> Children
+    {
+        get => _children;
+        init => _children = value.ToImmutableArray();
+    }
+}
 
 /// <summary>
 /// A synthetic node inserted when parsing fails at a given position.

--- a/Utils.Parser/Runtime/ParseNode.cs
+++ b/Utils.Parser/Runtime/ParseNode.cs
@@ -55,6 +55,30 @@ public record ParserNode(
         get => _children;
         init => _children = value.ToImmutableArray();
     }
+
+    /// <summary>Determines whether another parser node has the same value and ordered children.</summary>
+    /// <param name="other">The parser node to compare with this instance.</param>
+    /// <returns><see langword="true"/> when the node values and ordered children are equal; otherwise, <see langword="false"/>.</returns>
+    public virtual bool Equals(ParserNode? other)
+    {
+        return other is not null
+            && base.Equals(other)
+            && Children.SequenceEqual(other.Children);
+    }
+
+    /// <summary>Returns a hash code based on the node value and its ordered children.</summary>
+    /// <returns>A hash code for this parser node.</returns>
+    public override int GetHashCode()
+    {
+        HashCode hash = new();
+        hash.Add(base.GetHashCode());
+        foreach (ParseNode child in Children)
+        {
+            hash.Add(child);
+        }
+
+        return hash.ToHashCode();
+    }
 }
 
 /// <summary>
@@ -79,18 +103,7 @@ public record QuantifierNode(
     Rule Rule,
     /// <summary>One child per matched repetition of the quantifier body.</summary>
     IReadOnlyList<ParseNode> Children
-) : ParserNode(Span, ModeName, Rule, Children)
-{
-    /// <summary>Stores the immutable repetition child snapshot.</summary>
-    private IReadOnlyList<ParseNode> _children = Children.ToImmutableArray();
-
-    /// <summary>Gets the immutable ordered snapshot of repetition children.</summary>
-    public override IReadOnlyList<ParseNode> Children
-    {
-        get => _children;
-        init => _children = value.ToImmutableArray();
-    }
-}
+) : ParserNode(Span, ModeName, Rule, Children);
 
 /// <summary>
 /// A synthetic node inserted when parsing fails at a given position.

--- a/Utils.Parser/TODO-immutability.md
+++ b/Utils.Parser/TODO-immutability.md
@@ -136,6 +136,17 @@ Pour chaque type corrigé :
 
 ## `ParserDefinition`
 
+**Status: DONE (first tranche).**
+
+**Resolution:** External collections are normalized at construction and in collection `init` setters into immutable snapshots; ordinal comparers and source order are preserved.
+
+**Files:** Public model files in `Utils.Parser/Model`, `Utils.Parser/Runtime/ParseNode.cs`, and `Utils.Parser.Antlr4.Common`.
+
+**Tests:** `UtilsTest/Parser/ParserModelImmutabilityTests.cs` covers source mutation, mutable-type recasts, and `with`/object-initializer normalization.
+
+**API impact:** Existing collection interface signatures and record construction patterns are retained; `init` assignments now normalize rather than retain the assigned instance.
+
+
 Le type est explicitement documenté comme une description immutable de la grammaire.
 
 Auditer et corriger au minimum :
@@ -177,6 +188,17 @@ Si nécessaire, remplacer certaines propriétés `init` par une construction con
 
 ## `Rule` et métadonnées associées
 
+**Status: DONE (first tranche).**
+
+**Resolution:** External collections are normalized at construction and in collection `init` setters into immutable snapshots; ordinal comparers and source order are preserved.
+
+**Files:** Public model files in `Utils.Parser/Model`, `Utils.Parser/Runtime/ParseNode.cs`, and `Utils.Parser.Antlr4.Common`.
+
+**Tests:** `UtilsTest/Parser/ParserModelImmutabilityTests.cs` covers source mutation, mutable-type recasts, and `with`/object-initializer normalization.
+
+**API impact:** Existing collection interface signatures and record construction patterns are retained; `init` assignments now normalize rather than retain the assigned instance.
+
+
 ### `Rule`
 
 Auditer et corriger au minimum :
@@ -211,6 +233,17 @@ vers un dictionnaire immutable préservant le comparateur existant.
 ---
 
 # P1 — Arbre `RuleContent`
+
+**Status: DONE (first tranche).**
+
+**Resolution:** External collections are normalized at construction and in collection `init` setters into immutable snapshots; ordinal comparers and source order are preserved.
+
+**Files:** Public model files in `Utils.Parser/Model`, `Utils.Parser/Runtime/ParseNode.cs`, and `Utils.Parser.Antlr4.Common`.
+
+**Tests:** `UtilsTest/Parser/ParserModelImmutabilityTests.cs` covers source mutation, mutable-type recasts, and `with`/object-initializer normalization.
+
+**API impact:** Existing collection interface signatures and record construction patterns are retained; `init` assignments now normalize rather than retain the assigned instance.
+
 
 Auditer tous les records dérivant de `RuleContent`.
 
@@ -254,6 +287,17 @@ Passer en revue tous les autres descendants de `RuleContent` pour identifier d�
 
 # P1 — `LexerMode`
 
+**Status: DONE (first tranche).**
+
+**Resolution:** External collections are normalized at construction and in collection `init` setters into immutable snapshots; ordinal comparers and source order are preserved.
+
+**Files:** Public model files in `Utils.Parser/Model`, `Utils.Parser/Runtime/ParseNode.cs`, and `Utils.Parser.Antlr4.Common`.
+
+**Tests:** `UtilsTest/Parser/ParserModelImmutabilityTests.cs` covers source mutation, mutable-type recasts, and `with`/object-initializer normalization.
+
+**API impact:** Existing collection interface signatures and record construction patterns are retained; `init` assignments now normalize rather than retain the assigned instance.
+
+
 Corriger :
 
 ```text
@@ -265,6 +309,17 @@ Le tableau ou la liste fourni au constructeur ne doit plus pouvoir modifier le `
 ---
 
 # P1 — Arbre de parsing
+
+**Status: DONE (first tranche).**
+
+**Resolution:** External collections are normalized at construction and in collection `init` setters into immutable snapshots; ordinal comparers and source order are preserved.
+
+**Files:** Public model files in `Utils.Parser/Model`, `Utils.Parser/Runtime/ParseNode.cs`, and `Utils.Parser.Antlr4.Common`.
+
+**Tests:** `UtilsTest/Parser/ParserModelImmutabilityTests.cs` covers source mutation, mutable-type recasts, and `with`/object-initializer normalization.
+
+**API impact:** Existing collection interface signatures and record construction patterns are retained; `init` assignments now normalize rather than retain the assigned instance.
+
 
 ## `ParserNode`
 
@@ -294,6 +349,17 @@ Un parse tree produit par le moteur doit être stable. Une modification externe 
 
 # P1 — `LeftRecursiveRuleInfo`
 
+**Status: DONE (first tranche).**
+
+**Resolution:** External collections are normalized at construction and in collection `init` setters into immutable snapshots; ordinal comparers and source order are preserved.
+
+**Files:** Public model files in `Utils.Parser/Model`, `Utils.Parser/Runtime/ParseNode.cs`, and `Utils.Parser.Antlr4.Common`.
+
+**Tests:** `UtilsTest/Parser/ParserModelImmutabilityTests.cs` covers source mutation, mutable-type recasts, and `with`/object-initializer normalization.
+
+**API impact:** Existing collection interface signatures and record construction patterns are retained; `init` assignments now normalize rather than retain the assigned instance.
+
+
 Corriger :
 
 ```text
@@ -306,6 +372,17 @@ Les propriétés `required init` ne constituent pas une protection contre une co
 ---
 
 # P1 — `GrammarExtensionBinding`
+
+**Status: DONE (first tranche).**
+
+**Resolution:** External collections are normalized at construction and in collection `init` setters into immutable snapshots; ordinal comparers and source order are preserved.
+
+**Files:** Public model files in `Utils.Parser/Model`, `Utils.Parser/Runtime/ParseNode.cs`, and `Utils.Parser.Antlr4.Common`.
+
+**Tests:** `UtilsTest/Parser/ParserModelImmutabilityTests.cs` covers source mutation, mutable-type recasts, and `with`/object-initializer normalization.
+
+**API impact:** Existing collection interface signatures and record construction patterns are retained; `init` assignments now normalize rather than retain the assigned instance.
+
 
 Corriger :
 
@@ -320,6 +397,17 @@ Utiliser des sets immutables et préserver `StringComparer.Ordinal` lorsque c’
 ---
 
 # P1 — `Utils.Parser.Antlr4.Common`
+
+**Status: DONE (first tranche).**
+
+**Resolution:** External collections are normalized at construction and in collection `init` setters into immutable snapshots; ordinal comparers and source order are preserved.
+
+**Files:** Public model files in `Utils.Parser/Model`, `Utils.Parser/Runtime/ParseNode.cs`, and `Utils.Parser.Antlr4.Common`.
+
+**Tests:** `UtilsTest/Parser/ParserModelImmutabilityTests.cs` covers source mutation, mutable-type recasts, and `with`/object-initializer normalization.
+
+**API impact:** Existing collection interface signatures and record construction patterns are retained; `init` assignments now normalize rather than retain the assigned instance.
+
 
 ## `Antlr4PrequelModel`
 
@@ -357,6 +445,8 @@ vers un snapshot immutable.
 ---
 
 # P1 — `Utils.Parser.Expressions`
+
+**Status: OPEN — reserved for a subsequent PR.**
 
 ## `PreparedExpressionEmbeddedCodeRegistryBuildResult`
 
@@ -401,6 +491,8 @@ Le tableau issu de `ToArray()` ne doit plus rester recastable.
 
 # P1 — Résultats d’exécution
 
+**Status: OPEN — reserved for a subsequent PR.**
+
 ## `ParserActionExecutionOutcome`
 
 Corriger :
@@ -416,6 +508,8 @@ Le cas `params object?[] diagnosticArguments` doit faire l’objet d’un test s
 ---
 
 # P1/P2 — Résumés runtime publics
+
+**Status: OPEN — reserved for a subsequent PR.**
 
 ## `RuntimeTraceSummary`
 
@@ -443,6 +537,8 @@ vers un dictionnaire immutable.
 ---
 
 # P2 — Modèles internes du scheduler/runtime
+
+**Status: OPEN — reserved for a subsequent PR.**
 
 Même si ces types sont internes, ils sont souvent explicitement documentés comme immuables et servent de snapshots entre phases du parser.
 
@@ -511,6 +607,8 @@ ExpectedTokenNames
 ---
 
 # P2 — `GrammarImportCompositionPlanner`
+
+**Status: OPEN — reserved for a subsequent PR.**
 
 Auditer tous les records internes représentant le résultat de composition.
 

--- a/UtilsTest/Parser/ParserModelImmutabilityTests.cs
+++ b/UtilsTest/Parser/ParserModelImmutabilityTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Antlr4.Common;
+using Utils.Parser.Antlr4.Common.Diagnostics;
+using Utils.Parser.Model;
+using Utils.Parser.Runtime;
+using Utils.Parser.Source;
+
+namespace UtilsTest.Parser;
+
+/// <summary>Verifies defensive immutable snapshots in public parser models.</summary>
+[TestClass]
+public sealed class ParserModelImmutabilityTests
+{
+    /// <summary>Verifies ordered grammar structures reject array and list aliasing.</summary>
+    [TestMethod]
+    public void GrammarStructures_CaptureImmutableSnapshots()
+    {
+        RuleContent first = new LiteralMatch("first");
+        RuleContent second = new LiteralMatch("second");
+        RuleContent[] items = [first];
+        var sequence = new Sequence(items);
+        items[0] = second;
+        Assert.AreSame(first, sequence.Items[0]);
+        Assert.IsFalse(sequence.Items is RuleContent[]);
+        Assert.IsFalse(sequence.Items is List<RuleContent>);
+
+        var alternative1 = new Alternative(0, Associativity.Left, first);
+        var alternative2 = new Alternative(1, Associativity.Left, second);
+        var alternatives = new List<Alternative> { alternative1 };
+        var alternation = new Alternation(alternatives);
+        alternatives[0] = alternative2;
+        alternatives.Add(alternative2);
+        Assert.AreSame(alternative1, alternation.Alternatives[0]);
+        Assert.AreEqual(1, alternation.Alternatives.Count);
+    }
+
+    /// <summary>Verifies parser definitions and rule metadata normalize every external collection.</summary>
+    [TestMethod]
+    public void ParserDefinitionAndRule_CaptureImmutableSnapshots()
+    {
+        Rule first = CreateRule("first");
+        Rule second = CreateRule("second");
+        var actions = new List<GrammarAction> { new("header", "code") };
+        var imports = new List<GrammarImport> { new("Base") };
+        var modes = new List<LexerMode> { new("DEFAULT_MODE", [first]) };
+        var parserRules = new List<Rule> { first };
+        var tokens = new HashSet<string>(StringComparer.Ordinal) { "TOKEN" };
+        var definition = new ParserDefinition("Grammar", GrammarType.Combined, null, actions, imports, modes, tokens, tokens, [], parserRules, first);
+        actions.Clear(); imports.Clear(); modes.Clear(); parserRules[0] = second; tokens.Add("OTHER");
+        Assert.AreEqual(1, definition.Actions.Count);
+        Assert.AreEqual(1, definition.Imports.Count);
+        Assert.AreEqual(1, definition.Modes.Count);
+        Assert.AreSame(first, definition.ParserRules[0]);
+        Assert.IsFalse(definition.DeclaredTokens.Contains("OTHER"));
+
+        parserRules[0] = first;
+        var allRules = new Dictionary<string, Rule>(StringComparer.Ordinal) { ["first"] = first };
+        ParserDefinition resolved = definition with { AllRules = allRules, ParserRules = parserRules };
+        allRules["first"] = second; parserRules[0] = second;
+        Assert.AreSame(first, resolved.AllRules["first"]);
+        Assert.AreSame(first, resolved.ParserRules[0]);
+        Assert.IsFalse(resolved.AllRules is Dictionary<string, Rule>);
+        Assert.IsFalse(resolved.ParserRules is List<Rule>);
+
+        var parameters = new List<RuleParameter> { new("int", "value") };
+        var throws = new List<string> { "Exception" };
+        var catches = new List<RuleCatchClause> { new("Exception ex", "handle") };
+        var metadata = new RuleExceptionMetadata(throws, catches, null);
+        var rule = first with { Parameters = parameters, ExceptionMetadata = metadata };
+        parameters.Clear(); throws.Clear(); catches.Clear();
+        Assert.AreEqual(1, rule.Parameters!.Count);
+        Assert.AreEqual(1, rule.ExceptionMetadata!.Throws.Count);
+        Assert.AreEqual(1, rule.ExceptionMetadata.CatchClauses.Count);
+    }
+
+    /// <summary>Verifies lexer modes capture their ordered rule input.</summary>
+    [TestMethod]
+    public void LexerMode_CapturesImmutableRuleSnapshot()
+    {
+        Rule first = CreateRule("FIRST");
+        Rule second = CreateRule("SECOND");
+        Rule[] rules = [first];
+        var mode = new LexerMode("DEFAULT_MODE", rules);
+        rules[0] = second;
+        Assert.AreSame(first, mode.Rules[0]);
+        Assert.IsFalse(mode.Rules is Rule[]);
+    }
+
+    /// <summary>Verifies model dictionaries and sets preserve ordinal immutable snapshots.</summary>
+    [TestMethod]
+    public void MetadataCollections_CaptureImmutableSnapshotsAndOrdinalComparers()
+    {
+        var optionsSource = new Dictionary<string, string>(StringComparer.Ordinal) { ["A"] = "one" };
+        var options = new RuleOptions(optionsSource);
+        optionsSource["A"] = "two";
+        optionsSource["B"] = "three";
+        Assert.AreEqual("one", options.Values["A"]);
+        Assert.IsFalse(options.Values.ContainsKey("B"));
+        Assert.IsFalse(options.Values.ContainsKey("a"));
+        Assert.IsFalse(options.Values is Dictionary<string, string>);
+
+        var names = new HashSet<string>(StringComparer.Ordinal) { "A" };
+        var binding = new GrammarExtensionBinding { LexerRuleNames = names, DeclaredTokens = names, DeclaredChannels = names };
+        names.Add("B");
+        Assert.IsFalse(binding.LexerRuleNames.Contains("B"));
+        Assert.IsFalse(binding.LexerRuleNames.Contains("a"));
+        Assert.IsFalse(binding.LexerRuleNames is HashSet<string>);
+    }
+
+    /// <summary>Verifies init setters normalize mutable collections used through with expressions.</summary>
+    [TestMethod]
+    public void RecordWithExpressions_NormalizeAssignedCollections()
+    {
+        RuleContent first = new LiteralMatch("first");
+        RuleContent second = new LiteralMatch("second");
+        var original = new Sequence([first]);
+        RuleContent[] replacement = [first];
+        var copy = original with { Items = replacement };
+        replacement[0] = second;
+        Assert.AreSame(first, copy.Items[0]);
+        Assert.IsFalse(copy.Items is RuleContent[]);
+
+        var alternatives = new[] { new Alternative(0, Associativity.Left, first) };
+        var info = new LeftRecursiveRuleInfo { Rule = CreateRule("rule"), BaseAlternatives = alternatives, RecursiveAlternatives = alternatives };
+        alternatives[0] = new Alternative(1, Associativity.Right, second);
+        Assert.AreEqual(0, info.BaseAlternatives[0].Priority);
+    }
+
+    /// <summary>Verifies parse-tree nodes capture child arrays once without exposing them.</summary>
+    [TestMethod]
+    public void ParseNodes_CaptureImmutableChildrenSnapshot()
+    {
+        Rule rule = CreateRule("rule");
+        ParseNode first = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "first", rule);
+        ParseNode second = new ErrorNode(new SourceSpan(0, 0), "DEFAULT_MODE", "second", rule);
+        ParseNode[] children = [first];
+        var node = new ParserNode(new SourceSpan(0, 0), "DEFAULT_MODE", rule, children);
+        IReadOnlyList<ParseNode> snapshot = node.Children;
+        children[0] = second;
+        Assert.AreSame(first, node.Children[0]);
+        Assert.AreSame(snapshot, node.Children);
+        Assert.IsFalse(node.Children is ParseNode[]);
+        Assert.IsFalse(node.Children is List<ParseNode>);
+    }
+
+    /// <summary>Verifies ANTLR prequel models capture lists, sets, dictionaries, and diagnostics.</summary>
+    [TestMethod]
+    public void AntlrPrequelModels_CaptureImmutableSnapshots()
+    {
+        var values = new Dictionary<string, string>(StringComparer.Ordinal) { ["language"] = "CSharp" };
+        var optionSet = new Antlr4OptionSet(values);
+        values["language"] = "Java";
+        Assert.AreEqual("CSharp", optionSet.Values["language"]);
+        Assert.IsFalse(optionSet.Values is Dictionary<string, string>);
+
+        var imports = new List<Antlr4ImportInfo> { new("Base", null) };
+        var actions = new List<Antlr4ActionInfo> { new("header", "code", null) };
+        var tokens = new HashSet<string>(StringComparer.Ordinal) { "TOKEN" };
+        var model = new Antlr4PrequelModel(optionSet, imports, actions, tokens, tokens);
+        imports.Clear(); actions.Clear(); tokens.Add("OTHER");
+        Assert.AreEqual(1, model.Imports.Count);
+        Assert.AreEqual(1, model.Actions.Count);
+        Assert.IsFalse(model.DeclaredTokens.Contains("OTHER"));
+
+        var diagnostics = new List<Antlr4PrequelDiagnostic>();
+        var result = new Antlr4PrequelValidationResult(diagnostics);
+        diagnostics.Add(null!);
+        Assert.AreEqual(0, result.Diagnostics.Count);
+        Assert.IsFalse(result.Diagnostics is List<Antlr4PrequelDiagnostic>);
+    }
+
+    /// <summary>Creates a minimal rule for immutable model tests.</summary>
+    private static Rule CreateRule(string name)
+    {
+        return new Rule(name, 0, false, new Alternation([new Alternative(0, Associativity.Left, new Sequence([]))]));
+    }
+}

--- a/UtilsTest/Parser/ParserModelImmutabilityTests.cs
+++ b/UtilsTest/Parser/ParserModelImmutabilityTests.cs
@@ -143,6 +143,28 @@ public sealed class ParserModelImmutabilityTests
         Assert.IsFalse(node.Children is List<ParseNode>);
     }
 
+    /// <summary>Verifies quantifier-node with expressions use the inherited immutable child storage.</summary>
+    [TestMethod]
+    public void QuantifierNode_WithChildren_PreservesImmutabilityAndRecordEquality()
+    {
+        Rule rule = CreateRule("rule");
+        SourceSpan span = new(0, 0);
+        ParseNode first = new ErrorNode(span, "DEFAULT_MODE", "first", rule);
+        ParseNode second = new ErrorNode(span, "DEFAULT_MODE", "second", rule);
+        ParseNode third = new ErrorNode(span, "DEFAULT_MODE", "third", rule);
+        var original = new QuantifierNode(span, "DEFAULT_MODE", rule, [first]);
+        ParseNode[] replacement = [second];
+
+        QuantifierNode copy = original with { Children = replacement };
+        replacement[0] = third;
+        var expected = new QuantifierNode(span, "DEFAULT_MODE", rule, [second]);
+
+        Assert.AreSame(second, copy.Children[0]);
+        Assert.IsFalse(copy.Children is ParseNode[]);
+        Assert.AreEqual(expected, copy);
+        Assert.AreEqual(expected.GetHashCode(), copy.GetHashCode());
+    }
+
     /// <summary>Verifies ANTLR prequel models capture lists, sets, dictionaries, and diagnostics.</summary>
     [TestMethod]
     public void AntlrPrequelModels_CaptureImmutableSnapshots()


### PR DESCRIPTION
### Motivation
- Public parser model types exposed collections via `IReadOnly*` backed by mutable arrays/collections, allowing callers to mutate internal state by aliasing source collections or using `with`/object-initializer to reassign mutable instances. This breaks the promised immutability of grammar and parse-tree models. 
- The change ensures defensive copying at construction/initialization and stores truly immutable snapshots so the observable model cannot be altered by later mutations of caller-owned collections.

### Description
- Defensive snapshots: public model types now normalize incoming collections into immutable representations (`ImmutableArray`, immutable hashsets/dictionaries) at construction or in `init` setters; backing fields were introduced where needed to ensure normalization on `with`/object-initializer flows. 
- Affected model surfaces: `ParserDefinition`, `Rule` (and `RuleOptions`, `RuleExceptionMetadata`), all relevant `RuleContent` descendants (`Sequence`, `Alternation`, `CharSetMatch`, `EmbeddedAction`, ...), `LexerMode`, `LeftRecursiveRuleInfo`, `GrammarExtensionBinding`, parse-tree nodes (`ParserNode`, `QuantifierNode`), and ANTLR prequel DTOs (`Antlr4PrequelModel`, `Antlr4OptionSet`, `Antlr4PrequelValidationResult`).
- Collections and comparers preserved: `IReadOnly*` public signatures were retained where possible while switching to immutable storage; ordinal comparers (e.g. `StringComparer.Ordinal`) are explicitly preserved for sets/dictionaries that rely on them.
- Minimal API surface changes: no public API types were converted wholesale to BCL immutable types; instead internal backing fields provide immutability while keeping existing `IReadOnly*` contracts.
- Build/project changes: `System.Collections.Immutable` added to `Utils.Parser.Antlr4.Common` to support immutable collections.
- Tests and TODO/ROADMAP updates: added `UtilsTest/Parser/ParserModelImmutabilityTests.cs` exercising array/list/dictionary/set mutation, recast attempts, and `with` normalization; updated `Utils.Parser/TODO-immutability.md` and `Utils.Parser/ROADMAP.md` to mark the covered tranche as done.

### Testing
- Restored and built the solution: `dotnet restore` and `dotnet build --configuration Release --no-restore` completed successfully with repository-wide preexisting warnings but no new errors.
- Unit tests (Parser filter): `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter "FullyQualifiedName~Parser"` passed (Parser-related unit tests executed successfully).
- Functional Parser tests: `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --filter "FullyQualifiedName~Parser"` passed (Parser-related functional tests executed successfully).
- New immutability regression tests: `UtilsTest/Parser/ParserModelImmutabilityTests` added and executed as part of the test runs; they passed.
- Additional validations: `git diff --check` performed and working tree is clean after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7826c83d308326953bf86c723b39f2)