### PR TITLE
Make non-parser value collections immutable

### DIFF
--- a/TODO-immutability.md
+++ b/TODO-immutability.md
@@ -11,6 +11,28 @@ Corriger les types immuables ou utilisés comme snapshots dans les autres projet
 
 Une interface `IReadOnly*` n’est pas une garantie d’immutabilité.
 
+## Première tranche terminée (2026-08-10)
+
+Les cas suivants sont corrigés et couverts par des tests de non-aliasing :
+
+- [x] `SmtpMessage.Recipients` (construction et affectation par `with`) ;
+- [x] `DnsLookupException.Failures` ;
+- [x] `NtpQueryException.Failures` ;
+- [x] `NetworkInterfaceSnapshot.DnsAddresses` ;
+- [x] `SqlSyntaxOptions.IdentifierPrefixes` ;
+- [x] `ReflectionSerializationContract.Members` ;
+- [x] `Bytes` lors de la construction depuis un `byte[]`.
+
+Les collections séquentielles ci-dessus utilisent désormais des snapshots `ImmutableArray`,
+à l’exception de `Bytes`, qui conserve volontairement son tableau strictement privé après en
+avoir effectué une copie défensive. `SqlSyntaxOptions` utilise un `ImmutableHashSet<char>`.
+
+## Remaining work
+
+- Auditer et corriger les prochaines tranches hors Parser qui ne faisaient pas partie de cette PR.
+- Traiter séparément `VirtualProcess<TAddress>.Mappings`, amélioration P3 de contrat/performance
+  qui ne permet actuellement pas de modifier l’état interne du processus.
+
 ---
 
 ## Principe cible commun

--- a/Utils.Data/Sql/SqlSyntaxOptions.cs
+++ b/Utils.Data/Sql/SqlSyntaxOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 
 namespace Utils.Data.Sql;
@@ -10,7 +11,7 @@ public sealed class SqlSyntaxOptions
 {
     private static readonly char[] DefaultIdentifierPrefixes = { '@', '#', '$' };
 
-    private readonly HashSet<char> identifierPrefixes;
+    private readonly ImmutableHashSet<char> identifierPrefixes;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SqlSyntaxOptions"/> class.
@@ -30,7 +31,7 @@ public sealed class SqlSyntaxOptions
 
         resolvedPrefixes.Add(autoParameterPrefix);
 
-        this.identifierPrefixes = resolvedPrefixes;
+        this.identifierPrefixes = resolvedPrefixes.ToImmutableHashSet(resolvedPrefixes.Comparer);
         AutoParameterPrefix = autoParameterPrefix;
     }
 

--- a/Utils.IO/IO/Serialization/ReflectionSerializationContract.cs
+++ b/Utils.IO/IO/Serialization/ReflectionSerializationContract.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -13,7 +14,17 @@ internal enum SerializationDirection { Read, Write }
 internal sealed record SerializableMemberContract(MemberInfo Member, Type ValueType, int Order);
 
 /// <summary>Holds the reflection-independent decisions needed by delegate generation.</summary>
-internal sealed record ReflectionSerializationContract(Type Type, IReadOnlyList<SerializableMemberContract> Members);
+internal sealed record ReflectionSerializationContract(Type Type, IReadOnlyList<SerializableMemberContract> Members)
+{
+    private IReadOnlyList<SerializableMemberContract> _members = Members.ToImmutableArray();
+
+    /// <summary>Gets the serializable members as an immutable, stably ordered snapshot.</summary>
+    internal IReadOnlyList<SerializableMemberContract> Members
+    {
+        get => _members;
+        init => _members = value.ToImmutableArray();
+    }
+}
 
 /// <summary>Discovers and validates reflection serialization contracts before expressions are created.</summary>
 internal static class ReflectionContractBuilder
@@ -43,7 +54,7 @@ internal static class ReflectionContractBuilder
         }
 
         if (diagnostics.Count > 0) throw new SerializationContractException(type, diagnostics);
-        return new(type, members.OrderBy(member => member.Order).ThenBy(member => member.Member.Name, StringComparer.Ordinal).ToArray());
+        return new(type, members.OrderBy(member => member.Order).ThenBy(member => member.Member.Name, StringComparer.Ordinal).ToImmutableArray());
     }
 
     /// <summary>Validates one attributed member and returns its executable description.</summary>

