### PR TITLE
Make parser internal snapshots immutable (defensive copies)

### DIFF
--- a/Utils.Parser.Antlr4.Common/Composition/GrammarImportCompositionPlanner.cs
+++ b/Utils.Parser.Antlr4.Common/Composition/GrammarImportCompositionPlanner.cs
@@ -56,6 +56,7 @@ internal interface IGrammarCompositionSource
 /// <summary>Describes one dependency edge, its declared and effective kinds, and its import path.</summary>
 internal sealed record GrammarDependencyEdge
 {
+    /// <summary>Initializes a dependency edge and captures its ordered import path.</summary>
     internal GrammarDependencyEdge(GrammarIdentity importer, GrammarDependency declaredDependency, GrammarDependencyKind effectiveKind, GrammarIdentity? imported, IReadOnlyList<GrammarIdentity> importPath) { Importer = importer; DeclaredDependency = declaredDependency; EffectiveKind = effectiveKind; Imported = imported; ImportPath = importPath.ToImmutableArray(); }
     internal GrammarIdentity Importer { get; }
     internal GrammarDependency DeclaredDependency { get; }
@@ -70,6 +71,7 @@ internal sealed record MissingGrammarDependency(GrammarDependencyEdge Edge);
 /// <summary>Describes a dependency that resolved to multiple stable sources.</summary>
 internal sealed record AmbiguousGrammarDependency
 {
+    /// <summary>Initializes an ambiguous dependency and captures its ordered candidates.</summary>
     internal AmbiguousGrammarDependency(GrammarDependencyEdge edge, IReadOnlyList<GrammarIdentity> candidates) { Edge = edge; Candidates = candidates.ToImmutableArray(); }
     internal GrammarDependencyEdge Edge { get; }
     internal IReadOnlyList<GrammarIdentity> Candidates { get; }
@@ -78,6 +80,7 @@ internal sealed record AmbiguousGrammarDependency
 /// <summary>Describes a deterministic cycle path.</summary>
 internal sealed record GrammarImportCycle
 {
+    /// <summary>Initializes a cycle and captures its ordered diagnostic path.</summary>
     internal GrammarImportCycle(IReadOnlyList<GrammarIdentity> path) => Path = path.ToImmutableArray();
     internal IReadOnlyList<GrammarIdentity> Path { get; }
 }
@@ -85,6 +88,7 @@ internal sealed record GrammarImportCycle
 /// <summary>Describes an effective rule and its provenance.</summary>
 internal sealed record EffectiveGrammarRule
 {
+    /// <summary>Initializes an effective rule and captures its ordered provenance path.</summary>
     internal EffectiveGrammarRule(GrammarIdentity origin, GrammarRuleDescriptor rule, IReadOnlyList<GrammarIdentity> importPath, GrammarDependencyKind? introducedBy) { Origin = origin; Rule = rule; ImportPath = importPath.ToImmutableArray(); IntroducedBy = introducedBy; }
     internal GrammarIdentity Origin { get; }
     internal GrammarRuleDescriptor Rule { get; }
@@ -98,6 +102,7 @@ internal sealed record MaskedGrammarRule(EffectiveGrammarRule Rule, EffectiveGra
 /// <summary>Describes distinct imported declarations competing for one unqualified rule name.</summary>
 internal sealed record GrammarRuleCollision
 {
+    /// <summary>Initializes a rule collision and captures its ordered candidates.</summary>
     internal GrammarRuleCollision(string ruleName, IReadOnlyList<EffectiveGrammarRule> candidates) { RuleName = ruleName; Candidates = candidates.ToImmutableArray(); }
     internal string RuleName { get; }
     internal IReadOnlyList<EffectiveGrammarRule> Candidates { get; }
@@ -106,6 +111,7 @@ internal sealed record GrammarRuleCollision
 /// <summary>Contains the immutable result of dependency graph construction and effective-rule selection.</summary>
 internal sealed record GrammarImportCompositionPlan
 {
+    /// <summary>Initializes the immutable result of grammar import composition.</summary>
     internal GrammarImportCompositionPlan(IGrammarCompositionSource entry, IReadOnlyList<IGrammarCompositionSource> grammars, IReadOnlyList<GrammarDependencyEdge> dependencies, IReadOnlyList<GrammarImportCycle> cycles, IReadOnlyList<MissingGrammarDependency> missingDependencies, IReadOnlyList<AmbiguousGrammarDependency> ambiguousDependencies, IReadOnlyList<EffectiveGrammarRule> effectiveRules, IReadOnlyList<MaskedGrammarRule> maskedRules, IReadOnlyList<EffectiveGrammarRule> ignoredRules, IReadOnlyList<GrammarRuleCollision> collisions, object? rootRulePayload, IReadOnlyList<EffectiveGrammarRule> tokenVocabLexerRules) { Entry = entry; Grammars = grammars.ToImmutableArray(); Dependencies = dependencies.ToImmutableArray(); Cycles = cycles.ToImmutableArray(); MissingDependencies = missingDependencies.ToImmutableArray(); AmbiguousDependencies = ambiguousDependencies.ToImmutableArray(); EffectiveRules = effectiveRules.ToImmutableArray(); MaskedRules = maskedRules.ToImmutableArray(); IgnoredRules = ignoredRules.ToImmutableArray(); Collisions = collisions.ToImmutableArray(); RootRulePayload = rootRulePayload; TokenVocabLexerRules = tokenVocabLexerRules.ToImmutableArray(); }
     internal IGrammarCompositionSource Entry { get; }
     internal IReadOnlyList<IGrammarCompositionSource> Grammars { get; }

--- a/Utils.Parser.Antlr4.Common/Composition/GrammarImportCompositionPlanner.cs
+++ b/Utils.Parser.Antlr4.Common/Composition/GrammarImportCompositionPlanner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Utils.Parser.Antlr4.Common.Composition;
@@ -53,49 +54,72 @@ internal interface IGrammarCompositionSource
 }
 
 /// <summary>Describes one dependency edge, its declared and effective kinds, and its import path.</summary>
-internal sealed record GrammarDependencyEdge(
-    GrammarIdentity Importer,
-    GrammarDependency DeclaredDependency,
-    GrammarDependencyKind EffectiveKind,
-    GrammarIdentity? Imported,
-    IReadOnlyList<GrammarIdentity> ImportPath);
+internal sealed record GrammarDependencyEdge
+{
+    internal GrammarDependencyEdge(GrammarIdentity importer, GrammarDependency declaredDependency, GrammarDependencyKind effectiveKind, GrammarIdentity? imported, IReadOnlyList<GrammarIdentity> importPath) { Importer = importer; DeclaredDependency = declaredDependency; EffectiveKind = effectiveKind; Imported = imported; ImportPath = importPath.ToImmutableArray(); }
+    internal GrammarIdentity Importer { get; }
+    internal GrammarDependency DeclaredDependency { get; }
+    internal GrammarDependencyKind EffectiveKind { get; }
+    internal GrammarIdentity? Imported { get; init; }
+    internal IReadOnlyList<GrammarIdentity> ImportPath { get; }
+}
 
 /// <summary>Describes an unresolved dependency.</summary>
 internal sealed record MissingGrammarDependency(GrammarDependencyEdge Edge);
 
 /// <summary>Describes a dependency that resolved to multiple stable sources.</summary>
-internal sealed record AmbiguousGrammarDependency(GrammarDependencyEdge Edge, IReadOnlyList<GrammarIdentity> Candidates);
+internal sealed record AmbiguousGrammarDependency
+{
+    internal AmbiguousGrammarDependency(GrammarDependencyEdge edge, IReadOnlyList<GrammarIdentity> candidates) { Edge = edge; Candidates = candidates.ToImmutableArray(); }
+    internal GrammarDependencyEdge Edge { get; }
+    internal IReadOnlyList<GrammarIdentity> Candidates { get; }
+}
 
 /// <summary>Describes a deterministic cycle path.</summary>
-internal sealed record GrammarImportCycle(IReadOnlyList<GrammarIdentity> Path);
+internal sealed record GrammarImportCycle
+{
+    internal GrammarImportCycle(IReadOnlyList<GrammarIdentity> path) => Path = path.ToImmutableArray();
+    internal IReadOnlyList<GrammarIdentity> Path { get; }
+}
 
 /// <summary>Describes an effective rule and its provenance.</summary>
-internal sealed record EffectiveGrammarRule(
-    GrammarIdentity Origin,
-    GrammarRuleDescriptor Rule,
-    IReadOnlyList<GrammarIdentity> ImportPath,
-    GrammarDependencyKind? IntroducedBy);
+internal sealed record EffectiveGrammarRule
+{
+    internal EffectiveGrammarRule(GrammarIdentity origin, GrammarRuleDescriptor rule, IReadOnlyList<GrammarIdentity> importPath, GrammarDependencyKind? introducedBy) { Origin = origin; Rule = rule; ImportPath = importPath.ToImmutableArray(); IntroducedBy = introducedBy; }
+    internal GrammarIdentity Origin { get; }
+    internal GrammarRuleDescriptor Rule { get; }
+    internal IReadOnlyList<GrammarIdentity> ImportPath { get; }
+    internal GrammarDependencyKind? IntroducedBy { get; }
+}
 
 /// <summary>Describes a rule hidden by a local declaration.</summary>
 internal sealed record MaskedGrammarRule(EffectiveGrammarRule Rule, EffectiveGrammarRule MaskedBy);
 
 /// <summary>Describes distinct imported declarations competing for one unqualified rule name.</summary>
-internal sealed record GrammarRuleCollision(string RuleName, IReadOnlyList<EffectiveGrammarRule> Candidates);
+internal sealed record GrammarRuleCollision
+{
+    internal GrammarRuleCollision(string ruleName, IReadOnlyList<EffectiveGrammarRule> candidates) { RuleName = ruleName; Candidates = candidates.ToImmutableArray(); }
+    internal string RuleName { get; }
+    internal IReadOnlyList<EffectiveGrammarRule> Candidates { get; }
+}
 
 /// <summary>Contains the immutable result of dependency graph construction and effective-rule selection.</summary>
-internal sealed record GrammarImportCompositionPlan(
-    IGrammarCompositionSource Entry,
-    IReadOnlyList<IGrammarCompositionSource> Grammars,
-    IReadOnlyList<GrammarDependencyEdge> Dependencies,
-    IReadOnlyList<GrammarImportCycle> Cycles,
-    IReadOnlyList<MissingGrammarDependency> MissingDependencies,
-    IReadOnlyList<AmbiguousGrammarDependency> AmbiguousDependencies,
-    IReadOnlyList<EffectiveGrammarRule> EffectiveRules,
-    IReadOnlyList<MaskedGrammarRule> MaskedRules,
-    IReadOnlyList<EffectiveGrammarRule> IgnoredRules,
-    IReadOnlyList<GrammarRuleCollision> Collisions,
-    object? RootRulePayload,
-    IReadOnlyList<EffectiveGrammarRule> TokenVocabLexerRules);
+internal sealed record GrammarImportCompositionPlan
+{
+    internal GrammarImportCompositionPlan(IGrammarCompositionSource entry, IReadOnlyList<IGrammarCompositionSource> grammars, IReadOnlyList<GrammarDependencyEdge> dependencies, IReadOnlyList<GrammarImportCycle> cycles, IReadOnlyList<MissingGrammarDependency> missingDependencies, IReadOnlyList<AmbiguousGrammarDependency> ambiguousDependencies, IReadOnlyList<EffectiveGrammarRule> effectiveRules, IReadOnlyList<MaskedGrammarRule> maskedRules, IReadOnlyList<EffectiveGrammarRule> ignoredRules, IReadOnlyList<GrammarRuleCollision> collisions, object? rootRulePayload, IReadOnlyList<EffectiveGrammarRule> tokenVocabLexerRules) { Entry = entry; Grammars = grammars.ToImmutableArray(); Dependencies = dependencies.ToImmutableArray(); Cycles = cycles.ToImmutableArray(); MissingDependencies = missingDependencies.ToImmutableArray(); AmbiguousDependencies = ambiguousDependencies.ToImmutableArray(); EffectiveRules = effectiveRules.ToImmutableArray(); MaskedRules = maskedRules.ToImmutableArray(); IgnoredRules = ignoredRules.ToImmutableArray(); Collisions = collisions.ToImmutableArray(); RootRulePayload = rootRulePayload; TokenVocabLexerRules = tokenVocabLexerRules.ToImmutableArray(); }
+    internal IGrammarCompositionSource Entry { get; }
+    internal IReadOnlyList<IGrammarCompositionSource> Grammars { get; }
+    internal IReadOnlyList<GrammarDependencyEdge> Dependencies { get; }
+    internal IReadOnlyList<GrammarImportCycle> Cycles { get; }
+    internal IReadOnlyList<MissingGrammarDependency> MissingDependencies { get; }
+    internal IReadOnlyList<AmbiguousGrammarDependency> AmbiguousDependencies { get; }
+    internal IReadOnlyList<EffectiveGrammarRule> EffectiveRules { get; }
+    internal IReadOnlyList<MaskedGrammarRule> MaskedRules { get; }
+    internal IReadOnlyList<EffectiveGrammarRule> IgnoredRules { get; }
+    internal IReadOnlyList<GrammarRuleCollision> Collisions { get; }
+    internal object? RootRulePayload { get; }
+    internal IReadOnlyList<EffectiveGrammarRule> TokenVocabLexerRules { get; }
+}
 
 /// <summary>Builds a deterministic, consumer-neutral grammar import composition plan.</summary>
 internal static class GrammarImportCompositionPlanner

--- a/Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuildEntry.cs
+++ b/Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuildEntry.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Utils.Parser.Diagnostics;
 using Utils.Parser.EmbeddedCode;
 
@@ -43,7 +44,7 @@ public sealed record PreparedExpressionEmbeddedCodeRegistryBuildEntry
         Status = status;
         DiagnosticDescriptor = diagnosticDescriptor;
         Exception = exception;
-        DiagnosticArguments = diagnosticArguments?.ToArray() ?? [];
+        DiagnosticArguments = diagnosticArguments?.ToImmutableArray() ?? ImmutableArray<object?>.Empty;
         WasAddedToRegistry = wasAddedToRegistry;
         IsDuplicate = isDuplicate;
         IsSkipped = isSkipped;

--- a/Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuildResult.cs
+++ b/Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuildResult.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 namespace Utils.Parser.Expressions;
 
 /// <summary>
@@ -25,12 +26,12 @@ public sealed record PreparedExpressionEmbeddedCodeRegistryBuildResult
         IReadOnlyList<PreparedExpressionEmbeddedCodeRegistryBuildEntry> allEntries)
     {
         Registry = registry ?? throw new ArgumentNullException(nameof(registry));
-        SuccessfulSemanticPredicates = successfulSemanticPredicates?.ToArray() ?? throw new ArgumentNullException(nameof(successfulSemanticPredicates));
-        SuccessfulParserActions = successfulParserActions?.ToArray() ?? throw new ArgumentNullException(nameof(successfulParserActions));
-        NonSuccessEntries = nonSuccessEntries?.ToArray() ?? throw new ArgumentNullException(nameof(nonSuccessEntries));
-        DuplicateEntries = duplicateEntries?.ToArray() ?? throw new ArgumentNullException(nameof(duplicateEntries));
-        SkippedEntries = skippedEntries?.ToArray() ?? throw new ArgumentNullException(nameof(skippedEntries));
-        AllEntries = allEntries?.ToArray() ?? throw new ArgumentNullException(nameof(allEntries));
+        SuccessfulSemanticPredicates = successfulSemanticPredicates?.ToImmutableArray() ?? throw new ArgumentNullException(nameof(successfulSemanticPredicates));
+        SuccessfulParserActions = successfulParserActions?.ToImmutableArray() ?? throw new ArgumentNullException(nameof(successfulParserActions));
+        NonSuccessEntries = nonSuccessEntries?.ToImmutableArray() ?? throw new ArgumentNullException(nameof(nonSuccessEntries));
+        DuplicateEntries = duplicateEntries?.ToImmutableArray() ?? throw new ArgumentNullException(nameof(duplicateEntries));
+        SkippedEntries = skippedEntries?.ToImmutableArray() ?? throw new ArgumentNullException(nameof(skippedEntries));
+        AllEntries = allEntries?.ToImmutableArray() ?? throw new ArgumentNullException(nameof(allEntries));
     }
 
     /// <summary>

--- a/Utils.Parser/DONE-2026-08-09.md
+++ b/Utils.Parser/DONE-2026-08-09.md
@@ -446,7 +446,15 @@ vers un snapshot immutable.
 
 # P1 — `Utils.Parser.Expressions`
 
-**Status: OPEN — reserved for a subsequent PR.**
+**Status: DONE (second tranche).**
+
+**Resolution:** Registry build results and entries now capture ordered immutable snapshots with `ImmutableArray`.
+
+**Files:** `Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuildResult.cs`, `Utils.Parser.Expressions/PreparedExpressionEmbeddedCodeRegistryBuildEntry.cs`.
+
+**Tests:** `UtilsTest/Parser/ParserInternalImmutabilityTests.cs`.
+
+**API impact:** None; existing `IReadOnlyList<T>` signatures remain unchanged.
 
 ## `PreparedExpressionEmbeddedCodeRegistryBuildResult`
 
@@ -491,7 +499,15 @@ Le tableau issu de `ToArray()` ne doit plus rester recastable.
 
 # P1 — Résultats d’exécution
 
-**Status: OPEN — reserved for a subsequent PR.**
+**Status: DONE (second tranche).**
+
+**Resolution:** Parser action diagnostic arguments, including caller-owned `params` arrays, are captured as immutable snapshots.
+
+**Files:** `Utils.Parser/Runtime/ParserActionExecutionOutcome.cs`.
+
+**Tests:** `UtilsTest/Parser/ParserInternalImmutabilityTests.cs`.
+
+**API impact:** None.
 
 ## `ParserActionExecutionOutcome`
 
@@ -509,7 +525,15 @@ Le cas `params object?[] diagnosticArguments` doit faire l’objet d’un test s
 
 # P1/P2 — Résumés runtime publics
 
-**Status: OPEN — reserved for a subsequent PR.**
+**Status: DONE (second tranche).**
+
+**Resolution:** All distributions and deltas are immutable dictionaries; the ordinal rule-name comparer is preserved.
+
+**Files:** `Utils.Parser/Runtime/RuntimeTraceSummary.cs`, `Utils.Parser/Runtime/RuntimeTraceComparison.cs`.
+
+**Tests:** `UtilsTest/Parser/ParserInternalImmutabilityTests.cs`.
+
+**API impact:** None.
 
 ## `RuntimeTraceSummary`
 
@@ -538,7 +562,15 @@ vers un dictionnaire immutable.
 
 # P2 — Modèles internes du scheduler/runtime
 
-**Status: OPEN — reserved for a subsequent PR.**
+**Status: DONE (second tranche).**
+
+**Resolution:** Preparation inputs, descriptors, plans, segments, boundaries, validation results, and scheduling metadata capture immutable ordered snapshots while preserving nullable collections.
+
+**Files:** `Utils.Parser/Runtime/PreparedSchedulingInputs.cs` and the related scheduling descriptor files.
+
+**Tests:** `UtilsTest/Parser/ParserInternalImmutabilityTests.cs` plus the existing Parser scheduler suite.
+
+**API impact:** Internal implementation only.
 
 Même si ces types sont internes, ils sont souvent explicitement documentés comme immuables et servent de snapshots entre phases du parser.
 
@@ -608,7 +640,15 @@ ExpectedTokenNames
 
 # P2 — `GrammarImportCompositionPlanner`
 
-**Status: OPEN — reserved for a subsequent PR.**
+**Status: DONE (second tranche).**
+
+**Resolution:** Planner DTOs freeze paths, candidates, and every plan collection at the mutable-planning boundary.
+
+**Files:** `Utils.Parser.Antlr4.Common/Composition/GrammarImportCompositionPlanner.cs`.
+
+**Tests:** Existing `GrammarImportCompositionPlannerTests` plus the Parser regression suite.
+
+**API impact:** Internal implementation only.
 
 Auditer tous les records internes représentant le résultat de composition.
 
@@ -780,3 +820,8 @@ Le TODO est terminé lorsque :
 - la documentation ne repose plus sur des formulations telles que « callers must not mutate/cast this collection » ;
 - aucune modification du comportement fonctionnel du parser n’est introduite ;
 - tous les tests Parser existants restent verts.
+
+
+# Remaining work
+
+The scoped Parser models identified by this audit are complete. Mutable collections that remain in processing classes are transient algorithm state rather than immutable DTO storage. Cross-project immutability work remains tracked outside this Parser-specific TODO and was not modified by this tranche.

--- a/Utils.Parser/Runtime/AlternativeSchedulingMetadata.cs
+++ b/Utils.Parser/Runtime/AlternativeSchedulingMetadata.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Runtime;
 
 /// <summary>
@@ -7,8 +9,14 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal sealed class AlternativeSchedulingMetadata
 {
+    private IReadOnlyList<ParserSharedPrefixPlan> _sharedPrefixPlans = ImmutableArray<ParserSharedPrefixPlan>.Empty;
+
     /// <summary>
     /// Gets structural shared-prefix plans computed from shallow look-ahead observations.
     /// </summary>
-    public IReadOnlyList<ParserSharedPrefixPlan> SharedPrefixPlans { get; init; } = [];
+    public IReadOnlyList<ParserSharedPrefixPlan> SharedPrefixPlans
+    {
+        get => _sharedPrefixPlans;
+        init => _sharedPrefixPlans = value?.ToImmutableArray() ?? ImmutableArray<ParserSharedPrefixPlan>.Empty;
+    }
 }

--- a/Utils.Parser/Runtime/AlternativeStructuralDescriptor.cs
+++ b/Utils.Parser/Runtime/AlternativeStructuralDescriptor.cs
@@ -11,6 +11,9 @@ namespace Utils.Parser.Runtime;
 /// </summary>
 internal readonly record struct AlternativeStructuralDescriptor
 {
+    /// <summary>Initializes a structural descriptor and captures its ordered token snapshot.</summary>
+    /// <param name="alternativeIndex">Zero-based alternative index.</param>
+    /// <param name="structuralTokens">Ordered structural token names.</param>
     public AlternativeStructuralDescriptor(int alternativeIndex, IReadOnlyList<string> structuralTokens)
     {
         AlternativeIndex = alternativeIndex;

--- a/Utils.Parser/Runtime/AlternativeStructuralDescriptor.cs
+++ b/Utils.Parser/Runtime/AlternativeStructuralDescriptor.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Runtime;
 
 /// <summary>
@@ -7,14 +9,16 @@ namespace Utils.Parser.Runtime;
 /// <see cref="Utils.Parser.Model.RuleContent"/> references.
 /// It is safe to forward through the scheduler pipeline without coupling the scheduler to grammar internals.
 /// </summary>
-internal readonly record struct AlternativeStructuralDescriptor(
-    /// <summary>Zero-based index matching the alternative's position in its parent alternation.</summary>
-    int AlternativeIndex,
-    /// <summary>
-    /// Ordered structural token sequence extracted conservatively from the alternative's content.
-    /// Only <see cref="Utils.Parser.Model.RuleRef"/> and <see cref="Utils.Parser.Model.LiteralMatch"/>
-    /// elements at the head of a <see cref="Utils.Parser.Model.Sequence"/> are included.
-    /// Complex constructs (quantifiers, nested alternations, actions) stop extraction.
-    /// This list is read-only; callers must not attempt to cast or mutate it.
-    /// </summary>
-    IReadOnlyList<string> StructuralTokens);
+internal readonly record struct AlternativeStructuralDescriptor
+{
+    public AlternativeStructuralDescriptor(int alternativeIndex, IReadOnlyList<string> structuralTokens)
+    {
+        AlternativeIndex = alternativeIndex;
+        StructuralTokens = structuralTokens.ToImmutableArray();
+    }
+
+    public int AlternativeIndex { get; }
+
+    /// <summary>Gets the immutable structural-token snapshot captured at construction time.</summary>
+    public IReadOnlyList<string> StructuralTokens { get; }
+}

--- a/Utils.Parser/Runtime/ParserActionExecutionOutcome.cs
+++ b/Utils.Parser/Runtime/ParserActionExecutionOutcome.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Utils.Parser.Diagnostics;
 
 namespace Utils.Parser.Runtime;
@@ -23,7 +24,7 @@ public sealed record ParserActionExecutionOutcome
         Status = status;
         Diagnostic = diagnostic;
         Exception = exception;
-        DiagnosticArguments = diagnosticArguments ?? [];
+        DiagnosticArguments = diagnosticArguments?.ToImmutableArray() ?? ImmutableArray<object?>.Empty;
     }
 
     /// <summary>

--- a/Utils.Parser/Runtime/ParserContinuationDescriptor.cs
+++ b/Utils.Parser/Runtime/ParserContinuationDescriptor.cs
@@ -1,17 +1,12 @@
+using System.Collections.Immutable;
 namespace Utils.Parser.Runtime;
-
-/// <summary>
-/// Describes shallow continuation metadata captured during parser exploration.
-/// This descriptor is descriptive-only runtime metadata: it is non-authoritative and non-executable.
-/// It does not grant parse acceptance, branch selection, replay, continuation execution,
-/// resumable parsing, frame restoration, rollback safety, or semantic-equivalence guarantees.
-/// </summary>
-/// <param name="Key">Stable continuation identity.</param>
-/// <param name="Category">Descriptive continuation category.</param>
-/// <param name="ExpectedTokenNames">Optional shallow expected token names at this continuation point.</param>
-/// <param name="IsSharedPrefixCandidate">Indicates whether this continuation originated from a shared-prefix observation.</param>
-internal readonly record struct ParserContinuationDescriptor(
-    ParserContinuationKey Key,
-    ParserContinuationCategory Category,
-    IReadOnlyList<string>? ExpectedTokenNames,
-    bool IsSharedPrefixCandidate);
+/// <summary>Describes immutable shallow continuation metadata captured during parser exploration.</summary>
+internal readonly record struct ParserContinuationDescriptor
+{
+    /// <summary>Initializes a descriptor and captures its optional expected-token snapshot.</summary>
+    public ParserContinuationDescriptor(ParserContinuationKey key, ParserContinuationCategory category, IReadOnlyList<string>? expectedTokenNames, bool isSharedPrefixCandidate) { Key = key; Category = category; ExpectedTokenNames = expectedTokenNames?.ToImmutableArray(); IsSharedPrefixCandidate = isSharedPrefixCandidate; }
+    public ParserContinuationKey Key { get; }
+    public ParserContinuationCategory Category { get; }
+    public IReadOnlyList<string>? ExpectedTokenNames { get; }
+    public bool IsSharedPrefixCandidate { get; }
+}

--- a/Utils.Parser/Runtime/ParserContinuationDescriptor.cs
+++ b/Utils.Parser/Runtime/ParserContinuationDescriptor.cs
@@ -4,6 +4,10 @@ namespace Utils.Parser.Runtime;
 internal readonly record struct ParserContinuationDescriptor
 {
     /// <summary>Initializes a descriptor and captures its optional expected-token snapshot.</summary>
+    /// <param name="key">Stable continuation identity.</param>
+    /// <param name="category">Descriptive continuation category.</param>
+    /// <param name="expectedTokenNames">Optional expected-token names; <see langword="null"/> when unavailable.</param>
+    /// <param name="isSharedPrefixCandidate">Whether the continuation originated from a shared-prefix observation.</param>
     public ParserContinuationDescriptor(ParserContinuationKey key, ParserContinuationCategory category, IReadOnlyList<string>? expectedTokenNames, bool isSharedPrefixCandidate) { Key = key; Category = category; ExpectedTokenNames = expectedTokenNames?.ToImmutableArray(); IsSharedPrefixCandidate = isSharedPrefixCandidate; }
     public ParserContinuationKey Key { get; }
     public ParserContinuationCategory Category { get; }

--- a/Utils.Parser/Runtime/ParserContinuationPreparationInput.cs
+++ b/Utils.Parser/Runtime/ParserContinuationPreparationInput.cs
@@ -4,6 +4,11 @@ namespace Utils.Parser.Runtime;
 internal readonly record struct ParserContinuationPreparationInput
 {
     /// <summary>Initializes an input and captures its optional expected-token snapshot.</summary>
+    /// <param name="ruleName">Owning rule name.</param>
+    /// <param name="alternativeIndex">Ordered alternative index.</param>
+    /// <param name="sequencePosition">Normalized structural sequence position.</param>
+    /// <param name="expectedTokenNames">Optional shallow expected-token names.</param>
+    /// <param name="isSharedPrefixCandidate">Whether the continuation belongs to a shared-prefix candidate.</param>
     public ParserContinuationPreparationInput(string ruleName, int alternativeIndex, int sequencePosition, IReadOnlyList<string>? expectedTokenNames, bool isSharedPrefixCandidate) { RuleName = ruleName; AlternativeIndex = alternativeIndex; SequencePosition = sequencePosition; ExpectedTokenNames = expectedTokenNames?.ToImmutableArray(); IsSharedPrefixCandidate = isSharedPrefixCandidate; }
     public string RuleName { get; }
     public int AlternativeIndex { get; }

--- a/Utils.Parser/Runtime/ParserContinuationPreparationInput.cs
+++ b/Utils.Parser/Runtime/ParserContinuationPreparationInput.cs
@@ -1,17 +1,13 @@
+using System.Collections.Immutable;
 namespace Utils.Parser.Runtime;
-
-/// <summary>
-/// Immutable input used to prepare one continuation descriptor.
-/// This model is structural-only and carries no runtime execution authority.
-/// </summary>
-/// <param name="RuleName">Owning rule name.</param>
-/// <param name="AlternativeIndex">Ordered alternative index.</param>
-/// <param name="SequencePosition">Normalized structural sequence position.</param>
-/// <param name="ExpectedTokenNames">Shallow expected token names from look-ahead probe metadata.</param>
-/// <param name="IsSharedPrefixCandidate">Indicates whether this continuation belongs to a detected shared-prefix candidate.</param>
-internal readonly record struct ParserContinuationPreparationInput(
-    string RuleName,
-    int AlternativeIndex,
-    int SequencePosition,
-    IReadOnlyList<string>? ExpectedTokenNames,
-    bool IsSharedPrefixCandidate);
+/// <summary>Immutable input used to prepare one continuation descriptor.</summary>
+internal readonly record struct ParserContinuationPreparationInput
+{
+    /// <summary>Initializes an input and captures its optional expected-token snapshot.</summary>
+    public ParserContinuationPreparationInput(string ruleName, int alternativeIndex, int sequencePosition, IReadOnlyList<string>? expectedTokenNames, bool isSharedPrefixCandidate) { RuleName = ruleName; AlternativeIndex = alternativeIndex; SequencePosition = sequencePosition; ExpectedTokenNames = expectedTokenNames?.ToImmutableArray(); IsSharedPrefixCandidate = isSharedPrefixCandidate; }
+    public string RuleName { get; }
+    public int AlternativeIndex { get; }
+    public int SequencePosition { get; }
+    public IReadOnlyList<string>? ExpectedTokenNames { get; }
+    public bool IsSharedPrefixCandidate { get; }
+}

--- a/Utils.Parser/Runtime/ParserLookaheadProbeResult.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbeResult.cs
@@ -1,12 +1,15 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Runtime;
 
-/// <summary>
-/// Stores a lightweight structured look-ahead probe observation for a scheduled alternative start attempt.
-/// Probe results are transport metadata: they are observable and scheduler-usable, but non-authoritative
-/// and discardable without changing parse-tree authority or final parse acceptance rules.
-/// </summary>
-internal readonly record struct ParserLookaheadProbeResult(
-    ParserLookaheadProbeKind Kind,
-    string? TokenRuleName,
-    string? TokenText,
-    IReadOnlyList<string>? ExpectedTokenNames = null);
+/// <summary>Stores an immutable lightweight structured look-ahead probe observation.</summary>
+internal readonly record struct ParserLookaheadProbeResult
+{
+    /// <summary>Initializes a probe result and captures its optional expected-token snapshot.</summary>
+    public ParserLookaheadProbeResult(ParserLookaheadProbeKind kind, string? tokenRuleName, string? tokenText, IReadOnlyList<string>? expectedTokenNames = null)
+    { Kind = kind; TokenRuleName = tokenRuleName; TokenText = tokenText; ExpectedTokenNames = expectedTokenNames?.ToImmutableArray(); }
+    public ParserLookaheadProbeKind Kind { get; }
+    public string? TokenRuleName { get; }
+    public string? TokenText { get; }
+    public IReadOnlyList<string>? ExpectedTokenNames { get; }
+}

--- a/Utils.Parser/Runtime/ParserLookaheadProbeResult.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadProbeResult.cs
@@ -6,6 +6,10 @@ namespace Utils.Parser.Runtime;
 internal readonly record struct ParserLookaheadProbeResult
 {
     /// <summary>Initializes a probe result and captures its optional expected-token snapshot.</summary>
+    /// <param name="kind">Observed probe kind.</param>
+    /// <param name="tokenRuleName">Optional observed token rule name.</param>
+    /// <param name="tokenText">Optional observed token text.</param>
+    /// <param name="expectedTokenNames">Optional expected-token names; <see langword="null"/> when unavailable.</param>
     public ParserLookaheadProbeResult(ParserLookaheadProbeKind kind, string? tokenRuleName, string? tokenText, IReadOnlyList<string>? expectedTokenNames = null)
     { Kind = kind; TokenRuleName = tokenRuleName; TokenText = tokenText; ExpectedTokenNames = expectedTokenNames?.ToImmutableArray(); }
     public ParserLookaheadProbeKind Kind { get; }

--- a/Utils.Parser/Runtime/ParserLookaheadSharedPrefixCandidate.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadSharedPrefixCandidate.cs
@@ -1,10 +1,10 @@
+using System.Collections.Immutable;
 namespace Utils.Parser.Runtime;
-
-/// <summary>
-/// Represents a shallow shared first-token candidate observed across multiple alternatives.
-/// This candidate is observational grouping metadata only:
-/// it does not authorize execution sharing, replay, or branch merging.
-/// </summary>
-internal readonly record struct ParserLookaheadSharedPrefixCandidate(
-    string TokenName,
-    IReadOnlyList<int> AlternativeIndexes);
+/// <summary>Represents an immutable shallow shared first-token candidate.</summary>
+internal readonly record struct ParserLookaheadSharedPrefixCandidate
+{
+    /// <summary>Initializes a candidate and captures the ordered alternative indexes.</summary>
+    public ParserLookaheadSharedPrefixCandidate(string tokenName, IReadOnlyList<int> alternativeIndexes) { TokenName = tokenName; AlternativeIndexes = alternativeIndexes.ToImmutableArray(); }
+    public string TokenName { get; }
+    public IReadOnlyList<int> AlternativeIndexes { get; }
+}

--- a/Utils.Parser/Runtime/ParserLookaheadSharedPrefixCandidate.cs
+++ b/Utils.Parser/Runtime/ParserLookaheadSharedPrefixCandidate.cs
@@ -4,6 +4,8 @@ namespace Utils.Parser.Runtime;
 internal readonly record struct ParserLookaheadSharedPrefixCandidate
 {
     /// <summary>Initializes a candidate and captures the ordered alternative indexes.</summary>
+    /// <param name="tokenName">Shared shallow token name.</param>
+    /// <param name="alternativeIndexes">Ordered participating alternative indexes.</param>
     public ParserLookaheadSharedPrefixCandidate(string tokenName, IReadOnlyList<int> alternativeIndexes) { TokenName = tokenName; AlternativeIndexes = alternativeIndexes.ToImmutableArray(); }
     public string TokenName { get; }
     public IReadOnlyList<int> AlternativeIndexes { get; }

--- a/Utils.Parser/Runtime/ParserSharedPrefixBoundary.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixBoundary.cs
@@ -4,6 +4,8 @@ namespace Utils.Parser.Runtime;
 internal readonly record struct ParserSharedPrefixBoundary
 {
     /// <summary>Initializes a boundary and captures its optional expected-token snapshot.</summary>
+    /// <param name="sequencePosition">Conservative structural sequence position.</param>
+    /// <param name="expectedTokenNames">Optional expected-token names; <see langword="null"/> when unavailable.</param>
     public ParserSharedPrefixBoundary(int sequencePosition, IReadOnlyList<string>? expectedTokenNames) { SequencePosition = sequencePosition; ExpectedTokenNames = expectedTokenNames?.ToImmutableArray(); }
     public int SequencePosition { get; }
     public IReadOnlyList<string>? ExpectedTokenNames { get; }

--- a/Utils.Parser/Runtime/ParserSharedPrefixBoundary.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixBoundary.cs
@@ -1,14 +1,10 @@
+using System.Collections.Immutable;
 namespace Utils.Parser.Runtime;
-
-/// <summary>
-/// Represents a structural continuation boundary for shared-prefix planning metadata.
-/// This boundary is informational only and does not capture runtime parser state.
-/// </summary>
-/// <param name="SequencePosition">Conservative resumption position within meaningful sequence items.</param>
-/// <param name="ExpectedTokenNames">
-/// Optional shallow expected-token snapshot at this structural boundary.
-/// This value is intentionally <see langword="null"/> for now to avoid implying FOLLOW/restart semantics.
-/// </param>
-internal readonly record struct ParserSharedPrefixBoundary(
-    int SequencePosition,
-    IReadOnlyList<string>? ExpectedTokenNames);
+/// <summary>Represents an immutable structural continuation boundary.</summary>
+internal readonly record struct ParserSharedPrefixBoundary
+{
+    /// <summary>Initializes a boundary and captures its optional expected-token snapshot.</summary>
+    public ParserSharedPrefixBoundary(int sequencePosition, IReadOnlyList<string>? expectedTokenNames) { SequencePosition = sequencePosition; ExpectedTokenNames = expectedTokenNames?.ToImmutableArray(); }
+    public int SequencePosition { get; }
+    public IReadOnlyList<string>? ExpectedTokenNames { get; }
+}

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlan.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlan.cs
@@ -4,6 +4,10 @@ namespace Utils.Parser.Runtime;
 internal readonly record struct ParserSharedPrefixPlan
 {
     /// <summary>Initializes a plan and captures its ordered collection snapshots.</summary>
+    /// <param name="sharedTokenName">Shared shallow token name.</param>
+    /// <param name="alternativeIndexes">Ordered participating alternative indexes.</param>
+    /// <param name="continuations">Ordered continuation descriptors.</param>
+    /// <param name="segment">Shared-prefix segment and boundary metadata.</param>
     public ParserSharedPrefixPlan(string sharedTokenName, IReadOnlyList<int> alternativeIndexes, IReadOnlyList<ParserContinuationDescriptor> continuations, ParserSharedPrefixSegment segment) { SharedTokenName = sharedTokenName; AlternativeIndexes = alternativeIndexes.ToImmutableArray(); Continuations = continuations.ToImmutableArray(); Segment = segment; }
     public string SharedTokenName { get; }
     public IReadOnlyList<int> AlternativeIndexes { get; }

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlan.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlan.cs
@@ -1,17 +1,12 @@
+using System.Collections.Immutable;
 namespace Utils.Parser.Runtime;
-
-/// <summary>
-/// Represents structural shared-prefix planning metadata that associates a shallow shared token
-/// with the participating alternatives and their continuation descriptors.
-/// This plan is observable orchestration metadata only: it can guide diagnostics/audit workflows,
-/// but it cannot authorize parse acceptance, diagnostics authority, replay, or branch merging.
-/// </summary>
-/// <param name="SharedTokenName">Shallow shared token identifier observed during look-ahead.</param>
-/// <param name="AlternativeIndexes">Stable alternative indexes participating in this plan.</param>
-/// <param name="Continuations">Continuation descriptors associated with participating alternatives.</param>
-/// <param name="Segment">Explicit shared-prefix segment and conservative boundary metadata.</param>
-internal readonly record struct ParserSharedPrefixPlan(
-    string SharedTokenName,
-    IReadOnlyList<int> AlternativeIndexes,
-    IReadOnlyList<ParserContinuationDescriptor> Continuations,
-    ParserSharedPrefixSegment Segment);
+/// <summary>Represents immutable structural shared-prefix planning metadata.</summary>
+internal readonly record struct ParserSharedPrefixPlan
+{
+    /// <summary>Initializes a plan and captures its ordered collection snapshots.</summary>
+    public ParserSharedPrefixPlan(string sharedTokenName, IReadOnlyList<int> alternativeIndexes, IReadOnlyList<ParserContinuationDescriptor> continuations, ParserSharedPrefixSegment segment) { SharedTokenName = sharedTokenName; AlternativeIndexes = alternativeIndexes.ToImmutableArray(); Continuations = continuations.ToImmutableArray(); Segment = segment; }
+    public string SharedTokenName { get; }
+    public IReadOnlyList<int> AlternativeIndexes { get; }
+    public IReadOnlyList<ParserContinuationDescriptor> Continuations { get; }
+    public ParserSharedPrefixSegment Segment { get; }
+}

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanValidator.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanValidator.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Runtime;
 
 /// <summary>
@@ -33,9 +35,21 @@ internal readonly record struct ParserSharedPrefixPlanValidationIssue(
 /// otherwise, <see langword="false"/>.
 /// </param>
 /// <param name="Issues">Ordered structural metadata issues emitted during validation.</param>
-internal readonly record struct ParserSharedPrefixPlanValidationResult(
-    bool IsValid,
-    IReadOnlyList<ParserSharedPrefixPlanValidationIssue> Issues);
+internal readonly record struct ParserSharedPrefixPlanValidationResult
+{
+    /// <summary>Initializes a validation result and captures its ordered issues.</summary>
+    public ParserSharedPrefixPlanValidationResult(bool isValid, IReadOnlyList<ParserSharedPrefixPlanValidationIssue> issues)
+    {
+        IsValid = isValid;
+        Issues = issues.ToImmutableArray();
+    }
+
+    /// <summary>Gets whether the plan passed validation.</summary>
+    public bool IsValid { get; }
+
+    /// <summary>Gets the immutable ordered issue snapshot.</summary>
+    public IReadOnlyList<ParserSharedPrefixPlanValidationIssue> Issues { get; }
+}
 
 /// <summary>
 /// Validates shared-prefix planning metadata conservatively without executing parser logic.

--- a/Utils.Parser/Runtime/ParserSharedPrefixPlanValidator.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixPlanValidator.cs
@@ -30,14 +30,11 @@ internal readonly record struct ParserSharedPrefixPlanValidationIssue(
 /// <summary>
 /// Represents the immutable result of validating one shared-prefix plan.
 /// </summary>
-/// <param name="IsValid">
-/// <see langword="true"/> when no invalidating structural metadata was detected;
-/// otherwise, <see langword="false"/>.
-/// </param>
-/// <param name="Issues">Ordered structural metadata issues emitted during validation.</param>
 internal readonly record struct ParserSharedPrefixPlanValidationResult
 {
     /// <summary>Initializes a validation result and captures its ordered issues.</summary>
+    /// <param name="isValid"><see langword="true"/> when no invalidating structural metadata was detected; otherwise, <see langword="false"/>.</param>
+    /// <param name="issues">Ordered structural metadata issues emitted during validation.</param>
     public ParserSharedPrefixPlanValidationResult(bool isValid, IReadOnlyList<ParserSharedPrefixPlanValidationIssue> issues)
     {
         IsValid = isValid;

--- a/Utils.Parser/Runtime/ParserSharedPrefixSegment.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixSegment.cs
@@ -4,6 +4,9 @@ namespace Utils.Parser.Runtime;
 internal readonly record struct ParserSharedPrefixSegment
 {
     /// <summary>Initializes a segment and captures its ordered structural tokens.</summary>
+    /// <param name="sharedTokenName">Shared shallow token name.</param>
+    /// <param name="structuralTokens">Ordered shared structural token names.</param>
+    /// <param name="boundary">Conservative structural boundary.</param>
     public ParserSharedPrefixSegment(string sharedTokenName, IReadOnlyList<string> structuralTokens, ParserSharedPrefixBoundary boundary) { SharedTokenName = sharedTokenName; StructuralTokens = structuralTokens.ToImmutableArray(); Boundary = boundary; }
     public string SharedTokenName { get; }
     public IReadOnlyList<string> StructuralTokens { get; }

--- a/Utils.Parser/Runtime/ParserSharedPrefixSegment.cs
+++ b/Utils.Parser/Runtime/ParserSharedPrefixSegment.cs
@@ -1,13 +1,11 @@
+using System.Collections.Immutable;
 namespace Utils.Parser.Runtime;
-
-/// <summary>
-/// Represents a shallow shared-prefix segment and its conservative structural boundary.
-/// This metadata is preparatory only and is not executable.
-/// </summary>
-/// <param name="SharedTokenName">Shared shallow token identifier.</param>
-/// <param name="StructuralTokens">Ordered structural token sequence shared by all participating alternatives.</param>
-/// <param name="Boundary">Conservative boundary used for future continuation resumption planning.</param>
-internal readonly record struct ParserSharedPrefixSegment(
-    string SharedTokenName,
-    IReadOnlyList<string> StructuralTokens,
-    ParserSharedPrefixBoundary Boundary);
+/// <summary>Represents an immutable shallow shared-prefix segment.</summary>
+internal readonly record struct ParserSharedPrefixSegment
+{
+    /// <summary>Initializes a segment and captures its ordered structural tokens.</summary>
+    public ParserSharedPrefixSegment(string sharedTokenName, IReadOnlyList<string> structuralTokens, ParserSharedPrefixBoundary boundary) { SharedTokenName = sharedTokenName; StructuralTokens = structuralTokens.ToImmutableArray(); Boundary = boundary; }
+    public string SharedTokenName { get; }
+    public IReadOnlyList<string> StructuralTokens { get; }
+    public ParserSharedPrefixBoundary Boundary { get; }
+}

--- a/Utils.Parser/Runtime/PreparedSchedulingInputs.cs
+++ b/Utils.Parser/Runtime/PreparedSchedulingInputs.cs
@@ -5,12 +5,13 @@ namespace Utils.Parser.Runtime;
 /// <summary>
 /// Immutable aggregate carrying all preparation outputs required by scheduler orchestration.
 /// </summary>
-/// <param name="StructuralDescriptors">Precomputed structural descriptors for ordered alternatives.</param>
-/// <param name="LookaheadProbes">Precomputed shallow look-ahead probes for ordered alternatives.</param>
-/// <param name="SharedPrefixCandidates">Precomputed shared-prefix candidates derived from look-ahead probes.</param>
-/// <param name="ContinuationDescriptors">Precomputed continuation metadata descriptors.</param>
 internal sealed record PreparedSchedulingInputs
 {
+    /// <summary>Initializes immutable scheduling inputs.</summary>
+    /// <param name="structuralDescriptors">Precomputed structural descriptors for ordered alternatives.</param>
+    /// <param name="lookaheadProbes">Precomputed shallow look-ahead probes for ordered alternatives.</param>
+    /// <param name="sharedPrefixCandidates">Precomputed shared-prefix candidates derived from look-ahead probes.</param>
+    /// <param name="continuationDescriptors">Precomputed continuation metadata descriptors.</param>
     public PreparedSchedulingInputs(IReadOnlyList<AlternativeStructuralDescriptor> structuralDescriptors, IReadOnlyList<ParserLookaheadProbeResult> lookaheadProbes, IReadOnlyList<ParserLookaheadSharedPrefixCandidate> sharedPrefixCandidates, IReadOnlyList<ParserContinuationDescriptor> continuationDescriptors)
     {
         StructuralDescriptors = structuralDescriptors.ToImmutableArray();
@@ -19,8 +20,15 @@ internal sealed record PreparedSchedulingInputs
         ContinuationDescriptors = continuationDescriptors.ToImmutableArray();
     }
 
+    /// <summary>Gets the immutable structural-descriptor snapshot.</summary>
     public IReadOnlyList<AlternativeStructuralDescriptor> StructuralDescriptors { get; }
+
+    /// <summary>Gets the immutable look-ahead-probe snapshot.</summary>
     public IReadOnlyList<ParserLookaheadProbeResult> LookaheadProbes { get; }
+
+    /// <summary>Gets the immutable shared-prefix-candidate snapshot.</summary>
     public IReadOnlyList<ParserLookaheadSharedPrefixCandidate> SharedPrefixCandidates { get; }
+
+    /// <summary>Gets the immutable continuation-descriptor snapshot.</summary>
     public IReadOnlyList<ParserContinuationDescriptor> ContinuationDescriptors { get; }
 }

--- a/Utils.Parser/Runtime/PreparedSchedulingInputs.cs
+++ b/Utils.Parser/Runtime/PreparedSchedulingInputs.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Runtime;
 
 /// <summary>
@@ -7,8 +9,18 @@ namespace Utils.Parser.Runtime;
 /// <param name="LookaheadProbes">Precomputed shallow look-ahead probes for ordered alternatives.</param>
 /// <param name="SharedPrefixCandidates">Precomputed shared-prefix candidates derived from look-ahead probes.</param>
 /// <param name="ContinuationDescriptors">Precomputed continuation metadata descriptors.</param>
-internal sealed record PreparedSchedulingInputs(
-    IReadOnlyList<AlternativeStructuralDescriptor> StructuralDescriptors,
-    IReadOnlyList<ParserLookaheadProbeResult> LookaheadProbes,
-    IReadOnlyList<ParserLookaheadSharedPrefixCandidate> SharedPrefixCandidates,
-    IReadOnlyList<ParserContinuationDescriptor> ContinuationDescriptors);
+internal sealed record PreparedSchedulingInputs
+{
+    public PreparedSchedulingInputs(IReadOnlyList<AlternativeStructuralDescriptor> structuralDescriptors, IReadOnlyList<ParserLookaheadProbeResult> lookaheadProbes, IReadOnlyList<ParserLookaheadSharedPrefixCandidate> sharedPrefixCandidates, IReadOnlyList<ParserContinuationDescriptor> continuationDescriptors)
+    {
+        StructuralDescriptors = structuralDescriptors.ToImmutableArray();
+        LookaheadProbes = lookaheadProbes.ToImmutableArray();
+        SharedPrefixCandidates = sharedPrefixCandidates.ToImmutableArray();
+        ContinuationDescriptors = continuationDescriptors.ToImmutableArray();
+    }
+
+    public IReadOnlyList<AlternativeStructuralDescriptor> StructuralDescriptors { get; }
+    public IReadOnlyList<ParserLookaheadProbeResult> LookaheadProbes { get; }
+    public IReadOnlyList<ParserLookaheadSharedPrefixCandidate> SharedPrefixCandidates { get; }
+    public IReadOnlyList<ParserContinuationDescriptor> ContinuationDescriptors { get; }
+}

--- a/Utils.Parser/Runtime/RuntimeTraceComparison.cs
+++ b/Utils.Parser/Runtime/RuntimeTraceComparison.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Runtime;
 
 /// <summary>
@@ -9,10 +11,15 @@ namespace Utils.Parser.Runtime;
 /// <param name="FirstTotalObservations">Observation count in the first sequence.</param>
 /// <param name="SecondTotalObservations">Observation count in the second sequence.</param>
 /// <param name="EventCountDelta">Per-event-kind count deltas computed as first minus second.</param>
-public sealed record RuntimeTraceComparison(
-    bool AreSummariesEquivalent,
-    bool AreTextExportsIdentical,
-    bool AreJsonExportsIdentical,
-    int FirstTotalObservations,
-    int SecondTotalObservations,
-    IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventCountDelta);
+public sealed record RuntimeTraceComparison
+{
+    /// <summary>Initializes a comparison by capturing an immutable delta snapshot.</summary>
+    public RuntimeTraceComparison(bool areSummariesEquivalent, bool areTextExportsIdentical, bool areJsonExportsIdentical, int firstTotalObservations, int secondTotalObservations, IReadOnlyDictionary<ParserRuntimeObservationKind, int> eventCountDelta)
+    { AreSummariesEquivalent = areSummariesEquivalent; AreTextExportsIdentical = areTextExportsIdentical; AreJsonExportsIdentical = areJsonExportsIdentical; FirstTotalObservations = firstTotalObservations; SecondTotalObservations = secondTotalObservations; EventCountDelta = eventCountDelta.ToImmutableDictionary(); }
+    public bool AreSummariesEquivalent { get; }
+    public bool AreTextExportsIdentical { get; }
+    public bool AreJsonExportsIdentical { get; }
+    public int FirstTotalObservations { get; }
+    public int SecondTotalObservations { get; }
+    public IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventCountDelta { get; }
+}

--- a/Utils.Parser/Runtime/RuntimeTraceComparison.cs
+++ b/Utils.Parser/Runtime/RuntimeTraceComparison.cs
@@ -11,15 +11,22 @@ namespace Utils.Parser.Runtime;
 /// <param name="FirstTotalObservations">Observation count in the first sequence.</param>
 /// <param name="SecondTotalObservations">Observation count in the second sequence.</param>
 /// <param name="EventCountDelta">Per-event-kind count deltas computed as first minus second.</param>
-public sealed record RuntimeTraceComparison
+public sealed record RuntimeTraceComparison(
+    bool AreSummariesEquivalent,
+    bool AreTextExportsIdentical,
+    bool AreJsonExportsIdentical,
+    int FirstTotalObservations,
+    int SecondTotalObservations,
+    IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventCountDelta)
 {
-    /// <summary>Initializes a comparison by capturing an immutable delta snapshot.</summary>
-    public RuntimeTraceComparison(bool areSummariesEquivalent, bool areTextExportsIdentical, bool areJsonExportsIdentical, int firstTotalObservations, int secondTotalObservations, IReadOnlyDictionary<ParserRuntimeObservationKind, int> eventCountDelta)
-    { AreSummariesEquivalent = areSummariesEquivalent; AreTextExportsIdentical = areTextExportsIdentical; AreJsonExportsIdentical = areJsonExportsIdentical; FirstTotalObservations = firstTotalObservations; SecondTotalObservations = secondTotalObservations; EventCountDelta = eventCountDelta.ToImmutableDictionary(); }
-    public bool AreSummariesEquivalent { get; }
-    public bool AreTextExportsIdentical { get; }
-    public bool AreJsonExportsIdentical { get; }
-    public int FirstTotalObservations { get; }
-    public int SecondTotalObservations { get; }
-    public IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventCountDelta { get; }
+    /// <summary>Event-count deltas captured as an immutable snapshot.</summary>
+    private IReadOnlyDictionary<ParserRuntimeObservationKind, int> _eventCountDelta =
+        EventCountDelta.ToImmutableDictionary();
+
+    /// <summary>Gets the immutable event-count delta snapshot.</summary>
+    public IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventCountDelta
+    {
+        get => _eventCountDelta;
+        init => _eventCountDelta = value.ToImmutableDictionary();
+    }
 }

--- a/Utils.Parser/Runtime/RuntimeTraceSummary.cs
+++ b/Utils.Parser/Runtime/RuntimeTraceSummary.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Utils.Parser.Runtime;
 
 /// <summary>
@@ -8,9 +10,14 @@ namespace Utils.Parser.Runtime;
 /// <param name="StatusDistribution">Count per observation status.</param>
 /// <param name="RuleDistribution">Count per observed rule name.</param>
 /// <param name="AlternativeDistribution">Count per observed alternative index.</param>
-public sealed record RuntimeTraceSummary(
-    int TotalObservations,
-    IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventDistribution,
-    IReadOnlyDictionary<ParserRuntimeObservationStatus, int> StatusDistribution,
-    IReadOnlyDictionary<string, int> RuleDistribution,
-    IReadOnlyDictionary<int, int> AlternativeDistribution);
+public sealed record RuntimeTraceSummary
+{
+    /// <summary>Initializes a summary by capturing immutable distribution snapshots.</summary>
+    public RuntimeTraceSummary(int totalObservations, IReadOnlyDictionary<ParserRuntimeObservationKind, int> eventDistribution, IReadOnlyDictionary<ParserRuntimeObservationStatus, int> statusDistribution, IReadOnlyDictionary<string, int> ruleDistribution, IReadOnlyDictionary<int, int> alternativeDistribution)
+    { TotalObservations = totalObservations; EventDistribution = eventDistribution.ToImmutableDictionary(); StatusDistribution = statusDistribution.ToImmutableDictionary(); RuleDistribution = ruleDistribution.ToImmutableDictionary(StringComparer.Ordinal); AlternativeDistribution = alternativeDistribution.ToImmutableDictionary(); }
+    public int TotalObservations { get; }
+    public IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventDistribution { get; }
+    public IReadOnlyDictionary<ParserRuntimeObservationStatus, int> StatusDistribution { get; }
+    public IReadOnlyDictionary<string, int> RuleDistribution { get; }
+    public IReadOnlyDictionary<int, int> AlternativeDistribution { get; }
+}

--- a/Utils.Parser/Runtime/RuntimeTraceSummary.cs
+++ b/Utils.Parser/Runtime/RuntimeTraceSummary.cs
@@ -10,14 +10,54 @@ namespace Utils.Parser.Runtime;
 /// <param name="StatusDistribution">Count per observation status.</param>
 /// <param name="RuleDistribution">Count per observed rule name.</param>
 /// <param name="AlternativeDistribution">Count per observed alternative index.</param>
-public sealed record RuntimeTraceSummary
+public sealed record RuntimeTraceSummary(
+    int TotalObservations,
+    IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventDistribution,
+    IReadOnlyDictionary<ParserRuntimeObservationStatus, int> StatusDistribution,
+    IReadOnlyDictionary<string, int> RuleDistribution,
+    IReadOnlyDictionary<int, int> AlternativeDistribution)
 {
-    /// <summary>Initializes a summary by capturing immutable distribution snapshots.</summary>
-    public RuntimeTraceSummary(int totalObservations, IReadOnlyDictionary<ParserRuntimeObservationKind, int> eventDistribution, IReadOnlyDictionary<ParserRuntimeObservationStatus, int> statusDistribution, IReadOnlyDictionary<string, int> ruleDistribution, IReadOnlyDictionary<int, int> alternativeDistribution)
-    { TotalObservations = totalObservations; EventDistribution = eventDistribution.ToImmutableDictionary(); StatusDistribution = statusDistribution.ToImmutableDictionary(); RuleDistribution = ruleDistribution.ToImmutableDictionary(StringComparer.Ordinal); AlternativeDistribution = alternativeDistribution.ToImmutableDictionary(); }
-    public int TotalObservations { get; }
-    public IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventDistribution { get; }
-    public IReadOnlyDictionary<ParserRuntimeObservationStatus, int> StatusDistribution { get; }
-    public IReadOnlyDictionary<string, int> RuleDistribution { get; }
-    public IReadOnlyDictionary<int, int> AlternativeDistribution { get; }
+    /// <summary>Event distribution captured as an immutable snapshot.</summary>
+    private IReadOnlyDictionary<ParserRuntimeObservationKind, int> _eventDistribution =
+        EventDistribution.ToImmutableDictionary();
+
+    /// <summary>Status distribution captured as an immutable snapshot.</summary>
+    private IReadOnlyDictionary<ParserRuntimeObservationStatus, int> _statusDistribution =
+        StatusDistribution.ToImmutableDictionary();
+
+    /// <summary>Rule distribution captured as an immutable snapshot.</summary>
+    private IReadOnlyDictionary<string, int> _ruleDistribution =
+        RuleDistribution.ToImmutableDictionary(StringComparer.Ordinal);
+
+    /// <summary>Alternative distribution captured as an immutable snapshot.</summary>
+    private IReadOnlyDictionary<int, int> _alternativeDistribution =
+        AlternativeDistribution.ToImmutableDictionary();
+
+    /// <summary>Gets the immutable event distribution.</summary>
+    public IReadOnlyDictionary<ParserRuntimeObservationKind, int> EventDistribution
+    {
+        get => _eventDistribution;
+        init => _eventDistribution = value.ToImmutableDictionary();
+    }
+
+    /// <summary>Gets the immutable status distribution.</summary>
+    public IReadOnlyDictionary<ParserRuntimeObservationStatus, int> StatusDistribution
+    {
+        get => _statusDistribution;
+        init => _statusDistribution = value.ToImmutableDictionary();
+    }
+
+    /// <summary>Gets the immutable ordinal rule distribution.</summary>
+    public IReadOnlyDictionary<string, int> RuleDistribution
+    {
+        get => _ruleDistribution;
+        init => _ruleDistribution = value.ToImmutableDictionary(StringComparer.Ordinal);
+    }
+
+    /// <summary>Gets the immutable alternative distribution.</summary>
+    public IReadOnlyDictionary<int, int> AlternativeDistribution
+    {
+        get => _alternativeDistribution;
+        init => _alternativeDistribution = value.ToImmutableDictionary();
+    }
 }

--- a/UtilsTest/Parser/ParserInternalImmutabilityTests.cs
+++ b/UtilsTest/Parser/ParserInternalImmutabilityTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Utils.Parser.Expressions;
+using Utils.Parser.Runtime;
+
+namespace UtilsTest.Parser;
+
+/// <summary>Verifies immutable snapshots used by parser preparation and analysis results.</summary>
+[TestClass]
+public sealed class ParserInternalImmutabilityTests
+{
+    /// <summary>Verifies scheduling descriptors defensively capture ordered source collections.</summary>
+    [TestMethod]
+    public void SchedulingSnapshots_DoNotAliasMutableSequences()
+    {
+        string[] tokens = ["first"];
+        var descriptor = new AlternativeStructuralDescriptor(0, tokens);
+        tokens[0] = "second";
+
+        Assert.AreEqual("first", descriptor.StructuralTokens[0]);
+        Assert.IsFalse(descriptor.StructuralTokens is string[]);
+
+        int[] indexes = [0];
+        var candidate = new ParserLookaheadSharedPrefixCandidate("first", indexes);
+        indexes[0] = 1;
+
+        Assert.AreEqual(0, candidate.AlternativeIndexes[0]);
+        Assert.IsFalse(candidate.AlternativeIndexes is int[]);
+    }
+
+    /// <summary>Verifies runtime trace dictionaries are immutable construction-time snapshots.</summary>
+    [TestMethod]
+    public void RuntimeTraceResults_DoNotAliasMutableDictionaries()
+    {
+        var rules = new Dictionary<string, int>(StringComparer.Ordinal) { ["rule"] = 1 };
+        var summary = new RuntimeTraceSummary(1, new Dictionary<ParserRuntimeObservationKind, int>(), new Dictionary<ParserRuntimeObservationStatus, int>(), rules, new Dictionary<int, int>());
+        rules["rule"] = 42;
+
+        Assert.AreEqual(1, summary.RuleDistribution["rule"]);
+        Assert.IsFalse(summary.RuleDistribution is Dictionary<string, int>);
+
+        var deltas = new Dictionary<ParserRuntimeObservationKind, int> { [ParserRuntimeObservationKind.AlternativeStarted] = 1 };
+        var comparison = new RuntimeTraceComparison(false, false, false, 1, 0, deltas);
+        deltas[ParserRuntimeObservationKind.AlternativeStarted] = 2;
+        Assert.AreEqual(1, comparison.EventCountDelta[ParserRuntimeObservationKind.AlternativeStarted]);
+    }
+
+    /// <summary>Verifies params diagnostic arguments are captured rather than retained.</summary>
+    [TestMethod]
+    public void ParserActionOutcome_CapturesParamsArguments()
+    {
+        object?[] arguments = ["first"];
+        var outcome = ParserActionExecutionOutcome.NotExecuted(Utils.Parser.Diagnostics.ParserDiagnostics.EmbeddedCodeExecutionDisabled, null, arguments);
+        arguments[0] = "second";
+
+        Assert.AreEqual("first", outcome.DiagnosticArguments[0]);
+        Assert.IsFalse(outcome.DiagnosticArguments is object?[]);
+    }
+
+    /// <summary>Verifies expression registry result sequences cannot expose or retain mutable lists.</summary>
+    [TestMethod]
+    public void ExpressionRegistryResult_CapturesListsAndDoesNotExposeArrays()
+    {
+        var entries = new List<PreparedExpressionEmbeddedCodeRegistryBuildEntry>();
+        var result = new PreparedExpressionEmbeddedCodeRegistryBuildResult(new PreparedExpressionEmbeddedCodeRegistry(), entries, entries, entries, entries, entries, entries);
+        entries.Add(null!);
+
+        Assert.AreEqual(0, result.AllEntries.Count);
+        Assert.IsFalse(result.AllEntries is PreparedExpressionEmbeddedCodeRegistryBuildEntry[]);
+        Assert.IsFalse(result.AllEntries is List<PreparedExpressionEmbeddedCodeRegistryBuildEntry>);
+    }
+}

--- a/UtilsTest/Parser/ParserInternalImmutabilityTests.cs
+++ b/UtilsTest/Parser/ParserInternalImmutabilityTests.cs
@@ -44,6 +44,54 @@ public sealed class ParserInternalImmutabilityTests
         Assert.AreEqual(1, comparison.EventCountDelta[ParserRuntimeObservationKind.AlternativeStarted]);
     }
 
+    /// <summary>Verifies record cloning normalizes mutable dictionaries assigned to trace results.</summary>
+    [TestMethod]
+    public void RuntimeTraceResults_WithExpressionsCaptureMutableDictionaries()
+    {
+        var summary = new RuntimeTraceSummary(0, new Dictionary<ParserRuntimeObservationKind, int>(), new Dictionary<ParserRuntimeObservationStatus, int>(), new Dictionary<string, int>(), new Dictionary<int, int>());
+        var events = new Dictionary<ParserRuntimeObservationKind, int>
+        {
+            [ParserRuntimeObservationKind.AlternativeStarted] = 1
+        };
+        var summaryCopy = summary with { EventDistribution = events };
+
+        var comparison = new RuntimeTraceComparison(false, false, false, 0, 0, new Dictionary<ParserRuntimeObservationKind, int>());
+        var comparisonCopy = comparison with { EventCountDelta = events };
+        events.Clear();
+
+        Assert.AreEqual(1, summaryCopy.EventDistribution[ParserRuntimeObservationKind.AlternativeStarted]);
+        Assert.AreEqual(1, comparisonCopy.EventCountDelta[ParserRuntimeObservationKind.AlternativeStarted]);
+        Assert.IsFalse(summaryCopy.EventDistribution is Dictionary<ParserRuntimeObservationKind, int>);
+        Assert.IsFalse(comparisonCopy.EventCountDelta is Dictionary<ParserRuntimeObservationKind, int>);
+    }
+
+    /// <summary>Verifies positional trace records retain their public deconstruction contract.</summary>
+    [TestMethod]
+    public void RuntimeTraceResults_RetainDeconstructionContract()
+    {
+        var events = new Dictionary<ParserRuntimeObservationKind, int>();
+        var statuses = new Dictionary<ParserRuntimeObservationStatus, int>();
+        var rules = new Dictionary<string, int>();
+        var alternatives = new Dictionary<int, int>();
+        var summary = new RuntimeTraceSummary(3, events, statuses, rules, alternatives);
+        var comparison = new RuntimeTraceComparison(true, false, true, 3, 2, events);
+
+        var (total, deconstructedEvents, deconstructedStatuses, deconstructedRules, deconstructedAlternatives) = summary;
+        var (equivalent, textIdentical, jsonIdentical, firstTotal, secondTotal, eventDelta) = comparison;
+
+        Assert.AreEqual(3, total);
+        Assert.AreSame(summary.EventDistribution, deconstructedEvents);
+        Assert.AreSame(summary.StatusDistribution, deconstructedStatuses);
+        Assert.AreSame(summary.RuleDistribution, deconstructedRules);
+        Assert.AreSame(summary.AlternativeDistribution, deconstructedAlternatives);
+        Assert.IsTrue(equivalent);
+        Assert.IsFalse(textIdentical);
+        Assert.IsTrue(jsonIdentical);
+        Assert.AreEqual(3, firstTotal);
+        Assert.AreEqual(2, secondTotal);
+        Assert.AreSame(comparison.EventCountDelta, eventDelta);
+    }
+
     /// <summary>Verifies params diagnostic arguments are captured rather than retained.</summary>
     [TestMethod]
     public void ParserActionOutcome_CapturesParamsArguments()


### PR DESCRIPTION
### Motivation

- The parser preparation/runtime and related planners expose collections behind `IReadOnly*` that were still aliasable and mutable by callers, breaking the documented immutable-snapshot contract.  
- Defensive, single-point immutability is required to prevent source-side mutations, `params` aliasing, and recast attacks via arrays/lists/dictionaries.  
- Preserve existing semantics (order, comparers, nullability) while making DTOs/results true immutable snapshots at construction time.

### Description

- Normalize scheduling/runtime snapshots to immutable storage by copying inputs into `ImmutableArray`/immutable dictionaries where appropriate; key types updated include `PreparedSchedulingInputs`, `AlternativeStructuralDescriptor`, `ParserLookaheadProbeResult`, `ParserLookaheadSharedPrefixCandidate`, `ParserContinuationDescriptor`, `ParserContinuationPreparationInput`, `ParserSharedPrefixPlan`, `ParserSharedPrefixSegment` and `ParserSharedPrefixBoundary`.  
- Make runtime trace exports truly immutable by capturing distributions/deltas into immutable dictionaries and preserve `StringComparer.Ordinal` for `RuleDistribution` (`RuntimeTraceSummary`, `RuntimeTraceComparison`).  
- Freeze planner DTOs/results in the ANTLR composition planner by converting import paths/candidates/plan collections to immutable snapshots (`GrammarDependencyEdge`, `AmbiguousGrammarDependency`, `GrammarImportCycle`, `EffectiveGrammarRule`, `GrammarRuleCollision`, `GrammarImportCompositionPlan`).  
- Protect expression/embedded-code results and diagnostic `params` arrays by converting builder results and entries to `ImmutableArray` and copying `diagnosticArguments` (`PreparedExpressionEmbeddedCodeRegistryBuildResult`, `PreparedExpressionEmbeddedCodeRegistryBuildEntry`, `ParserActionExecutionOutcome`).  
- Minor support changes: normalize `AlternativeSchedulingMetadata.SharedPrefixPlans`, capture `ParserSharedPrefixPlanValidationResult.Issues`, update XML comments to reflect immutable snapshot contract, and mark the Parser TODO as completed for the covered tranche (renamed to `DONE-2026-08-09.md`).  
- Tests: add `UtilsTest/Parser/ParserInternalImmutabilityTests.cs` covering array/list/dictionary/set/`params` aliasing and recast checks for the modified families of types.

### Testing

- Ran `dotnet restore` and `dotnet build` for the solution; build completed successfully (pre-existing warnings remain but no build failures).  
- Ran parser-related unit tests: `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter "FullyQualifiedName~Parser"` — all parser-unit tests passed (report: 1908 passed, 0 failed for full unit suite in the run).  
- Ran targeted immutability/regression tests: `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter "FullyQualifiedName~ParserInternalImmutabilityTests|FullyQualifiedName~GrammarImportCompositionPlannerTests|FullyQualifiedName~PreparedExpressionEmbeddedCodeRegistryBuilderTests"` — targeted tests passed (39 passed, 0 failed).  
- Ran functional parser tests filter: `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --filter "FullyQualifiedName~Parser"` — functional parser tests passed in this environment (123 passed, 0 failed).  

All automated tests executed for this change that were in-scope passed; the changes are limited to defensive copies/immutable storage and do not change parser runtime behavior or public API signatures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78abdfe43483269f23e7805e04f0cd)