### PR TITLE
Protect collection views and cache immutable snapshots

### DIFF
--- a/TODO-immutability.md
+++ b/TODO-immutability.md
@@ -30,8 +30,37 @@ avoir effectué une copie défensive. `SqlSyntaxOptions` utilise un `ImmutableHa
 ## Remaining work
 
 - Auditer et corriger les prochaines tranches hors Parser qui ne faisaient pas partie de cette PR.
-- Traiter séparément `VirtualProcess<TAddress>.Mappings`, amélioration P3 de contrat/performance
-  qui ne permet actuellement pas de modifier l’état interne du processus.
+- Auditer `ControlFlowStack.Blocks` : cette vue live est exposée sous `IEnumerable<T>`, mais le
+  `Stack<T>` interne reste récupérable par cast. Une correction doit préserver l'ordre
+  d'énumération et éviter une allocation à chaque lecture.
+
+## Deuxième tranche terminée (2026-08-11)
+
+Les cas suivants sont corrigés et couverts par des tests d'encapsulation :
+
+- [x] `VirtualMemory<TAddress>.Pages` : vue read-only live créée une fois ;
+- [x] `VirtualMemory<TAddress>.Processes` : vue read-only live créée une fois ;
+- [x] `Scheduler<T>.Processes` : vue read-only live créée une fois ;
+- [x] `CallFrame.Locals` : `ReadOnlyDictionary` live créé une fois ;
+- [x] `VirtualProcess<TAddress>.Mappings` : snapshot `ImmutableArray` mis en cache avec
+  invalidation lazy après chaque mutation de la table des pages ;
+- [x] `TransactionException.RollbackExceptions` : copie défensive immutable à la construction.
+
+### Audit ciblé `Utils.VirtualMachine` et `Utils.Transactions`
+
+- `VirtualProcessor<T>.Instructions` expose bien les tableaux possédés servant de clés au
+  dictionnaire : un consommateur peut recaster `Opcode` en `byte[]` et modifier la clé après son
+  insertion. Le stockage clone les sources externes, mais ce clone interne reste exposé. Ce
+  finding est volontairement reporté : corriger le type de clé exige d'adapter et de tester le
+  comparateur de séquences, la détection des préfixes, la table rapide et le dispatch sans changer
+  leur sémantique.
+- `VirtualProcessor<T>.Breakpoints` reste volontairement mutable : la collection constitue l'API
+  publique de mutation.
+- `ReadOnlyRange<T>` reste volontairement une vue live sur la liste fournie par l'appelant.
+- Les tableaux privés statiques réellement encapsulés sont des faux positifs et ne nécessitent
+  pas de conversion.
+- Les modèles de protocole DNS à propriétés `byte[]` restent des DTO mutables hors périmètre ;
+  aucun invariant d'objet immutable n'a été établi pendant cette tranche.
 
 ---
 

--- a/TODO-immutability.md
+++ b/TODO-immutability.md
@@ -30,9 +30,6 @@ avoir effectué une copie défensive. `SqlSyntaxOptions` utilise un `ImmutableHa
 ## Remaining work
 
 - Auditer et corriger les prochaines tranches hors Parser qui ne faisaient pas partie de cette PR.
-- Auditer `ControlFlowStack.Blocks` : cette vue live est exposée sous `IEnumerable<T>`, mais le
-  `Stack<T>` interne reste récupérable par cast. Une correction doit préserver l'ordre
-  d'énumération et éviter une allocation à chaque lecture.
 
 ## Deuxième tranche terminée (2026-08-11)
 
@@ -42,6 +39,8 @@ Les cas suivants sont corrigés et couverts par des tests d'encapsulation :
 - [x] `VirtualMemory<TAddress>.Processes` : vue read-only live créée une fois ;
 - [x] `Scheduler<T>.Processes` : vue read-only live créée une fois ;
 - [x] `CallFrame.Locals` : `ReadOnlyDictionary` live créé une fois ;