--- a/Utils.Net/Net/DnsLookupFailures.cs
+++ b/Utils.Net/Net/DnsLookupFailures.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -91,9 +92,7 @@ namespace Utils.Net
         public DnsLookupException(IReadOnlyList<DnsServerFailure> failures)
             : base(BuildMessage(failures))
         {
-            Failures = failures is null
-                ? (IReadOnlyList<DnsServerFailure>)Array.Empty<DnsServerFailure>()
-                : failures.ToArray();
+            Failures = failures?.ToImmutableArray() ?? ImmutableArray<DnsServerFailure>.Empty;
         }
 
         private static string BuildMessage(IReadOnlyList<DnsServerFailure>? failures)

--- a/Utils.Net/Net/NetworkParameters.cs
+++ b/Utils.Net/Net/NetworkParameters.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -128,5 +129,17 @@ namespace Utils.Net
     /// <param name="DnsAddresses">The DNS resolver addresses configured on the interface.</param>
     internal sealed record NetworkInterfaceSnapshot(
         OperationalStatus Status,
-        IReadOnlyList<IPAddress> DnsAddresses);
+        IReadOnlyList<IPAddress> DnsAddresses)
+    {
+        private IReadOnlyList<IPAddress> _dnsAddresses = DnsAddresses.ToImmutableArray();
+
+        /// <summary>
+        /// Gets the DNS resolver addresses as an immutable snapshot.
+        /// </summary>
+        internal IReadOnlyList<IPAddress> DnsAddresses
+        {
+            get => _dnsAddresses;
+            init => _dnsAddresses = value.ToImmutableArray();
+        }
+    }
 }

--- a/Utils.Net/Net/NtpSupport.cs
+++ b/Utils.Net/Net/NtpSupport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -54,9 +55,7 @@ namespace Utils.Net
         public NtpQueryException(string message, IReadOnlyList<NtpEndpointFailure> failures)
             : base(message)
         {
-            Failures = failures is null
-                ? (IReadOnlyList<NtpEndpointFailure>)Array.Empty<NtpEndpointFailure>()
-                : failures.ToArray();
+            Failures = failures?.ToImmutableArray() ?? ImmutableArray<NtpEndpointFailure>.Empty;
         }
     }
 

--- a/Utils.Net/Net/SmtpMessage.cs
+++ b/Utils.Net/Net/SmtpMessage.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Collections.Generic;
 
 namespace Utils.Net;
@@ -8,4 +9,16 @@ namespace Utils.Net;
 /// <param name="From">Mail sender address.</param>
 /// <param name="Recipients">Recipient addresses.</param>
 /// <param name="Data">Raw message data.</param>
-public sealed record SmtpMessage(string From, IReadOnlyList<string> Recipients, string Data);
+public sealed record SmtpMessage(string From, IReadOnlyList<string> Recipients, string Data)
+{
+    private IReadOnlyList<string> _recipients = Recipients.ToImmutableArray();
+
+    /// <summary>
+    /// Gets the recipient addresses as an immutable snapshot.
+    /// </summary>
+    public IReadOnlyList<string> Recipients
+    {
+        get => _recipients;
+        init => _recipients = value.ToImmutableArray();
+    }
+}

--- a/Utils/Objects/Bytes.cs
+++ b/Utils/Objects/Bytes.cs
@@ -42,7 +42,8 @@ public readonly struct Bytes :
     /// <param name="byteArray">The byte array to store in the struct.</param>
     internal Bytes(params byte[] byteArray)
     {
-        _innerBytes = byteArray ?? [];
+        // Keep the private array representation, but never retain an array owned by the caller.
+        _innerBytes = byteArray is null ? [] : (byte[])byteArray.Clone();
     }
 
     /// <summary>

--- a/Utils/Objects/Bytes.cs
+++ b/Utils/Objects/Bytes.cs
@@ -41,9 +41,24 @@ public readonly struct Bytes :
     /// </summary>
     /// <param name="byteArray">The byte array to store in the struct.</param>
     internal Bytes(params byte[] byteArray)
+        : this(byteArray, copy: true)
     {
-        // Keep the private array representation, but never retain an array owned by the caller.
-        _innerBytes = byteArray is null ? [] : (byte[])byteArray.Clone();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Bytes"/> struct, optionally retaining the
+    /// supplied array for the explicitly aliasing <see cref="BytesExtensions.AsBytes(byte[])"/> contract.
+    /// </summary>
+    /// <param name="byteArray">The byte array to store in the struct.</param>
+    /// <param name="copy"><see langword="true"/> to copy the array; otherwise, to retain the exact array.</param>
+    internal Bytes(byte[] byteArray, bool copy)
+    {
+        // Only AsBytes requests the intentional alias; all ordinary construction copies caller data.
+        _innerBytes = byteArray is null
+            ? []
+            : copy
+                ? (byte[])byteArray.Clone()
+                : byteArray;
     }
 
     /// <summary>
@@ -516,10 +531,7 @@ public static class BytesExtensions
     public static Bytes ToBytes(this byte[] byteArray)
     {
         if (byteArray.IsNullOrEmptyCollection()) return Bytes.Empty;
-
-        var copy = new byte[byteArray.Length];
-        Array.Copy(byteArray, 0, copy, 0, byteArray.Length);
-        return new Bytes(copy);
+        return new Bytes(byteArray);
     }
 
     /// <summary>
@@ -539,7 +551,7 @@ public static class BytesExtensions
     /// </summary>
     /// <param name="byteArray">The byte array to wrap in a <see cref="Bytes"/>.</param>
     /// <returns>A <see cref="Bytes"/> referencing the exact array.</returns>
-    public static Bytes AsBytes(this byte[] byteArray) => byteArray is not null ? new Bytes(byteArray) : Bytes.Empty;
+    public static Bytes AsBytes(this byte[] byteArray) => byteArray is not null ? new Bytes(byteArray, copy: false) : Bytes.Empty;
 
     /// <summary>
     /// Concatenates all the byte arrays into a single <see cref="Bytes"/> instance.

--- a/UtilsTest/Immutability/NonParserImmutabilityTests.cs
+++ b/UtilsTest/Immutability/NonParserImmutabilityTests.cs
@@ -1,0 +1,186 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using Utils.Data.Sql;
+using Utils.IO.Serialization;
+using Utils.Net;
+using Utils.Objects;
+
+namespace UtilsTest.Immutability;
+
+/// <summary>
+/// Verifies defensive collection snapshots used by immutable types outside the parser projects.
+/// </summary>
+[TestClass]
+public sealed class NonParserImmutabilityTests
+{
+    /// <summary>Verifies that SMTP recipients are detached from array and list sources.</summary>
+    [TestMethod]
+    public void SmtpMessage_RecipientsAreImmutableSnapshot()
+    {
+        string[] array = ["first@example.com", "second@example.com"];
+        var message = new SmtpMessage("sender@example.com", array, "data");
+        array[0] = "changed@example.com";
+
+        var list = new List<string> { "list@example.com" };
+        var fromList = new SmtpMessage("sender@example.com", list, "data");
+        list.Clear();
+
+        CollectionAssert.AreEqual(
+            new[] { "first@example.com", "second@example.com" },
+            message.Recipients.ToArray());
+        Assert.AreEqual("list@example.com", fromList.Recipients[0]);
+        Assert.IsFalse(message.Recipients is string[]);
+        Assert.IsFalse(fromList.Recipients is List<string>);
+    }
+
+    /// <summary>Verifies that record cloning normalizes replacement SMTP recipients.</summary>
+    [TestMethod]
+    public void SmtpMessage_WithRecipientsCreatesImmutableSnapshot()
+    {
+        var original = new SmtpMessage("sender@example.com", ["original@example.com"], "data");
+        string[] replacement = ["replacement@example.com"];
+
+        SmtpMessage copy = original with { Recipients = replacement };
+        replacement[0] = "changed@example.com";
+
+        Assert.AreEqual("replacement@example.com", copy.Recipients[0]);
+        Assert.IsFalse(copy.Recipients is string[]);
+    }
+
+    /// <summary>Verifies that DNS failures retain source order without exposing mutable storage.</summary>
+    [TestMethod]
+    public void DnsLookupException_FailuresAreImmutableSnapshot()
+    {
+        DnsServerFailure first = DnsFailure("192.0.2.1");
+        DnsServerFailure second = DnsFailure("192.0.2.2");
+        var source = new List<DnsServerFailure> { first, second };
+
+        var exception = new DnsLookupException(source);
+        source.Clear();
+
+        CollectionAssert.AreEqual(new[] { first, second }, exception.Failures.ToArray());
+        Assert.IsFalse(exception.Failures is DnsServerFailure[]);
+        StringAssert.Contains(exception.Message, "2 configured DNS server attempt(s)");
+    }
+
+    /// <summary>Verifies that NTP failures retain source order without exposing mutable storage.</summary>
+    [TestMethod]
+    public void NtpQueryException_FailuresAreImmutableSnapshot()
+    {
+        NtpEndpointFailure first = NtpFailure("192.0.2.1");
+        NtpEndpointFailure second = NtpFailure("192.0.2.2");
+        NtpEndpointFailure[] source = [first, second];
+
+        var exception = new NtpQueryException("query failed", source);
+        source[0] = NtpFailure("192.0.2.3");
+
+        CollectionAssert.AreEqual(new[] { first, second }, exception.Failures.ToArray());
+        Assert.IsFalse(exception.Failures is NtpEndpointFailure[]);
+        Assert.AreEqual("query failed", exception.Message);
+    }
+
+    /// <summary>Verifies that SQL identifier prefixes cannot be mutated through either source or getter.</summary>
+    [TestMethod]
+    public void SqlSyntaxOptions_IdentifierPrefixesAreImmutableSnapshot()
+    {
+        var source = new HashSet<char> { '@', ':' };
+        var options = new SqlSyntaxOptions(source, '@');
+        source.Clear();
+
+        Assert.IsTrue(options.IsIdentifierPrefix('@'));
+        Assert.IsTrue(options.IsIdentifierPrefix(':'));
+        Assert.IsFalse(options.IdentifierPrefixes is HashSet<char>);
+    }
+
+    /// <summary>Verifies that network-interface snapshots normalize construction and with-expression inputs.</summary>
+    [TestMethod]
+    public void NetworkInterfaceSnapshot_DnsAddressesAreImmutableSnapshot()
+    {
+        IPAddress first = IPAddress.Parse("192.0.2.1");
+        IPAddress second = IPAddress.Parse("192.0.2.2");
+        IPAddress[] source = [first];
+        var snapshot = new NetworkInterfaceSnapshot(OperationalStatus.Up, source);
+        source[0] = second;
+
+        IPAddress[] replacement = [first];
+        NetworkInterfaceSnapshot copy = snapshot with { DnsAddresses = replacement };
+        replacement[0] = second;
+
+        Assert.AreEqual(first, snapshot.DnsAddresses[0]);
+        Assert.AreEqual(first, copy.DnsAddresses[0]);
+        Assert.IsFalse(snapshot.DnsAddresses is IPAddress[]);
+        Assert.IsFalse(copy.DnsAddresses is IPAddress[]);
+    }
+
+    /// <summary>Verifies that reflection contracts detach and normalize ordered member collections.</summary>
+    [TestMethod]
+    public void ReflectionSerializationContract_MembersAreImmutableSnapshot()
+    {
+        var first = new SerializableMemberContract(typeof(ContractModel).GetProperty(nameof(ContractModel.First))!, typeof(int), 1);
+        var second = new SerializableMemberContract(typeof(ContractModel).GetProperty(nameof(ContractModel.Second))!, typeof(int), 2);
+        var source = new List<SerializableMemberContract> { first, second };
+        var contract = new ReflectionSerializationContract(typeof(ContractModel), source);
+        source.Clear();
+
+        SerializableMemberContract[] replacement = [second, first];
+        ReflectionSerializationContract copy = contract with { Members = replacement };
+        replacement[0] = first;
+
+        CollectionAssert.AreEqual(new[] { first, second }, contract.Members.ToArray());
+        CollectionAssert.AreEqual(new[] { second, first }, copy.Members.ToArray());
+        Assert.IsFalse(contract.Members is SerializableMemberContract[]);
+        Assert.IsFalse(copy.Members is SerializableMemberContract[]);
+    }
+
+    /// <summary>Verifies that conversion from an array and conversion back do not alias a Bytes value.</summary>
+    [TestMethod]
+    public void Bytes_ArrayConversionsAreDefensive()
+    {
+        byte[] source = [1, 2, 3];
+        Bytes value = source;
+        source[0] = 9;
+
+        byte[] copy = value.ToArray();
+        copy[0] = 8;
+
+        Assert.AreEqual((byte)1, value[0]);
+    }
+
+    /// <summary>Verifies the existing empty, null, and default Bytes contracts.</summary>
+    [TestMethod]
+    public void Bytes_EmptyNullAndDefaultRemainEmpty()
+    {
+        byte[] nullSource = null!;
+        Bytes fromNull = nullSource;
+        Bytes fromEmpty = System.Array.Empty<byte>();
+        Bytes defaultValue = default;
+
+        Assert.AreEqual(0, fromNull.Count);
+        Assert.AreEqual(0, fromEmpty.Count);
+        Assert.AreEqual(0, defaultValue.Count);
+        Assert.AreEqual(0, defaultValue.ToArray().Length);
+    }
+
+    /// <summary>Creates a deterministic DNS failure for collection tests.</summary>
+    private static DnsServerFailure DnsFailure(string address) =>
+        new(new IPEndPoint(IPAddress.Parse(address), 53), DnsTransport.Udp, DnsFailureKind.Timeout, null, "timeout");
+
+    /// <summary>Creates a deterministic NTP failure for collection tests.</summary>
+    private static NtpEndpointFailure NtpFailure(string address) =>
+        new(new IPEndPoint(IPAddress.Parse(address), 123), AddressFamily.InterNetwork, NtpPhase.Exchange, null, "failure");
+
+    /// <summary>Provides reflected members for serialization contract tests.</summary>
+    private sealed class ContractModel
+    {
+        /// <summary>Gets or sets the first value.</summary>
+        public int First { get; set; }
+
+        /// <summary>Gets or sets the second value.</summary>
+        public int Second { get; set; }
+    }
+}

--- a/UtilsTest/Immutability/NonParserImmutabilityTests.cs
+++ b/UtilsTest/Immutability/NonParserImmutabilityTests.cs
@@ -151,6 +151,20 @@ public sealed class NonParserImmutabilityTests
         Assert.AreEqual((byte)1, value[0]);
     }
 