+- [x] `ControlFlowStack.Blocks` : vue enumerable live créée une fois, préservant l'ordre de pile
+  sans exposer le `Stack<T>` interne ;
 - [x] `VirtualProcess<TAddress>.Mappings` : snapshot `ImmutableArray` mis en cache avec
   invalidation lazy après chaque mutation de la table des pages ;
 - [x] `TransactionException.RollbackExceptions` : copie défensive immutable à la construction.

--- a/Utils.VirtualMachine/CallFrame.cs
+++ b/Utils.VirtualMachine/CallFrame.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Utils.VirtualMachine;
 
@@ -10,6 +11,7 @@ namespace Utils.VirtualMachine;
 public sealed class CallFrame
 {
     private readonly Dictionary<string, object?> _locals = [];
+    private readonly IReadOnlyDictionary<string, object?> _localsView;
 
     /// <summary>Gets the instruction-stream offset to resume when this frame is popped.</summary>
     public int ReturnAddress { get; }
@@ -22,9 +24,18 @@ public sealed class CallFrame
     /// property while the frame is being modified concurrently or re-entrantly is not safe.
     /// For stable diagnostic snapshots, copy the result: <c>frame.Locals.ToDictionary(...)</c>.
     /// </remarks>
-    public IReadOnlyDictionary<string, object?> Locals => _locals;
+    public IReadOnlyDictionary<string, object?> Locals => _localsView;
 
-    internal CallFrame(int returnAddress) => ReturnAddress = returnAddress;
+    /// <summary>
+    /// Initializes a frame with the specified return address and a persistent read-only view of
+    /// its local-variable storage.
+    /// </summary>
+    /// <param name="returnAddress">The instruction-stream offset to resume when this frame is popped.</param>
+    internal CallFrame(int returnAddress)
+    {
+        ReturnAddress = returnAddress;
+        _localsView = new ReadOnlyDictionary<string, object?>(_locals);
+    }
 
     /// <summary>
     /// Stores a local variable, overwriting any previous value under the same name.

--- a/Utils.VirtualMachine/ControlFlowStack.cs
+++ b/Utils.VirtualMachine/ControlFlowStack.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -19,6 +20,7 @@ public class ControlFlowStack
     public const int DefaultMaxDepth = 1024;
 
     private readonly Stack<IControlFlowBlock> _blocks = new();
+    private readonly IEnumerable<IControlFlowBlock> _blocksView;
 
     /// <summary>
     /// Gets the maximum number of blocks that may be open simultaneously.
@@ -39,7 +41,7 @@ public class ControlFlowStack
     /// Gets all currently open blocks from innermost (top of stack) to outermost (bottom),
     /// as a live enumerable. Useful for diagnostics and post-execution assertions.
     /// </summary>
-    public IEnumerable<IControlFlowBlock> Blocks => _blocks;
+    public IEnumerable<IControlFlowBlock> Blocks => _blocksView;
 
     /// <summary>
     /// Initializes a new <see cref="ControlFlowStack"/> with the specified maximum nesting depth.
@@ -51,6 +53,7 @@ public class ControlFlowStack
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxDepth"/> is less than one.</exception>
     public ControlFlowStack(int maxDepth = DefaultMaxDepth)
     {
+        _blocksView = new ReadOnlyEnumerable<IControlFlowBlock>(_blocks);
         if (maxDepth < 1)
             throw new ArgumentOutOfRangeException(nameof(maxDepth), "Maximum depth must be at least 1.");
         MaxDepth = maxDepth;
@@ -65,6 +68,33 @@ public class ControlFlowStack
     public ControlFlowStack(VirtualMachineLimits limits)
         : this((limits ?? throw new ArgumentNullException(nameof(limits))).MaxControlFlowDepth)
     {
+    }
+
+    /// <summary>
+    /// Provides a persistent live enumerable view without exposing its backing collection.
+    /// </summary>
+    /// <typeparam name="T">The type of item exposed by the view.</typeparam>
+    private sealed class ReadOnlyEnumerable<T> : IEnumerable<T>
+    {
+        private readonly IEnumerable<T> _source;
+
+        /// <summary>
+        /// Initializes a live view over the specified enumerable.
+        /// </summary>
+        /// <param name="source">The backing enumerable whose current contents are exposed.</param>
+        public ReadOnlyEnumerable(IEnumerable<T> source) => _source = source;
+
+        /// <summary>
+        /// Returns an enumerator over the current contents of the backing enumerable.
+        /// </summary>
+        /// <returns>An enumerator over the live view.</returns>
+        public IEnumerator<T> GetEnumerator() => _source.GetEnumerator();
+
+        /// <summary>
+        /// Returns a non-generic enumerator over the current contents of the backing enumerable.
+        /// </summary>
+        /// <returns>An enumerator over the live view.</returns>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     /// <summary>Opens a conditional (if/else) block.</summary>

--- a/Utils.VirtualMachine/Scheduler.cs
+++ b/Utils.VirtualMachine/Scheduler.cs
@@ -19,6 +19,7 @@ namespace Utils.VirtualMachine;
 public class Scheduler<T> where T : Context
 {
     private readonly List<ScheduledProcess<T>> _processes = [];
+    private readonly IReadOnlyList<ScheduledProcess<T>> _processesView;
     private int _nextId;
     private readonly int _maxScheduledProcesses;
 
@@ -32,8 +33,8 @@ public class Scheduler<T> where T : Context
     /// </summary>
     public long InstructionsExecuted { get; private set; }
 
-    /// <summary>Gets the list of all processes registered with this scheduler.</summary>
-    public IReadOnlyList<ScheduledProcess<T>> Processes => _processes;
+    /// <summary>Gets a live read-only view of all processes registered with this scheduler.</summary>
+    public IReadOnlyList<ScheduledProcess<T>> Processes => _processesView;
 
     /// <summary>
     /// Initializes a new <see cref="Scheduler{T}"/> with the specified quantum size.
@@ -46,6 +47,7 @@ public class Scheduler<T> where T : Context
     /// </exception>
     public Scheduler(int quantumSteps = 100)
     {
+        _processesView = _processes.AsReadOnly();
         if (quantumSteps < 1)
             throw new ArgumentOutOfRangeException(nameof(quantumSteps), "Quantum must be at least 1.");
         QuantumSteps = quantumSteps;
@@ -61,6 +63,7 @@ public class Scheduler<T> where T : Context
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="limits"/> is <see langword="null"/>.</exception>
     public Scheduler(VirtualMachineLimits limits)
     {
+        _processesView = _processes.AsReadOnly();
         ArgumentNullException.ThrowIfNull(limits);
         if (limits.SchedulerQuantumSteps < 1)
             throw new ArgumentOutOfRangeException(nameof(limits), "Quantum must be at least 1.");

--- a/Utils.VirtualMachine/VirtualMemory.cs
+++ b/Utils.VirtualMachine/VirtualMemory.cs
@@ -29,6 +29,8 @@ public class VirtualMemory<TAddress> where TAddress : IBinaryInteger<TAddress>
 {
     private readonly List<VirtualPage> _pages = [];
     private readonly List<VirtualProcess<TAddress>> _processes = [];
+    private readonly IReadOnlyList<VirtualPage> _pagesView;
+    private readonly IReadOnlyList<VirtualProcess<TAddress>> _processesView;
     private int _nextPageId;
     private int _nextProcessId;
     private TAddress _masterNextVirtualIndex = TAddress.Zero;
@@ -50,7 +52,7 @@ public class VirtualMemory<TAddress> where TAddress : IBinaryInteger<TAddress>
     /// <remarks>This is a live view over the internal page list. Allocating new pages while
     /// enumerating may modify the list; take a snapshot (<c>.ToList()</c>) for stable enumeration.
     /// </remarks>
-    public IReadOnlyList<VirtualPage> Pages => _pages;
+    public IReadOnlyList<VirtualPage> Pages => _pagesView;
 
     /// <summary>
     /// Gets the list of all processes, including the master process.
@@ -59,7 +61,7 @@ public class VirtualMemory<TAddress> where TAddress : IBinaryInteger<TAddress>
     /// while enumerating may modify the list; take a snapshot (<c>.ToList()</c>) for stable
     /// enumeration.
     /// </remarks>
-    public IReadOnlyList<VirtualProcess<TAddress>> Processes => _processes;
+    public IReadOnlyList<VirtualProcess<TAddress>> Processes => _processesView;
 
     /// <summary>
     /// Initializes a new <see cref="VirtualMemory{TAddress}"/> and creates the master process.
@@ -68,6 +70,8 @@ public class VirtualMemory<TAddress> where TAddress : IBinaryInteger<TAddress>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="pageSize"/> is less than one.</exception>
     public VirtualMemory(int pageSize = 4096)
     {
+        _pagesView = _pages.AsReadOnly();
+        _processesView = _processes.AsReadOnly();
         if (pageSize < 1) throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be at least 1.");
         PageSize = pageSize;
         _maxPhysicalPages = int.MaxValue;
@@ -86,6 +90,8 @@ public class VirtualMemory<TAddress> where TAddress : IBinaryInteger<TAddress>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="pageSize"/> is less than one.</exception>
     public VirtualMemory(int pageSize, VirtualMachineLimits limits)
     {
+        _pagesView = _pages.AsReadOnly();
+        _processesView = _processes.AsReadOnly();
         ArgumentNullException.ThrowIfNull(limits);
         if (pageSize < 1) throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be at least 1.");
         PageSize = pageSize;

--- a/Utils.VirtualMachine/VirtualProcess.cs
+++ b/Utils.VirtualMachine/VirtualProcess.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
 
@@ -49,6 +50,9 @@ namespace Utils.VirtualMachine;
 public class VirtualProcess<TAddress> where TAddress : IBinaryInteger<TAddress>
 {
     private readonly Dictionary<TAddress, (VirtualPage Page, PageAccess Access)> _pageTable = [];
+    private IReadOnlyList<(TAddress VirtualPageIndex, VirtualPage Page, PageAccess Access)> _mappingsSnapshot
+        = ImmutableArray<(TAddress, VirtualPage, PageAccess)>.Empty;
+    private bool _mappingsSnapshotDirty = true;
     private readonly int _pageSize;
     private bool _isFreed;
 
@@ -84,7 +88,14 @@ public class VirtualProcess<TAddress> where TAddress : IBinaryInteger<TAddress>
         get
         {
             ThrowIfFreed();
-            return _pageTable.Select(kv => (kv.Key, kv.Value.Page, kv.Value.Access)).ToArray();
+            if (_mappingsSnapshotDirty)
+            {
+                _mappingsSnapshot = _pageTable
+                    .Select(kv => (kv.Key, kv.Value.Page, kv.Value.Access))
+                    .ToImmutableArray();
+                _mappingsSnapshotDirty = false;
+            }
+            return _mappingsSnapshot;
         }
     }
 
@@ -98,7 +109,11 @@ public class VirtualProcess<TAddress> where TAddress : IBinaryInteger<TAddress>
     internal void MarkFreed() => _isFreed = true;
 
     /// <summary>Clears all page-table entries without checking <see cref="IsFreed"/>. For use by <see cref="VirtualMemory{TAddress}.FreeProcess"/> only.</summary>
-    internal void ClearAllMappings() => _pageTable.Clear();
+    internal void ClearAllMappings()
+    {
+        _pageTable.Clear();
+        InvalidateMappingsSnapshot();
+    }
 
     /// <summary>
     /// Removes all virtual page table entries that reference <paramref name="page"/>, without
@@ -112,6 +127,7 @@ public class VirtualProcess<TAddress> where TAddress : IBinaryInteger<TAddress>
             .ToList();
         foreach (var key in keysToRemove)
             _pageTable.Remove(key);
+        InvalidateMappingsSnapshot();
     }
 
     /// <summary>Returns <see langword="true"/> when <paramref name="page"/> is mapped into this process with at least <see cref="PageAccess.ReadOnly"/> access.</summary>
@@ -122,13 +138,20 @@ public class VirtualProcess<TAddress> where TAddress : IBinaryInteger<TAddress>
     {
         ThrowIfFreed();
         _pageTable[virtualPageIndex] = (page, access);
+        InvalidateMappingsSnapshot();
     }
 
     internal void UnmapPage(TAddress virtualPageIndex)
     {
         ThrowIfFreed();
         _pageTable.Remove(virtualPageIndex);
+        InvalidateMappingsSnapshot();
     }
+
+    /// <summary>
+    /// Marks the cached immutable mappings snapshot for rebuilding after page-table mutation.
+    /// </summary>
+    private void InvalidateMappingsSnapshot() => _mappingsSnapshotDirty = true;
 
     private void ThrowIfFreed()
     {

--- a/Utils/Transactions/TransactionExecutor.cs
+++ b/Utils/Transactions/TransactionExecutor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Utils.Transactions;
 
@@ -127,9 +128,15 @@ public sealed class TransactionException : Exception
         : base(BuildMessage(primaryException, rollbackExceptions), primaryException)
     {
         PrimaryException = primaryException;
-        RollbackExceptions = rollbackExceptions;
+        RollbackExceptions = rollbackExceptions.ToImmutableArray();
     }
 
+    /// <summary>
+    /// Builds the diagnostic message from the primary failure and the number of rollback failures.
+    /// </summary>
+    /// <param name="primary">The original transaction failure.</param>
+    /// <param name="rollbacks">The rollback failures included in the diagnostic.</param>
+    /// <returns>The complete transaction failure message.</returns>
     private static string BuildMessage(Exception primary, IReadOnlyList<Exception> rollbacks)
     {
         if (rollbacks.Count == 0)

--- a/UtilsTest/Transactions/TransactionExecutorTests.cs
+++ b/UtilsTest/Transactions/TransactionExecutorTests.cs
@@ -146,6 +146,25 @@ public class TransactionExecutorTests
     }
 
     [TestMethod]
+    public void TransactionException_RollbackExceptions_AreImmutableSnapshot()
+    {
+        var primary = new InvalidOperationException("primary");
+        var rollback = new InvalidOperationException("rollback");
+        var source = new List<Exception> { rollback };
+
+        var exception = new TransactionException(primary, source);
+        source.Clear();
+
+        Assert.AreEqual(1, exception.RollbackExceptions.Count);
+        Assert.AreSame(rollback, exception.RollbackExceptions[0]);
+        Assert.IsFalse(exception.RollbackExceptions is List<Exception>);
+        Assert.IsFalse(exception.RollbackExceptions is Exception[]);
+        var collection = (ICollection<Exception>)exception.RollbackExceptions;
+        Assert.IsTrue(collection.IsReadOnly);
+        Assert.ThrowsException<NotSupportedException>(() => collection.Clear());
+    }
+
+    [TestMethod]
     public void RollbackFailure_DoesNotSkipEarlierActions()
     {
         var executor = new TransactionExecutor();

--- a/UtilsTest/VirtualMachine/CallStackTests.cs
+++ b/UtilsTest/VirtualMachine/CallStackTests.cs
@@ -167,6 +167,23 @@ public class CallStackTests
     }
 
     [TestMethod]
+    public void CallFrame_Locals_IsLiveReadOnlyView()
+    {
+        var callStack = new CallStack();
+        callStack.Call(0);
+        var frame = callStack.CurrentFrame!;
+        var view = frame.Locals;
+
+        frame.SetLocal("x", 42);
+
+        Assert.AreEqual(42, view["x"]);
+        Assert.IsFalse(view is Dictionary<string, object?>);
+        var dictionary = (IDictionary<string, object?>)view;
+        Assert.IsTrue(dictionary.IsReadOnly);
+        Assert.ThrowsException<NotSupportedException>(() => dictionary.Clear());
+    }
+
+    [TestMethod]
     public void CallFrame_Locals_ArePerFrame()
     {
         var cs = new CallStack();

--- a/UtilsTest/VirtualMachine/ControlFlowStackTests.cs
+++ b/UtilsTest/VirtualMachine/ControlFlowStackTests.cs
@@ -95,6 +95,22 @@ public class ControlFlowTestMachine : VirtualProcessor<ControlFlowContext>
 [TestClass]
 public class ControlFlowStackTests
 {
+    [TestMethod]
+    public void Blocks_IsPersistentLiveViewWithoutExposingStack()
+    {
+        var controlFlow = new ControlFlowStack();
+        var view = controlFlow.Blocks;
+
+        controlFlow.PushLoop(10, 20);
+        controlFlow.PushConditional(11, 19);
+
+        Assert.AreSame(view, controlFlow.Blocks);
+        Assert.AreEqual(2, view.Count());
+        Assert.IsFalse(view is Stack<IControlFlowBlock>);
+        Assert.IsInstanceOfType<ConditionalBlock>(view.ElementAt(0));
+        Assert.IsInstanceOfType<LoopBlock>(view.ElementAt(1));
+    }
+
     // â"€â"€ ConditionalBlock â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€
 
     [TestMethod]

--- a/UtilsTest/VirtualMachine/SchedulerTests.cs
+++ b/UtilsTest/VirtualMachine/SchedulerTests.cs
@@ -60,6 +60,21 @@ public class SchedulerTests
     }
 
     [TestMethod]
+    public void Processes_IsLiveReadOnlyView()
+    {
+        var scheduler = new Scheduler<DefaultContext>();
+        var view = scheduler.Processes;
+
+        var process = scheduler.AddProcess(Ctx(0x00), Proc());
+
+        Assert.AreEqual(1, view.Count);
+        Assert.IsFalse(view is List<ScheduledProcess<DefaultContext>>);
+        var collection = (ICollection<ScheduledProcess<DefaultContext>>)view;
+        Assert.IsTrue(collection.IsReadOnly);
+        Assert.ThrowsException<NotSupportedException>(() => collection.Add(process));
+    }
+
+    [TestMethod]
     public void AddProcess_AssignsUniqueIds()
     {
         var scheduler = new Scheduler<DefaultContext>();

--- a/UtilsTest/VirtualMachine/VirtualMemoryTests.cs
+++ b/UtilsTest/VirtualMachine/VirtualMemoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Utils.VirtualMachine;
@@ -30,6 +31,21 @@ public class VirtualMemoryTests
     }
 
     [TestMethod]
+    public void Pages_IsLiveReadOnlyView()
+    {
+        var memory = new VirtualMemory<int>(pageSize: 16);
+        var view = memory.Pages;
+
+        var page = memory.AllocatePage();
+
+        Assert.AreEqual(1, view.Count);
+        Assert.IsFalse(view is List<VirtualPage>);
+        var collection = (ICollection<VirtualPage>)view;
+        Assert.IsTrue(collection.IsReadOnly);
+        Assert.ThrowsException<NotSupportedException>(() => collection.Add(page));
+    }
+
+    [TestMethod]
     public void AllocatePage_MasterAutoMapped_ReadWrite()
     {
         var mem = new VirtualMemory<int>(pageSize: 16);
@@ -58,6 +74,47 @@ public class VirtualMemoryTests
         var mem = new VirtualMemory<int>(pageSize: 16);
         var proc = mem.CreateProcess();
         Assert.IsTrue(mem.Processes.Contains(proc));
+    }
+
+    [TestMethod]
+    public void Processes_IsLiveReadOnlyView()
+    {
+        var memory = new VirtualMemory<int>(pageSize: 16);
+        var view = memory.Processes;
+
+        var process = memory.CreateProcess();
+
+        Assert.IsTrue(view.Contains(process));
+        Assert.IsFalse(view is List<VirtualProcess<int>>);
+        var collection = (ICollection<VirtualProcess<int>>)view;
+        Assert.IsTrue(collection.IsReadOnly);
+        Assert.ThrowsException<NotSupportedException>(() => collection.Add(process));
+    }
+
+    [TestMethod]
+    public void Mappings_AreCachedImmutableHistoricalSnapshots()
+    {
+        var memory = new VirtualMemory<int>(pageSize: 16);
+        var process = memory.CreateProcess();
+        var snapshot = process.Mappings;
+        var repeatedSnapshot = process.Mappings;
+        var page = memory.AllocatePage();
+
+        memory.MapPage(process, page, 0, PageAccess.ReadOnly);
+        var updated = process.Mappings;
+
+        Assert.AreSame(snapshot, repeatedSnapshot);
+        Assert.AreEqual(0, snapshot.Count);
+        Assert.AreEqual(1, updated.Count);
+        Assert.IsFalse(updated is (int VirtualPageIndex, VirtualPage Page, PageAccess Access)[]);
+        Assert.IsFalse(updated is List<(int VirtualPageIndex, VirtualPage Page, PageAccess Access)>);
+        var collection = (ICollection<(int VirtualPageIndex, VirtualPage Page, PageAccess Access)>)updated;
+        Assert.IsTrue(collection.IsReadOnly);
+        Assert.ThrowsException<NotSupportedException>(() => collection.Clear());
+
+        memory.FreeProcess(process);
+        Assert.AreEqual(1, updated.Count);
+        Assert.ThrowsException<ObjectDisposedException>(() => _ = process.Mappings);
     }
 
     [TestMethod]


### PR DESCRIPTION
### Motivation

- Prevent callers from casting/read-writing internal mutable collections that should be exposed as live read-only views or immutable snapshots.
- Preserve existing public contracts (`IReadOnlyList`, `IReadOnlyDictionary`) while avoiding per-getter allocations and preserving live vs snapshot semantics described in the immutability TODO.

### Description

- Replace direct exposure of internal `List<T>`/`Dictionary<TKey,TValue>` with single, persistent read-only views created once in constructors for `VirtualMemory.Pages`, `VirtualMemory.Processes`, `Scheduler.Processes`, and `CallFrame.Locals` to keep live semantics without allowing casts to the mutable backing collection.
- Cache `VirtualProcess<TAddress>.Mappings` as an `ImmutableArray` snapshot with lazy invalidation (`_mappingsSnapshotDirty`) and ensure all page-table mutation paths call the invalidation helper so the snapshot is rebuilt only when needed.
- Make `TransactionException.RollbackExceptions` a defensive immutable snapshot in the constructor via `.ToImmutableArray()` to prevent post-construction mutation of the source list.
- Update `TODO-immutability.md` to mark the corrected items and log findings (notably a reported `VirtualProcessor<T>.Instructions` exposure that requires a separate follow-up audit).
- Files changed: `Utils.VirtualMachine/VirtualMemory.cs`, `Utils.VirtualMachine/Scheduler.cs`, `Utils.VirtualMachine/CallFrame.cs`, `Utils.VirtualMachine/VirtualProcess.cs`, `Utils/Transactions/TransactionExecutor.cs`, plus unit tests and `TODO-immutability.md` updates and added tests under `UtilsTest/VirtualMachine` and `UtilsTest/Transactions` to assert live-view behavior and immutable snapshots.

### Testing

- Restored and built the solution with `dotnet restore Utils.sln` and `dotnet build Utils.sln --configuration Release --no-restore`, which completed with no errors (only existing preexisting warnings).
- Ran targeted unit tests: `dotnet test UtilsTest/UtilsTest.Unit.csproj --configuration Release --no-build --filter "FullyQualifiedName~VirtualMachine"` and `--filter "FullyQualifiedName~Transaction"`, both passed (VirtualMachine tests and Transaction tests succeeded with zero failures).
- Ran full unit suite with `dotnet test UtilsTest/UtilsTest.Unit.csproj --configuration Release --no-build`, which succeeded (all tests passed or skipped as expected).
- Ran functional tests with `dotnet test UtilsTest.Functional/UtilsTest.Functional.csproj --configuration Release --no-build`, which passed (no failures in the applicable functional suite).
- All added tests validating: live read-only views refuse mutation via cast, live views reflect owner mutations, `Mappings` snapshot immutability and cache behavior, and `TransactionException.RollbackExceptions` defensive snapshot passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ac157dd588326b124be5cf408b7cf)