+    /// <summary>Verifies the distinct copying and intentional aliasing byte-array extension contracts.</summary>
+    [TestMethod]
+    public void Bytes_ToBytesCopiesWhileAsBytesRetainsAliasingContract()
+    {
+        byte[] source = [1, 2, 3];
+        Bytes copy = source.ToBytes();
+        Bytes view = source.AsBytes();
+
+        source[0] = 9;
+
+        Assert.AreEqual((byte)1, copy[0]);
+        Assert.AreEqual((byte)9, view[0]);
+    }
+
     /// <summary>Verifies the existing empty, null, and default Bytes contracts.</summary>
     [TestMethod]
     public void Bytes_EmptyNullAndDefaultRemainEmpty()


### PR DESCRIPTION
### Motivation
- Eliminate aliasing of caller-owned mutable collections retained by types presented as immutable across `Utils.Net`, `Utils.Data`, `Utils.IO` and the `Bytes` value type.  
- Ensure defensive copying at construction and preserve deterministic order, existing comparers and `with` semantics for positional records.  
- Limit scope to the first tranche of the transversal immutability TODO so changes remain non-breaking and localized.

### Description
- `SmtpMessage` (Utils.Net) retains the positional record shape while normalizing `Recipients` to an immutable snapshot via `ToImmutableArray()` on construction and `init`, protecting `with` assignments.  
- `DnsLookupException.Failures` and `NtpQueryException.Failures` now store `ImmutableArray<T>` snapshots instead of exposing a castable array.  
- `NetworkInterfaceSnapshot.DnsAddresses` now holds an immutable snapshot and normalizes `with` inputs to `ImmutableArray<IPAddress>`.  
- `SqlSyntaxOptions.IdentifierPrefixes` uses `ImmutableHashSet<char>` constructed with the original comparer to prevent external mutation while preserving public `IReadOnlyCollection<char>` API.  
- `ReflectionSerializationContract.Members` is normalized to an immutable snapshot (constructor and `with`) and the builder returns an `ImmutableArray` to preserve order.  
- `Bytes` copies (clones) any incoming `byte[]` in its constructor to remove aliasing via the implicit `byte[] -> Bytes` conversion while keeping the private array representation.  
- Added `UtilsTest/Immutability/NonParserImmutabilityTests.cs` with focused tests for array/list/set mutation, recast checks and `with` behavior, and updated `TODO-immutability.md` to mark this tranche completed and list remaining work.

### Testing
- Ran the new focused tests via `dotnet test UtilsTest/UtilsTest.Unit.csproj --filter FullyQualifiedName~NonParserImmutabilityTests` and all 9 tests passed.  
- Performed a full solution validation: `dotnet restore` succeeded, `dotnet build --configuration Release --no-restore` succeeded with no errors, `dotnet test UtilsTest/UtilsTest.Unit.csproj --configuration Release --no-build` passed (5,847 passed, 61 skipped), and `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --configuration Release --no-build` passed (366 passed, 10 skipped).  
- `git diff --check` reported no whitespace/errors; release-quality gates script could not be executed here because `pwsh` was unavailable in the container, but equivalent restore/build/test validations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79e4970c4c8326a1a59815cb64913b)